### PR TITLE
Go lint fixes for core packages.

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -264,8 +264,8 @@ func (c *checker) resolveOverload(
 		argTypes = append(argTypes, c.getType(arg))
 	}
 
-	var resultType *expr.Type = nil
-	var checkedRef *expr.Reference = nil
+	var resultType *expr.Type
+	var checkedRef *expr.Reference
 	for _, overload := range fn.GetFunction().Overloads {
 		if (target == nil && overload.IsInstanceFunction) ||
 			(target != nil && !overload.IsInstanceFunction) {
@@ -316,7 +316,7 @@ func (c *checker) resolveOverload(
 
 func (c *checker) checkCreateList(e *expr.Expr) {
 	create := e.GetListExpr()
-	var elemType *expr.Type = nil
+	var elemType *expr.Type
 	for _, e := range create.Elements {
 		c.check(e)
 		elemType = c.joinTypes(c.location(e), elemType, c.getType(e))
@@ -339,8 +339,8 @@ func (c *checker) checkCreateStruct(e *expr.Expr) {
 
 func (c *checker) checkCreateMap(e *expr.Expr) {
 	mapVal := e.GetStructExpr()
-	var keyType *expr.Type = nil
-	var valueType *expr.Type = nil
+	var keyType *expr.Type
+	var valueType *expr.Type
 	for _, ent := range mapVal.GetEntries() {
 		key := ent.GetMapKey()
 		c.check(key)
@@ -391,11 +391,11 @@ func (c *checker) checkCreateMessage(e *expr.Expr) {
 		c.check(value)
 
 		fieldType := decls.Error
-		if t, found := c.lookupFieldType(c.locationById(ent.Id), messageType, field); found {
+		if t, found := c.lookupFieldType(c.locationByID(ent.Id), messageType, field); found {
 			fieldType = t.Type
 		}
 		if !c.isAssignable(fieldType, c.getType(value)) {
-			c.env.errors.fieldTypeMismatch(c.locationById(ent.Id), field, fieldType, c.getType(value))
+			c.env.errors.fieldTypeMismatch(c.locationByID(ent.Id), field, fieldType, c.getType(value))
 		}
 	}
 }
@@ -526,10 +526,10 @@ func newResolution(checkedRef *expr.Reference, t *expr.Type) *overloadResolution
 }
 
 func (c *checker) location(e *expr.Expr) common.Location {
-	return c.locationById(e.Id)
+	return c.locationByID(e.Id)
 }
 
-func (c *checker) locationById(id int64) common.Location {
+func (c *checker) locationByID(id int64) common.Location {
 	positions := c.sourceInfo.GetPositions()
 	var line = 1
 	var col = 0
@@ -537,7 +537,7 @@ func (c *checker) locationById(id int64) common.Location {
 		col = int(offset)
 		for _, lineOffset := range c.sourceInfo.LineOffsets {
 			if lineOffset < offset {
-				line += 1
+				line++
 				col = int(offset - lineOffset)
 			} else {
 				break

--- a/checker/errors.go
+++ b/checker/errors.go
@@ -45,10 +45,10 @@ func (e *typeErrors) fieldDoesNotSupportPresenceCheck(l common.Location, field s
 	e.ReportError(l, "field '%s' does not support presence check", field)
 }
 
-func (e *typeErrors) overlappingOverload(l common.Location, name string, overloadId1 string, f1 *expr.Type,
-	overloadId2 string, f2 *expr.Type) {
+func (e *typeErrors) overlappingOverload(l common.Location, name string, overloadID1 string, f1 *expr.Type,
+	overloadID2 string, f2 *expr.Type) {
 	e.ReportError(l, "overlapping overload for name '%s' (type '%s' with overloadId: '%s' cannot be distinguished from '%s' with "+
-		"overloadId: '%s')", name, FormatCheckedType(f1), overloadId1, FormatCheckedType(f2), overloadId2)
+		"overloadId: '%s')", name, FormatCheckedType(f1), overloadID1, FormatCheckedType(f2), overloadID2)
 }
 
 func (e *typeErrors) overlappingMacro(l common.Location, name string, args int) {

--- a/common/location.go
+++ b/common/location.go
@@ -27,10 +27,10 @@ type SourceLocation struct {
 }
 
 var (
-	// Ensure the SourceLocation implements the Location interface.
-	_          Location = &SourceLocation{}
+	// Location implements the SourcceLocation interface.
+	_ Location = &SourceLocation{}
 	// NoLocation is a particular illegal location.
-	NoLocation          = &SourceLocation{-1, -1}
+	NoLocation = &SourceLocation{-1, -1}
 )
 
 // NewLocation creates a new location.

--- a/common/source.go
+++ b/common/source.go
@@ -49,14 +49,14 @@ type Source interface {
 	// Snippet returns a line of content and whether the line was found.
 	Snippet(line int) (string, bool)
 
-	// IdOffset returns the raw character offset of an expression within
+	// IDOffset returns the raw character offset of an expression within
 	// the source, or false if the expression cannot be found.
-	IdOffset(exprID int64) (int32, bool)
+	IDOffset(exprID int64) (int32, bool)
 
-	// IdLocation returns a Location for the given expression id,
+	// IDLocation returns a Location for the given expression id,
 	// or false if one cannot be found.  It behaves as the obvious
 	// composition of IdOffset() and OffsetLocation().
-	IdLocation(exprID int64) (Location, bool)
+	IDLocation(exprID int64) (Location, bool)
 }
 
 // The sourceImpl type implementation of the Source interface.
@@ -135,15 +135,15 @@ func (s *sourceImpl) Snippet(line int) (string, bool) {
 	return s.contents[charStart:], true
 }
 
-func (s *sourceImpl) IdOffset(exprId int64) (int32, bool) {
-	if offset, found := s.idOffsets[exprId]; found {
+func (s *sourceImpl) IDOffset(exprID int64) (int32, bool) {
+	if offset, found := s.idOffsets[exprID]; found {
 		return offset, true
 	}
 	return -1, false
 }
 
-func (s *sourceImpl) IdLocation(exprId int64) (Location, bool) {
-	if offset, found := s.IdOffset(exprId); found {
+func (s *sourceImpl) IDLocation(exprID int64) (Location, bool) {
+	if offset, found := s.IDOffset(exprID); found {
 		if location, found := s.OffsetLocation(offset); found {
 			return location, true
 		}

--- a/common/source.go
+++ b/common/source.go
@@ -51,12 +51,12 @@ type Source interface {
 
 	// IdOffset returns the raw character offset of an expression within
 	// the source, or false if the expression cannot be found.
-	IdOffset(exprId int64) (int32, bool)
+	IdOffset(exprID int64) (int32, bool)
 
 	// IdLocation returns a Location for the given expression id,
 	// or false if one cannot be found.  It behaves as the obvious
 	// composition of IdOffset() and OffsetLocation().
-	IdLocation(exprId int64) (Location, bool)
+	IdLocation(exprID int64) (Location, bool)
 }
 
 // The sourceImpl type implementation of the Source interface.
@@ -76,7 +76,7 @@ func NewStringSource(contents string, description string) Source {
 	// Compute line offsets up front as they are referred to frequently.
 	lines := strings.Split(contents, "\n")
 	offsets := make([]int32, len(lines))
-	var offset int32 = 0
+	var offset int32
 	for i, line := range lines {
 		offset = offset + int32(len(line)) + 1
 		offsets[int32(i)] = offset
@@ -173,7 +173,7 @@ func (s *sourceImpl) findLine(characterOffset int32) (int32, int32) {
 		if lineOffset > characterOffset {
 			break
 		} else {
-			line += 1
+			line++
 		}
 	}
 	if line == 1 {

--- a/common/types/bool_test.go
+++ b/common/types/bool_test.go
@@ -60,7 +60,7 @@ func TestBool_ConvertToNative_Error(t *testing.T) {
 
 func TestBool_ConvertToNative_Json(t *testing.T) {
 	val, err := True.ConvertToNative(jsonValueType)
-	pbVal := &structpb.Value{Kind: &structpb.Value_BoolValue{true}}
+	pbVal := &structpb.Value{Kind: &structpb.Value_BoolValue{BoolValue: true}}
 	if err != nil {
 		t.Error(err)
 	} else if !proto.Equal(val.(proto.Message), pbVal) {

--- a/common/types/double_test.go
+++ b/common/types/double_test.go
@@ -75,7 +75,7 @@ func TestDouble_ConvertToNative_Float64(t *testing.T) {
 
 func TestDouble_ConvertToNative_Json(t *testing.T) {
 	val, err := Double(-1.4).ConvertToNative(jsonValueType)
-	pbVal := &structpb.Value{Kind: &structpb.Value_NumberValue{-1.4}}
+	pbVal := &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: -1.4}}
 	if err != nil {
 		t.Error(err)
 	} else if !proto.Equal(val.(proto.Message), pbVal) {

--- a/common/types/json_list.go
+++ b/common/types/json_list.go
@@ -33,9 +33,9 @@ type jsonListValue struct {
 	*structpb.ListValue
 }
 
-// NewJsonList creates a traits.Lister implementation backed by a JSON list
+// NewJSONList creates a traits.Lister implementation backed by a JSON list
 // that has been encoded in protocol buffer form.
-func NewJsonList(l *structpb.ListValue) traits.Lister {
+func NewJSONList(l *structpb.ListValue) traits.Lister {
 	return &jsonListValue{l}
 }
 
@@ -47,7 +47,7 @@ func (l *jsonListValue) Add(other ref.Value) ref.Value {
 	case *jsonListValue:
 		otherList := other.(*jsonListValue)
 		concatElems := append(l.GetValues(), otherList.GetValues()...)
-		return NewJsonList(&structpb.ListValue{Values: concatElems})
+		return NewJSONList(&structpb.ListValue{Values: concatElems})
 	}
 	return &concatList{
 		prevList: l,
@@ -173,7 +173,7 @@ func (it *jsonValueListIterator) HasNext() ref.Value {
 func (it *jsonValueListIterator) Next() ref.Value {
 	if it.HasNext() == True {
 		index := it.cursor
-		it.cursor += 1
+		it.cursor++
 		return NativeToValue(it.elems[index])
 	}
 	return nil

--- a/common/types/json_list_test.go
+++ b/common/types/json_list_test.go
@@ -26,22 +26,22 @@ import (
 )
 
 func TestJsonListValue_Add(t *testing.T) {
-	listA := NewJsonList(&structpb.ListValue{Values: []*structpb.Value{
-		{Kind: &structpb.Value_StringValue{"hello"}},
-		{Kind: &structpb.Value_NumberValue{1}}}})
-	listB := NewJsonList(&structpb.ListValue{Values: []*structpb.Value{
-		{Kind: &structpb.Value_NumberValue{2}},
-		{Kind: &structpb.Value_NumberValue{3}}}})
+	listA := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
+	listB := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+		{Kind: &structpb.Value_NumberValue{NumberValue: 2}},
+		{Kind: &structpb.Value_NumberValue{NumberValue: 3}}}})
 	list := listA.Add(listB)
 	nativeVal, err := list.ConvertToNative(jsonListValueType)
 	if err != nil {
 		t.Error(err)
 	}
 	expected := &structpb.ListValue{Values: []*structpb.Value{
-		{Kind: &structpb.Value_StringValue{"hello"}},
-		{Kind: &structpb.Value_NumberValue{1}},
-		{Kind: &structpb.Value_NumberValue{2}},
-		{Kind: &structpb.Value_NumberValue{3}}}}
+		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+		{Kind: &structpb.Value_NumberValue{NumberValue: 1}},
+		{Kind: &structpb.Value_NumberValue{NumberValue: 2}},
+		{Kind: &structpb.Value_NumberValue{NumberValue: 3}}}}
 	if !proto.Equal(nativeVal.(proto.Message), expected) {
 		t.Errorf("Concatenated lists did not combine as expected."+
 			" Got '%v', expected '%v'", nativeVal, expected)
@@ -49,9 +49,9 @@ func TestJsonListValue_Add(t *testing.T) {
 }
 
 func TestJsonListValue_Contains(t *testing.T) {
-	list := NewJsonList(&structpb.ListValue{Values: []*structpb.Value{
-		{Kind: &structpb.Value_StringValue{"hello"}},
-		{Kind: &structpb.Value_NumberValue{1}}}})
+	list := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	if !list.Contains(Double(1)).(Bool) {
 		t.Error("Expected value list to contain number '1'", list)
 	}
@@ -61,9 +61,9 @@ func TestJsonListValue_Contains(t *testing.T) {
 }
 
 func TestJsonListValue_ConvertToNative_Json(t *testing.T) {
-	list := NewJsonList(&structpb.ListValue{Values: []*structpb.Value{
-		{Kind: &structpb.Value_StringValue{"hello"}},
-		{Kind: &structpb.Value_NumberValue{1}}}})
+	list := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	listVal, err := list.ConvertToNative(jsonListValueType)
 	if err != nil {
 		t.Error(err)
@@ -84,9 +84,9 @@ func TestJsonListValue_ConvertToNative_Json(t *testing.T) {
 }
 
 func TestJsonListValue_ConvertToNative_Slice(t *testing.T) {
-	list := NewJsonList(&structpb.ListValue{Values: []*structpb.Value{
-		{Kind: &structpb.Value_StringValue{"hello"}},
-		{Kind: &structpb.Value_NumberValue{1}}}})
+	list := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	listVal, err := list.ConvertToNative(reflect.TypeOf([]*structpb.Value{}))
 	if err != nil {
 		t.Error(err)
@@ -100,9 +100,9 @@ func TestJsonListValue_ConvertToNative_Slice(t *testing.T) {
 }
 
 func TestJsonListValue_ConvertToNative_Any(t *testing.T) {
-	list := NewJsonList(&structpb.ListValue{Values: []*structpb.Value{
-		{Kind: &structpb.Value_StringValue{"hello"}},
-		{Kind: &structpb.Value_NumberValue{1}}}})
+	list := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	anyVal, err := list.ConvertToNative(anyValueType)
 	if err != nil {
 		t.Error(err)
@@ -118,9 +118,9 @@ func TestJsonListValue_ConvertToNative_Any(t *testing.T) {
 }
 
 func TestJsonListValue_ConvertToType(t *testing.T) {
-	list := NewJsonList(&structpb.ListValue{Values: []*structpb.Value{
-		{Kind: &structpb.Value_StringValue{"hello"}},
-		{Kind: &structpb.Value_NumberValue{1}}}})
+	list := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	if list.ConvertToType(TypeType) != ListType {
 		t.Error("Json list type was not a list.")
 	}
@@ -133,12 +133,12 @@ func TestJsonListValue_ConvertToType(t *testing.T) {
 }
 
 func TestJsonListValue_Equal(t *testing.T) {
-	listA := NewJsonList(&structpb.ListValue{Values: []*structpb.Value{
-		{Kind: &structpb.Value_StringValue{"hello"}},
-		{Kind: &structpb.Value_NumberValue{1}}}})
-	listB := NewJsonList(&structpb.ListValue{Values: []*structpb.Value{
-		{Kind: &structpb.Value_NumberValue{2}},
-		{Kind: &structpb.Value_NumberValue{3}}}})
+	listA := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
+	listB := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+		{Kind: &structpb.Value_NumberValue{NumberValue: 2}},
+		{Kind: &structpb.Value_NumberValue{NumberValue: 3}}}})
 	if listA.Equal(listB).(Bool) || listB.Equal(listA).(Bool) {
 		t.Error("Lists with different elements considered equal.")
 	}
@@ -154,9 +154,9 @@ func TestJsonListValue_Equal(t *testing.T) {
 }
 
 func TestJsonListValue_Get_OutOfRange(t *testing.T) {
-	list := NewJsonList(&structpb.ListValue{Values: []*structpb.Value{
-		{Kind: &structpb.Value_StringValue{"hello"}},
-		{Kind: &structpb.Value_NumberValue{1}}}})
+	list := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	if !IsError(list.Get(Int(-1))) {
 		t.Error("Negative index did not result in error.")
 	}
@@ -169,11 +169,11 @@ func TestJsonListValue_Get_OutOfRange(t *testing.T) {
 }
 
 func TestJsonListValue_Iterator(t *testing.T) {
-	list := NewJsonList(&structpb.ListValue{Values: []*structpb.Value{
-		{Kind: &structpb.Value_StringValue{"hello"}},
-		{Kind: &structpb.Value_NumberValue{1}},
-		{Kind: &structpb.Value_NumberValue{2}},
-		{Kind: &structpb.Value_NumberValue{3}}}})
+	list := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+		{Kind: &structpb.Value_NumberValue{NumberValue: 1}},
+		{Kind: &structpb.Value_NumberValue{NumberValue: 2}},
+		{Kind: &structpb.Value_NumberValue{NumberValue: 3}}}})
 	it := list.Iterator()
 	for i := Int(0); it.HasNext() != False; i++ {
 		v := it.Next()

--- a/common/types/json_struct.go
+++ b/common/types/json_struct.go
@@ -33,9 +33,9 @@ type jsonStruct struct {
 	*structpb.Struct
 }
 
-// NewJsonStruct creates a traits.Mapper implementation backed by a JSON struct
+// NewJSONStruct creates a traits.Mapper implementation backed by a JSON struct
 // that has been encoded in protocol buffer form.
-func NewJsonStruct(st *structpb.Struct) traits.Mapper {
+func NewJSONStruct(st *structpb.Struct) traits.Mapper {
 	return &jsonStruct{st}
 }
 
@@ -139,7 +139,7 @@ func (m *jsonStruct) Iterator() traits.Iterator {
 	f := m.GetFields()
 	keys := make([]string, len(m.GetFields()))
 	i := 0
-	for k, _ := range f {
+	for k := range f {
 		keys[i] = k
 		i++
 	}
@@ -175,7 +175,7 @@ func (it *jsonValueMapIterator) HasNext() ref.Value {
 func (it *jsonValueMapIterator) Next() ref.Value {
 	if it.HasNext() == True {
 		index := it.cursor
-		it.cursor += 1
+		it.cursor++
 		return String(it.mapKeys[index])
 	}
 	return nil

--- a/common/types/json_struct_test.go
+++ b/common/types/json_struct_test.go
@@ -26,9 +26,9 @@ import (
 )
 
 func TestJsonStruct_Contains(t *testing.T) {
-	mapVal := NewJsonStruct(&structpb.Struct{Fields: map[string]*structpb.Value{
-		"first":  {Kind: &structpb.Value_StringValue{"hello"}},
-		"second": {Kind: &structpb.Value_NumberValue{1}}}})
+	mapVal := NewJSONStruct(&structpb.Struct{Fields: map[string]*structpb.Value{
+		"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+		"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	if !mapVal.Contains(String("first")).(Bool) {
 		t.Error("Expected map to contain key 'first'", mapVal)
 	}
@@ -38,7 +38,7 @@ func TestJsonStruct_Contains(t *testing.T) {
 }
 
 func TestJsonStruct_ConvertToNative_Error(t *testing.T) {
-	val, err := NewJsonStruct(&structpb.Struct{}).ConvertToNative(jsonListValueType)
+	val, err := NewJSONStruct(&structpb.Struct{}).ConvertToNative(jsonListValueType)
 	if err == nil {
 		t.Errorf("Unsupported type conversion succeeded. "+
 			"Got '%v', expected error", val)
@@ -47,15 +47,15 @@ func TestJsonStruct_ConvertToNative_Error(t *testing.T) {
 
 func TestJsonStruct_ConvertToNative_Json(t *testing.T) {
 	structVal := &structpb.Struct{Fields: map[string]*structpb.Value{
-		"first":  {Kind: &structpb.Value_StringValue{"hello"}},
-		"second": {Kind: &structpb.Value_NumberValue{1}}}}
-	mapVal := NewJsonStruct(structVal)
+		"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+		"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}}
+	mapVal := NewJSONStruct(structVal)
 	val, err := mapVal.ConvertToNative(jsonValueType)
 	if err != nil {
 		t.Error(err)
 	}
 	if !proto.Equal(val.(proto.Message),
-		&structpb.Value{Kind: &structpb.Value_StructValue{structVal}}) {
+		&structpb.Value{Kind: &structpb.Value_StructValue{StructValue: structVal}}) {
 		t.Errorf("Got '%v', expected '%v'", val, structVal)
 	}
 
@@ -71,9 +71,9 @@ func TestJsonStruct_ConvertToNative_Json(t *testing.T) {
 func TestJsonStruct_ConvertToNative_Any(t *testing.T) {
 	structVal := &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			"first":  {Kind: &structpb.Value_StringValue{"hello"}},
-			"second": {Kind: &structpb.Value_NumberValue{1}}}}
-	mapVal := NewJsonStruct(structVal)
+			"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+			"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}}
+	mapVal := NewJSONStruct(structVal)
 	anyVal, err := mapVal.ConvertToNative(anyValueType)
 	if err != nil {
 		t.Error(err)
@@ -89,9 +89,9 @@ func TestJsonStruct_ConvertToNative_Any(t *testing.T) {
 
 func TestJsonStruct_ConvertToNative_Map(t *testing.T) {
 	structVal := &structpb.Struct{Fields: map[string]*structpb.Value{
-		"first":  {Kind: &structpb.Value_StringValue{"hello"}},
-		"second": {Kind: &structpb.Value_StringValue{"world"}}}}
-	mapVal := NewJsonStruct(structVal)
+		"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+		"second": {Kind: &structpb.Value_StringValue{StringValue: "world"}}}}
+	mapVal := NewJSONStruct(structVal)
 	val, err := mapVal.ConvertToNative(reflect.TypeOf(map[string]string{}))
 	if err != nil {
 		t.Error(err)
@@ -102,9 +102,9 @@ func TestJsonStruct_ConvertToNative_Map(t *testing.T) {
 }
 
 func TestJsonStruct_ConvertToType(t *testing.T) {
-	mapVal := NewJsonStruct(&structpb.Struct{Fields: map[string]*structpb.Value{
-		"first":  {Kind: &structpb.Value_StringValue{"hello"}},
-		"second": {Kind: &structpb.Value_NumberValue{1}}}})
+	mapVal := NewJSONStruct(&structpb.Struct{Fields: map[string]*structpb.Value{
+		"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+		"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	if mapVal.ConvertToType(MapType) != mapVal {
 		t.Error("Map could not be converted to a map.")
 	}
@@ -117,13 +117,13 @@ func TestJsonStruct_ConvertToType(t *testing.T) {
 }
 
 func TestJsonStruct_Equal(t *testing.T) {
-	mapVal := NewJsonStruct(&structpb.Struct{Fields: map[string]*structpb.Value{
-		"first":  {Kind: &structpb.Value_StringValue{"hello"}},
-		"second": {Kind: &structpb.Value_StringValue{"1"}}}})
+	mapVal := NewJSONStruct(&structpb.Struct{Fields: map[string]*structpb.Value{
+		"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+		"second": {Kind: &structpb.Value_StringValue{StringValue: "1"}}}})
 
-	otherVal := NewJsonStruct(&structpb.Struct{Fields: map[string]*structpb.Value{
-		"first":  {Kind: &structpb.Value_StringValue{"hello"}},
-		"second": {Kind: &structpb.Value_NumberValue{1}}}})
+	otherVal := NewJSONStruct(&structpb.Struct{Fields: map[string]*structpb.Value{
+		"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+		"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	if mapVal.Equal(otherVal) != False {
 		t.Errorf("Got equals 'true', expected 'false' for '%v' == '%v'",
 			mapVal, otherVal)
@@ -131,7 +131,7 @@ func TestJsonStruct_Equal(t *testing.T) {
 	if mapVal.Equal(mapVal) != True {
 		t.Error("Map was not equal to itself.")
 	}
-	if mapVal.Equal(NewJsonStruct(&structpb.Struct{})) != False {
+	if mapVal.Equal(NewJSONStruct(&structpb.Struct{})) != False {
 		t.Error("Map with key-value pairs was equal to empty map")
 	}
 	if mapVal.Equal(String("")) != False {
@@ -140,7 +140,7 @@ func TestJsonStruct_Equal(t *testing.T) {
 }
 
 func TestJsonStruct_Get(t *testing.T) {
-	if !IsError(NewJsonStruct(&structpb.Struct{}).Get(Int(1))) {
+	if !IsError(NewJSONStruct(&structpb.Struct{}).Get(Int(1))) {
 		t.Error("Structs may only have string keys.")
 	}
 }

--- a/common/types/list.go
+++ b/common/types/list.go
@@ -341,7 +341,8 @@ func (l *stringList) ConvertToNative(typeDesc reflect.Type) (interface{}, error)
 			elemCount := len(l.elems)
 			listVals := make([]*structpb.Value, elemCount, elemCount)
 			for i := 0; i < elemCount; i++ {
-				listVals[i] = &structpb.Value{Kind: &structpb.Value_StringValue{l.elems[i]}}
+				listVals[i] = &structpb.Value{
+					Kind: &structpb.Value_StringValue{StringValue: l.elems[i]}}
 			}
 			jsonList := &structpb.ListValue{Values: listVals}
 			if typeDesc == jsonListValueType {
@@ -393,11 +394,11 @@ func (l *valueList) Add(other ref.Value) ref.Value {
 func (l *valueList) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	natives := make([]interface{}, len(l.elems))
 	for _, v := range l.elems {
-		if n, e := v.ConvertToNative(typeDesc); e != nil {
+		n, e := v.ConvertToNative(typeDesc)
+		if e != nil {
 			return nil, e
-		} else {
-			natives = append(natives, n)
 		}
+		natives = append(natives, n)
 	}
 	return natives, nil
 }
@@ -431,7 +432,7 @@ func (it *listIterator) HasNext() ref.Value {
 func (it *listIterator) Next() ref.Value {
 	if it.HasNext() == True {
 		index := it.cursor
-		it.cursor += 1
+		it.cursor++
 		return it.listValue.Get(index)
 	}
 	return nil

--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -389,10 +389,10 @@ func TestStringList_Get_OutOfRange(t *testing.T) {
 
 func getElem(t *testing.T, list traits.Indexer, index Int) interface{} {
 	t.Helper()
-	if val := list.Get(index); IsError(val) {
+	val := list.Get(index)
+	if IsError(val) {
 		t.Errorf("Error reading list index %d, %v", index, val)
 		return nil
-	} else {
-		return val
 	}
+	return val
 }

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -190,7 +190,7 @@ func (it *mapIterator) HasNext() ref.Value {
 func (it *mapIterator) Next() ref.Value {
 	if it.HasNext() == True {
 		index := it.cursor
-		it.cursor += 1
+		it.cursor++
 		refKey := it.mapKeys[index]
 		return NativeToValue(refKey.Interface())
 	}

--- a/common/types/object.go
+++ b/common/types/object.go
@@ -137,7 +137,7 @@ func (it *msgIterator) Next() ref.Value {
 		return nil
 	}
 	fieldName, _ := it.typeDesc.FieldNameAtIndex(it.cursor, it.refValue)
-	it.cursor += 1
+	it.cursor++
 	return String(fieldName)
 }
 

--- a/common/types/pb/file.go
+++ b/common/types/pb/file.go
@@ -16,6 +16,7 @@ package pb
 
 import (
 	"fmt"
+
 	descpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 )
 
@@ -42,7 +43,7 @@ func (fd *FileDescription) GetEnumNames() []string {
 	i := 0
 	for _, e := range fd.enums {
 		enumNames[i] = e.Name()
-		i += 1
+		i++
 	}
 	return enumNames
 }
@@ -62,7 +63,7 @@ func (fd *FileDescription) GetTypeNames() []string {
 	i := 0
 	for _, t := range fd.types {
 		typeNames[i] = t.Name()
-		i += 1
+		i++
 	}
 	return typeNames
 }

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -205,11 +205,11 @@ func NativeToValue(value interface{}) ref.Value {
 	case *dpb.Duration:
 		return Duration{value.(*dpb.Duration)}
 	case *structpb.ListValue:
-		return NewJsonList(value.(*structpb.ListValue))
+		return NewJSONList(value.(*structpb.ListValue))
 	case structpb.NullValue:
 		return NullValue
 	case *structpb.Struct:
-		return NewJsonStruct(value.(*structpb.Struct))
+		return NewJSONStruct(value.(*structpb.Struct))
 	case *structpb.Value:
 		v := value.(*structpb.Value)
 		switch v.Kind.(type) {

--- a/common/types/providers_test.go
+++ b/common/types/providers_test.go
@@ -143,7 +143,7 @@ func TestNativeToValue_Any(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	expected := NewJsonStruct(&structpb.Struct{
+	expected := NewJSONStruct(&structpb.Struct{
 		Fields: map[string]*structpb.Value{
 			"a": {Kind: &structpb.Value_StringValue{StringValue: "world"}},
 			"b": {Kind: &structpb.Value_StringValue{StringValue: "five!"}}}})
@@ -159,7 +159,7 @@ func TestNativeToValue_Any(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	expected = NewJsonList(&structpb.ListValue{
+	expected = NewJSONList(&structpb.ListValue{
 		Values: []*structpb.Value{
 			{Kind: &structpb.Value_StringValue{StringValue: "world"}},
 			{Kind: &structpb.Value_StringValue{StringValue: "five!"}}}})
@@ -200,7 +200,7 @@ func TestNativeToValue_Json(t *testing.T) {
 					Values: []*structpb.Value{
 						{Kind: &structpb.Value_StringValue{StringValue: "world"}},
 						{Kind: &structpb.Value_StringValue{StringValue: "five!"}}}}}},
-		NewJsonList(&structpb.ListValue{
+		NewJSONList(&structpb.ListValue{
 			Values: []*structpb.Value{
 				{Kind: &structpb.Value_StringValue{StringValue: "world"}},
 				{Kind: &structpb.Value_StringValue{StringValue: "five!"}}}}))
@@ -213,7 +213,7 @@ func TestNativeToValue_Json(t *testing.T) {
 					Fields: map[string]*structpb.Value{
 						"a": {Kind: &structpb.Value_StringValue{StringValue: "world"}},
 						"b": {Kind: &structpb.Value_StringValue{StringValue: "five!"}}}}}},
-		NewJsonStruct(&structpb.Struct{
+		NewJSONStruct(&structpb.Struct{
 			Fields: map[string]*structpb.Value{
 				"a": {Kind: &structpb.Value_StringValue{StringValue: "world"}},
 				"b": {Kind: &structpb.Value_StringValue{StringValue: "five!"}}}}))

--- a/common/types/string_test.go
+++ b/common/types/string_test.go
@@ -55,13 +55,13 @@ func TestString_Compare(t *testing.T) {
 func TestString_ConvertToNative_Error(t *testing.T) {
 	val, err := String("hello").ConvertToNative(reflect.TypeOf(0))
 	if err == nil {
-		t.Error("Got '%v', expected error", val)
+		t.Errorf("Got '%v', expected error", val)
 	}
 }
 
 func TestString_ConvertToNative_Json(t *testing.T) {
 	val, err := String("hello").ConvertToNative(jsonValueType)
-	pbVal := &structpb.Value{Kind: &structpb.Value_StringValue{"hello"}}
+	pbVal := &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "hello"}}
 	if err != nil {
 		t.Error(err)
 	} else if !proto.Equal(val.(proto.Message), pbVal) {

--- a/common/types/timestamp.go
+++ b/common/types/timestamp.go
@@ -271,10 +271,10 @@ func timeZone(tz ref.Value, visitor timestampVisitor) timestampVisitor {
 		if StringType != tz.Type() {
 			return NewErr("unsupported overload")
 		}
-		if loc, err := time.LoadLocation(string(tz.(String))); err == nil {
+		loc, err := time.LoadLocation(string(tz.(String)))
+		if err == nil {
 			return visitor(t.In(loc))
-		} else {
-			return &Err{err}
 		}
+		return &Err{err}
 	}
 }

--- a/common/types/type.go
+++ b/common/types/type.go
@@ -55,7 +55,7 @@ func NewObjectTypeValue(name string) *TypeValue {
 // ConvertToNative implements ref.Value.ConvertToNative.
 func (t *TypeValue) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	// TODO: replace the internal type representation with a proto-value.
-	return nil, fmt.Errorf("type conversion not supported for 'type'.")
+	return nil, fmt.Errorf("type conversion not supported for 'type'")
 }
 
 // ConvertToType implements ref.Value.ConvertToType.

--- a/interpreter/activation.go
+++ b/interpreter/activation.go
@@ -27,7 +27,7 @@ type Activation interface {
 
 	// ResolveReference returns a value from the activation by expression id,
 	// or false if the id-based reference could not be found.
-	ResolveReference(exprId int64) (ref.Value, bool)
+	ResolveReference(exprID int64) (ref.Value, bool)
 
 	// ResolveName returns a value from the activation by qualified name, or
 	// false if the name could not be found.
@@ -76,8 +76,8 @@ func (a *mapActivation) ResolveName(name string) (ref.Value, bool) {
 	return nil, false
 }
 
-func (a *mapActivation) ResolveReference(exprId int64) (ref.Value, bool) {
-	object, found := a.references[exprId]
+func (a *mapActivation) ResolveReference(exprID int64) (ref.Value, bool) {
+	object, found := a.references[exprID]
 	return object, found
 }
 
@@ -99,11 +99,11 @@ func (a *hierarchicalActivation) ResolveName(name string) (ref.Value, bool) {
 	return a.parent.ResolveName(name)
 }
 
-func (a *hierarchicalActivation) ResolveReference(exprId int64) (ref.Value, bool) {
-	if object, found := a.child.ResolveReference(exprId); found {
+func (a *hierarchicalActivation) ResolveReference(exprID int64) (ref.Value, bool) {
+	if object, found := a.child.ResolveReference(exprID); found {
 		return object, found
 	}
-	return a.parent.ResolveReference(exprId)
+	return a.parent.ResolveReference(exprID)
 }
 
 // NewHierarchicalActivation takes two activations and produces a new one which prioritizes

--- a/interpreter/dispatcher.go
+++ b/interpreter/dispatcher.go
@@ -92,7 +92,7 @@ func (d *defaultDispatcher) Add(overloads ...*functions.Overload) error {
 }
 
 func (d *defaultDispatcher) Dispatch(ctx *CallContext) ref.Value {
-	function, overloadId := ctx.Function()
+	function, overloadID := ctx.Function()
 	operand := ctx.args[0]
 	if overload, found := d.overloads[function]; found {
 		if !operand.Type().HasTrait(overload.OperandTrait) {
@@ -111,7 +111,7 @@ func (d *defaultDispatcher) Dispatch(ctx *CallContext) ref.Value {
 	}
 	// Special dispatch for member functions.
 	if operand.Type().HasTrait(traits.ReceiverType) {
-		operand.(traits.Receiver).Receive(function, overloadId, ctx.args[1:])
+		operand.(traits.Receiver).Receive(function, overloadID, ctx.args[1:])
 	}
 	return types.NewErr("no such overload")
 }

--- a/interpreter/evalstate.go
+++ b/interpreter/evalstate.go
@@ -20,9 +20,9 @@ import (
 
 // EvalState tracks the values associated with expression ids during execution.
 type EvalState interface {
-	// GetRuntimeExpressionId returns the runtime id corresponding to the
+	// GetRuntimeExpressionID returns the runtime id corresponding to the
 	// expression id from the AST.
-	GetRuntimeExpressionId(exprId int64) int64
+	GetRuntimeExpressionID(exprID int64) int64
 
 	// OnlyValue returns the value in the eval state, if only one exists.
 	OnlyValue() (ref.Value, bool)
@@ -36,35 +36,35 @@ type EvalState interface {
 type MutableEvalState interface {
 	EvalState
 
-	// SetRuntimeExpressionId sets the runtimeId for the given exprId.
-	SetRuntimeExpressionId(exprId int64, runtimeId int64)
+	// SetRuntimeExpressionID sets the runtime id for the given expr id.
+	SetRuntimeExpressionID(exprID int64, runtimeID int64)
 
 	// SetValue associates an expression id with a value.
 	SetValue(int64, ref.Value)
 }
 
 // NewEvalState returns a MutableEvalState.
-func NewEvalState(instructionCount int64) *defaultEvalState {
+func NewEvalState(instructionCount int64) MutableEvalState {
 	return &defaultEvalState{exprCount: instructionCount,
 		exprValues: make([]ref.Value, instructionCount, instructionCount),
-		exprIdMap:  make(map[int64]int64)}
+		exprIDMap:  make(map[int64]int64)}
 }
 
 type defaultEvalState struct {
 	exprCount  int64
 	exprValues []ref.Value
-	exprIdMap  map[int64]int64
+	exprIDMap  map[int64]int64
 }
 
-func (s *defaultEvalState) GetRuntimeExpressionId(exprId int64) int64 {
-	if val, ok := s.exprIdMap[exprId]; ok {
+func (s *defaultEvalState) GetRuntimeExpressionID(exprID int64) int64 {
+	if val, ok := s.exprIDMap[exprID]; ok {
 		return val
 	}
-	return exprId
+	return exprID
 }
 
 func (s *defaultEvalState) OnlyValue() (ref.Value, bool) {
-	var result ref.Value = nil
+	var result ref.Value
 	i := 0
 	for _, val := range s.exprValues {
 		if val != nil {
@@ -78,21 +78,21 @@ func (s *defaultEvalState) OnlyValue() (ref.Value, bool) {
 	return nil, false
 }
 
-func (s *defaultEvalState) SetRuntimeExpressionId(exprId int64, runtimeId int64) {
-	s.exprIdMap[exprId] = runtimeId
+func (s *defaultEvalState) SetRuntimeExpressionID(exprID int64, runtimeID int64) {
+	s.exprIDMap[exprID] = runtimeID
 }
 
-func (s *defaultEvalState) SetValue(exprId int64, value ref.Value) {
-	s.exprValues[exprId] = value
+func (s *defaultEvalState) SetValue(exprID int64, value ref.Value) {
+	s.exprValues[exprID] = value
 }
 
-func (s *defaultEvalState) Value(exprId int64) (ref.Value, bool) {
+func (s *defaultEvalState) Value(exprID int64) (ref.Value, bool) {
 	// TODO: The eval state assumes a dense progrma expression id space. While
 	// this is true of how the cel-go parser generates identifiers, it may not
 	// be true for all implementations or for the long term. Replace the use of
 	// parse-time generated expression ids with a dense runtiem identifier.
-	if exprId >= 0 && exprId < s.exprCount {
-		return s.exprValues[exprId], true
+	if exprID >= 0 && exprID < s.exprCount {
+		return s.exprValues[exprID], true
 	}
 	return nil, false
 }

--- a/interpreter/instructions.go
+++ b/interpreter/instructions.go
@@ -25,16 +25,16 @@ import (
 // Instruction represents a single step within a CEL program.
 type Instruction interface {
 	fmt.Stringer
-	GetId() int64
+	GetID() int64
 }
 
 type baseInstruction struct {
-	Id int64
+	ID int64
 }
 
-// GetId returns the Expr id for the instruction.
-func (e *baseInstruction) GetId() int64 {
-	return e.Id
+// GetID returns the Expr id for the instruction.
+func (e *baseInstruction) GetID() int64 {
+	return e.ID
 }
 
 // ConstExpr is a constant expression.
@@ -45,12 +45,12 @@ type ConstExpr struct {
 
 // String generates pseudo-assembly for the instruction.
 func (e *ConstExpr) String() string {
-	return fmt.Sprintf("const %v, r%d", e.Value, e.GetId())
+	return fmt.Sprintf("const %v, r%d", e.Value, e.GetID())
 }
 
 // NewLiteral generates a ConstExpr.
-func NewLiteral(exprId int64, value ref.Value) *ConstExpr {
-	return &ConstExpr{&baseInstruction{exprId}, value}
+func NewLiteral(exprID int64, value ref.Value) *ConstExpr {
+	return &ConstExpr{&baseInstruction{exprID}, value}
 }
 
 // IdentExpr is an identifier expression.
@@ -61,12 +61,12 @@ type IdentExpr struct {
 
 // String generates pseudo-assembly for the instruction.
 func (e *IdentExpr) String() string {
-	return fmt.Sprintf("local '%s', r%d", e.Name, e.GetId())
+	return fmt.Sprintf("local '%s', r%d", e.Name, e.GetID())
 }
 
 // NewIdent generates an IdentExpr.
-func NewIdent(exprId int64, name string) *IdentExpr {
-	return &IdentExpr{&baseInstruction{exprId}, name}
+func NewIdent(exprID int64, name string) *IdentExpr {
+	return &IdentExpr{&baseInstruction{exprID}, name}
 }
 
 // CallExpr is a call expression where the args are referenced by id.
@@ -87,17 +87,17 @@ func (e *CallExpr) String() string {
 	return fmt.Sprintf("call  %s(%v), r%d",
 		e.Function,
 		strings.Join(argRegs, ", "),
-		e.GetId())
+		e.GetID())
 }
 
 // NewCall generates a CallExpr for non-overload calls.
-func NewCall(exprId int64, function string, argIds []int64) *CallExpr {
-	return &CallExpr{&baseInstruction{exprId}, function, argIds, "", checkIsStrict(function)}
+func NewCall(exprID int64, function string, argIDs []int64) *CallExpr {
+	return &CallExpr{&baseInstruction{exprID}, function, argIDs, "", checkIsStrict(function)}
 }
 
 // NewCallOverload generates a CallExpr for overload calls.
-func NewCallOverload(exprId int64, function string, argIds []int64, overload string) *CallExpr {
-	return &CallExpr{&baseInstruction{exprId}, function, argIds, overload, checkIsStrict(function)}
+func NewCallOverload(exprID int64, function string, argIDs []int64, overload string) *CallExpr {
+	return &CallExpr{&baseInstruction{exprID}, function, argIDs, overload, checkIsStrict(function)}
 }
 
 func checkIsStrict(function string) bool {
@@ -117,12 +117,12 @@ type SelectExpr struct {
 // String generates pseudo-assembly for the instruction.
 func (e *SelectExpr) String() string {
 	return fmt.Sprintf("call  select(%d, '%s'), r%d",
-		e.Operand, e.Field, e.GetId())
+		e.Operand, e.Field, e.GetID())
 }
 
 // NewSelect generates a SelectExpr.
-func NewSelect(exprId int64, operandId int64, field string) *SelectExpr {
-	return &SelectExpr{&baseInstruction{exprId}, operandId, field}
+func NewSelect(exprID int64, operandID int64, field string) *SelectExpr {
+	return &SelectExpr{&baseInstruction{exprID}, operandID, field}
 }
 
 // CreateListExpr will create a new list from the elements referened by their ids.
@@ -133,12 +133,12 @@ type CreateListExpr struct {
 
 // String generates pseudo-assembly for the instruction.
 func (e *CreateListExpr) String() string {
-	return fmt.Sprintf("mov   list(%v), r%d", e.Elements, e.GetId())
+	return fmt.Sprintf("mov   list(%v), r%d", e.Elements, e.GetID())
 }
 
 // NewList generates a CreateListExpr.
-func NewList(exprId int64, elements []int64) *CreateListExpr {
-	return &CreateListExpr{&baseInstruction{exprId}, elements}
+func NewList(exprID int64, elements []int64) *CreateListExpr {
+	return &CreateListExpr{&baseInstruction{exprID}, elements}
 }
 
 // CreateMapExpr will create a map from the key value pairs where each key and
@@ -150,12 +150,12 @@ type CreateMapExpr struct {
 
 // String generates pseudo-assembly for the instruction.
 func (e *CreateMapExpr) String() string {
-	return fmt.Sprintf("mov   map(%v), r%d", e.KeyValues, e.GetId())
+	return fmt.Sprintf("mov   map(%v), r%d", e.KeyValues, e.GetID())
 }
 
 // NewMap generates a CreateMapExpr.
-func NewMap(exprId int64, keyValues map[int64]int64) *CreateMapExpr {
-	return &CreateMapExpr{&baseInstruction{exprId}, keyValues}
+func NewMap(exprID int64, keyValues map[int64]int64) *CreateMapExpr {
+	return &CreateMapExpr{&baseInstruction{exprID}, keyValues}
 }
 
 // CreateObjectExpr generates a new typed object with field values referenced
@@ -168,13 +168,13 @@ type CreateObjectExpr struct {
 
 // String generates pseudo-assembly for the instruction.
 func (e *CreateObjectExpr) String() string {
-	return fmt.Sprintf("mov   type(%s%v), r%d", e.Name, e.FieldValues, e.GetId())
+	return fmt.Sprintf("mov   type(%s%v), r%d", e.Name, e.FieldValues, e.GetID())
 }
 
 // NewObject generates a CreateObjectExpr.
-func NewObject(exprId int64, name string,
+func NewObject(exprID int64, name string,
 	fieldValues map[string]int64) *CreateObjectExpr {
-	return &CreateObjectExpr{&baseInstruction{exprId}, name, fieldValues}
+	return &CreateObjectExpr{&baseInstruction{exprID}, name, fieldValues}
 }
 
 // JumpInst represents an conditional jump to an instruction offset.
@@ -186,13 +186,13 @@ type JumpInst struct {
 
 // String generates pseudo-assembly for the instruction.
 func (e *JumpInst) String() string {
-	return fmt.Sprintf("jump  %d if cond<r%d>", e.Count, e.GetId())
+	return fmt.Sprintf("jump  %d if cond<r%d>", e.Count, e.GetID())
 }
 
 // NewJump generates a JumpInst.
-func NewJump(exprId int64, instructionCount int, cond func(EvalState) bool) *JumpInst {
+func NewJump(exprID int64, instructionCount int, cond func(EvalState) bool) *JumpInst {
 	return &JumpInst{
-		baseInstruction: &baseInstruction{exprId},
+		baseInstruction: &baseInstruction{exprID},
 		Count:           instructionCount,
 		OnCondition:     cond}
 }
@@ -200,17 +200,17 @@ func NewJump(exprId int64, instructionCount int, cond func(EvalState) bool) *Jum
 // MovInst assigns the value of one expression id to another.
 type MovInst struct {
 	*baseInstruction
-	ToExprId int64
+	ToExprID int64
 }
 
 // String generates pseudo-assembly for the instruction.
 func (e *MovInst) String() string {
-	return fmt.Sprintf("mov   r%d, r%d", e.GetId(), e.ToExprId)
+	return fmt.Sprintf("mov   r%d, r%d", e.GetID(), e.ToExprID)
 }
 
 // NewMov generates a MovInst.
-func NewMov(exprId int64, toExprId int64) *MovInst {
-	return &MovInst{&baseInstruction{exprId}, toExprId}
+func NewMov(exprID int64, toExprID int64) *MovInst {
+	return &MovInst{&baseInstruction{exprID}, toExprID}
 }
 
 // PushScopeInst results in the generation of a new Activation containing the values
@@ -226,8 +226,8 @@ func (e *PushScopeInst) String() string {
 }
 
 // NewPushScope generates a PushScopeInst.
-func NewPushScope(exprId int64, declarations map[string]int64) *PushScopeInst {
-	return &PushScopeInst{&baseInstruction{exprId}, declarations}
+func NewPushScope(exprID int64, declarations map[string]int64) *PushScopeInst {
+	return &PushScopeInst{&baseInstruction{exprID}, declarations}
 }
 
 // PopScopeInst resets the current activation to the Activation#Parent() of the
@@ -242,6 +242,6 @@ func (e *PopScopeInst) String() string {
 }
 
 // NewPopScope generates a PopScopeInst.
-func NewPopScope(exprId int64) *PopScopeInst {
-	return &PopScopeInst{&baseInstruction{exprId}}
+func NewPopScope(exprID int64) *PopScopeInst {
+	return &PopScopeInst{&baseInstruction{exprID}}
 }

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -284,8 +284,8 @@ func BenchmarkInterpreter_EqualsDispatch(b *testing.B) {
 			args:       []ref.Value{xRef},
 			activation: activation,
 		}
-		evalState.SetValue(callTypeOf.GetId(), d.Dispatch(ctxType))
-		typeOfXRef, _ := evalState.Value(callTypeOf.GetId())
+		evalState.SetValue(callTypeOf.GetID(), d.Dispatch(ctxType))
+		typeOfXRef, _ := evalState.Value(callTypeOf.GetID())
 		// not-found here.
 		activation.ResolveName("uint")
 		uintType, _ := p.FindIdent("uint")
@@ -294,7 +294,7 @@ func BenchmarkInterpreter_EqualsDispatch(b *testing.B) {
 			args:       []ref.Value{typeOfXRef, uintType},
 			activation: activation,
 		}
-		evalState.SetValue(callEq.GetId(), d.Dispatch(ctxEq))
+		evalState.SetValue(callEq.GetID(), d.Dispatch(ctxEq))
 	}
 }
 

--- a/interpreter/metadata.go
+++ b/interpreter/metadata.go
@@ -21,12 +21,12 @@ import (
 // Metadata interface for accessing position information about expressions.
 // TODO(jimlarson) Replace with common.Source.
 type Metadata interface {
-	// IdOffset returns raw character offset of an expression within
+	// IDOffset returns raw character offset of an expression within
 	// Source, or false if the expression cannot be found.
-	IdOffset(exprId int64) (int32, bool)
+	IDOffset(exprID int64) (int32, bool)
 
-	// IdLocation returns a common.Location for the given expression id,
+	// IDLocation returns a common.Location for the given expression id,
 	// or false if one cannot be found.  It behaves as the obvious
 	// composition of IdOffset() and OffsetLocation().
-	IdLocation(exprId int64) (common.Location, bool)
+	IDLocation(exprID int64) (common.Location, bool)
 }

--- a/interpreter/program.go
+++ b/interpreter/program.go
@@ -33,16 +33,16 @@ type Program interface {
 	Begin() InstructionStepper
 
 	// GetInstruction returns the instruction at the given runtime expression id.
-	GetInstruction(runtimeId int64) Instruction
+	GetInstruction(runtimeID int64) Instruction
 
 	// Init ensures that instructions have been properly initialized prior to
 	// beginning the execution of a program. The init step may optimize the
 	// instruction set.
 	Init(dispatcher Dispatcher, state MutableEvalState)
 
-	// MaxInstructionId returns the identifier of the last expression in the
+	// MaxInstructionID returns the identifier of the last expression in the
 	// program.
-	MaxInstructionId() int64
+	MaxInstructionID() int64
 
 	// Metadata used to determine source locations of sub-expressions.
 	Metadata() Metadata
@@ -93,25 +93,25 @@ func (p *exprProgram) Begin() InstructionStepper {
 	return &exprStepper{p, 0}
 }
 
-func (p *exprProgram) GetInstruction(runtimeId int64) Instruction {
-	return p.instructions[p.revInstructions[runtimeId]]
+func (p *exprProgram) GetInstruction(runtimeID int64) Instruction {
+	return p.instructions[p.revInstructions[runtimeID]]
 }
 
 func (p *exprProgram) Init(dispatcher Dispatcher, state MutableEvalState) {
 	if p.instructions == nil {
 		p.instructions = WalkExpr(p.expression, p.metadata, dispatcher, state)
 		for i, inst := range p.instructions {
-			p.revInstructions[inst.GetId()] = i
+			p.revInstructions[inst.GetID()] = i
 		}
 	}
 }
 
-func (p *exprProgram) MaxInstructionId() int64 {
+func (p *exprProgram) MaxInstructionID() int64 {
 	// The max instruction id is computed as the highest expression id + 1
 	// combined with the number of comprehensions times two. Each comprehension
 	// introduces two generated ids (one for an iterator and one for current
 	// iterator value) once the program is initialized.
-	return maxId(p.expression) + comprehensionCount(p.expression)*2
+	return maxID(p.expression) + comprehensionCount(p.expression)*2
 }
 
 func (p *exprProgram) Metadata() Metadata {
@@ -136,7 +136,7 @@ type exprStepper struct {
 func (s *exprStepper) Next() (Instruction, bool) {
 	if s.instruction < len(s.program.instructions) {
 		inst := s.instruction
-		s.instruction += 1
+		s.instruction++
 		return s.program.instructions[inst], true
 	}
 	return nil, false
@@ -164,11 +164,11 @@ func newExprMetadata(info *expr.SourceInfo) Metadata {
 	return &exprMetadata{info: info}
 }
 
-func (m *exprMetadata) IdLocation(exprId int64) (common.Location, bool) {
-	if exprOffset, found := m.IdOffset(exprId); found {
+func (m *exprMetadata) IDLocation(exprID int64) (common.Location, bool) {
+	if exprOffset, found := m.IDOffset(exprID); found {
 		var index = 0
 		var lineIndex = 0
-		var lineOffset int32 = 0
+		var lineOffset int32
 		for index, lineOffset = range m.info.LineOffsets {
 			if lineOffset > exprOffset {
 				break
@@ -182,7 +182,7 @@ func (m *exprMetadata) IdLocation(exprId int64) (common.Location, bool) {
 	return nil, false
 }
 
-func (m *exprMetadata) IdOffset(exprId int64) (int32, bool) {
-	position, found := m.info.Positions[exprId]
+func (m *exprMetadata) IDOffset(exprID int64) (int32, bool) {
+	position, found := m.info.Positions[exprID]
 	return position, found
 }

--- a/interpreter/program_test.go
+++ b/interpreter/program_test.go
@@ -55,17 +55,16 @@ func TestNewProgram_LogicalOr(t *testing.T) {
 	program := NewProgram(
 		test.LogicalOr.Expr,
 		test.LogicalOr.Info(t.Name()))
-	if loc, found := program.Metadata().IdLocation(1); found {
+	if loc, found := program.Metadata().IDLocation(1); found {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
-	state := NewEvalState(program.MaxInstructionId() + 1)
+	state := NewEvalState(program.MaxInstructionID() + 1)
 	program.Init(dispatcher(), state)
 	if _, hasNext := program.Begin().Next(); !hasNext {
 		t.Error("Expected a step in program, but found none")
 	}
 	fmt.Printf("%s\n%s\n\n", t.Name(), program)
 }
-
 
 func TestNewProgram_Conditional(t *testing.T) {
 	program := NewProgram(

--- a/interpreter/program_test.go
+++ b/interpreter/program_test.go
@@ -26,10 +26,10 @@ func TestNewProgram_Empty(t *testing.T) {
 	program := NewProgram(
 		test.Empty.Expr,
 		test.Empty.Info(t.Name()))
-	if loc, found := program.Metadata().IdLocation(0); found {
+	if loc, found := program.Metadata().IDLocation(0); found {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
-	state := NewEvalState(program.MaxInstructionId() + 1)
+	state := NewEvalState(program.MaxInstructionID() + 1)
 	program.Init(dispatcher(), state)
 	if step, hasNext := program.Begin().Next(); hasNext {
 		t.Errorf("Unexpected step in empty program: %v", step)
@@ -40,10 +40,10 @@ func TestNewProgram_LogicalAnd(t *testing.T) {
 	program := NewProgram(
 		test.LogicalAnd.Expr,
 		test.LogicalAnd.Info(t.Name()))
-	if loc, found := program.Metadata().IdLocation(1); found {
+	if loc, found := program.Metadata().IDLocation(1); found {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
-	state := NewEvalState(program.MaxInstructionId() + 1)
+	state := NewEvalState(program.MaxInstructionID() + 1)
 	program.Init(dispatcher(), state)
 	if _, hasNext := program.Begin().Next(); !hasNext {
 		t.Error("Expected a step in program, but found none")
@@ -71,10 +71,10 @@ func TestNewProgram_Conditional(t *testing.T) {
 	program := NewProgram(
 		test.Conditional.Expr,
 		test.Conditional.Info(t.Name()))
-	if loc, found := program.Metadata().IdLocation(1); found {
+	if loc, found := program.Metadata().IDLocation(1); found {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
-	state := NewEvalState(program.MaxInstructionId() + 1)
+	state := NewEvalState(program.MaxInstructionID() + 1)
 	program.Init(dispatcher(), state)
 	if _, hasNext := program.Begin().Next(); !hasNext {
 		t.Error("Expected a step in program, but found none")
@@ -102,10 +102,10 @@ func TestNewProgram_Comprehension(t *testing.T) {
 	program := NewProgram(
 		test.Exists.Expr,
 		test.Exists.Info(t.Name()))
-	if loc, found := program.Metadata().IdLocation(1); !found {
+	if loc, found := program.Metadata().IDLocation(1); !found {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
-	state := NewEvalState(program.MaxInstructionId() + 1)
+	state := NewEvalState(program.MaxInstructionID() + 1)
 	program.Init(dispatcher(), state)
 	if _, hasNext := program.Begin().Next(); !hasNext {
 		t.Error("Expected a step in program, but found none")
@@ -117,10 +117,10 @@ func TestNewProgram_DynMap(t *testing.T) {
 	program := NewProgram(
 		test.DynMap.Expr,
 		test.DynMap.Info(t.Name()))
-	if loc, found := program.Metadata().IdLocation(1); found {
+	if loc, found := program.Metadata().IDLocation(1); found {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
-	state := NewEvalState(program.MaxInstructionId() + 1)
+	state := NewEvalState(program.MaxInstructionID() + 1)
 	program.Init(dispatcher(), state)
 	if _, hasNext := program.Begin().Next(); !hasNext {
 		t.Error("Expected a step in program, but found none")

--- a/interpreter/prune.go
+++ b/interpreter/prune.go
@@ -103,9 +103,8 @@ func (p *astPruner) maybePruneConditional(node *expr.Expr) (*expr.Expr, bool) {
 
 	if condVal.Value().(bool) {
 		return call.Args[1], true
-	} else {
-		return call.Args[2], true
 	}
+	return call.Args[2], true
 }
 
 func (p *astPruner) maybePruneFunction(node *expr.Expr) (*expr.Expr, bool) {
@@ -133,25 +132,25 @@ func (p *astPruner) prune(node *expr.Expr) (*expr.Expr, bool) {
 		switch val.Type() {
 		case types.BoolType:
 			return p.createLiteral(node,
-				&expr.Constant{ConstantKind: &expr.Constant_BoolValue{val.Value().(bool)}}), true
+				&expr.Constant{ConstantKind: &expr.Constant_BoolValue{BoolValue: val.Value().(bool)}}), true
 		case types.IntType:
 			return p.createLiteral(node,
-				&expr.Constant{ConstantKind: &expr.Constant_Int64Value{val.Value().(int64)}}), true
+				&expr.Constant{ConstantKind: &expr.Constant_Int64Value{Int64Value: val.Value().(int64)}}), true
 		case types.UintType:
 			return p.createLiteral(node,
-				&expr.Constant{ConstantKind: &expr.Constant_Uint64Value{val.Value().(uint64)}}), true
+				&expr.Constant{ConstantKind: &expr.Constant_Uint64Value{Uint64Value: val.Value().(uint64)}}), true
 		case types.StringType:
 			return p.createLiteral(node,
-				&expr.Constant{ConstantKind: &expr.Constant_StringValue{val.Value().(string)}}), true
+				&expr.Constant{ConstantKind: &expr.Constant_StringValue{StringValue: val.Value().(string)}}), true
 		case types.DoubleType:
 			return p.createLiteral(node,
-				&expr.Constant{ConstantKind: &expr.Constant_DoubleValue{val.Value().(float64)}}), true
+				&expr.Constant{ConstantKind: &expr.Constant_DoubleValue{DoubleValue: val.Value().(float64)}}), true
 		case types.BytesType:
 			return p.createLiteral(node,
-				&expr.Constant{ConstantKind: &expr.Constant_BytesValue{val.Value().([]byte)}}), true
+				&expr.Constant{ConstantKind: &expr.Constant_BytesValue{BytesValue: val.Value().([]byte)}}), true
 		case types.NullType:
 			return p.createLiteral(node,
-				&expr.Constant{ConstantKind: &expr.Constant_NullValue{val.Value().(structpb.NullValue)}}), true
+				&expr.Constant{ConstantKind: &expr.Constant_NullValue{NullValue: val.Value().(structpb.NullValue)}}), true
 		}
 	}
 
@@ -241,7 +240,7 @@ func (p *astPruner) prune(node *expr.Expr) (*expr.Expr, bool) {
 }
 
 func (p *astPruner) value(id int64) (ref.Value, bool) {
-	val, found := p.state.Value(p.state.GetRuntimeExpressionId(id))
+	val, found := p.state.Value(p.state.GetRuntimeExpressionID(id))
 	return val, (found && val != nil)
 }
 

--- a/parser/helper.go
+++ b/parser/helper.go
@@ -11,7 +11,7 @@ type parserHelper struct {
 	source    common.Source
 	errors    *parseErrors
 	macros    map[string]Macro
-	nextId    int64
+	nextID    int64
 	positions map[int64]int32
 }
 
@@ -25,7 +25,7 @@ func newParserHelper(source common.Source, macros Macros) *parserHelper {
 		errors:    &parseErrors{common.NewErrors(source)},
 		source:    source,
 		macros:    macroMap,
-		nextId:    1,
+		nextID:    1,
 		positions: make(map[int64]int32),
 	}
 }
@@ -60,31 +60,31 @@ func (p *parserHelper) newLiteral(ctx interface{}, value *expr.Constant) *expr.E
 
 func (p *parserHelper) newLiteralBool(ctx interface{}, value bool) *expr.Expr {
 	return p.newLiteral(ctx,
-		&expr.Constant{ConstantKind: &expr.Constant_BoolValue{value}})
+		&expr.Constant{ConstantKind: &expr.Constant_BoolValue{BoolValue: value}})
 }
 
 func (p *parserHelper) newLiteralString(ctx interface{}, value string) *expr.Expr {
 	return p.newLiteral(ctx,
-		&expr.Constant{ConstantKind: &expr.Constant_StringValue{value}})
+		&expr.Constant{ConstantKind: &expr.Constant_StringValue{StringValue: value}})
 }
 
 func (p *parserHelper) newLiteralBytes(ctx interface{}, value []byte) *expr.Expr {
 	return p.newLiteral(ctx,
-		&expr.Constant{ConstantKind: &expr.Constant_BytesValue{value}})
+		&expr.Constant{ConstantKind: &expr.Constant_BytesValue{BytesValue: value}})
 }
 
 func (p *parserHelper) newLiteralInt(ctx interface{}, value int64) *expr.Expr {
 	return p.newLiteral(ctx,
-		&expr.Constant{ConstantKind: &expr.Constant_Int64Value{value}})
+		&expr.Constant{ConstantKind: &expr.Constant_Int64Value{Int64Value: value}})
 }
 
 func (p *parserHelper) newLiteralUint(ctx interface{}, value uint64) *expr.Expr {
-	return p.newLiteral(ctx, &expr.Constant{ConstantKind: &expr.Constant_Uint64Value{value}})
+	return p.newLiteral(ctx, &expr.Constant{ConstantKind: &expr.Constant_Uint64Value{Uint64Value: value}})
 }
 
 func (p *parserHelper) newLiteralDouble(ctx interface{}, value float64) *expr.Expr {
 	return p.newLiteral(ctx,
-		&expr.Constant{ConstantKind: &expr.Constant_DoubleValue{value}})
+		&expr.Constant{ConstantKind: &expr.Constant_DoubleValue{DoubleValue: value}})
 }
 
 func (p *parserHelper) newIdent(ctx interface{}, name string) *expr.Expr {
@@ -191,7 +191,7 @@ func (p *parserHelper) newExpr(ctx interface{}) *expr.Expr {
 }
 
 func (p *parserHelper) id(ctx interface{}) int64 {
-	var token antlr.Token = nil
+	var token antlr.Token
 	switch ctx.(type) {
 	case antlr.ParserRuleContext:
 		token = (ctx.(antlr.ParserRuleContext)).GetStart()
@@ -202,9 +202,9 @@ func (p *parserHelper) id(ctx interface{}) int64 {
 		return -1
 	}
 	location := common.NewLocation(token.GetLine(), token.GetColumn())
-	id := p.nextId
+	id := p.nextID
 	p.positions[id], _ = p.source.LocationOffset(location)
-	p.nextId++
+	p.nextID++
 	return id
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -701,13 +701,13 @@ type testInfo struct {
 }
 
 type metadata interface {
-	GetLocation(exprId int64) (common.Location, bool)
+	GetLocation(exprID int64) (common.Location, bool)
 }
 
-type kindAndIdAdorner struct {
+type kindAndIDAdorner struct {
 }
 
-func (k *kindAndIdAdorner) GetMetadata(elem interface{}) string {
+func (k *kindAndIDAdorner) GetMetadata(elem interface{}) string {
 	switch elem.(type) {
 	case *expr.Expr:
 		e := elem.(*expr.Expr)
@@ -730,14 +730,14 @@ type locationAdorner struct {
 
 var _ metadata = &locationAdorner{}
 
-func (l *locationAdorner) GetLocation(exprId int64) (common.Location, bool) {
-	if pos, found := l.sourceInfo.Positions[exprId]; found {
+func (l *locationAdorner) GetLocation(exprID int64) (common.Location, bool) {
+	if pos, found := l.sourceInfo.Positions[exprID]; found {
 		var line = 1
 		for _, lineOffset := range l.sourceInfo.LineOffsets {
 			if lineOffset > pos {
 				break
 			} else {
-				line += 1
+				line++
 			}
 		}
 		var column = pos
@@ -750,15 +750,15 @@ func (l *locationAdorner) GetLocation(exprId int64) (common.Location, bool) {
 }
 
 func (l *locationAdorner) GetMetadata(elem interface{}) string {
-	var elemId int64 = 0
+	var elemID int64
 	switch elem.(type) {
 	case *expr.Expr:
-		elemId = elem.(*expr.Expr).Id
+		elemID = elem.(*expr.Expr).Id
 	case *expr.Expr_CreateStruct_Entry:
-		elemId = elem.(*expr.Expr_CreateStruct_Entry).Id
+		elemID = elem.(*expr.Expr_CreateStruct_Entry).Id
 	}
-	location, _ := l.GetLocation(elemId)
-	return fmt.Sprintf("^#%d[%d,%d]#", elemId, location.Line(), location.Column())
+	location, _ := l.GetLocation(elemID)
+	return fmt.Sprintf("^#%d[%d,%d]#", elemID, location.Line(), location.Column())
 }
 
 func Test(t *testing.T) {
@@ -779,7 +779,7 @@ func Test(t *testing.T) {
 				tt.Fatalf("Expected error not thrown: '%s'", tst.E)
 			}
 
-			actualWithKind := debug.ToAdornedDebugString(expression.Expr, &kindAndIdAdorner{})
+			actualWithKind := debug.ToAdornedDebugString(expression.Expr, &kindAndIDAdorner{})
 			if !test.Compare(actualWithKind, tst.P) {
 				tt.Fatal(test.DiffMessage("structure", actualWithKind, tst.P))
 			}

--- a/parser/unescape.go
+++ b/parser/unescape.go
@@ -54,7 +54,7 @@ func unescape(value string) (string, error) {
 				return value, fmt.Errorf("unable to unescape string")
 			}
 			value = "\"" + value[3:n-3] + "\""
-		} else if strings.HasPrefix(value,`"""`) {
+		} else if strings.HasPrefix(value, `"""`) {
 			if !strings.HasSuffix(value, `"""`) {
 				return value, fmt.Errorf("unable to unescape string")
 			}
@@ -110,7 +110,7 @@ func unescapeChar(s string) (value rune, multibyte bool, tail string, err error)
 
 	// 2. Last character is the start of an escape sequence.
 	if len(s) <= 1 {
-		err = fmt.Errorf("unable to unescape string, found '\\' as last character.")
+		err = fmt.Errorf("unable to unescape string, found '\\' as last character")
 		return
 	}
 


### PR DESCRIPTION
Address minor variable name and Go style issues identified by `go lint` for the
`checker`, `common`, `parser`, and `interpreter` packages.