### PR TITLE
Fix creation of proto values containing oneof fields.

### DIFF
--- a/common/types/providers_test.go
+++ b/common/types/providers_test.go
@@ -31,9 +31,9 @@ func TestTypeProvider_NewValue(t *testing.T) {
 	if sourceInfo := typeProvider.NewValue(
 		"google.api.expr.v1.SourceInfo",
 		map[string]ref.Value{
-			"Location":    String("TestTypeProvider_NewValue"),
-			"LineOffsets": NewDynamicList([]int64{0, 2}),
-			"Positions":   NewDynamicMap(map[int64]int64{1: 2, 2: 4}),
+			"location":     String("TestTypeProvider_NewValue"),
+			"line_offsets": NewDynamicList([]int64{0, 2}),
+			"positions":    NewDynamicMap(map[int64]int64{1: 2, 2: 4}),
 		}); IsError(sourceInfo) {
 		t.Error(sourceInfo)
 	} else {
@@ -42,6 +42,22 @@ func TestTypeProvider_NewValue(t *testing.T) {
 			!reflect.DeepEqual(info.LineOffsets, []int32{0, 2}) ||
 			!reflect.DeepEqual(info.Positions, map[int64]int32{1: 2, 2: 4}) {
 			t.Errorf("Source info not properly configured: %v", info)
+		}
+	}
+}
+
+func TestTypeProvider_NewValue_OneofFields(t *testing.T) {
+	typeProvider := NewProvider(&expr.ParsedExpr{})
+	if exp := typeProvider.NewValue(
+		"google.api.expr.v1.Expr",
+		map[string]ref.Value{
+			"literal_expr": NewObject(&expr.Literal{LiteralKind: &expr.Literal_StringValue{StringValue: "oneof"}}),
+		}); IsError(exp) {
+		t.Error(exp)
+	} else {
+		e := exp.Value().(*expr.Expr)
+		if e.GetLiteralExpr().GetStringValue() != "oneof" {
+			t.Errorf("Expr with oneof could not be created: %v", e)
 		}
 	}
 }

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -17,8 +17,8 @@ package interpreter
 import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cel-go/checker"
-	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/packages"
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter/functions"
 	"github.com/google/cel-go/parser"
@@ -92,22 +92,32 @@ func TestInterpreter_ComprehensionExpr(t *testing.T) {
 }
 
 func TestInterpreter_BuildObject(t *testing.T) {
-	parsed, errors := parser.ParseText("v1.Expr{id: 1}")
+	parsed, errors := parser.ParseText("v1.Expr{id: 1, " +
+		"literal_expr: v1.Literal{string_value: \"oneof_test\"}}")
+	if len(errors.GetErrors()) != 0 {
+		t.Errorf(errors.ToDisplayString())
+	}
 
 	pkgr := packages.NewPackage("google.api.expr")
 	provider := types.NewProvider(&expr.Expr{})
 	env := checker.NewStandardEnv(pkgr, provider, errors)
 	checked := checker.Check(parsed, env)
+	if len(errors.GetErrors()) != 0 {
+		t.Errorf(errors.ToDisplayString())
+	}
 
 	i := NewStandardIntepreter(pkgr, provider)
 	eval := i.NewInterpretable(NewCheckedProgram(checked))
 	result, _ := eval.Eval(NewActivation(map[string]interface{}{}))
-	if !proto.Equal(
-		result.(ref.Value).Value().(proto.Message),
-		&expr.Expr{Id: 1}) {
+	expected := &expr.Expr{Id: 1,
+		ExprKind: &expr.Expr_LiteralExpr{
+			LiteralExpr: &expr.Literal{
+				LiteralKind: &expr.Literal_StringValue{
+					StringValue: "oneof_test"}}}}
+	if !proto.Equal(result.(ref.Value).Value().(proto.Message), expected) {
 		t.Errorf("Could not build object properly. Got '%v', wanted '%v'",
 			result.(ref.Value).Value(),
-			&expr.Expr{Id: 1})
+			expected)
 	}
 }
 


### PR DESCRIPTION
#36 Fixes setting proto oneof fields during object construction.

In go, oneof fields have a wrapper struct which is generated that is not a `proto.Message`
instance; however, all wrappers for oneof fields only contain a single field definition. This
fix relies on this behavior to detect and set oneof fields properly in object construction
expressions like: `v1.Expr{id: 1, literal_expr: v1.Literal{string_value: 'oneof-test'}}`

Note, the above expression is not quite as easy to use as the proto textformat where the
type of `literal_expr` field would be deduced at runtime without the developer needing
to specify it.