### PR TITLE
Implement has() macro in interpreter.

### DIFF
--- a/common/types/object.go
+++ b/common/types/object.go
@@ -83,6 +83,27 @@ func (o *protoObj) Equal(other ref.Value) ref.Value {
 	return Bool(proto.Equal(o.value, other.Value().(proto.Message)))
 }
 
+func (o *protoObj) IsSet(field ref.Value) ref.Value {
+	if field.Type() != StringType {
+		return NewErr("illegal object field type '%s'", field.Type())
+	}
+	protoFieldName := string(field.(String))
+	if f, found := o.typeDesc.FieldByName(protoFieldName); found {
+		if !f.IsOneof() {
+			return isFieldSet(o.refValue.Elem().Field(f.Index()))
+		}
+
+		getter := o.refValue.MethodByName(f.GetterName())
+		if getter.IsValid() {
+			refField := getter.Call([]reflect.Value{})[0]
+			if refField.IsValid() {
+				return isFieldSet(refField)
+			}
+		}
+	}
+	return NewErr("no such field '%s'", field)
+}
+
 func (o *protoObj) Get(index ref.Value) ref.Value {
 	if index.Type() != StringType {
 		return NewErr("illegal object field type '%s'", index.Type())
@@ -145,9 +166,16 @@ var (
 	protoDefaultInstanceMap = make(map[reflect.Type]ref.Value)
 )
 
-func getOrDefaultInstance(refVal reflect.Value) ref.Value {
-	value := refVal.Interface()
+func isFieldSet(refVal reflect.Value) ref.Value {
 	if refVal.Kind() != reflect.Ptr || !refVal.IsNil() {
+		return True
+	}
+	return False
+}
+
+func getOrDefaultInstance(refVal reflect.Value) ref.Value {
+	if isFieldSet(refVal) == True {
+		value := refVal.Interface()
 		return NativeToValue(value)
 	}
 	return getDefaultInstance(refVal.Type())

--- a/common/types/object.go
+++ b/common/types/object.go
@@ -83,6 +83,7 @@ func (o *protoObj) Equal(other ref.Value) ref.Value {
 	return Bool(proto.Equal(o.value, other.Value().(proto.Message)))
 }
 
+// IsSet tests whether a field which is defined is set to a non-default value.
 func (o *protoObj) IsSet(field ref.Value) ref.Value {
 	if field.Type() != StringType {
 		return NewErr("illegal object field type '%s'", field.Type())
@@ -167,10 +168,10 @@ var (
 )
 
 func isFieldSet(refVal reflect.Value) ref.Value {
-	if refVal.Kind() != reflect.Ptr || !refVal.IsNil() {
-		return True
+	if refVal.Kind() == reflect.Ptr && refVal.IsNil() {
+		return False
 	}
-	return False
+	return True
 }
 
 func getOrDefaultInstance(refVal reflect.Value) ref.Value {

--- a/common/types/traits/BUILD.bazel
+++ b/common/types/traits/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
     srcs = [
         "comparer.go",
         "container.go",
-        "field_definer.go",
+        "field_tester.go",
         "indexer.go",
         "iterator.go",
         "lister.go",

--- a/common/types/traits/BUILD.bazel
+++ b/common/types/traits/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     srcs = [
         "comparer.go",
         "container.go",
+        "field_definer.go",
         "indexer.go",
         "iterator.go",
         "lister.go",

--- a/common/types/traits/field_definer.go
+++ b/common/types/traits/field_definer.go
@@ -1,0 +1,30 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package traits
+
+import (
+	"github.com/google/cel-go/common/types/ref"
+)
+
+// FieldDefiner indicates if a defined field on an objec type is set to a
+// non-default value.
+//
+// For use with the `has()` macro.
+type FieldDefiner interface {
+	// IsSet returns true if the field is defined and set to a non-default
+	// value. The method will return false if defiend and not set, and an error
+	// if the field is not defined.
+	IsSet(field ref.Value) ref.Value
+}

--- a/common/types/traits/field_tester.go
+++ b/common/types/traits/field_tester.go
@@ -18,13 +18,13 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 )
 
-// FieldDefiner indicates if a defined field on an objec type is set to a
+// FieldTester indicates if a defined field on an object type is set to a
 // non-default value.
 //
 // For use with the `has()` macro.
-type FieldDefiner interface {
+type FieldTester interface {
 	// IsSet returns true if the field is defined and set to a non-default
-	// value. The method will return false if defiend and not set, and an error
+	// value. The method will return false if defined and not set, and an error
 	// if the field is not defined.
 	IsSet(field ref.Value) ref.Value
 }

--- a/common/types/traits/traits.go
+++ b/common/types/traits/traits.go
@@ -39,6 +39,8 @@ const (
 	MultiplierType
 	// NegatorType types support either negation via '!' or '-'
 	NegatorType
+	// FieldDefinerType types support the detection of field value presence.
+	FieldDefinerType
 	// ReceiverType types support dynamic dispatch to instance methods.
 	ReceiverType
 	// SizerType types support the size() method.

--- a/common/types/traits/traits.go
+++ b/common/types/traits/traits.go
@@ -19,12 +19,14 @@ package traits
 const (
 	// AdderType types provide a '+' operator overload.
 	AdderType = 1 << iota
-	// ComparerType types support ordering comparisons '<', '<=', '>', '>='.
+	// CompFarerType types support ordering comparisons '<', '<=', '>', '>='.
 	ComparerType
 	// ContainerType types support 'in' operations.
 	ContainerType
 	// DividerType types support '/' operations.
 	DividerType
+	// FieldTesterType types support the detection of field value presence.
+	FieldTesterType
 	// IndexerType types support index access with dynamic values.
 	IndexerType
 	// IterableType types can be iterated over in comprehensions.
@@ -39,8 +41,6 @@ const (
 	MultiplierType
 	// NegatorType types support either negation via '!' or '-'
 	NegatorType
-	// FieldDefinerType types support the detection of field value presence.
-	FieldDefinerType
 	// ReceiverType types support dynamic dispatch to instance methods.
 	ReceiverType
 	// SizerType types support the size() method.

--- a/common/types/type.go
+++ b/common/types/type.go
@@ -48,7 +48,7 @@ func NewTypeValue(name string, traits ...int) *TypeValue {
 // annotated with the traits relevant to all objects.
 func NewObjectTypeValue(name string) *TypeValue {
 	return NewTypeValue(name,
-		traits.FieldDefinerType,
+		traits.FieldTesterType,
 		traits.IndexerType,
 		traits.IterableType)
 }

--- a/common/types/type.go
+++ b/common/types/type.go
@@ -48,6 +48,7 @@ func NewTypeValue(name string, traits ...int) *TypeValue {
 // annotated with the traits relevant to all objects.
 func NewObjectTypeValue(name string) *TypeValue {
 	return NewTypeValue(name,
+		traits.FieldDefinerType,
 		traits.IndexerType,
 		traits.IterableType)
 }

--- a/interpreter/astwalker.go
+++ b/interpreter/astwalker.go
@@ -121,7 +121,7 @@ func (w *astWalker) walkSelect(node *exprpb.Expr) []Instruction {
 	operandID := w.getID(sel.Operand)
 	return append(
 		w.walk(sel.Operand),
-		NewSelect(node.Id, operandID, sel.Field))
+		NewSelect(node.Id, operandID, sel.Field, sel.GetTestOnly()))
 }
 
 func (w *astWalker) walkCall(node *exprpb.Expr) []Instruction {

--- a/interpreter/instructions.go
+++ b/interpreter/instructions.go
@@ -110,8 +110,9 @@ func checkIsStrict(function string) bool {
 // SelectExpr is a select expression where the operand is represented by id.
 type SelectExpr struct {
 	*baseInstruction
-	Operand int64
-	Field   string
+	Operand  int64
+	Field    string
+	TestOnly bool
 }
 
 // String generates pseudo-assembly for the instruction.
@@ -121,8 +122,12 @@ func (e *SelectExpr) String() string {
 }
 
 // NewSelect generates a SelectExpr.
-func NewSelect(exprID int64, operandID int64, field string) *SelectExpr {
-	return &SelectExpr{&baseInstruction{exprID}, operandID, field}
+func NewSelect(exprID int64, operandID int64, field string, testOnly bool) *SelectExpr {
+	return &SelectExpr{
+		baseInstruction: &baseInstruction{ID: exprID},
+		Operand:         operandID,
+		Field:           field,
+		TestOnly:        testOnly}
 }
 
 // CreateListExpr will create a new list from the elements referened by their ids.

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -171,8 +171,8 @@ func (i *exprInterpretable) evalSelect(selExpr *SelectExpr, currActivation Activ
 			i.setValue(selExpr.GetID(), operand.(traits.Container).Contains(field))
 			return
 		}
-		if operand.Type().HasTrait(traits.FieldDefinerType) {
-			i.setValue(selExpr.GetID(), operand.(traits.FieldDefiner).IsSet(field))
+		if operand.Type().HasTrait(traits.FieldTesterType) {
+			i.setValue(selExpr.GetID(), operand.(traits.FieldTester).IsSet(field))
 			return
 		}
 		i.setValue(selExpr.GetID(), types.NewErr("invalid operand in select"))

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -165,11 +165,20 @@ func (i *exprInterpretable) evalSelect(selExpr *SelectExpr, currActivation Activ
 		}
 		return
 	}
-	fieldValue := operand.(traits.Indexer).Get(types.String(selExpr.Field))
+	field := types.String(selExpr.Field)
 	if selExpr.TestOnly {
-		i.setValue(selExpr.GetID(), !types.Bool(types.IsUnknownOrError(fieldValue)))
+		if operand.Type() == types.MapType {
+			i.setValue(selExpr.GetID(), operand.(traits.Container).Contains(field))
+			return
+		}
+		if operand.Type().HasTrait(traits.FieldDefinerType) {
+			i.setValue(selExpr.GetID(), operand.(traits.FieldDefiner).IsSet(field))
+			return
+		}
+		i.setValue(selExpr.GetID(), types.NewErr("invalid operand in select"))
 		return
 	}
+	fieldValue := operand.(traits.Indexer).Get(field)
 	i.setValue(selExpr.GetID(), fieldValue)
 }
 

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -166,6 +166,10 @@ func (i *exprInterpretable) evalSelect(selExpr *SelectExpr, currActivation Activ
 		return
 	}
 	fieldValue := operand.(traits.Indexer).Get(types.String(selExpr.Field))
+	if selExpr.TestOnly {
+		i.setValue(selExpr.GetID(), !types.Bool(types.IsUnknownOrError(fieldValue)))
+		return
+	}
 	i.setValue(selExpr.GetID(), fieldValue)
 }
 

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -231,6 +231,13 @@ func TestInterpreter_Timestamp(t *testing.T) {
 	}
 }
 
+func TestInterpreter_HasTest(t *testing.T) {
+	result, _ := evalExpr(t, "has({'a':1}.a) && !has({}.a)")
+	if result != types.True {
+		t.Errorf("Got %v, wanted true", result)
+	}
+}
+
 func TestInterpreter_LogicalAnd(t *testing.T) {
 	// a && {c: true}.c
 	program := NewProgram(

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -246,13 +246,6 @@ func TestInterpreter_HasTest(t *testing.T) {
 	}
 }
 
-func TestInterpreter_HasTest(t *testing.T) {
-	result, _ := evalExpr(t, "has({'a':1}.a) && !has({}.a)")
-	if result != types.True {
-		t.Errorf("Got %v, wanted true", result)
-	}
-}
-
 func TestInterpreter_LogicalAnd(t *testing.T) {
 	// a && {c: true}.c
 	program := NewProgram(

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -232,6 +232,21 @@ func TestInterpreter_Timestamp(t *testing.T) {
 }
 
 func TestInterpreter_HasTest(t *testing.T) {
+	result, _ := evalExpr(t,
+		`has({'a':1}.a) &&
+		 !has({}.a) &&
+		 has(google.api.expr.v1alpha1.ParsedExpr{
+			expr:google.api.expr.v1alpha1.Expr{id: 1}}
+			.expr) &&
+		 !has(google.api.expr.v1alpha1.ParsedExpr{
+			expr:google.api.expr.v1alpha1.Expr{id: 1}}
+			.source_info)`)
+	if result != types.True {
+		t.Errorf("Got %v, wanted true", result)
+	}
+}
+
+func TestInterpreter_HasTest(t *testing.T) {
 	result, _ := evalExpr(t, "has({'a':1}.a) && !has({}.a)")
 	if result != types.True {
 		t.Errorf("Got %v, wanted true", result)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -107,6 +107,12 @@ func (p *parser) Visit(tree antlr.ParseTree) interface{} {
 		return p.VisitIndex(tree.(*gen.IndexContext))
 	case *gen.UnaryContext:
 		return p.VisitUnary(tree.(*gen.UnaryContext))
+	case *gen.CreateListContext:
+		return p.VisitCreateList(tree.(*gen.CreateListContext))
+	case *gen.CreateMessageContext:
+		return p.VisitCreateMessage(tree.(*gen.CreateMessageContext))
+	case *gen.CreateStructContext:
+		return p.VisitCreateStruct(tree.(*gen.CreateStructContext))
 	}
 
 	text := "<<nil>>"


### PR DESCRIPTION
The `has()` macro was not implemented in the interpreter as it was not a function but a macro
on the select expression that wasn't being checked. Fixed and tested.

closes #133 