### PR TITLE
Emit constant return values with no program steps

### DIFF
--- a/interpreter/evalstate.go
+++ b/interpreter/evalstate.go
@@ -20,9 +20,12 @@ import (
 
 // EvalState tracks the values associated with expression ids during execution.
 type EvalState interface {
-	// Return the runtime expression id corresponding to the expression id from
-	// the AST.
+	// GetRuntimeExpressionId returns the runtime id corresponding to the
+	// expression id from the AST.
 	GetRuntimeExpressionId(exprId int64) int64
+
+	// OnlyValue returns the value in the eval state, if only one exists.
+	OnlyValue() (ref.Value, bool)
 
 	// Value of the given expression id, false if not found.
 	Value(int64) (ref.Value, bool)
@@ -33,7 +36,7 @@ type EvalState interface {
 type MutableEvalState interface {
 	EvalState
 
-	// Set runtimeId for the given exprId
+	// SetRuntimeExpressionId sets the runtimeId for the given exprId.
 	SetRuntimeExpressionId(exprId int64, runtimeId int64)
 
 	// SetValue associates an expression id with a value.
@@ -60,13 +63,17 @@ func (s *defaultEvalState) GetRuntimeExpressionId(exprId int64) int64 {
 	return exprId
 }
 
-func (s *defaultEvalState) Value(exprId int64) (ref.Value, bool) {
-	// TODO: The eval state assumes a dense progrma expression id space. While
-	// this is true of how the cel-go parser generates identifiers, it may not
-	// be true for all implementations or for the long term. Replace the use of
-	// parse-time generated expression ids with a dense runtiem identifier.
-	if exprId >= 0 && exprId < s.exprCount {
-		return s.exprValues[exprId], true
+func (s *defaultEvalState) OnlyValue() (ref.Value, bool) {
+	var result ref.Value = nil
+	i := 0
+	for _, val := range s.exprValues {
+		if val != nil {
+			result = val
+			i++
+		}
+	}
+	if i == 1 {
+		return result, true
 	}
 	return nil, false
 }
@@ -78,3 +85,15 @@ func (s *defaultEvalState) SetRuntimeExpressionId(exprId int64, runtimeId int64)
 func (s *defaultEvalState) SetValue(exprId int64, value ref.Value) {
 	s.exprValues[exprId] = value
 }
+
+func (s *defaultEvalState) Value(exprId int64) (ref.Value, bool) {
+	// TODO: The eval state assumes a dense progrma expression id space. While
+	// this is true of how the cel-go parser generates identifiers, it may not
+	// be true for all implementations or for the long term. Replace the use of
+	// parse-time generated expression ids with a dense runtiem identifier.
+	if exprId >= 0 && exprId < s.exprCount {
+		return s.exprValues[exprId], true
+	}
+	return nil, false
+}
+

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -123,7 +123,11 @@ func (i *exprInterpretable) Eval(activation Activation) (interface{}, EvalState)
 			currActivation = currActivation.Parent()
 		}
 	}
-	return i.value(resultId), i.state
+	result := i.value(resultId)
+	if result == nil {
+		result, _ = i.state.OnlyValue()
+	}
+	return result, i.state
 }
 
 func (i *exprInterpretable) evalConst(constExpr *ConstExpr) {

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -89,6 +89,19 @@ func TestInterpreter_ComprehensionExpr(t *testing.T) {
 	}
 }
 
+func TestInterpreter_ConstantReturnValue(t *testing.T) {
+	parsed, err := parser.ParseText("1")
+	if len(err.GetErrors()) != 0 {
+		t.Error(err)
+	}
+	prg := NewProgram(parsed.GetExpr(), parsed.GetSourceInfo(), "")
+	i := interpreter.NewInterpretable(prg)
+	res, _ := i.Eval(NewActivation(map[string]interface{}{}))
+	if int64(res.(types.Int)) != int64(1) {
+		t.Error("Got '%v', wanted 1", res)
+	}
+}
+
 func TestInterpreter_InList(t *testing.T) {
 	parsed, err := parser.ParseText("1 in [1, 2, 3]")
 	if len(err.GetErrors()) != 0 {


### PR DESCRIPTION
When a program is generated that contains only constant values,
the state has a single value in it, but the program is empty. This
pull fixes the case where the state would not be inspected to see
if there is a single constant return value for the program at the end
of interpretation.