### PR TITLE
Isolation of `common.Errors` between parser and checker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ import(
 )
 
 // Parse the expression and returns the accumulated errors.
-p, errors := parser.ParseText("a || b && c.exists(x, x > 2)")
+src := common.NewTextSource("a || b && c.exists(x, x > 2)")
+expr, errors := parser.Parse(src)
 if len(errors.GetErrors()) != 0 {
     return nil, fmt.Error(errors.ToDisplayString())
 }
@@ -69,11 +70,11 @@ if len(errors.GetErrors()) != 0 {
 // the identifiers a, b, c where the identifiers are scoped to the default
 // package (empty string):
 typeProvider := types.NewProvider()
-env := checker.NewStandardEnv(packages.DefaultPackage, typeProvider, errors)
+env := checker.NewStandardEnv(packages.DefaultPackage, typeProvider)
 env.Add(decls.NewIdent("a", decls.Bool, nil),
     decls.NewIdent("b", decls.Bool, nil),
     decls.NewIdent("c", decls.NewListType(decls.Int), nil))
-c := checker.Check(p, env)
+c, errors := checker.Check(expr, src, env)
 if len(errors.GetErrors()) != 0 {
     return nil, fmt.Error(errors.ToDisplayString())
 }

--- a/checker/BUILD.bazel
+++ b/checker/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
     size = "small",
     srcs = [
         "checker_test.go",
+        "env_test.go",
     ],
     embed = [
         ":go_default_library",

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -18,10 +18,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/cel-go/common"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/packages"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
@@ -1003,8 +1002,8 @@ func TestCheck(t *testing.T) {
 		name := fmt.Sprintf("%d %s", i, tst.I)
 		t.Run(name, func(tt *testing.T) {
 
-			src := common.NewStringSource(tst.I, "<input>")
-			expression, errors := parser.Parse(src, parser.AllMacros)
+			src := common.NewTextSource(tst.I)
+			expression, errors := parser.Parse(src)
 			if len(errors.GetErrors()) > 0 {
 				tt.Fatalf("Unexpected parse errors: %v",
 					errors.ToDisplayString())

--- a/checker/env_test.go
+++ b/checker/env_test.go
@@ -1,0 +1,63 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/overloads"
+	"github.com/google/cel-go/common/packages"
+	"github.com/google/cel-go/common/types"
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+func TestOverlappingIdentifier(t *testing.T) {
+	env := NewStandardEnv(packages.DefaultPackage, types.NewProvider())
+	err := env.Add(
+		decls.NewIdent("int", decls.NewTypeType(nil), nil))
+	if err == nil {
+		t.Error("Got nil, wanted error")
+	} else if !strings.Contains(err.Error(), "overlapping identifier") {
+		t.Errorf("Got %v, wanted overlapping identifier error", err)
+	}
+}
+
+func TestOverlappingMacro(t *testing.T) {
+	env := NewStandardEnv(packages.DefaultPackage, types.NewProvider())
+	err := env.Add(decls.NewFunction("has",
+		decls.NewOverload("has", []*exprpb.Type{decls.String}, decls.Bool)))
+	if err == nil {
+		t.Error("Got nil, wanted error")
+	} else if !strings.Contains(err.Error(), "overlapping macro") {
+		t.Errorf("Got %v, wanted overlapping macro error", err)
+	}
+}
+
+func TestOverlappingOverload(t *testing.T) {
+	env := NewStandardEnv(packages.DefaultPackage, types.NewProvider())
+	paramA := decls.NewTypeParamType("A")
+	typeParamAList := []string{"A"}
+	err := env.Add(decls.NewFunction(overloads.TypeConvertDyn,
+		decls.NewParameterizedOverload(overloads.ToDyn,
+			[]*exprpb.Type{paramA}, decls.Dyn,
+			typeParamAList)))
+	if err == nil {
+		t.Error("Got nil, wanted error")
+	} else if !strings.Contains(err.Error(), "overlapping overload") {
+		t.Errorf("Got %v, wanted overlapping overload error", err)
+	}
+}

--- a/common/source.go
+++ b/common/source.go
@@ -71,6 +71,11 @@ type sourceImpl struct {
 // within the UTF-8 encoded string.  It currently indexes bytes.
 // Can be accomplished by using rune[] instead of string for contents.
 
+// NewTextSource creates a new Source from the input text string.
+func NewTextSource(text string) Source {
+	return NewStringSource(text, "<input>")
+}
+
 // NewStringSource creates a new Source from the given contents and description.
 func NewStringSource(contents string, description string) Source {
 	// Compute line offsets up front as they are referred to frequently.

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -18,6 +18,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/cel-go/common"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/common/packages"
@@ -167,16 +169,20 @@ func TestInterpreter_LogicalOrEquals(t *testing.T) {
 }
 
 func TestInterpreter_BuildObject(t *testing.T) {
-	parsed, errors := parser.ParseText("v1alpha1.Expr{id: 1, " +
-		"const_expr: v1alpha1.Constant{string_value: \"oneof_test\"}}")
+	src := common.NewStringSource(
+		"v1alpha1.Expr{id: 1, "+
+			"const_expr: v1alpha1.Constant{ "+
+			"string_value: \"oneof_test\"}}",
+		"<input>")
+	parsed, errors := parser.Parse(src, parser.AllMacros)
 	if len(errors.GetErrors()) != 0 {
 		t.Errorf(errors.ToDisplayString())
 	}
 
 	pkgr := packages.NewPackage("google.api.expr")
 	provider := types.NewProvider(&exprpb.Expr{})
-	env := checker.NewStandardEnv(pkgr, provider, errors)
-	checked := checker.Check(parsed, env)
+	env := checker.NewStandardEnv(pkgr, provider)
+	checked, errors := checker.Check(parsed, src, env)
 	if len(errors.GetErrors()) != 0 {
 		t.Errorf(errors.ToDisplayString())
 	}
@@ -197,7 +203,9 @@ func TestInterpreter_BuildObject(t *testing.T) {
 }
 
 func TestInterpreter_ConstantReturnValue(t *testing.T) {
-	parsed, err := parser.ParseText("1")
+	parsed, err := parser.Parse(
+		common.NewStringSource("1", "<input>"),
+		parser.AllMacros)
 	if len(err.GetErrors()) != 0 {
 		t.Error(err)
 	}
@@ -210,7 +218,9 @@ func TestInterpreter_ConstantReturnValue(t *testing.T) {
 }
 
 func TestInterpreter_InList(t *testing.T) {
-	parsed, err := parser.ParseText("1 in [1, 2, 3]")
+	parsed, err := parser.Parse(
+		common.NewStringSource("1 in [1, 2, 3]", "<input>"),
+		parser.AllMacros)
 	if len(err.GetErrors()) != 0 {
 		t.Error(err)
 	}
@@ -223,7 +233,9 @@ func TestInterpreter_InList(t *testing.T) {
 }
 
 func TestInterpreter_BuildMap(t *testing.T) {
-	parsed, err := parser.ParseText("{'b': '''hi''', 'c': name}")
+	parsed, err := parser.Parse(
+		common.NewStringSource("{'b': '''hi''', 'c': name}", "<input>"),
+		parser.AllMacros)
 	if len(err.GetErrors()) != 0 {
 		t.Error(err)
 	}
@@ -239,7 +251,9 @@ func TestInterpreter_BuildMap(t *testing.T) {
 }
 
 func TestInterpreter_MapIndex(t *testing.T) {
-	parsed, err := parser.ParseText("{'a':1}['a']")
+	parsed, err := parser.Parse(
+		common.NewStringSource("{'a':1}['a']", "<input>"),
+		parser.AllMacros)
 	if len(err.GetErrors()) != 0 {
 		t.Error(err)
 	}

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -169,12 +169,11 @@ func TestInterpreter_LogicalOrEquals(t *testing.T) {
 }
 
 func TestInterpreter_BuildObject(t *testing.T) {
-	src := common.NewStringSource(
-		"v1alpha1.Expr{id: 1, "+
-			"const_expr: v1alpha1.Constant{ "+
-			"string_value: \"oneof_test\"}}",
-		"<input>")
-	parsed, errors := parser.Parse(src, parser.AllMacros)
+	src := common.NewTextSource(
+		"v1alpha1.Expr{id: 1, " +
+			"const_expr: v1alpha1.Constant{ " +
+			"string_value: \"oneof_test\"}}")
+	parsed, errors := parser.Parse(src)
 	if len(errors.GetErrors()) != 0 {
 		t.Errorf(errors.ToDisplayString())
 	}
@@ -203,9 +202,7 @@ func TestInterpreter_BuildObject(t *testing.T) {
 }
 
 func TestInterpreter_ConstantReturnValue(t *testing.T) {
-	parsed, err := parser.Parse(
-		common.NewStringSource("1", "<input>"),
-		parser.AllMacros)
+	parsed, err := parser.Parse(common.NewTextSource("1"))
 	if len(err.GetErrors()) != 0 {
 		t.Error(err)
 	}
@@ -218,9 +215,7 @@ func TestInterpreter_ConstantReturnValue(t *testing.T) {
 }
 
 func TestInterpreter_InList(t *testing.T) {
-	parsed, err := parser.Parse(
-		common.NewStringSource("1 in [1, 2, 3]", "<input>"),
-		parser.AllMacros)
+	parsed, err := parser.Parse(common.NewTextSource("1 in [1, 2, 3]"))
 	if len(err.GetErrors()) != 0 {
 		t.Error(err)
 	}
@@ -233,9 +228,7 @@ func TestInterpreter_InList(t *testing.T) {
 }
 
 func TestInterpreter_BuildMap(t *testing.T) {
-	parsed, err := parser.Parse(
-		common.NewStringSource("{'b': '''hi''', 'c': name}", "<input>"),
-		parser.AllMacros)
+	parsed, err := parser.Parse(common.NewTextSource("{'b': '''hi''', 'c': name}"))
 	if len(err.GetErrors()) != 0 {
 		t.Error(err)
 	}
@@ -251,9 +244,7 @@ func TestInterpreter_BuildMap(t *testing.T) {
 }
 
 func TestInterpreter_MapIndex(t *testing.T) {
-	parsed, err := parser.Parse(
-		common.NewStringSource("{'a':1}['a']", "<input>"),
-		parser.AllMacros)
+	parsed, err := parser.Parse(common.NewTextSource("{'a':1}['a']"))
 	if len(err.GetErrors()) != 0 {
 		t.Error(err)
 	}

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -30,13 +30,13 @@ func (e *parseErrors) syntaxError(l common.Location, message string) {
 }
 
 func (e *parseErrors) invalidHasArgument(l common.Location) {
-	e.ReportError(l, "The argument to the function 'has' must be a field selection")
+	e.ReportError(l, "Argument to the function 'has' must be a field selection")
 }
 
 func (e *parseErrors) argumentIsNotIdent(l common.Location) {
-	e.ReportError(l, "The argument must be a simple name")
+	e.ReportError(l, "Argument must be a simple name")
 }
 
 func (e *parseErrors) notAQualifiedName(l common.Location) {
-	e.ReportError(l, "expected a qualified name")
+	e.ReportError(l, "Expected a qualified name")
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -30,21 +30,6 @@ import (
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
-// ParseText converts a text input into a parsed expression, if valid, as
-// well as a list of syntax errors encountered.
-//
-// By default all macros are enabled. For customization of the input data
-// or for customization of the macro set see Parse.
-//
-// Note: syntax errors may produce parse trees of unusual shape which could
-// in segfaults at parse-time. While the code attempts to account for all
-// such cases, it is possible a few still remain. These should be fixed by
-// adding a repro case to the parser_test.go and appropriate defensive coding
-// within the parser.
-func ParseText(text string) (*exprpb.ParsedExpr, *common.Errors) {
-	return Parse(common.NewStringSource(text, "<input>"), AllMacros)
-}
-
 // Parse converts a source input and macros set to a parsed expression.
 func Parse(source common.Source, macros Macros) (*exprpb.ParsedExpr, *common.Errors) {
 	p := parser{helper: newParserHelper(source, macros)}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -30,19 +30,35 @@ import (
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
-// Parse converts a source input and macros set to a parsed expression.
-func Parse(source common.Source, macros Macros) (*exprpb.ParsedExpr, *common.Errors) {
-	p := parser{helper: newParserHelper(source, macros)}
+// Parse converts a source input a parsed expression.
+// This function calls ParseWithMacros with AllMacros.
+func Parse(source common.Source) (*exprpb.ParsedExpr, *common.Errors) {
+	return ParseWithMacros(source, AllMacros)
+}
+
+// ParseWithMacros converts a source input and macros set to a parsed expression.
+func ParseWithMacros(source common.Source, macros Macros) (*exprpb.ParsedExpr, *common.Errors) {
+	macroMap := make(map[string]Macro)
+	for _, m := range macros {
+		macroMap[makeMacroKey(m.name, m.args, m.instanceStyle)] = m
+	}
+	p := parser{
+		errors: &parseErrors{common.NewErrors(source)},
+		helper: newParserHelper(source),
+		macros: macroMap,
+	}
 	e := p.parse(source.Content())
 	return &exprpb.ParsedExpr{
 		Expr:       e,
 		SourceInfo: p.helper.getSourceInfo(),
-	}, p.helper.errors.Errors
+	}, p.errors.Errors
 }
 
 type parser struct {
 	gen.BaseCELVisitor
+	errors *parseErrors
 	helper *parserHelper
+	macros map[string]Macro
 }
 
 var _ gen.CELVisitor = (*parser)(nil)
@@ -54,15 +70,14 @@ func (p *parser) parse(expression string) *exprpb.Expr {
 
 	lexer.RemoveErrorListeners()
 	prsr.RemoveErrorListeners()
-	lexer.AddErrorListener(p.helper)
-	prsr.AddErrorListener(p.helper)
+	lexer.AddErrorListener(p)
+	prsr.AddErrorListener(p)
 
 	return p.Visit(prsr.Start()).(*exprpb.Expr)
 }
 
 // Visitor implementations.
 func (p *parser) Visit(tree antlr.ParseTree) interface{} {
-
 	switch tree.(type) {
 	case *gen.StartContext:
 		return p.VisitStart(tree.(*gen.StartContext))
@@ -115,7 +130,7 @@ func (p *parser) VisitExpr(ctx *gen.ExprContext) interface{} {
 
 	ifTrue := p.Visit(ctx.GetE1()).(*exprpb.Expr)
 	ifFalse := p.Visit(ctx.GetE2()).(*exprpb.Expr)
-	return p.helper.newGlobalCall(ctx.GetOp(), operators.Conditional, result, ifTrue, ifFalse)
+	return p.globalCallOrMacro(ctx.GetOp(), operators.Conditional, result, ifTrue, ifFalse)
 }
 
 // Visit a parse tree produced by CELParser#conditionalOr.
@@ -126,7 +141,7 @@ func (p *parser) VisitConditionalOr(ctx *gen.ConditionalOrContext) interface{} {
 	}
 	for i, op := range ctx.GetOps() {
 		next := p.Visit(ctx.GetE1()[i]).(*exprpb.Expr)
-		result = p.helper.newGlobalCall(op, operators.LogicalOr, result, next)
+		result = p.globalCallOrMacro(op, operators.LogicalOr, result, next)
 	}
 	return result
 }
@@ -139,7 +154,7 @@ func (p *parser) VisitConditionalAnd(ctx *gen.ConditionalAndContext) interface{}
 	}
 	for i, op := range ctx.GetOps() {
 		next := p.Visit(ctx.GetE1()[i]).(*exprpb.Expr)
-		result = p.helper.newGlobalCall(op, operators.LogicalAnd, result, next)
+		result = p.globalCallOrMacro(op, operators.LogicalAnd, result, next)
 	}
 	return result
 }
@@ -157,9 +172,9 @@ func (p *parser) VisitRelation(ctx *gen.RelationContext) interface{} {
 	if op, found := operators.Find(opText); found {
 		lhs := p.Visit(ctx.Relation(0)).(*exprpb.Expr)
 		rhs := p.Visit(ctx.Relation(1)).(*exprpb.Expr)
-		return p.helper.newGlobalCall(ctx.GetOp(), op, lhs, rhs)
+		return p.globalCallOrMacro(ctx.GetOp(), op, lhs, rhs)
 	}
-	return p.helper.reportError(ctx, "operator not found")
+	return p.reportError(ctx, "operator not found")
 }
 
 // Visit a parse tree produced by CELParser#calc.
@@ -174,9 +189,9 @@ func (p *parser) VisitCalc(ctx *gen.CalcContext) interface{} {
 	if op, found := operators.Find(opText); found {
 		lhs := p.Visit(ctx.Calc(0)).(*exprpb.Expr)
 		rhs := p.Visit(ctx.Calc(1)).(*exprpb.Expr)
-		return p.helper.newGlobalCall(ctx.GetOp(), op, lhs, rhs)
+		return p.globalCallOrMacro(ctx.GetOp(), op, lhs, rhs)
 	}
-	return p.helper.reportError(ctx, "operator not found")
+	return p.reportError(ctx, "operator not found")
 }
 
 func (p *parser) VisitUnary(ctx *gen.UnaryContext) interface{} {
@@ -195,7 +210,7 @@ func (p *parser) VisitMemberExpr(ctx *gen.MemberExprContext) interface{} {
 	case *gen.CreateMessageContext:
 		return p.VisitCreateMessage(ctx.Member().(*gen.CreateMessageContext))
 	}
-	return p.helper.reportError(ctx, "unsupported simple expression")
+	return p.reportError(ctx, "unsupported simple expression")
 }
 
 // Visit a parse tree produced by CELParser#LogicalNot.
@@ -204,7 +219,7 @@ func (p *parser) VisitLogicalNot(ctx *gen.LogicalNotContext) interface{} {
 		return p.Visit(ctx.Member())
 	}
 	target := p.Visit(ctx.Member()).(*exprpb.Expr)
-	return p.helper.newGlobalCall(ctx.GetOps()[0], operators.LogicalNot, target)
+	return p.globalCallOrMacro(ctx.GetOps()[0], operators.LogicalNot, target)
 }
 
 func (p *parser) VisitNegate(ctx *gen.NegateContext) interface{} {
@@ -212,7 +227,7 @@ func (p *parser) VisitNegate(ctx *gen.NegateContext) interface{} {
 		return p.Visit(ctx.Member())
 	}
 	target := p.Visit(ctx.Member()).(*exprpb.Expr)
-	return p.helper.newGlobalCall(ctx.GetOps()[0], operators.Negate, target)
+	return p.globalCallOrMacro(ctx.GetOps()[0], operators.Negate, target)
 }
 
 // Visit a parse tree produced by CELParser#SelectOrCall.
@@ -224,7 +239,7 @@ func (p *parser) VisitSelectOrCall(ctx *gen.SelectOrCallContext) interface{} {
 	}
 	id := ctx.GetId().GetText()
 	if ctx.GetOpen() != nil {
-		return p.helper.newMemberCall(ctx.GetOpen(), id, operand, p.visitList(ctx.GetArgs())...)
+		return p.memberCallOrMacro(ctx.GetOpen(), id, operand, p.visitList(ctx.GetArgs())...)
 	}
 	return p.helper.newSelect(ctx.GetOp(), operand, id)
 }
@@ -244,14 +259,14 @@ func (p *parser) VisitPrimaryExpr(ctx *gen.PrimaryExprContext) interface{} {
 		return p.VisitConstantLiteral(ctx.Primary().(*gen.ConstantLiteralContext))
 	}
 
-	return p.helper.reportError(ctx, "invalid primary expression")
+	return p.reportError(ctx, "invalid primary expression")
 }
 
 // Visit a parse tree produced by CELParser#Index.
 func (p *parser) VisitIndex(ctx *gen.IndexContext) interface{} {
 	target := p.Visit(ctx.Member()).(*exprpb.Expr)
 	index := p.Visit(ctx.GetIndex()).(*exprpb.Expr)
-	return p.helper.newGlobalCall(ctx.GetOp(), operators.Index, target, index)
+	return p.globalCallOrMacro(ctx.GetOp(), operators.Index, target, index)
 }
 
 // Visit a parse tree produced by CELParser#CreateMessage.
@@ -291,7 +306,7 @@ func (p *parser) VisitIdentOrGlobalCall(ctx *gen.IdentOrGlobalCallContext) inter
 	identName += ctx.GetId().GetText()
 
 	if ctx.GetOp() != nil {
-		return p.helper.newGlobalCall(ctx.GetOp(), identName, p.visitList(ctx.GetArgs())...)
+		return p.globalCallOrMacro(ctx.GetOp(), identName, p.visitList(ctx.GetArgs())...)
 	}
 	return p.helper.newIdent(ctx.GetId(), identName)
 }
@@ -335,7 +350,7 @@ func (p *parser) VisitConstantLiteral(ctx *gen.ConstantLiteralContext) interface
 	case *gen.NullContext:
 		return p.VisitNull(ctx.Literal().(*gen.NullContext))
 	}
-	return p.helper.reportError(ctx, "invalid literal")
+	return p.reportError(ctx, "invalid literal")
 }
 
 // Visit a parse tree produced by CELParser#exprList.
@@ -376,7 +391,7 @@ func (p *parser) VisitInt(ctx *gen.IntContext) interface{} {
 	}
 	i, err := strconv.ParseInt(text, 10, 64)
 	if err != nil {
-		return p.helper.reportError(ctx, "invalid int literal")
+		return p.reportError(ctx, "invalid int literal")
 	}
 	return p.helper.newLiteralInt(ctx, i)
 }
@@ -388,7 +403,7 @@ func (p *parser) VisitUint(ctx *gen.UintContext) interface{} {
 	text = text[:len(text)-1]
 	i, err := strconv.ParseUint(text, 10, 64)
 	if err != nil {
-		return p.helper.reportError(ctx, "invalid uint literal")
+		return p.reportError(ctx, "invalid uint literal")
 	}
 	return p.helper.newLiteralUint(ctx, i)
 }
@@ -401,7 +416,7 @@ func (p *parser) VisitDouble(ctx *gen.DoubleContext) interface{} {
 	}
 	f, err := strconv.ParseFloat(txt, 64)
 	if err != nil {
-		return p.helper.reportError(ctx, "invalid double literal")
+		return p.reportError(ctx, "invalid double literal")
 	}
 	return p.helper.newLiteralDouble(ctx, f)
 
@@ -472,15 +487,81 @@ func (p *parser) extractQualifiedName(e *exprpb.Expr) (string, bool) {
 	}
 	// TODO: Add a method to Source to get location from character offset.
 	location := p.helper.getLocation(e.Id)
-	p.helper.reportError(location, "expected a qualified name")
+	p.reportError(location, "expected a qualified name")
 	return "", false
 }
 
 func (p *parser) unquote(ctx interface{}, value string) string {
 	text, err := unescape(value)
 	if err != nil {
-		p.helper.reportError(ctx, err.Error())
+		p.reportError(ctx, err.Error())
 		return value
 	}
 	return text
+}
+
+func (p *parser) reportError(ctx interface{}, format string, args ...interface{}) *exprpb.Expr {
+	var location common.Location
+	switch ctx.(type) {
+	case common.Location:
+		location = ctx.(common.Location)
+	case antlr.Token, antlr.ParserRuleContext:
+		err := p.helper.newExpr(ctx)
+		location = p.helper.getLocation(err.Id)
+	}
+	err := p.helper.newExpr(ctx)
+	// Provide arguments to the report error.
+	p.errors.ReportError(location, format, args...)
+	return err
+}
+
+// ANTLR Parse listener implementations
+func (p *parser) SyntaxError(recognizer antlr.Recognizer, offendingSymbol interface{}, line, column int, msg string, e antlr.RecognitionException) {
+	// TODO: Snippet
+	l := common.NewLocation(line, column)
+	p.errors.syntaxError(l, msg)
+}
+
+func (p *parser) ReportAmbiguity(recognizer antlr.Parser, dfa *antlr.DFA, startIndex, stopIndex int, exact bool, ambigAlts *antlr.BitSet, configs antlr.ATNConfigSet) {
+	// Intentional
+}
+
+func (p *parser) ReportAttemptingFullContext(recognizer antlr.Parser, dfa *antlr.DFA, startIndex, stopIndex int, conflictingAlts *antlr.BitSet, configs antlr.ATNConfigSet) {
+	// Intentional
+}
+
+func (p *parser) ReportContextSensitivity(recognizer antlr.Parser, dfa *antlr.DFA, startIndex, stopIndex, prediction int, configs antlr.ATNConfigSet) {
+	// Intentional
+}
+
+func (p *parser) globalCallOrMacro(ctx interface{}, function string, args ...*exprpb.Expr) *exprpb.Expr {
+	if expr, found := p.expandMacro(ctx, function, nil, args...); found {
+		return expr
+	}
+	return p.helper.newGlobalCall(ctx, function, args...)
+}
+
+func (p *parser) memberCallOrMacro(ctx interface{}, function string, target *exprpb.Expr, args ...*exprpb.Expr) *exprpb.Expr {
+	if expr, found := p.expandMacro(ctx, function, target, args...); found {
+		return expr
+	}
+	return p.helper.newMemberCall(ctx, function, target, args...)
+}
+
+func (p *parser) expandMacro(ctx interface{}, function string, target *exprpb.Expr, args ...*exprpb.Expr) (*exprpb.Expr, bool) {
+	if macro, found := p.macros[makeMacroKey(function, len(args), target != nil)]; found {
+		expr, err := macro.expander(p.helper, ctx, target, args)
+		if err != nil {
+			if err.Location != nil {
+				return p.reportError(err.Location, err.Message), true
+			}
+			return p.reportError(ctx, err.Message), true
+		}
+		return expr, true
+	}
+	return nil, false
+}
+
+func makeMacroKey(name string, args int, instanceStyle bool) string {
+	return fmt.Sprintf("%s:%d:%v", name, args, instanceStyle)
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -761,12 +761,13 @@ func (l *locationAdorner) GetMetadata(elem interface{}) string {
 	return fmt.Sprintf("^#%d[%d,%d]#", elemID, location.Line(), location.Column())
 }
 
-func Test(t *testing.T) {
+func TestParse(t *testing.T) {
 	for i, tst := range testCases {
 		name := fmt.Sprintf("%d %s", i, tst.I)
 		t.Run(name, func(tt *testing.T) {
 
-			expression, errors := ParseText(tst.I)
+			src := common.NewStringSource(tst.I, "<input>")
+			expression, errors := Parse(src, AllMacros)
 			if len(errors.GetErrors()) > 0 {
 				actualErr := errors.ToDisplayString()
 				if tst.E == "" {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -766,8 +766,8 @@ func TestParse(t *testing.T) {
 		name := fmt.Sprintf("%d %s", i, tst.I)
 		t.Run(name, func(tt *testing.T) {
 
-			src := common.NewStringSource(tst.I, "<input>")
-			expression, errors := Parse(src, AllMacros)
+			src := common.NewTextSource(tst.I)
+			expression, errors := Parse(src)
 			if len(errors.GetErrors()) > 0 {
 				actualErr := errors.ToDisplayString()
 				if tst.E == "" {

--- a/server/server.go
+++ b/server/server.go
@@ -62,15 +62,15 @@ func (s *CelServer) Check(ctx context.Context, in *exprpb.CheckRequest) (*exprpb
 	}
 	pkg := packages.NewPackage(in.Container)
 	typeProvider := types.NewProvider()
-	errs := common.NewErrors(common.NewInfoSource(in.ParsedExpr.SourceInfo))
+	srcInfo := common.NewInfoSource(in.ParsedExpr.SourceInfo)
 	var env *checker.Env
 	if in.NoStdEnv {
-		env = checker.NewEnv(pkg, typeProvider, errs)
+		env = checker.NewEnv(pkg, typeProvider)
 	} else {
-		env = checker.NewStandardEnv(pkg, typeProvider, errs)
+		env = checker.NewStandardEnv(pkg, typeProvider)
 	}
 	env.Add(in.TypeEnv...)
-	c := checker.Check(in.ParsedExpr, env)
+	c, errs := checker.Check(in.ParsedExpr, srcInfo, env)
 	resp := exprpb.CheckResponse{}
 	if len(errs.GetErrors()) == 0 {
 		// Success

--- a/server/server.go
+++ b/server/server.go
@@ -38,7 +38,7 @@ func (s *CelServer) Parse(ctx context.Context, in *exprpb.ParseRequest) (*exprpb
 	} else {
 		macs = parser.AllMacros
 	}
-	pexpr, errs := parser.Parse(src, macs)
+	pexpr, errs := parser.ParseWithMacros(src, macs)
 	resp := exprpb.ParseResponse{}
 	if len(errs.GetErrors()) == 0 {
 		// Success


### PR DESCRIPTION
#55 Sharing `common.Errors` between the `parser` and `checker` is confusing and hampers
the use of CEL in applications which might want to parse, check, and evaluate multiple expressions
concurrently. This CL removes `common.Errors` from the `Env` struct and isolates the use of the
`common.Errors` objects to `checker.go` and `parser.go` files only.

Note: This PR does not attempt to unify the use of a standard environment for use in all CEL
execution phases. Per #55, it should be possible to create and share an `Env` value for multiple
purposes thus simplifying setup and reducing the boilerplate present in the `README.md`

