### PR TITLE
Fix issue with inverted operands for 'in'

### DIFF
--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -922,6 +922,19 @@ _&&_(_==_(list~type(list(int))^list,
 		`,
 		Type: Bool,
 	},
+
+	{
+		I: `1 in [1, 2, 3]`,
+		R: `_in_(
+    		  1~int,
+    		  [
+    		    1~int,
+    		    2~int,
+    		    3~int
+    		  ]~list(int)
+    		)~bool^in_list`,
+		Type: Bool,
+	},
 }
 
 var typeProvider = initTypeProvider()

--- a/interpreter/BUILD.bazel
+++ b/interpreter/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//common/types:go_default_library",
         "//interpreter/functions:go_default_library",
         "//io:syntax_proto",
+        "//parser:go_default_library",
         "//test:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@io_bazel_rules_go//proto/wkt:duration_go_proto",

--- a/interpreter/functions/standard.go
+++ b/interpreter/functions/standard.go
@@ -176,9 +176,11 @@ func StandardOverloads() []*Overload {
 
 		// In operator
 		{Operator: operators.In,
-			OperandTrait: traits.ContainerType,
 			Binary: func(lhs ref.Value, rhs ref.Value) ref.Value {
-				return lhs.(traits.Container).Contains(rhs)
+				if rhs.Type().HasTrait(traits.ContainerType) {
+					return rhs.(traits.Container).Contains(lhs)
+				}
+				return types.NewErr("no such overload")
 			}},
 
 		// Matches function

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter/functions"
+	"github.com/google/cel-go/parser"
 	"github.com/google/cel-go/test"
 	expr "github.com/google/cel-spec/proto/v1/syntax"
 	"testing"
@@ -85,6 +86,19 @@ func TestInterpreter_ComprehensionExpr(t *testing.T) {
 		NewActivation(map[string]interface{}{}))
 	if result != types.True {
 		t.Errorf("Expected true, got: %v", result)
+	}
+}
+
+func TestInterpreter_InList(t *testing.T) {
+	parsed, err := parser.ParseText("1 in [1, 2, 3]")
+	if len(err.GetErrors()) != 0 {
+		t.Error(err)
+	}
+	prg := NewProgram(parsed.GetExpr(), parsed.GetSourceInfo(), "")
+	i := interpreter.NewInterpretable(prg)
+	res, _ := i.Eval(NewActivation(map[string]interface{}{}))
+	if res != types.True {
+		t.Error("Got '%v', wanted 'true'", res)
 	}
 }
 


### PR DESCRIPTION
The operands to the 'in' operator were flipped causing calls to fail.

Added a fix and test cases.