### PR TITLE
Support ref.Value keys in Dynamic Maps

### DIFF
--- a/common/types/bool.go
+++ b/common/types/bool.go
@@ -55,8 +55,12 @@ func (b Bool) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 		return &structpb.Value{
 			Kind: &structpb.Value_BoolValue{
 				BoolValue: b.Value().(bool)}}, nil
-	} else if typeDesc.Kind() == reflect.Bool {
+	}
+	if typeDesc.Kind() == reflect.Bool {
 		return b.Value(), nil
+	}
+	if reflect.TypeOf(b).AssignableTo(typeDesc) {
+		return b, nil
 	}
 	return nil, fmt.Errorf("type conversion error from bool to '%v'", typeDesc)
 }

--- a/common/types/bytes.go
+++ b/common/types/bytes.go
@@ -55,6 +55,9 @@ func (b Bytes) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 			return b.Value(), nil
 		}
 	}
+	if reflect.TypeOf(b).AssignableTo(typeDesc) {
+		return b, nil
+	}
 	return nil, fmt.Errorf("type conversion error from Bytes to '%v'", typeDesc)
 }
 

--- a/common/types/double.go
+++ b/common/types/double.go
@@ -72,6 +72,9 @@ func (d Double) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 					NumberValue: float64(d)}}, nil
 		}
 	}
+	if reflect.TypeOf(d).AssignableTo(typeDesc) {
+		return d, nil
+	}
 	return nil, fmt.Errorf("type conversion error from Double to '%v'", typeDesc)
 }
 

--- a/common/types/duration.go
+++ b/common/types/duration.go
@@ -99,6 +99,10 @@ func (d Duration) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	if typeDesc == reflect.TypeOf(&dpb.Duration{}) {
 		return d.Value(), nil
 	}
+	// If the duration is already assignable to the desired type return it.
+	if reflect.TypeOf(d).AssignableTo(typeDesc) {
+		return d, nil
+	}
 	return nil, fmt.Errorf("type conversion error from "+
 		"'google.protobuf.Duration' to '%v'", typeDesc)
 }

--- a/common/types/int.go
+++ b/common/types/int.go
@@ -51,6 +51,19 @@ func (i Int) Add(other ref.Value) ref.Value {
 	return i + other.(Int)
 }
 
+func (i Int) Compare(other ref.Value) ref.Value {
+	if IntType != other.Type() {
+		return NewErr("unsupported overload")
+	}
+	if i < other.(Int) {
+		return IntNegOne
+	}
+	if i > other.(Int) {
+		return IntOne
+	}
+	return IntZero
+}
+
 func (i Int) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	refKind := typeDesc.Kind()
 	switch refKind {
@@ -65,20 +78,10 @@ func (i Int) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 					NumberValue: float64(i)}}, nil
 		}
 	}
+	if reflect.TypeOf(i).AssignableTo(typeDesc) {
+		return i, nil
+	}
 	return nil, fmt.Errorf("unsupported type conversion from 'int' to %v", typeDesc)
