### PR TITLE
Return ref.Value from interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ if len(errors.GetErrors()) != 0 {
 // Interpret the checked expression using the standard overloads.
 i := interpreter.NewStandardInterpreter(packages.DefaultPackage, typeProvider)
 eval := i.NewInterpretable(interpreter.NewCheckedProgram(c))
-result, err := eval.Interpret(
+result, state := eval.Interpret(
     interpreter.NewActivation(
         map[string]interface{}{
             "a": false,

--- a/common/types/BUILD.bazel
+++ b/common/types/BUILD.bazel
@@ -27,7 +27,7 @@ go_library(
         "type.go",
         "uint.go",
         "unknown.go",
-	    "util.go",
+        "util.go",
     ],
     importpath = "github.com/google/cel-go/common/types",
     deps = [

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -36,7 +36,7 @@ type Interpreter interface {
 // data might be necessary to complete the evaluation.
 type Interpretable interface {
 	// Eval an Activation to produce an output and EvalState.
-	Eval(activation Activation) (interface{}, EvalState)
+	Eval(activation Activation) (ref.Value, EvalState)
 }
 
 type exprInterpreter struct {
@@ -82,7 +82,7 @@ type exprInterpretable struct {
 	state       MutableEvalState
 }
 
-func (i *exprInterpretable) Eval(activation Activation) (interface{}, EvalState) {
+func (i *exprInterpretable) Eval(activation Activation) (ref.Value, EvalState) {
 	// register machine-like evaluation of the program with the given activation.
 	currActivation := activation
 	stepper := i.program.Begin()


### PR DESCRIPTION
The interpreter currently returns an `interface{}` value, but this value
always happens to be a `ref.Value` implementation. The change clarifies
the usage contract for the interpreter and makes it easier to handle the
result without a type assertion.