### PR TITLE
Server test

### DIFF
--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["server_test.go"],
+    args = ["$(location :cel_server)"],
     data = [":cel_server"],
     deps = [
         ":go_default_library",

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     srcs = ["server_test.go"],
     args = ["$(location :cel_server)"],
     data = [":cel_server"],
+    rundir = ".",
     deps = [
         ":go_default_library",
         "//checker/decls:go_default_library",

--- a/server/main.go
+++ b/server/main.go
@@ -14,9 +14,12 @@ import (
 
 func main() {
 	log.Println("Server opening listening port")
-	lis, err := net.Listen("tcp", "127.0.0.1:")
+	lis, err := net.Listen("tcp4", "127.0.0.1:")
 	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
+		lis, err = net.Listen("tcp6", "[::1]:0")
+		if err != nil {
+			log.Fatalf("failed to listen: %v", err)
+		}
 	}
 	log.Println("Server opened port ", lis.Addr())
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -50,7 +50,7 @@ func setup() error {
 	if len(os.Args) < 2 {
 		log.Fatalf("Expect binary path: %s <binary>\n", os.Args[0])
 	}
-	globals.cmd = exec.Command("../" + os.Args[1])
+	globals.cmd = exec.Command(os.Args[1])
 
 	out, err := globals.cmd.StdoutPipe()
 	if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -51,8 +51,7 @@ func setup() error {
 		log.Fatalf("Expect binary path: %s <binary>\n", os.Args[0])
 	}
 	log.Println(os.Args[1])
-	globals.cmd = exec.Command(os.Args[1])
-	globals.cmd = exec.Command("cel_server")
+	globals.cmd = exec.Command("../" + os.Args[1])
 
 	out, err := globals.cmd.StdoutPipe()
 	if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -47,6 +47,11 @@ func mainHelper(m *testing.M) int {
 }
 
 func setup() error {
+	if len(os.Args) < 2 {
+		log.Fatalf("Expect binary path: %s <binary>\n", os.Args[0])
+	}
+	log.Println(os.Args[1])
+	globals.cmd = exec.Command(os.Args[1])
 	globals.cmd = exec.Command("cel_server")
 
 	out, err := globals.cmd.StdoutPipe()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -50,7 +50,6 @@ func setup() error {
 	if len(os.Args) < 2 {
 		log.Fatalf("Expect binary path: %s <binary>\n", os.Args[0])
 	}
-	log.Println(os.Args[1])
 	globals.cmd = exec.Command("../" + os.Args[1])
 
 	out, err := globals.cmd.StdoutPipe()


### PR DESCRIPTION
Update cel-service #69 

Also added tag 'rundir' to the go_test target of server_test. The test is set to execute under the root of the repository, which the test can call the cel_server binary correctly with the location argument from the command line.