### PR TITLE
Fix error message indicators for strings with wide characters

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,3 +57,10 @@ go_repository(
   tag = "v1.11.3",
   remote = "https://github.com/grpc/grpc-go.git",
 )
+
+go_repository(
+  name = "org_golang_x_text",
+  importpath = "golang.org/x/text",
+  tag = "v0.3.0",
+  remote = "https://github.com/golang/text",
+)

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     importpath = "github.com/google/cel-go/common",
     deps = [
         "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",
+        "@org_golang_x_text//width:go_default_library",
     ],
 )
 

--- a/common/error.go
+++ b/common/error.go
@@ -17,6 +17,9 @@ package common
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/text/width"
 )
 
 // Error type which references a location within source and a message.
@@ -24,6 +27,16 @@ type Error struct {
 	Location Location
 	Message  string
 }
+
+const (
+	dot = "."
+	ind = "^"
+)
+
+var (
+	wideDot = width.Widen.String(dot)
+	wideInd = width.Widen.String(ind)
+)
 
 // ToDisplayString decorates the error message with the source location.
 func (e *Error) ToDisplayString(source Source) string {
@@ -33,11 +46,21 @@ func (e *Error) ToDisplayString(source Source) string {
 		e.Location.Column()+1, // add one to the 0-based column for display
 		e.Message)
 	if snippet, found := source.Snippet(e.Location.Line()); found {
-		result += "\n | "
-		result += snippet
-		result += "\n | "
-		result += strings.Repeat(".", e.Location.Column())
-		result += "^"
+		snippet := strings.Replace(snippet, "\t", " ", -1)
+		srcLine := "\n | " + snippet
+		var bytes = []byte(snippet)
+		var indLine = "\n | "
+		for i := 0; i < e.Location.Column() && len(bytes) > 0; i++ {
+			_, sz := utf8.DecodeRune(bytes)
+			bytes = bytes[sz:]
+			if sz > 1 {
+				indLine += wideDot
+			} else {
+				indLine += dot
+			}
+		}
+		indLine += ind
+		result += srcLine + indLine
 	}
 	return result
 }

--- a/common/error.go
+++ b/common/error.go
@@ -59,7 +59,11 @@ func (e *Error) ToDisplayString(source Source) string {
 				indLine += dot
 			}
 		}
-		indLine += ind
+		if _, sz := utf8.DecodeRune(bytes); sz > 1 {
+			indLine += wideInd
+		} else {
+			indLine += ind
+		}
 		result += srcLine + indLine
 	}
 	return result

