### PR TITLE
Update the cel-go workspace to point to latest cel-spec

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,6 +18,6 @@ go_repository(
 
 git_repository(
   name = "com_google_cel_spec",
-  commit = "a11579912f054e1fc0a983bddd62668c676aac3f",
+  commit = "3769a0b59441e6a2ebe747154dd1a4c85ce65ae0",
   remote = "https://github.com/google/cel-spec.git",
 )

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -73,23 +73,23 @@ func (c *checker) check(e *expr.Expr) {
 	}
 
 	switch e.ExprKind.(type) {
-	case *expr.Expr_ConstExpr:
-		constExpr := e.GetConstExpr()
-		switch constExpr.ConstantKind.(type) {
-		case *expr.Constant_BoolValue:
-			c.checkBoolConstant(e)
-		case *expr.Constant_BytesValue:
-			c.checkBytesConstant(e)
-		case *expr.Constant_DoubleValue:
-			c.checkDoubleConstant(e)
-		case *expr.Constant_Int64Value:
-			c.checkInt64Constant(e)
-		case *expr.Constant_NullValue:
-			c.checkNullConstant(e)
-		case *expr.Constant_StringValue:
-			c.checkStringConstant(e)
-		case *expr.Constant_Uint64Value:
-			c.checkUint64Constant(e)
+	case *expr.Expr_LiteralExpr:
+		literal := e.GetLiteralExpr()
+		switch literal.LiteralKind.(type) {
+		case *expr.Literal_BoolValue:
+			c.checkBoolLiteral(e)
+		case *expr.Literal_BytesValue:
+			c.checkBytesLiteral(e)
+		case *expr.Literal_DoubleValue:
+			c.checkDoubleLiteral(e)
+		case *expr.Literal_Int64Value:
+			c.checkInt64Literal(e)
+		case *expr.Literal_NullValue:
+			c.checkNullLiteral(e)
+		case *expr.Literal_StringValue:
+			c.checkStringLiteral(e)
+		case *expr.Literal_Uint64Value:
+			c.checkUint64Literal(e)
 		}
 	case *expr.Expr_IdentExpr:
 		c.checkIdent(e)
@@ -108,31 +108,31 @@ func (c *checker) check(e *expr.Expr) {
 	}
 }
 
-func (c *checker) checkInt64Constant(e *expr.Expr) {
+func (c *checker) checkInt64Literal(e *expr.Expr) {
 	c.setType(e, Int)
 }
 
-func (c *checker) checkUint64Constant(e *expr.Expr) {
+func (c *checker) checkUint64Literal(e *expr.Expr) {
 	c.setType(e, Uint)
 }
 
-func (c *checker) checkStringConstant(e *expr.Expr) {
+func (c *checker) checkStringLiteral(e *expr.Expr) {
 	c.setType(e, String)
 }
 
-func (c *checker) checkBytesConstant(e *expr.Expr) {
+func (c *checker) checkBytesLiteral(e *expr.Expr) {
 	c.setType(e, Bytes)
 }
 
-func (c *checker) checkDoubleConstant(e *expr.Expr) {
+func (c *checker) checkDoubleLiteral(e *expr.Expr) {
 	c.setType(e, Double)
 }
 
-func (c *checker) checkBoolConstant(e *expr.Expr) {
+func (c *checker) checkBoolLiteral(e *expr.Expr) {
 	c.setType(e, Bool)
 }
 
-func (c *checker) checkNullConstant(e *expr.Expr) {
+func (c *checker) checkNullLiteral(e *expr.Expr) {
 	c.setType(e, Null)
 }
 
@@ -540,7 +540,7 @@ func (c *checker) locationById(id int64) common.Location {
 	return common.NoLocation
 }
 
-func newIdentReference(name string, value *expr.Constant) *checked.Reference {
+func newIdentReference(name string, value *expr.Literal) *checked.Reference {
 	return &checked.Reference{Name: name, Value: value}
 }
 

--- a/checker/decls/decls.go
+++ b/checker/decls/decls.go
@@ -6,7 +6,7 @@ import (
 	expr "github.com/google/cel-spec/proto/v1/syntax"
 )
 
-func NewIdent(name string, t *checked.Type, v *expr.Constant) *checked.Decl {
+func NewIdent(name string, t *checked.Type, v *expr.Literal) *checked.Decl {
 	return &checked.Decl{
 		Name: name,
 		DeclKind: &checked.Decl_Ident{

--- a/checker/env.go
+++ b/checker/env.go
@@ -130,8 +130,8 @@ func (e *Env) LookupIdent(container string, typeName string) *checked.Decl {
 		if enumValue := e.typeProvider.EnumValue(candidate); enumValue.Type() != types.ErrType {
 			decl := decls.NewIdent(candidate,
 				Int,
-				&expr.Constant{
-					ConstantKind: &expr.Constant_Int64Value{
+				&expr.Literal{
+					LiteralKind: &expr.Literal_Int64Value{
 						Int64Value: int64(enumValue.(types.Int))}})
 			e.declarations.AddIdent(decl)
 			return decl

--- a/checker/types.go
+++ b/checker/types.go
@@ -17,7 +17,7 @@ package checker
 import (
 	"fmt"
 	"strings"
-	
+
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/golang/protobuf/ptypes/struct"

--- a/common/debug/debug.go
+++ b/common/debug/debug.go
@@ -80,8 +80,8 @@ func (w *debugWriter) Buffer(e *expr.Expr) {
 		return
 	}
 	switch e.ExprKind.(type) {
-	case *expr.Expr_ConstExpr:
-		w.append(formatConstant(e.GetConstExpr()))
+	case *expr.Expr_LiteralExpr:
+		w.append(formatLiteral(e.GetLiteralExpr()))
 	case *expr.Expr_IdentExpr:
 		w.append(e.GetIdentExpr().Name)
 	case *expr.Expr_SelectExpr:
@@ -240,21 +240,21 @@ func (w *debugWriter) appendComprehension(comprehension *expr.Expr_Comprehension
 	w.removeIndent()
 }
 
-func formatConstant(c *expr.Constant) string {
-	switch c.ConstantKind.(type) {
-	case *expr.Constant_BoolValue:
+func formatLiteral(c *expr.Literal) string {
+	switch c.LiteralKind.(type) {
+	case *expr.Literal_BoolValue:
 		return fmt.Sprintf("%t", c.GetBoolValue())
-	case *expr.Constant_BytesValue:
+	case *expr.Literal_BytesValue:
 		return fmt.Sprintf("b\"%s\"", string(c.GetBytesValue()))
-	case *expr.Constant_DoubleValue:
+	case *expr.Literal_DoubleValue:
 		return fmt.Sprintf("%v", c.GetDoubleValue())
-	case *expr.Constant_Int64Value:
+	case *expr.Literal_Int64Value:
 		return fmt.Sprintf("%d", c.GetInt64Value())
-	case *expr.Constant_StringValue:
+	case *expr.Literal_StringValue:
 		return strconv.Quote(c.GetStringValue())
-	case *expr.Constant_Uint64Value:
+	case *expr.Literal_Uint64Value:
 		return fmt.Sprintf("%du", c.GetUint64Value())
-	case *expr.Constant_NullValue:
+	case *expr.Literal_NullValue:
 		return "null"
 	default:
 		panic("Unknown constant type")

--- a/interpreter/instructions.go
+++ b/interpreter/instructions.go
@@ -44,7 +44,7 @@ func (e *ConstExpr) String() string {
 	return fmt.Sprintf("const %v, r%d", e.Value, e.GetId())
 }
 
-func NewConst(exprId int64, value ref.Value) *ConstExpr {
+func NewLiteral(exprId int64, value ref.Value) *ConstExpr {
 	return &ConstExpr{&baseInstruction{exprId}, value}
 }
 

--- a/parser/helper.go
+++ b/parser/helper.go
@@ -51,34 +51,34 @@ func (p *parserHelper) reportError(ctx interface{}, format string, args ...inter
 	return err
 }
 
-func (p *parserHelper) newConstant(ctx interface{}, value *expr.Constant) *expr.Expr {
+func (p *parserHelper) newLiteral(ctx interface{}, value *expr.Literal) *expr.Expr {
 	exprNode := p.newExpr(ctx)
-	exprNode.ExprKind = &expr.Expr_ConstExpr{ConstExpr: value}
+	exprNode.ExprKind = &expr.Expr_LiteralExpr{LiteralExpr: value}
 	return exprNode
 }
 
-func (p *parserHelper) newConstBool(ctx interface{}, value bool) *expr.Expr {
-	return p.newConstant(ctx, &expr.Constant{&expr.Constant_BoolValue{value}})
+func (p *parserHelper) newLiteralBool(ctx interface{}, value bool) *expr.Expr {
+	return p.newLiteral(ctx, &expr.Literal{&expr.Literal_BoolValue{value}})
 }
 
-func (p *parserHelper) newConstString(ctx interface{}, value string) *expr.Expr {
-	return p.newConstant(ctx, &expr.Constant{&expr.Constant_StringValue{value}})
+func (p *parserHelper) newLiteralString(ctx interface{}, value string) *expr.Expr {
+	return p.newLiteral(ctx, &expr.Literal{&expr.Literal_StringValue{value}})
 }
 
-func (p *parserHelper) newConstBytes(ctx interface{}, value []byte) *expr.Expr {
-	return p.newConstant(ctx, &expr.Constant{&expr.Constant_BytesValue{value}})
+func (p *parserHelper) newLiteralBytes(ctx interface{}, value []byte) *expr.Expr {
+	return p.newLiteral(ctx, &expr.Literal{&expr.Literal_BytesValue{value}})
 }
 
-func (p *parserHelper) newConstInt(ctx interface{}, value int64) *expr.Expr {
-	return p.newConstant(ctx, &expr.Constant{&expr.Constant_Int64Value{value}})
+func (p *parserHelper) newLiteralInt(ctx interface{}, value int64) *expr.Expr {
+	return p.newLiteral(ctx, &expr.Literal{&expr.Literal_Int64Value{value}})
 }
 
-func (p *parserHelper) newConstUint(ctx interface{}, value uint64) *expr.Expr {
-	return p.newConstant(ctx, &expr.Constant{&expr.Constant_Uint64Value{value}})
+func (p *parserHelper) newLiteralUint(ctx interface{}, value uint64) *expr.Expr {
+	return p.newLiteral(ctx, &expr.Literal{&expr.Literal_Uint64Value{value}})
 }
 
-func (p *parserHelper) newConstDouble(ctx interface{}, value float64) *expr.Expr {
-	return p.newConstant(ctx, &expr.Constant{&expr.Constant_DoubleValue{value}})
+func (p *parserHelper) newLiteralDouble(ctx interface{}, value float64) *expr.Expr {
+	return p.newLiteral(ctx, &expr.Literal{&expr.Literal_DoubleValue{value}})
 }
 
 func (p *parserHelper) newIdent(ctx interface{}, name string) *expr.Expr {

--- a/parser/macro.go
+++ b/parser/macro.go
@@ -154,19 +154,19 @@ func makeQuantifier(kind quantifierKind, p *parserHelper, ctx interface{}, targe
 	var result *expr.Expr
 	switch kind {
 	case quantifierAll:
-		init = p.newConstBool(ctx, true)
+		init = p.newLiteralBool(ctx, true)
 		condition = accuIdent()
 		step = p.newGlobalCall(ctx, operators.LogicalAnd, accuIdent(), args[1])
 		result = accuIdent()
 	case quantifierExists:
-		init = p.newConstBool(ctx, false)
+		init = p.newLiteralBool(ctx, false)
 		condition = p.newGlobalCall(ctx, operators.LogicalNot, accuIdent())
 		step = p.newGlobalCall(ctx, operators.LogicalOr, accuIdent(), args[1])
 		result = accuIdent()
 	case quantifierExistsOne:
 		// TODO: make consistent with the CEL semantics.
-		zeroExpr := p.newConstInt(ctx, 0)
-		oneExpr := p.newConstInt(ctx, 1)
+		zeroExpr := p.newLiteralInt(ctx, 0)
+		oneExpr := p.newLiteralInt(ctx, 1)
 		init = zeroExpr
 		condition = p.newGlobalCall(ctx, operators.LessEquals, accuIdent(), oneExpr)
 		step = p.newGlobalCall(ctx, operators.Conditional, args[1],
@@ -197,7 +197,7 @@ func makeMap(p *parserHelper, ctx interface{}, target *expr.Expr, args []*expr.E
 
 	accuExpr := p.newIdent(ctx, accumulatorName)
 	init := p.newList(ctx)
-	condition := p.newConstBool(ctx, true)
+	condition := p.newLiteralBool(ctx, true)
 	// TODO: use compiler internal method for faster, stateful add.
 	step := p.newGlobalCall(ctx, operators.Add, accuExpr, p.newList(ctx, fn))
 
@@ -216,7 +216,7 @@ func makeFilter(p *parserHelper, ctx interface{}, target *expr.Expr, args []*exp
 	filter := args[1]
 	accuExpr := p.newIdent(ctx, accumulatorName)
 	init := p.newList(ctx)
-	condition := p.newConstBool(ctx, true)
+	condition := p.newLiteralBool(ctx, true)
 	// TODO: use compiler internal method for faster, stateful add.
 	step := p.newGlobalCall(ctx, operators.Add, accuExpr, p.newList(ctx, args[0]))
 	step = p.newGlobalCall(ctx, operators.Conditional, filter, step, accuExpr)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -189,7 +189,7 @@ func (p *parser) VisitCalc(ctx *gen.CalcContext) interface{} {
 }
 
 func (p *parser) VisitUnary(ctx *gen.UnaryContext) interface{} {
-	return p.helper.newConstString(ctx, "<<error>>")
+	return p.helper.newLiteralString(ctx, "<<error>>")
 }
 
 // Visit a parse tree produced by CELParser#StatementExpr.
@@ -375,7 +375,7 @@ func (p *parser) VisitInt(ctx *gen.IntContext) interface{} {
 	if err != nil {
 		return p.helper.reportError(ctx, "invalid int literal")
 	}
-	return p.helper.newConstInt(ctx, i)
+	return p.helper.newLiteralInt(ctx, i)
 }
 
 // Visit a parse tree produced by CELParser#Uint.
@@ -386,7 +386,7 @@ func (p *parser) VisitUint(ctx *gen.UintContext) interface{} {
 	if err != nil {
 		return p.helper.reportError(ctx, "invalid uint literal")
 	}
-	return p.helper.newConstUint(ctx, i)
+	return p.helper.newLiteralUint(ctx, i)
 }
 
 // Visit a parse tree produced by CELParser#Double.
@@ -395,38 +395,38 @@ func (p *parser) VisitDouble(ctx *gen.DoubleContext) interface{} {
 	if err != nil {
 		return p.helper.reportError(ctx, "invalid double literal")
 	}
-	return p.helper.newConstDouble(ctx, f)
+	return p.helper.newLiteralDouble(ctx, f)
 
 }
 
 // Visit a parse tree produced by CELParser#String.
 func (p *parser) VisitString(ctx *gen.StringContext) interface{} {
 	s := p.unquote(ctx, ctx.GetText())
-	return p.helper.newConstString(ctx, s)
+	return p.helper.newLiteralString(ctx, s)
 }
 
 // Visit a parse tree produced by CELParser#Bytes.
 func (p *parser) VisitBytes(ctx *gen.BytesContext) interface{} {
 	// TODO(ozben): Not sure if this is the right encoding.
 	b := []byte(p.unquote(ctx, ctx.GetTok().GetText()[1:]))
-	return p.helper.newConstBytes(ctx, b)
+	return p.helper.newLiteralBytes(ctx, b)
 }
 
 // Visit a parse tree produced by CELParser#BoolTrue.
 func (p *parser) VisitBoolTrue(ctx *gen.BoolTrueContext) interface{} {
-	return p.helper.newConstBool(ctx, true)
+	return p.helper.newLiteralBool(ctx, true)
 }
 
 // Visit a parse tree produced by CELParser#BoolFalse.
 func (p *parser) VisitBoolFalse(ctx *gen.BoolFalseContext) interface{} {
-	return p.helper.newConstBool(ctx, false)
+	return p.helper.newLiteralBool(ctx, false)
 }
 
 // Visit a parse tree produced by CELParser#Null.
 func (p *parser) VisitNull(ctx *gen.NullContext) interface{} {
-	return p.helper.newConstant(ctx,
-		&expr.Constant{
-			&expr.Constant_NullValue{
+	return p.helper.newLiteral(ctx,
+		&expr.Literal{
+			&expr.Literal_NullValue{
 				structpb.NullValue_NULL_VALUE}})
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -28,49 +28,49 @@ import (
 var testCases = []testInfo{
 	{
 		I: `"A"`,
-		P: `"A"^#1:*syntax.Constant_StringValue#`,
+		P: `"A"^#1:*syntax.Literal_StringValue#`,
 	},
 	{
 		I: `true`,
-		P: `true^#1:*syntax.Constant_BoolValue#`,
+		P: `true^#1:*syntax.Literal_BoolValue#`,
 	},
 	{
 		I: `false`,
-		P: `false^#1:*syntax.Constant_BoolValue#`,
+		P: `false^#1:*syntax.Literal_BoolValue#`,
 	},
 	{
 		I: `0`,
-		P: `0^#1:*syntax.Constant_Int64Value#`,
+		P: `0^#1:*syntax.Literal_Int64Value#`,
 	},
 	{
 		I: `42`,
-		P: `42^#1:*syntax.Constant_Int64Value#`,
+		P: `42^#1:*syntax.Literal_Int64Value#`,
 	},
 	{
 		I: `0u`,
-		P: `0u^#1:*syntax.Constant_Uint64Value#`,
+		P: `0u^#1:*syntax.Literal_Uint64Value#`,
 	},
 	{
 		I: `23u`,
-		P: `23u^#1:*syntax.Constant_Uint64Value#`,
+		P: `23u^#1:*syntax.Literal_Uint64Value#`,
 	},
 	{
 		I: `24u`,
-		P: `24u^#1:*syntax.Constant_Uint64Value#`,
+		P: `24u^#1:*syntax.Literal_Uint64Value#`,
 	},
 	{
 		I: `-1`,
 		P: `-_(
-    		  1^#1:*syntax.Constant_Int64Value#
+    		  1^#1:*syntax.Literal_Int64Value#
 			)^#2:*syntax.Expr_CallExpr#`,
 	},
 	{
 		I: `b"abc"`,
-		P: `b"abc"^#1:*syntax.Constant_BytesValue#`,
+		P: `b"abc"^#1:*syntax.Literal_BytesValue#`,
 	},
 	{
 		I: `23.39`,
-		P: `23.39^#1:*syntax.Constant_DoubleValue#`,
+		P: `23.39^#1:*syntax.Literal_DoubleValue#`,
 	},
 	{
 		I: `!a`,
@@ -80,7 +80,7 @@ var testCases = []testInfo{
 	},
 	{
 		I: `null`,
-		P: `null^#1:*syntax.Constant_NullValue#`,
+		P: `null^#1:*syntax.Literal_NullValue#`,
 	},
 	{
 		I: `a`,
@@ -340,25 +340,25 @@ ERROR: <input>:1:5: Syntax error: extraneous input 'b' expecting <EOF>
     		  // Accumulator
     		  __result__,
     		  // Init
-    		  0^#4:*syntax.Constant_Int64Value#,
+    		  0^#4:*syntax.Literal_Int64Value#,
     		  // LoopCondition
     		  _<=_(
     		    __result__^#6:*syntax.Expr_IdentExpr#,
-    		    1^#5:*syntax.Constant_Int64Value#
+    		    1^#5:*syntax.Literal_Int64Value#
   			  )^#7:*syntax.Expr_CallExpr#,
     		  // LoopStep
     		  _?_:_(
     		    f^#3:*syntax.Expr_IdentExpr#,
     		    _+_(
     		      __result__^#8:*syntax.Expr_IdentExpr#,
-    		      1^#5:*syntax.Constant_Int64Value#
+    		      1^#5:*syntax.Literal_Int64Value#
 				)^#9:*syntax.Expr_CallExpr#,
     		    __result__^#10:*syntax.Expr_IdentExpr#
 			  )^#11:*syntax.Expr_CallExpr#,
     		  // Result
     		  _==_(
     		    __result__^#12:*syntax.Expr_IdentExpr#,
-    		    1^#5:*syntax.Constant_Int64Value#
+    		    1^#5:*syntax.Literal_Int64Value#
 		      )^#13:*syntax.Expr_CallExpr#)^#14:*syntax.Expr_ComprehensionExpr#`,
 	},
 	{
@@ -373,7 +373,7 @@ ERROR: <input>:1:5: Syntax error: extraneous input 'b' expecting <EOF>
     		  // Init
     		  []^#5:*syntax.Expr_ListExpr#,
     		  // LoopCondition
-    		  true^#6:*syntax.Constant_BoolValue#,
+    		  true^#6:*syntax.Literal_BoolValue#,
     		  // LoopStep
     		  _+_(
     		    __result__^#4:*syntax.Expr_IdentExpr#,
@@ -397,7 +397,7 @@ ERROR: <input>:1:5: Syntax error: extraneous input 'b' expecting <EOF>
     		  // Init
     		  []^#6:*syntax.Expr_ListExpr#,
     		  // LoopCondition
-    		  true^#7:*syntax.Constant_BoolValue#,
+    		  true^#7:*syntax.Literal_BoolValue#,
     		  // LoopStep
     		  _?_:_(
     		    p^#3:*syntax.Expr_IdentExpr#,
@@ -426,7 +426,7 @@ ERROR: <input>:1:5: Syntax error: extraneous input 'b' expecting <EOF>
     		  // Init
     		  []^#5:*syntax.Expr_ListExpr#,
     		  // LoopCondition
-    		  true^#6:*syntax.Constant_BoolValue#,
+    		  true^#6:*syntax.Literal_BoolValue#,
     		  // LoopStep
     		  _?_:_(
     		    p^#3:*syntax.Expr_IdentExpr#,
@@ -449,28 +449,28 @@ ERROR: <input>:1:5: Syntax error: extraneous input 'b' expecting <EOF>
     		  _+_(
     		    []^#1:*syntax.Expr_ListExpr#,
     		    [
-    		      1^#2:*syntax.Constant_Int64Value#,
-    		      2^#3:*syntax.Constant_Int64Value#,
-    		      3^#4:*syntax.Constant_Int64Value#
+    		      1^#2:*syntax.Literal_Int64Value#,
+    		      2^#3:*syntax.Literal_Int64Value#,
+    		      3^#4:*syntax.Literal_Int64Value#
     		    ]^#5:*syntax.Expr_ListExpr#
     		  )^#6:*syntax.Expr_CallExpr#,
     		  [
-    		    4^#7:*syntax.Constant_Int64Value#
+    		    4^#7:*syntax.Literal_Int64Value#
     		  ]^#8:*syntax.Expr_ListExpr#
     		)^#9:*syntax.Expr_CallExpr#`,
 	},
 	{
 		I: `{1:2u, 2:3u}`,
 		P: `{
-    		  1^#1:*syntax.Constant_Int64Value#:2u^#2:*syntax.Constant_Uint64Value#^#3:*syntax.Expr_CreateStruct_Entry#,
-    		  2^#4:*syntax.Constant_Int64Value#:3u^#5:*syntax.Constant_Uint64Value#^#6:*syntax.Expr_CreateStruct_Entry#
+    		  1^#1:*syntax.Literal_Int64Value#:2u^#2:*syntax.Literal_Uint64Value#^#3:*syntax.Expr_CreateStruct_Entry#,
+    		  2^#4:*syntax.Literal_Int64Value#:3u^#5:*syntax.Literal_Uint64Value#^#6:*syntax.Expr_CreateStruct_Entry#
     		}^#7:*syntax.Expr_StructExpr#`,
 	},
 	{
 		I: `TestAllTypes{single_int32: 1, single_int64: 2}`,
 		P: `TestAllTypes{
-    		  single_int32:1^#2:*syntax.Constant_Int64Value#^#3:*syntax.Expr_CreateStruct_Entry#,
-    		  single_int64:2^#4:*syntax.Constant_Int64Value#^#5:*syntax.Expr_CreateStruct_Entry#
+    		  single_int32:1^#2:*syntax.Literal_Int64Value#^#3:*syntax.Expr_CreateStruct_Entry#,
+    		  single_int64:2^#4:*syntax.Literal_Int64Value#^#5:*syntax.Expr_CreateStruct_Entry#
     		}^#6:*syntax.Expr_StructExpr#`,
 	},
 	{
@@ -512,17 +512,17 @@ ERROR: <input>:2:1: Syntax error: mismatched input '3' expecting <EOF>
 	},
 	{
 		I: `"\""`,
-		P: `"\""^#1:*syntax.Constant_StringValue#`,
+		P: `"\""^#1:*syntax.Literal_StringValue#`,
 	},
 	{
 		I: `[1,3,4][0]`,
 		P: `_[_](
     		  [
-    		    1^#1:*syntax.Constant_Int64Value#,
-    		    3^#2:*syntax.Constant_Int64Value#,
-    		    4^#3:*syntax.Constant_Int64Value#
+    		    1^#1:*syntax.Literal_Int64Value#,
+    		    3^#2:*syntax.Literal_Int64Value#,
+    		    4^#3:*syntax.Literal_Int64Value#
     		  ]^#4:*syntax.Expr_ListExpr#,
-    		  0^#5:*syntax.Constant_Int64Value#
+    		  0^#5:*syntax.Literal_Int64Value#
     		)^#6:*syntax.Expr_CallExpr#`,
 	},
 	{
@@ -538,16 +538,16 @@ ERROR: <input>:1:7: argument must be a simple name
 		P: `_==_(
     		  _[_](
     		    x^#1:*syntax.Expr_IdentExpr#,
-    		    "a"^#2:*syntax.Constant_StringValue#
+    		    "a"^#2:*syntax.Literal_StringValue#
     		  )^#3:*syntax.Expr_CallExpr#.single_int32^#4:*syntax.Expr_SelectExpr#,
-    		  23^#5:*syntax.Constant_Int64Value#
+    		  23^#5:*syntax.Literal_Int64Value#
     		)^#6:*syntax.Expr_CallExpr#`,
 	},
 	{
 		I: `x.single_nested_message != null`,
 		P: `_!=_(
     		  x^#1:*syntax.Expr_IdentExpr#.single_nested_message^#2:*syntax.Expr_SelectExpr#,
-    		  null^#3:*syntax.Constant_NullValue#
+    		  null^#3:*syntax.Literal_NullValue#
     		)^#4:*syntax.Expr_CallExpr#`,
 	},
 	{
@@ -555,22 +555,22 @@ ERROR: <input>:1:7: argument must be a simple name
 		P: `_?_:_(
     		  _||_(
     		    _&&_(
-    		      false^#1:*syntax.Constant_BoolValue#,
+    		      false^#1:*syntax.Literal_BoolValue#,
     		      !_(
-    		        true^#2:*syntax.Constant_BoolValue#
+    		        true^#2:*syntax.Literal_BoolValue#
     		      )^#3:*syntax.Expr_CallExpr#
     		    )^#4:*syntax.Expr_CallExpr#,
-    		    false^#5:*syntax.Constant_BoolValue#
+    		    false^#5:*syntax.Literal_BoolValue#
     		  )^#6:*syntax.Expr_CallExpr#,
-    		  2^#7:*syntax.Constant_Int64Value#,
-    		  3^#8:*syntax.Constant_Int64Value#
+    		  2^#7:*syntax.Literal_Int64Value#,
+    		  3^#8:*syntax.Literal_Int64Value#
     		)^#9:*syntax.Expr_CallExpr#`,
 	},
 	{
 		I: `b"abc" + B"def"`,
 		P: `_+_(
-    		  b"abc"^#1:*syntax.Constant_BytesValue#,
-    		  b"def"^#2:*syntax.Constant_BytesValue#
+    		  b"abc"^#1:*syntax.Literal_BytesValue#,
+    		  b"def"^#2:*syntax.Literal_BytesValue#
     		)^#3:*syntax.Expr_CallExpr#`,
 	},
 	{
@@ -578,20 +578,20 @@ ERROR: <input>:1:7: argument must be a simple name
 		P: `_==_(
     		  _-_(
     		    _+_(
-    		      1^#1:*syntax.Constant_Int64Value#,
+    		      1^#1:*syntax.Literal_Int64Value#,
     		      _*_(
-    		        2^#2:*syntax.Constant_Int64Value#,
-    		        3^#3:*syntax.Constant_Int64Value#
+    		        2^#2:*syntax.Literal_Int64Value#,
+    		        3^#3:*syntax.Literal_Int64Value#
     		      )^#4:*syntax.Expr_CallExpr#
     		    )^#5:*syntax.Expr_CallExpr#,
     		    _/_(
-    		      1^#6:*syntax.Constant_Int64Value#,
-    		      2^#7:*syntax.Constant_Int64Value#
+    		      1^#6:*syntax.Literal_Int64Value#,
+    		      2^#7:*syntax.Literal_Int64Value#
     		    )^#8:*syntax.Expr_CallExpr#
     		  )^#9:*syntax.Expr_CallExpr#,
     		  _%_(
-    		    6^#10:*syntax.Constant_Int64Value#,
-    		    1^#11:*syntax.Constant_Int64Value#
+    		    6^#10:*syntax.Literal_Int64Value#,
+    		    1^#11:*syntax.Literal_Int64Value#
     		  )^#12:*syntax.Expr_CallExpr#
     		)^#13:*syntax.Expr_CallExpr#`,
 	},
@@ -609,8 +609,8 @@ ERROR: <input>:1:6: Syntax error: mismatched input '<EOF>' expecting {'in', '[',
 	{
 		I: `"abc" + "def"`,
 		P: `_+_(
-    		  "abc"^#1:*syntax.Constant_StringValue#,
-    		  "def"^#2:*syntax.Constant_StringValue#
+    		  "abc"^#1:*syntax.Literal_StringValue#,
+    		  "def"^#2:*syntax.Literal_StringValue#
     		)^#3:*syntax.Expr_CallExpr#`,
 	},
 }
@@ -642,8 +642,8 @@ func (k *kindAndIdAdorner) GetMetadata(elem interface{}) string {
 		e := elem.(*expr.Expr)
 		var valType interface{} = e.ExprKind
 		switch valType.(type) {
-		case *expr.Expr_ConstExpr:
-			valType = e.GetConstExpr().ConstantKind
+		case *expr.Expr_LiteralExpr:
+			valType = e.GetLiteralExpr().LiteralKind
 		}
 		return fmt.Sprintf("^#%d:%s#", e.Id, reflect.TypeOf(valType))
 	case *expr.Expr_CreateStruct_Entry:

--- a/test/expr.go
+++ b/test/expr.go
@@ -18,9 +18,7 @@ package test
 
 import (
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/struct"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/cel-go/common/operators"
 	expr "github.com/google/cel-spec/proto/v1/syntax"
 )
@@ -50,11 +48,11 @@ var (
 		ExprComprehension(1,
 			"x",
 			ExprList(5,
-				ExprConst(2, int64(1)),
-				ExprConst(3, uint64(1)),
-				ExprConst(4, float64(1.0))),
+				ExprLiteral(2, int64(1)),
+				ExprLiteral(3, uint64(1)),
+				ExprLiteral(4, float64(1.0))),
 			"_accu_",
-			ExprConst(6, false),
+			ExprLiteral(6, false),
 			ExprCall(8,
 				operators.LogicalNot,
 				ExprIdent(7, "_accu_")),
@@ -92,22 +90,16 @@ var (
 	DynMap = &TestExpr{
 		ExprMap(17,
 			ExprEntry(2,
-				ExprConst(1, "hello"),
+				ExprLiteral(1, "hello"),
 				ExprMemberCall(3,
 					"size",
-					ExprConst(4, "world"))),
-			ExprEntry(6,
-				ExprConst(5, "dur"),
-				ExprConst(7, &duration.Duration{Seconds: 10})),
-			ExprEntry(9,
-				ExprConst(8, "ts"),
-				ExprConst(10, &timestamp.Timestamp{Seconds: 1000})),
+					ExprLiteral(4, "world"))),
 			ExprEntry(12,
-				ExprConst(11, "null"),
-				ExprConst(13, structpb.NullValue_NULL_VALUE)),
+				ExprLiteral(11, "null"),
+				ExprLiteral(13, structpb.NullValue_NULL_VALUE)),
 			ExprEntry(15,
-				ExprConst(14, "bytes"),
-				ExprConst(16, []byte("bytes-string")))),
+				ExprLiteral(14, "bytes"),
+				ExprLiteral(16, []byte("bytes-string")))),
 
 		&expr.SourceInfo{
 			LineOffsets: []int32{},
@@ -119,7 +111,7 @@ var (
 			ExprIdent(1, "a"),
 			ExprSelect(6,
 				ExprType(5, "TestProto",
-					ExprField(4, "c", ExprConst(5, true))),
+					ExprField(4, "c", ExprLiteral(5, true))),
 				"c")),
 		&expr.SourceInfo{
 			LineOffsets: []int32{},
@@ -132,11 +124,11 @@ var (
 			ExprCall(3,
 				operators.Less,
 				ExprIdent(2, "b"),
-				ExprConst(4, 1.0)),
+				ExprLiteral(4, 1.0)),
 			ExprCall(6,
 				operators.Equals,
 				ExprIdent(5, "c"),
-				ExprList(8, ExprConst(7, "hello")))),
+				ExprList(8, ExprLiteral(7, "hello")))),
 		&expr.SourceInfo{
 			LineOffsets: []int32{},
 			Positions:   map[int64]int32{}}}
@@ -157,7 +149,7 @@ var (
 		ExprCall(2,
 			operators.Equals,
 			ExprIdent(1, "a"),
-			ExprConst(3, int64(42))),
+			ExprLiteral(3, int64(42))),
 		&expr.SourceInfo{
 			LineOffsets: []int32{},
 			Positions:   map[int64]int32{}}}
@@ -174,39 +166,33 @@ func ExprSelect(id int64, operand *expr.Expr, field string) *expr.Expr {
 			&expr.Expr_Select{operand, field, false}}}
 }
 
-func ExprConst(id int64, value interface{}) *expr.Expr {
-	var constExpr *expr.Constant
+func ExprLiteral(id int64, value interface{}) *expr.Expr {
+	var literal *expr.Literal
 	switch value.(type) {
 	case bool:
-		constExpr = &expr.Constant{&expr.Constant_BoolValue{value.(bool)}}
+		literal = &expr.Literal{&expr.Literal_BoolValue{value.(bool)}}
 	case int64:
-		constExpr = &expr.Constant{&expr.Constant_Int64Value{
+		literal = &expr.Literal{&expr.Literal_Int64Value{
 			value.(int64)}}
 	case uint64:
-		constExpr = &expr.Constant{&expr.Constant_Uint64Value{
+		literal = &expr.Literal{&expr.Literal_Uint64Value{
 			value.(uint64)}}
 	case float64:
-		constExpr = &expr.Constant{&expr.Constant_DoubleValue{
+		literal = &expr.Literal{&expr.Literal_DoubleValue{
 			value.(float64)}}
 	case string:
-		constExpr = &expr.Constant{&expr.Constant_StringValue{
+		literal = &expr.Literal{&expr.Literal_StringValue{
 			value.(string)}}
 	case structpb.NullValue:
-		constExpr = &expr.Constant{&expr.Constant_NullValue{
+		literal = &expr.Literal{&expr.Literal_NullValue{
 			value.(structpb.NullValue)}}
 	case []byte:
-		constExpr = &expr.Constant{&expr.Constant_BytesValue{
+		literal = &expr.Literal{&expr.Literal_BytesValue{
 			value.([]byte)}}
-	case *timestamp.Timestamp:
-		constExpr = &expr.Constant{&expr.Constant_TimestampValue{
-			value.(*timestamp.Timestamp)}}
-	case *duration.Duration:
-		constExpr = &expr.Constant{&expr.Constant_DurationValue{
-			value.(*duration.Duration)}}
 	default:
-		panic("constant type not implemented")
+		panic("literal type not implemented")
 	}
-	return &expr.Expr{id, &expr.Expr_ConstExpr{ConstExpr: constExpr}}
+	return &expr.Expr{id, &expr.Expr_LiteralExpr{LiteralExpr: literal}}
 }
 
 func ExprCall(id int64, function string, args ...*expr.Expr) *expr.Expr {


### PR DESCRIPTION
Updates the workspace to refer to latest changes present in the cel-spec
proto definitions. Namely replaces `Constant` with `Literal`