### PR TITLE
Fix missing return on receiver-style dispatch.

### DIFF
--- a/common/types/timestamp.go
+++ b/common/types/timestamp.go
@@ -130,7 +130,7 @@ func (t Timestamp) Receive(function string, overload string, args []ref.Value) r
 			return f(tstamp, args[0])
 		}
 	}
-	return NewErr("unsupported overload")
+	return NewErr("no such overload")
 }
 
 // Subtract implements traits.Subtractor.Subtract.

--- a/interpreter/dispatcher.go
+++ b/interpreter/dispatcher.go
@@ -111,7 +111,7 @@ func (d *defaultDispatcher) Dispatch(ctx *CallContext) ref.Value {
 	}
 	// Special dispatch for member functions.
 	if operand.Type().HasTrait(traits.ReceiverType) {
-		operand.(traits.Receiver).Receive(function, overloadID, ctx.args[1:])
+		return operand.(traits.Receiver).Receive(function, overloadID, ctx.args[1:])
 	}
 	return types.NewErr("no such overload")
 }

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -224,6 +224,13 @@ func TestInterpreter_Filter(t *testing.T) {
 	}
 }
 
+func TestInterpreter_Timestamp(t *testing.T) {
+	result, _ := evalExpr(t, "timestamp('2001-01-01T01:23:45Z').getDayOfWeek() == 1")
+	if result != types.True {
+		t.Errorf("Got %v, wanted true", result)
+	}
+}
+
 func TestInterpreter_LogicalAnd(t *testing.T) {
 	// a && {c: true}.c
 	program := NewProgram(


### PR DESCRIPTION
There was a missing `return` from receiver style dispatch. Fixed with test case provided.