### PR TITLE
Export the checker printing function.

### DIFF
--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1170,7 +1170,7 @@ func TestCheck(t *testing.T) {
 			}
 
 			if tst.R != "" {
-				actualStr := print(expression.Expr, semantics)
+				actualStr := Print(expression.Expr, semantics)
 				if !test.Compare(actualStr, tst.R) {
 					tt.Error(test.DiffMessage("Structure error", actualStr, tst.R))
 				}

--- a/checker/printer.go
+++ b/checker/printer.go
@@ -62,7 +62,10 @@ func (a *semanticAdorner) GetMetadata(elem interface{}) string {
 	return result
 }
 
-func print(e *exprpb.Expr, checks *exprpb.CheckedExpr) string {
+// Print returns a string representation of the Expr message,
+// annotated with types from the CheckedExpr.  The Expr must
+// be a sub-expression embedded in the CheckedExpr.
+func Print(e *exprpb.Expr, checks *exprpb.CheckedExpr) string {
 	a := &semanticAdorner{checks: checks}
 	return debug.ToAdornedDebugString(e, a)
 }


### PR DESCRIPTION
Export the checker printing function for use in external tests.