### PR TITLE
use correct constant for defining matches() std fn

### DIFF
--- a/interpreter/functions/standard.go
+++ b/interpreter/functions/standard.go
@@ -184,7 +184,7 @@ func StandardOverloads() []*Overload {
 			}},
 
 		// Matches function
-		{Operator: overloads.MatchString,
+		{Operator: overloads.Matches,
 			OperandTrait: traits.MatcherType,
 			Binary: func(lhs ref.Value, rhs ref.Value) ref.Value {
 				return lhs.(traits.Matcher).Match(rhs)


### PR DESCRIPTION
The standard interpreter environment is missing the `matches(str, regexp)` function because the overload name is being used as a function name. This change could break code using `matches_string`