### PR TITLE
Support conversion of primitive values to pointer types.

### DIFF
--- a/checker/env.go
+++ b/checker/env.go
@@ -17,8 +17,8 @@ package checker
 import (
 	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common"
-	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/packages"
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/parser"
 	"github.com/google/cel-spec/proto/checked/v1/checked"

--- a/common/types/bool.go
+++ b/common/types/bool.go
@@ -51,16 +51,23 @@ func (b Bool) Compare(other ref.Value) ref.Value {
 }
 
 func (b Bool) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
-	if typeDesc == jsonValueType {
-		return &structpb.Value{
-			Kind: &structpb.Value_BoolValue{
-				BoolValue: b.Value().(bool)}}, nil
-	}
-	if typeDesc.Kind() == reflect.Bool {
-		return b.Value(), nil
-	}
-	if reflect.TypeOf(b).AssignableTo(typeDesc) {
-		return b, nil
+	switch typeDesc.Kind() {
+	case reflect.Bool:
+		return bool(b), nil
+	case reflect.Ptr:
+		if typeDesc == jsonValueType {
+			return &structpb.Value{
+				Kind: &structpb.Value_BoolValue{
+					BoolValue: b.Value().(bool)}}, nil
+		}
+		if typeDesc.Elem().Kind() == reflect.Bool {
+			p := bool(b)
+			return &p, nil
+		}
+	case reflect.Interface:
+		if reflect.TypeOf(b).Implements(typeDesc) {
+			return b, nil
+		}
 	}
 	return nil, fmt.Errorf("type conversion error from bool to '%v'", typeDesc)
 }

--- a/common/types/bool_test.go
+++ b/common/types/bool_test.go
@@ -42,8 +42,10 @@ func TestBool_Compare(t *testing.T) {
 func TestBool_ConvertToNative_Bool(t *testing.T) {
 	refType := reflect.TypeOf(true)
 	val, err := True.ConvertToNative(refType)
-	if err != nil || IsError(val) || !val.(bool) {
-		t.Error("Error during conversion to bool", err, val)
+	if err != nil {
+		t.Error(err)
+	} else if !val.(bool) {
+		t.Error("Error during conversion to bool", val)
 	}
 }
 
@@ -51,17 +53,28 @@ func TestBool_ConvertToNative_Error(t *testing.T) {
 	refType := reflect.TypeOf("")
 	val, err := True.ConvertToNative(refType)
 	if err == nil {
-		t.Error("Got '%v', expected error", val)
+		t.Errorf("Got '%v', expected error", val)
 	}
 }
 
 func TestBool_ConvertToNative_Json(t *testing.T) {
 	val, err := True.ConvertToNative(jsonValueType)
 	pbVal := &structpb.Value{Kind: &structpb.Value_BoolValue{true}}
-	if err != nil ||
-		IsError(val) ||
-		!proto.Equal(val.(proto.Message), pbVal) {
-		t.Error("Error during conversion to json Value type", err, val)
+	if err != nil {
+		t.Error(err)
+	} else if !proto.Equal(val.(proto.Message), pbVal) {
+		t.Error("Error during conversion to json Value type", val)
+	}
+}
+
+func TestBool_ConvertToNative_Ptr(t *testing.T) {
+	ptrType := true
+	refType := reflect.TypeOf(&ptrType)
+	val, err := True.ConvertToNative(refType)
+	if err != nil {
+		t.Error(err)
+	} else if !*val.(*bool) {
+		t.Error("Error during conversion to *bool", val)
 	}
 }
 

--- a/common/types/bytes.go
+++ b/common/types/bytes.go
@@ -54,9 +54,10 @@ func (b Bytes) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 		if typeDesc.Elem().Kind() == reflect.Uint8 {
 			return b.Value(), nil
 		}
-	}
-	if reflect.TypeOf(b).AssignableTo(typeDesc) {
-		return b, nil
+	case reflect.Interface:
+		if reflect.TypeOf(b).Implements(typeDesc) {
+			return b, nil
+		}
 	}
 	return nil, fmt.Errorf("type conversion error from Bytes to '%v'", typeDesc)
 }

--- a/common/types/bytes_test.go
+++ b/common/types/bytes_test.go
@@ -46,8 +46,8 @@ func TestBytes_Compare(t *testing.T) {
 
 func TestBytes_ConvertToNative_ByteSlice(t *testing.T) {
 	val, err := Bytes("123").ConvertToNative(reflect.TypeOf([]byte{}))
-	if err != nil || IsError(val) || !bytes.Equal(val.([]byte), []byte{49, 50, 51}) {
-		t.Errorf("Got '%v', wanted []byte{49, 50, 51}", val)
+	if err != nil || !bytes.Equal(val.([]byte), []byte{49, 50, 51}) {
+		t.Error("Got unexpected value, wanted []byte{49, 50, 51}", err, val)
 	}
 }
 

--- a/common/types/double.go
+++ b/common/types/double.go
@@ -58,22 +58,29 @@ func (d Double) Compare(other ref.Value) ref.Value {
 }
 
 func (d Double) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
-	value := d.Value()
-	refKind := typeDesc.Kind()
-	switch refKind {
+	switch typeDesc.Kind() {
 	case reflect.Float32:
-		return float32(value.(float64)), nil
+		return float32(d), nil
 	case reflect.Float64:
-		return value, nil
+		return float64(d), nil
 	case reflect.Ptr:
 		if typeDesc == jsonValueType {
 			return &structpb.Value{
 				Kind: &structpb.Value_NumberValue{
 					NumberValue: float64(d)}}, nil
 		}
-	}
-	if reflect.TypeOf(d).AssignableTo(typeDesc) {
-		return d, nil
+		switch typeDesc.Elem().Kind() {
+		case reflect.Float32:
+			p := float32(d)
+			return &p, nil
+		case reflect.Float64:
+			p := float64(d)
+			return &p, nil
+		}
+	case reflect.Interface:
+		if reflect.TypeOf(d).Implements(typeDesc) {
+			return d, nil
+		}
 	}
 	return nil, fmt.Errorf("type conversion error from Double to '%v'", typeDesc)
 }

--- a/common/types/double_test.go
+++ b/common/types/double_test.go
@@ -56,14 +56,18 @@ func TestDouble_ConvertToNative_Error(t *testing.T) {
 
 func TestDouble_ConvertToNative_Float32(t *testing.T) {
 	val, err := Double(3.1415).ConvertToNative(reflect.TypeOf(float32(0)))
-	if err != nil || val.(float32) != 3.1415 {
+	if err != nil {
+		t.Error(err)
+	} else if val.(float32) != 3.1415 {
 		t.Errorf("Got '%v', wanted 3.1415", val)
 	}
 }
 
 func TestDouble_ConvertToNative_Float64(t *testing.T) {
 	val, err := Double(30000000.1).ConvertToNative(reflect.TypeOf(float64(0)))
-	if err != nil || val.(float64) != 30000000.1 {
+	if err != nil {
+		t.Error(err)
+	} else if val.(float64) != 30000000.1 {
 		t.Errorf("Got '%v', wanted 330000000.1", val)
 	}
 }
@@ -71,10 +75,30 @@ func TestDouble_ConvertToNative_Float64(t *testing.T) {
 func TestDouble_ConvertToNative_Json(t *testing.T) {
 	val, err := Double(-1.4).ConvertToNative(jsonValueType)
 	pbVal := &structpb.Value{Kind: &structpb.Value_NumberValue{-1.4}}
-	if err != nil ||
-		IsError(val) ||
-		!proto.Equal(val.(proto.Message), pbVal) {
-		t.Error("Error during conversion to json Value type", err, val)
+	if err != nil {
+		t.Error(err)
+	} else if !proto.Equal(val.(proto.Message), pbVal) {
+		t.Errorf("Got '%v', expected -1.4", val)
+	}
+}
+
+func TestDouble_ConvertToNative_Ptr_Float32(t *testing.T) {
+	ptrType := float32(0)
+	val, err := Double(3.1415).ConvertToNative(reflect.TypeOf(&ptrType))
+	if err != nil {
+		t.Error(err)
+	} else if *val.(*float32) != 3.1415 {
+		t.Errorf("Got '%v', wanted 3.1415", val)
+	}
+}
+
+func TestDouble_ConvertToNative_Ptr_Float64(t *testing.T) {
+	ptrType := float64(0)
+	val, err := Double(30000000.1).ConvertToNative(reflect.TypeOf(&ptrType))
+	if err != nil {
+		t.Error(err)
+	} else if *val.(*float64) != 30000000.1 {
+		t.Errorf("Got '%v', wanted 330000000.1", val)
 	}
 }
 

--- a/common/types/duration.go
+++ b/common/types/duration.go
@@ -96,7 +96,7 @@ func (d Duration) Compare(other ref.Value) ref.Value {
 }
 
 func (d Duration) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
-	if typeDesc == reflect.TypeOf(&dpb.Duration{}) {
+	if typeDesc == durationValueType {
 		return d.Value(), nil
 	}
 	// If the duration is already assignable to the desired type return it.
@@ -167,6 +167,8 @@ func (d Duration) Value() interface{} {
 }
 
 var (
+	durationValueType = reflect.TypeOf(&dpb.Duration{})
+
 	durationZeroArgOverloads = map[string]func(time.Duration) ref.Value{
 		overloads.TimeGetHours: func(dur time.Duration) ref.Value {
 			return Int(dur.Hours())

--- a/common/types/int.go
+++ b/common/types/int.go
@@ -65,8 +65,7 @@ func (i Int) Compare(other ref.Value) ref.Value {
 }
 
 func (i Int) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
-	refKind := typeDesc.Kind()
-	switch refKind {
+	switch typeDesc.Kind() {
 	case reflect.Int32:
 		return int32(i), nil
 	case reflect.Int64:
@@ -77,9 +76,18 @@ func (i Int) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 				Kind: &structpb.Value_NumberValue{
 					NumberValue: float64(i)}}, nil
 		}
-	}
-	if reflect.TypeOf(i).AssignableTo(typeDesc) {
-		return i, nil
+		switch typeDesc.Elem().Kind() {
+		case reflect.Int32:
+			p := int32(i)
+			return &p, nil
+		case reflect.Int64:
+			p := int64(i)
+			return &p, nil
+		}
+	case reflect.Interface:
+		if reflect.TypeOf(i).Implements(typeDesc) {
+			return i, nil
+		}
 	}
 	return nil, fmt.Errorf("unsupported type conversion from 'int' to %v", typeDesc)
 }

--- a/common/types/int_test.go
+++ b/common/types/int_test.go
@@ -56,24 +56,51 @@ func TestInt_ConvertToNative_Error(t *testing.T) {
 
 func TestInt_ConvertToNative_Int32(t *testing.T) {
 	val, err := Int(20050).ConvertToNative(reflect.TypeOf(int32(0)))
-	if err != nil || val.(int32) != 20050 {
-		t.Errorf("Got '%v', expected 20050", err)
+	if err != nil {
+		t.Error(err)
+	} else if val.(int32) != 20050 {
+		t.Errorf("Got '%v', expected 20050", val)
 	}
 }
 
 func TestInt_ConvertToNative_Int64(t *testing.T) {
 	// Value greater than max int32.
 	val, err := Int(4147483648).ConvertToNative(reflect.TypeOf(int64(0)))
-	if err != nil || val.(int64) != 4147483648 {
-		t.Errorf("Got '%v', expected 4147483648", err)
+	if err != nil {
+		t.Error(err)
+	} else if val.(int64) != 4147483648 {
+		t.Errorf("Got '%v', expected 4147483648", val)
 	}
 }
 
 func TestInt_ConvertToNative_Json(t *testing.T) {
 	val, err := Int(4147483648).ConvertToNative(jsonValueType)
-	if err != nil || !proto.Equal(val.(proto.Message),
+	if err != nil {
+		t.Error(err)
+	} else if !proto.Equal(val.(proto.Message),
 		&structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: 4147483648}}) {
-		t.Errorf("Got '%v', expected a json number")
+		t.Errorf("Got '%v', expected a json number", val)
+	}
+}
+
+func TestInt_ConvertToNative_Ptr_Int32(t *testing.T) {
+	ptrType := int32(0)
+	val, err := Int(20050).ConvertToNative(reflect.TypeOf(&ptrType))
+	if err != nil {
+		t.Error(err)
+	} else if *val.(*int32) != 20050 {
+		t.Errorf("Got '%v', expected 20050", val)
+	}
+}
+
+func TestInt_ConvertToNative_Ptr_Int64(t *testing.T) {
+	// Value greater than max int32.
+	ptrType := int64(0)
+	val, err := Int(4147483648).ConvertToNative(reflect.TypeOf(&ptrType))
+	if err != nil {
+		t.Error(err)
+	} else if *val.(*int64) != 4147483648 {
+		t.Errorf("Got '%v', expected 4147483648", val)
 	}
 }
 

--- a/common/types/json_list.go
+++ b/common/types/json_list.go
@@ -76,22 +76,24 @@ func (l *jsonListValue) ConvertToNative(typeDesc reflect.Type) (interface{}, err
 			nativeList.Index(i).Set(reflect.ValueOf(nativeElemVal))
 		}
 		return nativeList.Interface(), nil
+
 	case reflect.Ptr:
-		if typeDesc == jsonValueType {
+		switch typeDesc {
+		case jsonValueType:
 			return &structpb.Value{
 				Kind: &structpb.Value_ListValue{
 					ListValue: l.ListValue}}, nil
-		}
-		if typeDesc == jsonListValueType {
+		case jsonListValueType:
 			return l.ListValue, nil
-		}
-		if typeDesc == anyValueType {
+		case anyValueType:
 			return ptypes.MarshalAny(l.Value().(proto.Message))
 		}
-	}
-	// If the list is already assignable to the desired type return it.
-	if reflect.TypeOf(l).AssignableTo(typeDesc) {
-		return l, nil
+
+	case reflect.Interface:
+		// If the list is already assignable to the desired type return it.
+		if reflect.TypeOf(l).Implements(typeDesc) {
+			return l, nil
+		}
 	}
 	return nil, fmt.Errorf("no conversion found from list type to native type."+
 		" list elem: google.protobuf.Value, native type: %v", typeDesc)

--- a/common/types/json_struct.go
+++ b/common/types/json_struct.go
@@ -64,22 +64,24 @@ func (m *jsonStruct) ConvertToNative(typeDesc reflect.Type) (interface{}, error)
 			}
 			return nativeMap.Interface(), nil
 		}
+
 	case reflect.Ptr:
-		if typeDesc == jsonValueType {
+		switch typeDesc {
+		case jsonValueType:
 			return &structpb.Value{
 				Kind: &structpb.Value_StructValue{
 					StructValue: m.Struct}}, nil
-		}
-		if typeDesc == jsonStructType {
+		case jsonStructType:
 			return m.Struct, nil
-		}
-		if typeDesc == anyValueType {
+		case anyValueType:
 			return ptypes.MarshalAny(m.Value().(proto.Message))
 		}
-	}
-	// If the struct is already assignable to the desired type return it.
-	if reflect.TypeOf(m).AssignableTo(typeDesc) {
-		return m, nil
+
+	case reflect.Interface:
+		// If the struct is already assignable to the desired type return it.
+		if reflect.TypeOf(m).Implements(typeDesc) {
+			return m, nil
+		}
 	}
 	return nil, fmt.Errorf(
 		"no conversion found from map type to native type."+

--- a/common/types/string.go
+++ b/common/types/string.go
@@ -55,19 +55,26 @@ func (s String) Compare(other ref.Value) ref.Value {
 }
 
 func (s String) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
-	if typeDesc == jsonValueType {
-		return &structpb.Value{
-			Kind: &structpb.Value_StringValue{
-				StringValue: s.Value().(string)}}, nil
+	switch typeDesc.Kind() {
+	case reflect.String:
+		return string(s), nil
+	case reflect.Ptr:
+		if typeDesc == jsonValueType {
+			return &structpb.Value{
+				Kind: &structpb.Value_StringValue{
+					StringValue: s.Value().(string)}}, nil
+		}
+		if typeDesc.Elem().Kind() == reflect.String {
+			p := string(s)
+			return &p, nil
+		}
+	case reflect.Interface:
+		if reflect.TypeOf(s).Implements(typeDesc) {
+			return s, nil
+		}
 	}
-	if reflect.TypeOf(s).AssignableTo(typeDesc) {
-		return s, nil
-	}
-	if typeDesc.Kind() != reflect.String {
-		return nil, fmt.Errorf(
-			"unsupported native conversion from string to '%v'", typeDesc)
-	}
-	return s.Value(), nil
+	return nil, fmt.Errorf(
+		"unsupported native conversion from string to '%v'", typeDesc)
 }
 
 func (s String) ConvertToType(typeVal ref.Type) ref.Value {

--- a/common/types/string_test.go
+++ b/common/types/string_test.go
@@ -60,17 +60,29 @@ func TestString_ConvertToNative_Error(t *testing.T) {
 func TestString_ConvertToNative_Json(t *testing.T) {
 	val, err := String("hello").ConvertToNative(jsonValueType)
 	pbVal := &structpb.Value{Kind: &structpb.Value_StringValue{"hello"}}
-	if err != nil ||
-		IsError(val) ||
-		!proto.Equal(val.(proto.Message), pbVal) {
-		t.Error("Error during conversion to json Value type", err, val)
+	if err != nil {
+		t.Error(err)
+	} else if !proto.Equal(val.(proto.Message), pbVal) {
+		t.Errorf("Got '%v', expected json Value type", val)
+	}
+}
+
+func TestString_ConvertToNative_Ptr(t *testing.T) {
+	ptrType := ""
+	val, err := String("hello").ConvertToNative(reflect.TypeOf(&ptrType))
+	if err != nil {
+		t.Error(err)
+	} else if *val.(*string) != "hello" {
+		t.Errorf("Got '%v', expected 'hello'", val)
 	}
 }
 
 func TestString_ConvertToNative_String(t *testing.T) {
 	val, err := String("hello").ConvertToNative(reflect.TypeOf(""))
-	if err != nil || val.(string) != "hello" {
-		t.Error("Got '%v', expected 'hello'", val)
+	if err != nil {
+		t.Error(err)
+	} else if val.(string) != "hello" {
+		t.Errorf("Got '%v', expected 'hello'", val)
 	}
 }
 

--- a/common/types/timestamp.go
+++ b/common/types/timestamp.go
@@ -73,7 +73,7 @@ func (t Timestamp) Compare(other ref.Value) ref.Value {
 }
 
 func (t Timestamp) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
-	if typeDesc == reflect.TypeOf(&tpb.Timestamp{}) {
+	if typeDesc == timestampValueType {
 		return t.Value(), nil
 	}
 	// If the timestamp is already assignable to the desired type return it.
@@ -164,6 +164,8 @@ func (t Timestamp) Value() interface{} {
 }
 
 var (
+	timestampValueType = reflect.TypeOf(&tpb.Timestamp{})
+
 	timestampZeroArgOverloads = map[string]func(time.Time) ref.Value{
 		overloads.TimeGetFullYear:     timestampGetFullYear,
 		overloads.TimeGetMonth:        timestampGetMonth,

--- a/common/types/uint.go
+++ b/common/types/uint.go
@@ -62,8 +62,7 @@ func (i Uint) Compare(other ref.Value) ref.Value {
 
 func (i Uint) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	value := i.Value()
-	refKind := typeDesc.Kind()
-	switch refKind {
+	switch typeDesc.Kind() {
 	case reflect.Uint32:
 		return uint32(value.(uint64)), nil
 	case reflect.Uint64:
@@ -74,9 +73,18 @@ func (i Uint) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 				Kind: &structpb.Value_NumberValue{
 					NumberValue: float64(i)}}, nil
 		}
-	}
-	if reflect.TypeOf(i).AssignableTo(typeDesc) {
-		return i, nil
+		switch typeDesc.Elem().Kind() {
+		case reflect.Uint32:
+			p := uint32(i)
+			return &p, nil
+		case reflect.Uint64:
+			p := uint64(i)
+			return &p, nil
+		}
+	case reflect.Interface:
+		if reflect.TypeOf(i).Implements(typeDesc) {
+			return i, nil
+		}
 	}
 	return nil, fmt.Errorf("unsupported type conversion from 'uint' to %v", typeDesc)
 }

--- a/common/types/uint_test.go
+++ b/common/types/uint_test.go
@@ -57,9 +57,28 @@ func TestUint_ConvertToNative_Json(t *testing.T) {
 	val, err := Uint(10000).ConvertToNative(jsonValueType)
 	if err != nil {
 		t.Error(err)
-	}
-	if val.(*structpb.Value).GetNumberValue() != 10000. {
+	} else if val.(*structpb.Value).GetNumberValue() != 10000. {
 		t.Errorf("Error converting uint to json number. Got '%v', expected 10000.", val)
+	}
+}
+
+func TestUint_ConvertToNative_Ptr_Uint32(t *testing.T) {
+	ptrType := uint32(0)
+	val, err := Uint(10000).ConvertToNative(reflect.TypeOf(&ptrType))
+	if err != nil {
+		t.Error(err)
+	} else if *val.(*uint32) != uint32(10000) {
+		t.Errorf("Error converting uint to *uint32. Got '%v', expected 10000.", val)
+	}
+}
+
+func TestUint_ConvertToNative_Ptr_Uint64(t *testing.T) {
+	ptrType := uint64(0)
+	val, err := Uint(18446744073709551612).ConvertToNative(reflect.TypeOf(&ptrType))
+	if err != nil {
+		t.Error(err)
+	} else if *val.(*uint64) != uint64(18446744073709551612) {
+		t.Errorf("Error converting uint to *uint64. Got '%v', expected 18446744073709551612.", val)
 	}
 }
 

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -18,8 +18,8 @@
 package interpreter
 
 import (
-	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/packages"
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 	"github.com/google/cel-go/interpreter/functions"

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -17,8 +17,8 @@ package interpreter
 import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cel-go/checker"
-	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/packages"
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter/functions"
 	"github.com/google/cel-go/parser"


### PR DESCRIPTION
#35 Support conversion to pointer type for primitive values.

During proto2 message construction, primitive fields are set by pointer rather than
by value (as they are in proto3). This pull request ensures that primitive values can be
converted to pointer references.