### PR TITLE
Use builtin "context" now that it is standard Go.

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -10,7 +11,6 @@ import (
 	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/test"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"


### PR DESCRIPTION
This was taken from a Google-internal large scale change, making it to
the upstream repo instead. The originating change said:

The "context" library added in Go 1.7 was based on Google's and has
the same API. It is now aliased to "context" so the two can be used
interchangeably. This change is a cleanup that standardizes on the
standard library "context" package.