### PR TITLE
Check time support for JSON and well-known types.

### DIFF
--- a/checker/BUILD.bazel
+++ b/checker/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//common/packages:go_default_library",
         "//common/types:go_default_library",
         "//common/types/ref:go_default_library",
+        "//common/types/pb:go_default_library",
         "//parser:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@io_bazel_rules_go//proto/wkt:empty_go_proto",

--- a/checker/decls/decls.go
+++ b/checker/decls/decls.go
@@ -2,7 +2,7 @@
 package decls
 
 import (
-	"github.com/golang/protobuf/ptypes/struct"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 
 	emptypb "github.com/golang/protobuf/ptypes/empty"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
@@ -40,6 +40,16 @@ var (
 	Duration  = NewWellKnownType(exprpb.Type_DURATION)
 	Timestamp = NewWellKnownType(exprpb.Type_TIMESTAMP)
 )
+
+// NewAbstractType creates an abstract type declaration which references a proto
+// message name and may also include type parameters.
+func NewAbstractType(name string, paramTypes ...*exprpb.Type) *exprpb.Type {
+	return &exprpb.Type{
+		TypeKind: &exprpb.Type_AbstractType_{
+			AbstractType: &exprpb.Type_AbstractType{
+				Name:           name,
+				ParameterTypes: paramTypes}}}
+}
 
 // NewFunctionType creates a function invocation contract, typically only used
 // by type-checking steps after overload resolution.

--- a/checker/env.go
+++ b/checker/env.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/packages"
 	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/pb"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/parser"
 
@@ -28,8 +29,8 @@ import (
 )
 
 // Env is the environment for type checking.
-// It consists of a Packager, a Type Provider, declarations,
-// and collection of errors encountered during checking.
+// It consists of a Packager, a Type Provider, declarations, and collection of errors encountered
+// during checking.
 type Env struct {
 	packager     packages.Packager
 	typeProvider ref.TypeProvider
@@ -68,12 +69,55 @@ func (e *Env) Add(decls ...*exprpb.Decl) error {
 	for _, decl := range decls {
 		switch decl.DeclKind.(type) {
 		case *exprpb.Decl_Ident:
-			errMsgs = append(errMsgs, e.addIdent(decl))
+			errMsgs = append(errMsgs, e.addIdent(sanitizeIdent(decl)))
 		case *exprpb.Decl_Function:
-			errMsgs = append(errMsgs, e.addFunction(decl)...)
+			errMsgs = append(errMsgs, e.addFunction(sanitizeFunction(decl))...)
 		}
 	}
 	return formatError(errMsgs)
+}
+
+// LookupIdent returns a Decl proto for typeName as an identifier in the Env.
+// Returns nil if no such identifier is found in the Env.
+func (e *Env) LookupIdent(typeName string) *exprpb.Decl {
+	for _, candidate := range e.packager.ResolveCandidateNames(typeName) {
+		if ident := e.declarations.FindIdent(candidate); ident != nil {
+			return ident
+		}
+
+		// Next try to import the name as a reference to a message type. If found,
+		// the declaration is added to the outest (global) scope of the
+		// environment, so next time we can access it faster.
+		if t, found := e.typeProvider.FindType(candidate); found {
+			decl := decls.NewIdent(candidate, t, nil)
+			e.declarations.AddIdent(decl)
+			return decl
+		}
+
+		// Next try to import this as an enum value by splitting the name in a type prefix and
+		// the enum inside.
+		if enumValue := e.typeProvider.EnumValue(candidate); enumValue.Type() != types.ErrType {
+			decl := decls.NewIdent(candidate,
+				decls.Int,
+				&exprpb.Constant{
+					ConstantKind: &exprpb.Constant_Int64Value{
+						Int64Value: int64(enumValue.(types.Int))}})
+			e.declarations.AddIdent(decl)
+			return decl
+		}
+	}
+	return nil
+}
+
+// LookupFunction returns a Decl proto for typeName as a function in env.
+// Returns nil if no such function is found in env.
+func (e *Env) LookupFunction(typeName string) *exprpb.Decl {
+	for _, candidate := range e.packager.ResolveCandidateNames(typeName) {
+		if fn := e.declarations.FindFunction(candidate); fn != nil {
+			return fn
+		}
+	}
+	return nil
 }
 
 // addOverload adds overload to function declaration f.
@@ -142,57 +186,104 @@ func (e *Env) addIdent(decl *exprpb.Decl) errorMsg {
 	return ""
 }
 
-// LookupIdent returns a Decl proto for typeName as an identifier in the Env.
-// Returns nil if no such identifier is found in the Env.
-func (e *Env) LookupIdent(typeName string) *exprpb.Decl {
-	for _, candidate := range e.packager.ResolveCandidateNames(typeName) {
-		if ident := e.declarations.FindIdent(candidate); ident != nil {
-			return ident
+// sanitizeFunction replaces well-known types referenced by message name with their equivalent
+// CEL built-in type instances.
+func sanitizeFunction(decl *exprpb.Decl) *exprpb.Decl {
+	fn := decl.GetFunction()
+	// Determine whether the declaration requires replacements from proto-based message type
+	// references to well-known CEL type references.
+	var needsSanitizing bool
+	for _, o := range fn.GetOverloads() {
+		if isObjectWellKnownType(o.GetResultType()) {
+			needsSanitizing = true
+			break
 		}
-
-		// Next try to import the name as a reference to a message type. If found,
-		// the declaration is added to the outest (global) scope of the
-		// environment, so next time we can access it faster.
-		if t, found := e.typeProvider.FindType(candidate); found {
-			decl := decls.NewIdent(candidate, t, nil)
-			e.declarations.AddIdent(decl)
-			return decl
-		}
-
-		// Next try to import this as an enum value by splitting the name in a type prefix and
-		// the enum inside.
-		if enumValue := e.typeProvider.EnumValue(candidate); enumValue.Type() != types.ErrType {
-			decl := decls.NewIdent(candidate,
-				decls.Int,
-				&exprpb.Constant{
-					ConstantKind: &exprpb.Constant_Int64Value{
-						Int64Value: int64(enumValue.(types.Int))}})
-			e.declarations.AddIdent(decl)
-			return decl
+		for _, p := range o.GetParams() {
+			if isObjectWellKnownType(p) {
+				needsSanitizing = true
+				break
+			}
 		}
 	}
-	return nil
-}
 
-// LookupFunction returns a Decl proto for typeName as a function in env.
-// Returns nil if no such function is found in env.
-func (e *Env) LookupFunction(typeName string) *exprpb.Decl {
-	for _, candidate := range e.packager.ResolveCandidateNames(typeName) {
-		if fn := e.declarations.FindFunction(candidate); fn != nil {
-			return fn
+	// Early return if the declaration requires no modification.
+	if !needsSanitizing {
+		return decl
+	}
+
+	// Sanitize all of the overloads if any overload requires an update to its type references.
+	overloads := make([]*exprpb.Decl_FunctionDecl_Overload, 0, len(fn.GetOverloads()))
+	for i, o := range fn.GetOverloads() {
+		var sanitized bool
+		rt := o.GetResultType()
+		if isObjectWellKnownType(rt) {
+			rt = getObjectWellKnownType(rt)
+			sanitized = true
+		}
+		params := make([]*exprpb.Type, 0, len(o.GetParams()))
+		copy(params, o.GetParams())
+		for j, p := range params {
+			if isObjectWellKnownType(p) {
+				params[j] = getObjectWellKnownType(p)
+				sanitized = true
+			}
+		}
+		// If sanitized, replace the overload definition.
+		if sanitized {
+			if o.IsInstanceFunction {
+				overloads[i] =
+					decls.NewInstanceOverload(o.GetOverloadId(), params, rt)
+			} else {
+				overloads[i] =
+					decls.NewOverload(o.GetOverloadId(), params, rt)
+			}
+			// Otherwise, preserve the original overload.
+		} else {
+			overloads[i] = o
 		}
 	}
-	return nil
+	return decls.NewFunction(decl.GetName(), overloads...)
 }
 
+// sanitizeIdent replaces the identifier's well-known types referenced by message name with
+// references to CEL built-in type instances.
+func sanitizeIdent(decl *exprpb.Decl) *exprpb.Decl {
+	id := decl.GetIdent()
+	t := id.GetType()
+	if !isObjectWellKnownType(t) {
+		return decl
+	}
+	return decls.NewIdent(decl.GetName(), getObjectWellKnownType(t), id.GetValue())
+}
+
+// isObjectWellKnownType returns true if the input type is an OBJECT type with a message name
+// that corresponds the message name of a built-in CEL type.
+func isObjectWellKnownType(t *exprpb.Type) bool {
+	if kindOf(t) != kindObject {
+		return false
+	}
+	_, found := pb.CheckedWellKnowns[t.GetMessageType()]
+	return found
+}
+
+// getObjectWellKnownType returns the built-in CEL type declaration for input type's message name.
+func getObjectWellKnownType(t *exprpb.Type) *exprpb.Type {
+	return pb.CheckedWellKnowns[t.GetMessageType()]
+}
+
+// enterScope pushes a new declaration set onto the stack, to ensure variables
+// and function identifiers are appropriately shadowed / enclosed as needed.
 func (e *Env) enterScope() {
 	e.declarations.Push()
 }
 
+// exitScope pops the local declarations of the current frame.
 func (e *Env) exitScope() {
 	e.declarations.Pop()
 }
 
+// errorMsg is a type alias meant to represent error-based return values which
+// may be accumulated into an error at a later point in execution.
 type errorMsg string
 
 func overlappingIdentifierError(name string) errorMsg {

--- a/checker/env.go
+++ b/checker/env.go
@@ -237,8 +237,8 @@ func sanitizeFunction(decl *exprpb.Decl) *exprpb.Decl {
 				overloads[i] =
 					decls.NewOverload(o.GetOverloadId(), params, rt)
 			}
-			// Otherwise, preserve the original overload.
 		} else {
+			// Otherwise, preserve the original overload.
 			overloads[i] = o
 		}
 	}

--- a/checker/types.go
+++ b/checker/types.go
@@ -44,6 +44,22 @@ const (
 // FormatCheckedType converts a type message into a string representation.
 func FormatCheckedType(t *exprpb.Type) string {
 	switch kindOf(t) {
+	case kindDyn:
+		return "dyn"
+	case kindFunction:
+		return formatFunction(t.GetFunction().GetResultType(),
+			t.GetFunction().GetArgTypes(),
+			false)
+	case kindList:
+		return fmt.Sprintf("list(%s)", FormatCheckedType(t.GetListType().ElemType))
+	case kindObject:
+		return t.GetMessageType()
+	case kindMap:
+		return fmt.Sprintf("map(%s, %s)",
+			FormatCheckedType(t.GetMapType().KeyType),
+			FormatCheckedType(t.GetMapType().ValueType))
+	case kindNull:
+		return "null"
 	case kindPrimitive:
 		switch t.GetPrimitive() {
 		case exprpb.Type_UINT64:
@@ -52,63 +68,86 @@ func FormatCheckedType(t *exprpb.Type) string {
 			return "int"
 		}
 		return strings.Trim(strings.ToLower(t.GetPrimitive().String()), " ")
-	case kindFunction:
-		return formatFunction(t.GetFunction().GetResultType(),
-			t.GetFunction().GetArgTypes(),
-			false)
-	case kindWrapper:
-		return fmt.Sprintf("wrapper(%s)",
-			FormatCheckedType(decls.NewPrimitiveType(t.GetWrapper())))
-	case kindObject:
-		return t.GetMessageType()
-	case kindList:
-		return fmt.Sprintf("list(%s)", FormatCheckedType(t.GetListType().ElemType))
-	case kindMap:
-		return fmt.Sprintf("map(%s, %s)",
-			FormatCheckedType(t.GetMapType().KeyType),
-			FormatCheckedType(t.GetMapType().ValueType))
-	case kindNull:
-		return "null"
-	case kindDyn:
-		return "dyn"
 	case kindType:
 		if t.GetType() == nil {
 			return "type"
 		}
 		return fmt.Sprintf("type(%s)", FormatCheckedType(t.GetType()))
+	case kindWellKnown:
+		switch t.GetWellKnown() {
+		case exprpb.Type_ANY:
+			return "any"
+		case exprpb.Type_DURATION:
+			return "duration"
+		case exprpb.Type_TIMESTAMP:
+			return "timestamp"
+		}
+	case kindWrapper:
+		return fmt.Sprintf("wrapper(%s)",
+			FormatCheckedType(decls.NewPrimitiveType(t.GetWrapper())))
 	case kindError:
 		return "!error!"
 	}
 	return t.String()
 }
 
-/**
- * Check whether one type is equal or less specific than the other one. A type is less specific if
- * it matches the other type using the DYN type.
- */
+// isDyn returns true if the input t is either type DYN or a well-known ANY message.
+func isDyn(t *exprpb.Type) bool {
+	// Note: object type values that are well-known and map to a DYN value in practice
+	// are sanitized prior to being added to the environment.
+	switch kindOf(t) {
+	case kindDyn:
+		return true
+	case kindWellKnown:
+		return t.GetWellKnown() == exprpb.Type_ANY
+	default:
+		return false
+	}
+}
+
+// isDynOrError returns true if the input is either an Error, DYN, or well-known ANY message.
+func isDynOrError(t *exprpb.Type) bool {
+	switch kindOf(t) {
+	case kindError:
+		return true
+	default:
+		return isDyn(t)
+	}
+}
+
+// isEqualOrLessSpecific checks whether one type is equal or less specific than the other one.
+// A type is less specific if it matches the other type using the DYN type.
 func isEqualOrLessSpecific(t1 *exprpb.Type, t2 *exprpb.Type) bool {
 	kind1, kind2 := kindOf(t1), kindOf(t2)
 	// The first type is less specific.
-	if kind1 == kindDyn || kind1 == kindTypeParam {
+	if isDyn(t1) || kind1 == kindTypeParam {
 		return true
 	}
-	if kind2 == kindDyn || kind2 == kindTypeParam {
+	// The first type is not less specific.
+	if isDyn(t2) || kind2 == kindTypeParam {
 		return false
 	}
+	// Types must be of the same kind to be equal.
 	if kind1 != kind2 {
 		return false
 	}
 
+	// With limited exceptions for ANY and JSON values, the types must agree and be equivalent in
+	// order to return true.
 	switch kind1 {
-	case kindObject, kindPrimitive, kindWellKnown, kindWrapper:
-		return proto.Equal(t1, t2)
-	case kindList:
-		return isEqualOrLessSpecific(t1.GetListType().ElemType, t2.GetListType().ElemType)
-	case kindMap:
-		m1 := t1.GetMapType()
-		m2 := t2.GetMapType()
-		return isEqualOrLessSpecific(m1.KeyType, m2.KeyType) &&
-			isEqualOrLessSpecific(m1.KeyType, m2.KeyType)
+	case kindAbstract:
+		a1 := t1.GetAbstractType()
+		a2 := t2.GetAbstractType()
+		if a1.GetName() != a2.GetName() ||
+			len(a1.GetParameterTypes()) != len(a2.GetParameterTypes()) {
+			return false
+		}
+		for i, p1 := range a1.GetParameterTypes() {
+			if !isEqualOrLessSpecific(p1, a2.GetParameterTypes()[i]) {
+				return false
+			}
+		}
+		return true
 	case kindFunction:
 		fn1 := t1.GetFunction()
 		fn2 := t2.GetFunction()
@@ -124,23 +163,21 @@ func isEqualOrLessSpecific(t1 *exprpb.Type, t2 *exprpb.Type) bool {
 			}
 		}
 		return true
-	default:
+	case kindList:
+		return isEqualOrLessSpecific(t1.GetListType().ElemType, t2.GetListType().ElemType)
+	case kindMap:
+		m1 := t1.GetMapType()
+		m2 := t2.GetMapType()
+		return isEqualOrLessSpecific(m1.KeyType, m2.KeyType) &&
+			isEqualOrLessSpecific(m1.KeyType, m2.KeyType)
+	case kindType:
 		return true
+	default:
+		return proto.Equal(t1, t2)
 	}
 }
 
-func internalIsAssignableList(m *mapping, l1 []*exprpb.Type, l2 []*exprpb.Type) bool {
-	if len(l1) != len(l2) {
-		return false
-	}
-	for i, t1 := range l1 {
-		if !internalIsAssignable(m, t1, l2[i]) {
-			return false
-		}
-	}
-	return true
-}
-
+/// internalIsAssignable returns true if t1 is assignable to t2.
 func internalIsAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) bool {
 	// Process type parameters.
 	kind1, kind2 := kindOf(t1), kindOf(t2)
@@ -162,7 +199,6 @@ func internalIsAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) bool {
 			return true
 		}
 	}
-
 	if kind1 == kindTypeParam {
 		// For the lower type bound, we currently do not perform adjustment. The restricted
 		// way we use type parameters in lower type bounds, it is not necessary, but may
@@ -176,50 +212,129 @@ func internalIsAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) bool {
 		}
 	}
 
-	if kind1 == kindDyn || kind1 == kindError {
+	// Next check for wildcard types.
+	if isDynOrError(t1) || isDynOrError(t2) {
 		return true
-	}
-	if kind2 == kindDyn || kind2 == kindError {
-		return true
-	}
-	if kind1 == kindNull && isNullable(kind2) {
-		return true
-	}
-	// Unwrap box types
-	if kind1 == kindWrapper {
-		return internalIsAssignable(m, decls.NewPrimitiveType(t1.GetWrapper()), t2)
-	}
-	// Finally check equality and type args recursively.
-	if kind1 != kind2 {
-		return false
 	}
 
+	// Test for when the types do not need to agree, but are more specific than dyn.
 	switch kind1 {
-	case kindPrimitive, kindWellKnown, kindObject:
-		return proto.Equal(t1, t2)
-	case kindList:
-		return internalIsAssignable(m, t1.GetListType().ElemType, t2.GetListType().ElemType)
-	case kindMap:
-		m1 := t1.GetMapType()
-		m2 := t2.GetMapType()
-		return internalIsAssignableList(m,
-			[]*exprpb.Type{m1.KeyType, m1.ValueType},
-			[]*exprpb.Type{m2.KeyType, m2.ValueType})
+	case kindNull:
+		return internalIsAssignableNull(t2)
+	case kindPrimitive:
+		return internalIsAssignablePrimitive(t1.GetPrimitive(), t2)
+	case kindWrapper:
+		return internalIsAssignable(m, decls.NewPrimitiveType(t1.GetWrapper()), t2)
+	default:
+		if kind1 != kind2 {
+			return false
+		}
+	}
+
+	// Test for when the types must agree.
+	switch kind1 {
+	// ERROR, TYPE_PARAM, and DYN handled above.
+	case kindAbstract:
+		return internalIsAssignableAbstractType(m,
+			t1.GetAbstractType(), t2.GetAbstractType())
 	case kindFunction:
-		fn1 := t1.GetFunction()
-		fn2 := t2.GetFunction()
-		return internalIsAssignableList(m,
-			append(fn1.ArgTypes, fn1.ResultType),
-			append(fn2.ArgTypes, fn2.ResultType))
+		return internalIsAssignableFunction(m,
+			t1.GetFunction(), t2.GetFunction())
+	case kindList:
+		return internalIsAssignable(m,
+			t1.GetListType().GetElemType(),
+			t2.GetListType().GetElemType())
+	case kindMap:
+		return internalIsAssignableMap(m, t1.GetMapType(), t2.GetMapType())
+	case kindObject:
+		return t1.GetMessageType() == t2.GetMessageType()
 	case kindType:
 		// A type is a type is a type, any additional parameterization of the
 		// type cannot affect method resolution or assignability.
+		return true
+	case kindWellKnown:
+		return t1.GetWellKnown() == t2.GetWellKnown()
+	default:
+		return false
+	}
+}
+
+// internalIsAssignableAbstractType returns true if the abstract type names agree and all type
+// parameters are assignable.
+func internalIsAssignableAbstractType(m *mapping,
+	a1 *exprpb.Type_AbstractType,
+	a2 *exprpb.Type_AbstractType) bool {
+	if a1.GetName() != a2.GetName() {
+		return false
+	}
+	if internalIsAssignableList(m, a1.GetParameterTypes(), a2.GetParameterTypes()) {
+		return true
+	}
+	return false
+}
+
+// internalIsAssignableFunction returns true if the function return type and arg types are
+// assignable.
+func internalIsAssignableFunction(m *mapping,
+	f1 *exprpb.Type_FunctionType,
+	f2 *exprpb.Type_FunctionType) bool {
+	if internalIsAssignableList(m,
+		append(f1.GetArgTypes(), f1.GetResultType()),
+		append(f2.GetArgTypes(), f2.GetResultType())) {
+		return true
+	}
+	return false
+}
+
+// internalIsAssignableList returns true if the element types at each index in the list are
+// assignable from l1[i] to l2[i]. The list lengths must also agree for the lists to be
+// assignable.
+func internalIsAssignableList(m *mapping, l1 []*exprpb.Type, l2 []*exprpb.Type) bool {
+	if len(l1) != len(l2) {
+		return false
+	}
+	for i, t1 := range l1 {
+		if !internalIsAssignable(m, t1, l2[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// internalIsAssignableMap returns true if map m1 may be assigned to map m2.
+func internalIsAssignableMap(m *mapping, m1 *exprpb.Type_MapType, m2 *exprpb.Type_MapType) bool {
+	if internalIsAssignableList(m,
+		[]*exprpb.Type{m1.GetKeyType(), m1.GetValueType()},
+		[]*exprpb.Type{m2.GetKeyType(), m2.GetValueType()}) {
+		return true
+	}
+	return false
+}
+
+// internalIsAssignableNull returns true if the type is nullable.
+func internalIsAssignableNull(t *exprpb.Type) bool {
+	switch kindOf(t) {
+	case kindAbstract, kindObject, kindWellKnown, kindWrapper:
 		return true
 	default:
 		return false
 	}
 }
 
+// internalIsAssignablePrimitive returns true if the target type is the same or if it is a wrapper
+// for the primitive type.
+func internalIsAssignablePrimitive(p exprpb.Type_PrimitiveType, target *exprpb.Type) bool {
+	switch kindOf(target) {
+	case kindPrimitive:
+		return p == target.GetPrimitive()
+	case kindWrapper:
+		return p == target.GetWrapper()
+	default:
+		return false
+	}
+}
+
+// isAssignable returns an updated type substitution mapping if t1 is assignable to t2.
 func isAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) *mapping {
 	mCopy := m.copy()
 	if internalIsAssignable(mCopy, t1, t2) {
@@ -228,6 +343,7 @@ func isAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) *mapping {
 	return nil
 }
 
+// isAssignableList returns an updated type substitution mapping if l1 is assignable to l2.
 func isAssignableList(m *mapping, l1 []*exprpb.Type, l2 []*exprpb.Type) *mapping {
 	mCopy := m.copy()
 	if internalIsAssignableList(mCopy, l1, l2) {
@@ -236,15 +352,7 @@ func isAssignableList(m *mapping, l1 []*exprpb.Type, l2 []*exprpb.Type) *mapping
 	return nil
 }
 
-func isNullable(kind int) bool {
-	switch kind {
-	case kindObject, kindWrapper, kindWellKnown:
-		return true
-	default:
-		return false
-	}
-}
-
+// kindOf returns the kind of the type as defined in the checked.proto.
 func kindOf(t *exprpb.Type) int {
 	if t == nil || t.TypeKind == nil {
 		return kindUnknown
@@ -278,7 +386,7 @@ func kindOf(t *exprpb.Type) int {
 	return kindUnknown
 }
 
-/** Returns the more general of two types which are known to unify. */
+// mostGeneral returns the more general of two types which are known to unify.
 func mostGeneral(t1 *exprpb.Type, t2 *exprpb.Type) *exprpb.Type {
 	if isEqualOrLessSpecific(t1, t2) {
 		return t1
@@ -286,56 +394,22 @@ func mostGeneral(t1 *exprpb.Type, t2 *exprpb.Type) *exprpb.Type {
 	return t2
 }
 
-/**
- * Apply substitution to given type, replacing all direct and indirect occurrences of bound type
- * parameters. Unbound type parameters are replaced by DYN if typeParamToDyn is true.
- */
-func substitute(m *mapping, t *exprpb.Type, typeParamToDyn bool) *exprpb.Type {
-	if tSub, found := m.find(t); found {
-		return substitute(m, tSub, typeParamToDyn)
-	}
-	kind := kindOf(t)
-	if typeParamToDyn && kind == kindTypeParam {
-		return decls.Dyn
-	}
-	switch kind {
-	case kindType:
-		if t.GetType() != nil {
-			return decls.NewTypeType(substitute(m, t.GetType(), typeParamToDyn))
-		}
-		return t
-	case kindList:
-		return decls.NewListType(substitute(m, t.GetListType().ElemType, typeParamToDyn))
-	case kindMap:
-		mt := t.GetMapType()
-		return decls.NewMapType(substitute(m, mt.KeyType, typeParamToDyn),
-			substitute(m, mt.ValueType, typeParamToDyn))
-	case kindFunction:
-		fn := t.GetFunction()
-		rt := substitute(m, fn.ResultType, typeParamToDyn)
-		args := make([]*exprpb.Type, len(fn.ArgTypes))
-		for i, a := range fn.ArgTypes {
-			args[i] = substitute(m, a, typeParamToDyn)
-		}
-		return decls.NewFunctionType(rt, args...)
-	default:
-		return t
-	}
-}
-
+// notReferencedIn checks whether the type doesn't appear directly or transitively within the other
+// type. This is a standard requirement for type unification, commonly referred to as the "occurs
+// check".
 func notReferencedIn(t *exprpb.Type, withinType *exprpb.Type) bool {
 	if proto.Equal(t, withinType) {
 		return false
 	}
 	withinKind := kindOf(withinType)
 	switch withinKind {
-	case kindWrapper:
-		return notReferencedIn(t, decls.NewPrimitiveType(withinType.GetWrapper()))
-	case kindList:
-		return notReferencedIn(t, withinType.GetListType().ElemType)
-	case kindMap:
-		m := withinType.GetMapType()
-		return notReferencedIn(t, m.KeyType) && notReferencedIn(t, m.ValueType)
+	case kindAbstract:
+		for _, pt := range withinType.GetAbstractType().GetParameterTypes() {
+			if !notReferencedIn(t, pt) {
+				return false
+			}
+		}
+		return true
 	case kindFunction:
 		fn := withinType.GetFunction()
 		types := append(fn.ArgTypes, fn.ResultType)
@@ -345,8 +419,58 @@ func notReferencedIn(t *exprpb.Type, withinType *exprpb.Type) bool {
 			}
 		}
 		return true
+	case kindList:
+		return notReferencedIn(t, withinType.GetListType().ElemType)
+	case kindMap:
+		m := withinType.GetMapType()
+		return notReferencedIn(t, m.KeyType) && notReferencedIn(t, m.ValueType)
+	case kindWrapper:
+		return notReferencedIn(t, decls.NewPrimitiveType(withinType.GetWrapper()))
 	default:
 		return true
+	}
+}
+
+// substitute replaces all direct and indirect occurrences of bound type parameters. Unbound type
+// parameters are replaced by DYN if typeParamToDyn is true.
+func substitute(m *mapping, t *exprpb.Type, typeParamToDyn bool) *exprpb.Type {
+	if tSub, found := m.find(t); found {
+		return substitute(m, tSub, typeParamToDyn)
+	}
+	kind := kindOf(t)
+	if typeParamToDyn && kind == kindTypeParam {
+		return decls.Dyn
+	}
+	switch kind {
+	case kindAbstract:
+		// TODO: implement!
+		at := t.GetAbstractType()
+		params := make([]*exprpb.Type, len(at.GetParameterTypes()))
+		for i, p := range at.GetParameterTypes() {
+			params[i] = substitute(m, p, typeParamToDyn)
+		}
+		return decls.NewAbstractType(at.GetName(), params...)
+	case kindFunction:
+		fn := t.GetFunction()
+		rt := substitute(m, fn.ResultType, typeParamToDyn)
+		args := make([]*exprpb.Type, len(fn.ArgTypes))
+		for i, a := range fn.ArgTypes {
+			args[i] = substitute(m, a, typeParamToDyn)
+		}
+		return decls.NewFunctionType(rt, args...)
+	case kindList:
+		return decls.NewListType(substitute(m, t.GetListType().ElemType, typeParamToDyn))
+	case kindMap:
+		mt := t.GetMapType()
+		return decls.NewMapType(substitute(m, mt.KeyType, typeParamToDyn),
+			substitute(m, mt.ValueType, typeParamToDyn))
+	case kindType:
+		if t.GetType() != nil {
+			return decls.NewTypeType(substitute(m, t.GetType(), typeParamToDyn))
+		}
+		return t
+	default:
+		return t
 	}
 }
 

--- a/common/types/pb/BUILD.bazel
+++ b/common/types/pb/BUILD.bazel
@@ -18,9 +18,13 @@ go_library(
     deps = [
         "@com_github_golang_protobuf//descriptor:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@io_bazel_rules_go//proto/wkt:any_go_proto",
         "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
+        "@io_bazel_rules_go//proto/wkt:duration_go_proto",
         "@io_bazel_rules_go//proto/wkt:empty_go_proto",
         "@io_bazel_rules_go//proto/wkt:struct_go_proto",
+        "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
+        "@io_bazel_rules_go//proto/wkt:wrappers_go_proto",
         "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",
     ],
 )

--- a/common/types/pb/checked.go
+++ b/common/types/pb/checked.go
@@ -17,7 +17,7 @@ package pb
 import (
 	descpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	emptypb "github.com/golang/protobuf/ptypes/empty"
-	"github.com/golang/protobuf/ptypes/struct"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
@@ -41,33 +41,50 @@ var (
 	// CheckedWellKnowns map from qualified proto type name to expr.Type for
 	// well-known proto types.
 	CheckedWellKnowns = map[string]*exprpb.Type{
+		// Wrapper types.
+		"google.protobuf.BoolValue":   checkedWrap(checkedBool),
+		"google.protobuf.BytesValue":  checkedWrap(checkedBytes),
 		"google.protobuf.DoubleValue": checkedWrap(checkedDouble),
 		"google.protobuf.FloatValue":  checkedWrap(checkedDouble),
 		"google.protobuf.Int64Value":  checkedWrap(checkedInt),
 		"google.protobuf.Int32Value":  checkedWrap(checkedInt),
 		"google.protobuf.UInt64Value": checkedWrap(checkedUint),
 		"google.protobuf.UInt32Value": checkedWrap(checkedUint),
-		"google.protobuf.BoolValue":   checkedWrap(checkedBool),
 		"google.protobuf.StringValue": checkedWrap(checkedString),
-		"google.protobuf.BytesValue":  checkedWrap(checkedBytes),
-		"google.protobuf.NullValue":   checkedNull,
-		"google.protobuf.Timestamp":   checkedTimestamp,
-		"google.protobuf.Duration":    checkedDuration,
-		"google.protobuf.Struct":      checkedDyn,
-		"google.protobuf.Value":       checkedDyn,
-		"google.protobuf.ListValue":   checkedDyn,
-		"google.protobuf.Any":         checkedAny}
+		// Well-known types.
+		"google.protobuf.Any":       checkedAny,
+		"google.protobuf.Duration":  checkedDuration,
+		"google.protobuf.Timestamp": checkedTimestamp,
+		// Json types.
+		"google.protobuf.ListValue": checkedListDyn,
+		"google.protobuf.NullValue": checkedNull,
+		"google.protobuf.Struct":    checkedMapStringDyn,
+		"google.protobuf.Value":     checkedDyn,
+	}
 
 	// common types
-	checkedBool      = checkedPrimitive(exprpb.Type_BOOL)
-	checkedBytes     = checkedPrimitive(exprpb.Type_BYTES)
-	checkedDouble    = checkedPrimitive(exprpb.Type_DOUBLE)
-	checkedDyn       = &exprpb.Type{TypeKind: &exprpb.Type_Dyn{Dyn: &emptypb.Empty{}}}
-	checkedInt       = checkedPrimitive(exprpb.Type_INT64)
-	checkedNull      = &exprpb.Type{TypeKind: &exprpb.Type_Null{Null: structpb.NullValue_NULL_VALUE}}
-	checkedString    = checkedPrimitive(exprpb.Type_STRING)
-	checkedUint      = checkedPrimitive(exprpb.Type_UINT64)
+	checkedDyn = &exprpb.Type{TypeKind: &exprpb.Type_Dyn{Dyn: &emptypb.Empty{}}}
+	// Wrapper and primitive types.
+	checkedBool   = checkedPrimitive(exprpb.Type_BOOL)
+	checkedBytes  = checkedPrimitive(exprpb.Type_BYTES)
+	checkedDouble = checkedPrimitive(exprpb.Type_DOUBLE)
+	checkedInt    = checkedPrimitive(exprpb.Type_INT64)
+	checkedString = checkedPrimitive(exprpb.Type_STRING)
+	checkedUint   = checkedPrimitive(exprpb.Type_UINT64)
+	// Well-known type equivalents.
 	checkedAny       = checkedWellKnown(exprpb.Type_ANY)
 	checkedDuration  = checkedWellKnown(exprpb.Type_DURATION)
 	checkedTimestamp = checkedWellKnown(exprpb.Type_TIMESTAMP)
+	// Json-based type equivalents.
+	checkedNull = &exprpb.Type{
+		TypeKind: &exprpb.Type_Null{
+			Null: structpb.NullValue_NULL_VALUE}}
+	checkedListDyn = &exprpb.Type{
+		TypeKind: &exprpb.Type_ListType_{
+			ListType: &exprpb.Type_ListType{ElemType: checkedDyn}}}
+	checkedMapStringDyn = &exprpb.Type{
+		TypeKind: &exprpb.Type_MapType_{
+			MapType: &exprpb.Type_MapType{
+				KeyType:   checkedString,
+				ValueType: checkedDyn}}}
 )

--- a/common/types/pb/pb.go
+++ b/common/types/pb/pb.go
@@ -20,10 +20,16 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
+	"io/ioutil"
+
 	"github.com/golang/protobuf/descriptor"
 	"github.com/golang/protobuf/proto"
 	descpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
-	"io/ioutil"
+	anypb "github.com/golang/protobuf/ptypes/any"
+	durpb "github.com/golang/protobuf/ptypes/duration"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	tspb "github.com/golang/protobuf/ptypes/timestamp"
+	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 )
 
 // DescribeEnum takes a qualified enum name and returns an EnumDescription.
@@ -113,4 +119,18 @@ func fileDescriptor(protoFileName string) (*descpb.FileDescriptorProto, error) {
 		return nil, fmt.Errorf("bad gzipped descriptor: %v", err)
 	}
 	return fd, nil
+}
+
+func init() {
+	// Describe well-known types to ensure they can always be resolved by the check and interpret
+	// execution phases.
+	//
+	// The following subset of message types is enough to ensure that all well-known types can
+	// resolved in the runtime, since describing the value results in describing the whole file
+	// where the message is declared.
+	DescribeValue(&anypb.Any{})
+	DescribeValue(&durpb.Duration{})
+	DescribeValue(&tspb.Timestamp{})
+	DescribeValue(&structpb.Value{})
+	DescribeValue(&wrapperspb.BoolValue{})
 }

--- a/common/types/pb/type_test.go
+++ b/common/types/pb/type_test.go
@@ -20,6 +20,41 @@ func TestTypeDescription_FieldCount(t *testing.T) {
 	}
 }
 
+func TestTypeDescription_Any(t *testing.T) {
+	_, err := DescribeType(".google.protobuf.Any")
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTypeDescription_Json(t *testing.T) {
+	_, err := DescribeType(".google.protobuf.Value")
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTypeDescription_JsonNotInTypeInit(t *testing.T) {
+	_, err := DescribeType(".google.protobuf.ListValue")
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTypeDescription_Wrapper(t *testing.T) {
+	_, err := DescribeType(".google.protobuf.BoolValue")
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTypeDescription_WrapperNotInTypeInit(t *testing.T) {
+	_, err := DescribeType(".google.protobuf.BytesValue")
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestTypeDescription_Field(t *testing.T) {
 	td, err := DescribeValue(&testpb.NestedTestAllTypes{})
 	if err != nil {

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/struct"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/cel-go/common/types/pb"
 	"github.com/google/cel-go/common/types/ref"
 
@@ -109,13 +109,8 @@ func (p *protoTypeProvider) FindType(typeName string) (*exprpb.Type, bool) {
 	if _, err := pb.DescribeType(typeName); err != nil {
 		return nil, false
 	}
-
-	// TODO: verify that well-known message types are handled correctly
 	if typeName != "" && typeName[0] == '.' {
 		typeName = typeName[1:]
-	}
-	if checkedType, found := pb.CheckedWellKnowns[typeName]; found {
-		return checkedType, true
 	}
 	return &exprpb.Type{
 		TypeKind: &exprpb.Type_Type{


### PR DESCRIPTION
Built-in CEL types based on protobufs were not properly being identified at `check` time when
referenced by their proto message name. This change sanitizes the environment by mapping
proto messages to their appropriate CEL built-in type when appropriate. 

closes #47 