--- a/common/errors_test.go
+++ b/common/errors_test.go
@@ -32,15 +32,44 @@ func TestErrors(t *testing.T) {
 	if len(errors.GetErrors()) != 2 {
 		t.Errorf("%s second error not recorded", t.Name())
 	}
-	expected :=
+	got := errors.ToDisplayString()
+	want :=
 		"ERROR: errors-test:1:2: No such field\n" +
 			" | a.b\n" +
 			" | .^\n" +
 			"ERROR: errors-test:2:21: Syntax error, missing paren\n" +
 			" | &&arg(missing, paren\n" +
 			" | ....................^"
-	actual := errors.ToDisplayString()
-	if actual != expected {
-		t.Errorf("%s got %s, wanted %s", t.Name(), actual, expected)
+	if got != want {
+		t.Errorf("%s got %s, wanted %s", t.Name(), got, want)
+	}
+}
+
+func TestErrors_WideAndNarrowCharacters(t *testing.T) {
+	source := NewStringSource("你好吗\n我b很好\n", "errors-test")
+	errors := NewErrors(source)
+	errors.ReportError(NewLocation(2, 3), "Unexpected character '好'")
+
+	got := errors.ToDisplayString()
+	want := "ERROR: errors-test:2:4: Unexpected character '好'\n" +
+		" | 我b很好\n" +
+		" | ．.．＾"
+	if got != want {
+		t.Errorf("%s got %s, wanted %s", t.Name(), got, want)
+	}
+}
+
+func TestErrors_WideAndNarrowCharacters_Emojis(t *testing.T) {
+	source := NewStringSource("      '😁' in ['😁', '😑', '😦'] && in.😁", "errors-test")
+	errors := NewErrors(source)
+	errors.ReportError(NewLocation(1, 32), "Syntax error: extraneous input 'in' expecting {'[', '{', '(', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}")
+	errors.ReportError(NewLocation(1, 35), "Syntax error: token recognition error at: '😁'")
+	errors.ReportError(NewLocation(1, 36), "Syntax error: missing IDENTIFIER at '<EOF>'")
+	got := errors.ToDisplayString()
+	want := "ERROR: errors-test:3:9: No such field '️😊️'\n" +
+		" | 	 &&	 in.️😊️\n" +
+		" | ........^"
+	if got != want {
+		t.Errorf("%s got %s, wanted %s", t.Name(), got, want)
 	}
 }

--- a/common/errors_test.go
+++ b/common/errors_test.go
@@ -66,9 +66,15 @@ func TestErrors_WideAndNarrowCharacters_Emojis(t *testing.T) {
 	errors.ReportError(NewLocation(1, 35), "Syntax error: token recognition error at: '😁'")
 	errors.ReportError(NewLocation(1, 36), "Syntax error: missing IDENTIFIER at '<EOF>'")
 	got := errors.ToDisplayString()
-	want := "ERROR: errors-test:3:9: No such field '️😊️'\n" +
-		" | 	 &&	 in.️😊️\n" +
-		" | ........^"
+	want := "ERROR: errors-test:1:33: Syntax error: extraneous input 'in' expecting {'[', '{', '(', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}\n" +
+		" |       '😁' in ['😁', '😑', '😦'] && in.😁\n" +
+		" | .......．.......．....．....．......^\n" +
+		"ERROR: errors-test:1:36: Syntax error: token recognition error at: '😁'\n" +
+		" |       '😁' in ['😁', '😑', '😦'] && in.😁\n" +
+		" | .......．.......．....．....．.........＾\n" +
+		"ERROR: errors-test:1:37: Syntax error: missing IDENTIFIER at '<EOF>'\n" +
+		" |       '😁' in ['😁', '😑', '😦'] && in.😁\n" +
+		" | .......．.......．....．....．.........．^"
 	if got != want {
 		t.Errorf("%s got %s, wanted %s", t.Name(), got, want)
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
-	"github.com/golang/protobuf/ptypes/struct"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/parser/gen"

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -684,6 +684,20 @@ ERROR: <input>:1:6: Syntax error: mismatched input '<EOF>' expecting {'[', '{', 
     		 | "\a\b\f\n\r\t\v\'\"\\\? Illegal escape \>"
     		 | ..........................................^`,
 	},
+
+	{
+		I: `      '😁' in ['😁', '😑', '😦'] 
+			&& in.😁`,
+		E: `ERROR: <input>:2:7: Syntax error: extraneous input 'in' expecting {'[', '{', '(', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}
+		|    && in.😁
+		| ......^
+	   ERROR: <input>:2:10: Syntax error: token recognition error at: '😁'
+		|    && in.😁
+		| .........^
+	   ERROR: <input>:2:11: Syntax error: missing IDENTIFIER at '<EOF>'
+		|    && in.😁
+		| .........．^`,
+	},
 }
 
 type testInfo struct {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -693,7 +693,7 @@ ERROR: <input>:1:6: Syntax error: mismatched input '<EOF>' expecting {'[', '{', 
 		| ......^
 	   ERROR: <input>:2:10: Syntax error: token recognition error at: '😁'
 		|    && in.😁
-		| .........^
+		| .........＾
 	   ERROR: <input>:2:11: Syntax error: missing IDENTIFIER at '<EOF>'
 		|    && in.😁
 		| .........．^`,


### PR DESCRIPTION
Wide characters, such as emojis or kanji, require slightly different formatting in error
messages in order for the error indicator to make sense when displayed in the terminal.

Additionally, this change swaps each tab for a single space when computing the error
message for display.

closes #127 