-}
-
-func (i Int) Compare(other ref.Value) ref.Value {
-	if IntType != other.Type() {
-		return NewErr("unsupported overload")
-	}
-	if i < other.(Int) {
-		return IntNegOne
-	}
-	if i > other.(Int) {
-		return IntOne
-	}
-	return IntZero
 }
 
 func (i Int) ConvertToType(typeVal ref.Type) ref.Value {

--- a/common/types/json_list.go
+++ b/common/types/json_list.go
@@ -62,14 +62,14 @@ func (l *jsonListValue) Contains(elem ref.Value) ref.Value {
 	return False
 }
 
-func (l *jsonListValue) ConvertToNative(refType reflect.Type) (interface{}, error) {
-	switch refType.Kind() {
+func (l *jsonListValue) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
+	switch typeDesc.Kind() {
 	case reflect.Array, reflect.Slice:
 		elemCount := int(l.Size().(Int))
-		nativeList := reflect.MakeSlice(refType, elemCount, elemCount)
+		nativeList := reflect.MakeSlice(typeDesc, elemCount, elemCount)
 		for i := 0; i < elemCount; i++ {
 			elem := l.Get(Int(i))
-			nativeElemVal, err := elem.ConvertToNative(refType.Elem())
+			nativeElemVal, err := elem.ConvertToNative(typeDesc.Elem())
 			if err != nil {
 				return nil, err
 			}
@@ -77,20 +77,24 @@ func (l *jsonListValue) ConvertToNative(refType reflect.Type) (interface{}, erro
 		}
 		return nativeList.Interface(), nil
 	case reflect.Ptr:
-		if refType == jsonValueType {
+		if typeDesc == jsonValueType {
 			return &structpb.Value{
 				Kind: &structpb.Value_ListValue{
 					ListValue: l.ListValue}}, nil
 		}
-		if refType == jsonListValueType {
+		if typeDesc == jsonListValueType {
 			return l.ListValue, nil
 		}
-		if refType == anyValueType {
+		if typeDesc == anyValueType {
 			return ptypes.MarshalAny(l.Value().(proto.Message))
 		}
 	}
+	// If the list is already assignable to the desired type return it.
+	if reflect.TypeOf(l).AssignableTo(typeDesc) {
+		return l, nil
+	}
 	return nil, fmt.Errorf("no conversion found from list type to native type."+
-		" list elem: google.protobuf.Value, native type: %v", refType)
+		" list elem: google.protobuf.Value, native type: %v", typeDesc)
 }
 
 func (l *jsonListValue) ConvertToType(typeVal ref.Type) ref.Value {

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -142,7 +142,7 @@ func (m *baseMap) Get(key ref.Value) ref.Value {
 		return &Err{err}
 	}
 	nativeKeyVal := reflect.ValueOf(nativeKey)
-	if nativeKeyVal.Type() != thisKeyType {
+	if !nativeKeyVal.Type().AssignableTo(thisKeyType) {
 		return NewErr("no such key: '%v'", nativeKey)
 	}
 	value := m.refValue.MapIndex(nativeKeyVal)

--- a/common/types/null.go
+++ b/common/types/null.go
@@ -32,18 +32,21 @@ var (
 	NullValue = Null(structpb.NullValue_NULL_VALUE)
 )
 
-func (n Null) ConvertToNative(refType reflect.Type) (interface{}, error) {
-	if refType == jsonValueType {
+func (n Null) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
+	if typeDesc == jsonValueType {
 		return &structpb.Value{
 			Kind: &structpb.Value_NullValue{
 				NullValue: structpb.NullValue_NULL_VALUE}}, nil
 	}
-	if refType == anyValueType {
+	if typeDesc == anyValueType {
 		pb, err := n.ConvertToNative(jsonValueType)
 		if err != nil {
 			return nil, err
 		}
 		return ptypes.MarshalAny(pb.(proto.Message))
+	}
+	if reflect.TypeOf(n).AssignableTo(typeDesc) {
+		return n, nil
 	}
 	return structpb.NullValue_NULL_VALUE, nil
 }

--- a/common/types/object.go
+++ b/common/types/object.go
@@ -54,6 +54,10 @@ func (o *protoObj) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	if typeDesc == anyValueType {
 		return ptypes.MarshalAny(o.Value().(proto.Message))
 	}
+	// If the object is already assignable to the desired type return it.
+	if reflect.TypeOf(o).AssignableTo(typeDesc) {
+		return o, nil
+	}
 	return nil, fmt.Errorf("type conversion error from '%v' to '%v'",
 		o.refValue.Type(), typeDesc)
 }

--- a/common/types/string.go
+++ b/common/types/string.go
@@ -60,6 +60,9 @@ func (s String) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 			Kind: &structpb.Value_StringValue{
 				StringValue: s.Value().(string)}}, nil
 	}
+	if reflect.TypeOf(s).AssignableTo(typeDesc) {
+		return s, nil
+	}
 	if typeDesc.Kind() != reflect.String {
 		return nil, fmt.Errorf(
 			"unsupported native conversion from string to '%v'", typeDesc)

--- a/common/types/timestamp.go
+++ b/common/types/timestamp.go
@@ -76,6 +76,10 @@ func (t Timestamp) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	if typeDesc == reflect.TypeOf(&tpb.Timestamp{}) {
 		return t.Value(), nil
 	}
+	// If the timestamp is already assignable to the desired type return it.
+	if reflect.TypeOf(t).AssignableTo(typeDesc) {
+		return t, nil
+	}
 	return nil, fmt.Errorf("type conversion error from "+
 		"'google.protobuf.Duration' to '%v'", typeDesc)
 }

--- a/common/types/uint.go
+++ b/common/types/uint.go
@@ -75,6 +75,9 @@ func (i Uint) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 					NumberValue: float64(i)}}, nil
 		}
 	}
+	if reflect.TypeOf(i).AssignableTo(typeDesc) {
+		return i, nil
+	}
 	return nil, fmt.Errorf("unsupported type conversion from 'uint' to %v", typeDesc)
 }
 

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -102,6 +102,19 @@ func TestInterpreter_InList(t *testing.T) {
 	}
 }
 
+func TestInterpreter_MapIndex(t *testing.T) {
+	parsed, err := parser.ParseText("{'a':1}['a']")
+	if len(err.GetErrors()) != 0 {
+		t.Error(err)
+	}
+	prg := NewProgram(parsed.GetExpr(), parsed.GetSourceInfo(), "")
+	i := interpreter.NewInterpretable(prg)
+	res, _ := i.Eval(NewActivation(map[string]interface{}{}))
+	if res != types.Int(1) {
+		t.Errorf("Got '%v', wanted 1", res)
+	}
+}
+
 func BenchmarkInterpreter_ConditionalExpr(b *testing.B) {
 	// a ? b < 1.0 : c == ["hello"]
 	program := NewProgram(


### PR DESCRIPTION
The expectation for most dynamic maps is that they are based on some
backing protocol buffer implementation; however, for maps constructed
as part of expression evaluation, the keys are actually already `ref.Value`
instances.

This pull ensures that all types which are suitable as map indices or values
are successfully returned from `ConvertToNative` functions.