### PR TITLE
Check overloads against existing overloads and macros for ambiguity.

### DIFF
--- a/checker/BUILD.bazel
+++ b/checker/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//checker/types:go_default_library",
         "//io:checked_proto",
         "//io:syntax_proto",
+	"//parser:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
     visibility = ["//visibility:public"],

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -886,7 +886,7 @@ _&&_(_==_(list~type(list(int))^list,
 					decls.NewOverload("yourfunc_id", []*checked.Type{types.Dyn}, types.Dyn)),
 			},
 		},
-		Error: `ERROR: <input>:-1:0: overlapping overload for name 'myfunc' (type 'function:<result_type:<dyn:<> > arg_types:<dyn:<> > > ' cannot be distinguished from 'function:<result_type:<dyn:<> > arg_types:<dyn:<> > > ')`,
+		Error: `ERROR: <input>:-1:0: overlapping overload for name 'myfunc' (type 'function(dyn) : dyn' with overloadId: 'yourfunc_id' cannot be distinguished from 'function(dyn) : dyn' with overloadId: 'myfunc_id')`,
 	},
 	{
 		I: `size(x) > 4`,

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -867,21 +867,27 @@ _&&_(_==_(list~type(list(int))^list,
 
 	// TODO: This doesn't seem like the right path for this kind of error. Env should catch the case and throw
 	// during env setup
-	//	{
-	//		I: `false`,
-	//		Env: env{
-	//			functions: []*checked.Decl{
-	//				decls.NewFunction("has",
-	//					semantics.NewOverload("has_id", false, types.Dynamic, types.Dynamic)),
-	//			},
-	//		},
-	//		Error: `
-	//ERROR: <input>:1:1: overload for name 'has' with 1 argument(s) overlaps with predefined macro
-	// | false
-	// | ^
-	//		`,
-	//	},
-
+	{
+		I: `false`,
+		Env: env{
+			functions: []*checked.Decl{
+				decls.NewFunction("has",
+					decls.NewOverload("has_id", []*checked.Type{types.Dyn}, types.Dyn)),
+			},
+		},
+		Error: `ERROR: <input>:-1:0: overload for name 'has' with 1 argument(s) overlaps with predefined macro`,
+	},
+	{
+		I: `false`,
+		Env: env{
+			functions: []*checked.Decl{
+				decls.NewFunction("myfunc",
+					decls.NewOverload("myfunc_id", []*checked.Type{types.Dyn}, types.Dyn),
+					decls.NewOverload("yourfunc_id", []*checked.Type{types.Dyn}, types.Dyn)),
+			},
+		},
+		Error: `ERROR: <input>:-1:0: overlapping overload for name 'myfunc' (type 'function:<result_type:<dyn:<> > arg_types:<dyn:<> > > ' cannot be distinguished from 'function:<result_type:<dyn:<> > arg_types:<dyn:<> > > ')`,
+	},
 	{
 		I: `size(x) > 4`,
 		Env: env{

--- a/checker/env.go
+++ b/checker/env.go
@@ -91,6 +91,7 @@ func (e *Env) addOverload(f *checked.Decl, overload *checked.Decl_FunctionDecl_O
 func (e *Env) addFunction(decl *checked.Decl) {
 	current := e.declarations.FindFunction(decl.Name)
 	if current == nil {
+		//Add the function declaration without overloads and check the overloads below.
 		current = decls.NewFunction(decl.Name)
 		e.declarations.AddFunction(current)
 	}
@@ -100,7 +101,6 @@ func (e *Env) addFunction(decl *checked.Decl) {
 	for _, overload := range decl.GetFunction().GetOverloads() {
 		e.addOverload(current, overload)
 	}
-	decl = current
 }
 
 func (e *Env) addIdent(decl *checked.Decl) {

--- a/checker/env.go
+++ b/checker/env.go
@@ -72,8 +72,8 @@ func (e *Env) addOverload(f *checked.Decl, overload *checked.Decl_FunctionDecl_O
 			types.IsAssignable(emptyMappings, existingErased, overloadErased) != nil)
 		if overlap &&
 			overload.GetIsInstanceFunction() == existing.GetIsInstanceFunction() {
-			e.errors.overlappingOverload(common.NoLocation, f.Name, overloadFunction,
-				existingFunction)
+			e.errors.overlappingOverload(common.NoLocation, f.Name, overload.GetOverloadId(), overloadFunction,
+				existing.GetOverloadId(), existingFunction)
 			return
 		}
 	}
@@ -95,9 +95,7 @@ func (e *Env) addFunction(decl *checked.Decl) {
 		current = decls.NewFunction(decl.Name)
 		e.declarations.AddFunction(current)
 	}
-	if current.Name != decl.Name {
-		return
-	}
+
 	for _, overload := range decl.GetFunction().GetOverloads() {
 		e.addOverload(current, overload)
 	}

--- a/checker/env.go
+++ b/checker/env.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/checker/types"
 	"github.com/google/cel-go/common"
+	"github.com/google/cel-go/parser"
 	"github.com/google/cel-spec/proto/checked/v1/checked"
 	expr "github.com/google/cel-spec/proto/v1/syntax"
 )
@@ -57,20 +58,49 @@ func (e *Env) Add(decls ...*checked.Decl) {
 	}
 }
 
-func (e *Env) addFunction(decl *checked.Decl) {
-	current := e.declarations.FindFunction(decl.Name)
-	if current != nil {
-		if current.Name != decl.Name {
+func (e *Env) addOverload(f *checked.Decl, overload *checked.Decl_FunctionDecl_Overload) {
+	function := f.GetFunction()
+	emptyMappings := types.NewMapping()
+	overloadFunction := types.NewFunction(overload.GetResultType(),
+		overload.GetParams()...)
+	overloadErased := types.Substitute(emptyMappings, overloadFunction, true)
+	for _, existing := range function.GetOverloads() {
+		existingFunction := types.NewFunction(existing.GetResultType(),
+			existing.GetParams()...)
+		existingErased := types.Substitute(emptyMappings, existingFunction, true)
+		overlap := (types.IsAssignable(emptyMappings, overloadErased, existingErased) != nil ||
+			types.IsAssignable(emptyMappings, existingErased, overloadErased) != nil)
+		if overlap &&
+			overload.GetIsInstanceFunction() == existing.GetIsInstanceFunction() {
+			e.errors.overlappingOverload(common.NoLocation, f.Name, overloadFunction,
+				existingFunction)
 			return
 		}
-		// TODO: Check for conflicts.
-		function := current.GetFunction()
-		function.Overloads = append(function.Overloads,
-			decl.GetFunction().Overloads...)
-		decl = current
-	} else {
-		e.declarations.AddFunction(decl)
 	}
+
+	for _, macro := range parser.AllMacros {
+		if macro.GetName() == f.Name && macro.GetIsInstanceStyle() == overload.GetIsInstanceFunction() &&
+			macro.GetArgCount() == len(overload.GetParams()) {
+			e.errors.overlappingMacro(common.NoLocation, f.Name, macro.GetArgCount())
+			return
+		}
+	}
+	function.Overloads = append(function.GetOverloads(), overload)
+}
+
+func (e *Env) addFunction(decl *checked.Decl) {
+	current := e.declarations.FindFunction(decl.Name)
+	if current == nil {
+		current = decls.NewFunction(decl.Name)
+		e.declarations.AddFunction(current)
+	}
+	if current.Name != decl.Name {
+		return
+	}
+	for _, overload := range decl.GetFunction().GetOverloads() {
+		e.addOverload(current, overload)
+	}
+	decl = current
 }
 
 func (e *Env) addIdent(decl *checked.Decl) {

--- a/checker/errors.go
+++ b/checker/errors.go
@@ -45,6 +45,16 @@ func (e *typeErrors) fieldDoesNotSupportPresenceCheck(l common.Location, field s
 	e.ReportError(l, "field '%s' does not support presence check", field)
 }
 
+func (e *typeErrors) overlappingOverload(l common.Location, name string, f1 *checked.Type, f2 *checked.Type) {
+	e.ReportError(l, "overlapping overload for name '%s' (type '%s' cannot be distinguished from '%s')",
+		name, types.FormatType(f1), types.FormatType(f2))
+}
+
+func (e *typeErrors) overlappingMacro(l common.Location, name string, args int) {
+	e.ReportError(l, "overload for name '%s' with %d argument(s) overlaps with predefined macro",
+		name, args)
+}
+
 func (e *typeErrors) noMatchingOverload(l common.Location, name string, args []*checked.Type, isInstance bool) {
 	signature := formatFunction(nil, args, isInstance)
 	e.ReportError(l, "found no matching overload for '%s' applied to '%s'", name, signature)

--- a/checker/errors.go
+++ b/checker/errors.go
@@ -45,9 +45,10 @@ func (e *typeErrors) fieldDoesNotSupportPresenceCheck(l common.Location, field s
 	e.ReportError(l, "field '%s' does not support presence check", field)
 }
 
-func (e *typeErrors) overlappingOverload(l common.Location, name string, f1 *checked.Type, f2 *checked.Type) {
-	e.ReportError(l, "overlapping overload for name '%s' (type '%s' cannot be distinguished from '%s')",
-		name, types.FormatType(f1), types.FormatType(f2))
+func (e *typeErrors) overlappingOverload(l common.Location, name string, overloadId1 string, f1 *checked.Type,
+	overloadId2 string, f2 *checked.Type) {
+	e.ReportError(l, "overlapping overload for name '%s' (type '%s' with overloadId: '%s' cannot be distinguished from '%s' with "+
+		"overloadId: '%s')", name, types.FormatType(f1), overloadId1, types.FormatType(f2), overloadId2)
 }
 
 func (e *typeErrors) overlappingMacro(l common.Location, name string, args int) {

--- a/checker/types/types.go
+++ b/checker/types/types.go
@@ -19,7 +19,6 @@ package types
 import (
 	"fmt"
 	"strings"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/golang/protobuf/ptypes/struct"

--- a/checker/types/types.go
+++ b/checker/types/types.go
@@ -19,6 +19,7 @@ package types
 import (
 	"fmt"
 	"strings"
+	
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/golang/protobuf/ptypes/struct"
@@ -403,14 +404,14 @@ func formatFunction(resultType *checked.Type, args []*checked.Type) string {
 		result = fmt.Sprintf(" : %s", FormatType(resultType))
 	}
 
-	formatter := func(args []*checked.Type) []string {
+	formatter := func() []string {
 		formatted := make([]string, 0, len(args))
 		for _, arg := range args {
 			formatted = append(formatted, FormatType(arg))
 		}
 		return formatted
 	}
-	return fmt.Sprintf("function(%s)%s", strings.Join(formatter(args), ","), result)
+	return fmt.Sprintf("function(%s)%s", strings.Join(formatter(), ","), result)
 }
 
 func FormatType(t *checked.Type) string {

--- a/parser/macro.go
+++ b/parser/macro.go
@@ -94,6 +94,18 @@ var AllMacros = []Macro{
 // NoMacros list.
 var NoMacros = []Macro{}
 
+func (m *Macro) GetName() string {
+	return m.name
+}
+
+func (m *Macro) GetArgCount() int {
+	return m.args
+}
+
+func (m *Macro) GetIsInstanceStyle() bool {
+	return m.instanceStyle
+}
+
 func makeHas(p *parserHelper, ctx interface{}, target *expr.Expr, args []*expr.Expr) *expr.Expr {
 	if s, ok := args[0].ExprKind.(*expr.Expr_SelectExpr); ok {
 		return p.newPresenceTest(ctx, s.SelectExpr.Operand, s.SelectExpr.Field)

--- a/parser/macro.go
+++ b/parser/macro.go
@@ -21,6 +21,8 @@ import (
 	expr "github.com/google/cel-spec/proto/v1/syntax"
 )
 
+// TODO: Consider moving macros to common.
+
 // Macros type alias for a collection of Macros.
 type Macros []Macro
 


### PR DESCRIPTION
#13 This implementation pretty much follows the Java one. Note that I did not
add a source location to the error. This seems to be inline with the
Java implementation. If we wanted to add this, we would probably have to
pass the environment the sourceinfo which would lead to more changes