### PR TITLE
Add declarations for `null_type` and `type` identifiers

### DIFF
--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cel-go/checker/decls"
-	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/packages"
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/parser"
 	"github.com/google/cel-go/test"
@@ -834,10 +834,10 @@ ERROR: <input>:1:5: undeclared reference to 'x' (in container '')
 	{
 		I: `list == type([1]) && map == type({1:2u})`,
 		R: `
-_&&_(_==_(list~type(list(int))^list,
+_&&_(_==_(list~type(list(dyn))^list,
            type([1~int]~list(int))~type(list(int))^type)
        ~bool^equals,
-      _==_(map~type(map(int, uint))^map,
+      _==_(map~type(map(dyn, dyn))^map,
             type({1~int : 2u~uint}~map(int, uint))~type(map(int, uint))^type)
         ~bool^equals)
   ~bool^logical_and
@@ -940,6 +940,28 @@ _&&_(_==_(list~type(list(int))^list,
     		    3~int
     		  ]~list(int)
     		)~bool^in_list`,
+		Type: decls.Bool,
+	},
+
+	{
+		I: `type(null) == null_type`,
+		R: `_==_(
+    		  type(
+    		    null~null
+    		  )~type(null)^type,
+    		  null_type~type(null)^null_type
+    		)~bool^equals`,
+		Type: decls.Bool,
+	},
+
+	{
+		I: `type(type) == type`,
+		R: `_==_(
+    		  type(
+    		    type~type(type)^type
+    		  )~type(type(type))^type,
+    		  type~type(type)^type
+    		)~bool^equals`,
 		Type: decls.Bool,
 	},
 }

--- a/checker/standard.go
+++ b/checker/standard.go
@@ -39,7 +39,9 @@ func StandardDeclarations() []*checked.Decl {
 	}
 	idents = append(idents,
 		decls.NewIdent("list", decls.NewTypeType(listOfA), nil),
-		decls.NewIdent("map", decls.NewTypeType(mapOfAB), nil))
+		decls.NewIdent("map", decls.NewTypeType(mapOfAB), nil),
+		decls.NewIdent("null_type", decls.NewTypeType(decls.Null), nil),
+		decls.NewIdent("type", decls.NewTypeType(decls.NewTypeType(nil)), nil))
 
 	// Booleans
 	// TODO: allow the conditional to return a heterogenous type.


### PR DESCRIPTION
Add declarations for null and type identifiers to `standard.go` for use with
type-checking.

These types were missing from the checker, but present in the interpreter,
leading to programs that could be parsed and executed, but not checked.
This change also removes recursive checks `type` identifier parameterizations,
meaning that the equivalence between types is trivially true.