### PR TITLE
In-place call dispatch and reduced memory allocations

### DIFF
--- a/common/types/bool.go
+++ b/common/types/bool.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/golang/protobuf/ptypes/struct"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 )
@@ -93,7 +93,7 @@ func (b Bool) ConvertToType(typeVal ref.Type) ref.Value {
 
 // Equal implements ref.Value.Equal.
 func (b Bool) Equal(other ref.Value) ref.Value {
-	return Bool(BoolType == other.Type() && b.Value() == other.Value())
+	return Bool(BoolType == other.Type() && b == other.(Bool))
 }
 
 // Negate implements traits.Negater.Negate.

--- a/common/types/bytes.go
+++ b/common/types/bytes.go
@@ -82,7 +82,7 @@ func (b Bytes) ConvertToType(typeVal ref.Type) ref.Value {
 // Equal implements ref.Value.Equal.
 func (b Bytes) Equal(other ref.Value) ref.Value {
 	return Bool(BytesType == other.Type() &&
-		bytes.Equal([]byte(b), other.(Bytes)))
+		bytes.Equal(b, other.(Bytes)))
 }
 
 // Size implements traits.Sizer.Size.

--- a/common/types/double.go
+++ b/common/types/double.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/golang/protobuf/ptypes/struct"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 )
@@ -119,7 +119,7 @@ func (d Double) Divide(other ref.Value) ref.Value {
 
 // Equal implements ref.Value.Equal.
 func (d Double) Equal(other ref.Value) ref.Value {
-	return Bool(DoubleType == other.Type() && d == other)
+	return Bool(DoubleType == other.Type() && d == other.(Double))
 }
 
 // Multiply implements traits.Multiplier.Multiply.

--- a/common/types/int.go
+++ b/common/types/int.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/golang/protobuf/ptypes/struct"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 )
@@ -127,7 +127,7 @@ func (i Int) Divide(other ref.Value) ref.Value {
 
 // Equal implements ref.Value.Equal.
 func (i Int) Equal(other ref.Value) ref.Value {
-	return Bool(IntType == other.Type() && i.Value() == other.Value())
+	return Bool(IntType == other.Type() && i == other.(Int))
 }
 
 // Modulo implements traits.Modder.Modulo.

--- a/common/types/json_struct.go
+++ b/common/types/json_struct.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/struct"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 )
@@ -40,7 +40,7 @@ func NewJSONStruct(st *structpb.Struct) traits.Mapper {
 }
 
 func (m *jsonStruct) Contains(index ref.Value) ref.Value {
-	return !Bool(IsError(m.Get(index)))
+	return !Bool(IsError(m.Get(index).Type()))
 }
 
 func (m *jsonStruct) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/golang/protobuf/ptypes/struct"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 )

--- a/common/types/type.go
+++ b/common/types/type.go
@@ -72,7 +72,10 @@ func (t *TypeValue) ConvertToType(typeVal ref.Type) ref.Value {
 
 // Equal implements ref.Value.Equal.
 func (t *TypeValue) Equal(other ref.Value) ref.Value {
-	return Bool(TypeType == other.Type() && t.Value() == other.Value())
+	if TypeType == other.Type() && t.TypeName() == other.(ref.Type).TypeName() {
+		return True
+	}
+	return False
 }
 
 // HasTrait indicates whether the type supports the given trait.

--- a/common/types/uint.go
+++ b/common/types/uint.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/golang/protobuf/ptypes/struct"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 )
@@ -125,8 +125,7 @@ func (i Uint) Divide(other ref.Value) ref.Value {
 
 // Equal implements ref.Value.Equal.
 func (i Uint) Equal(other ref.Value) ref.Value {
-	return Bool(UintType == other.Type() &&
-		i.Value() == other.Value())
+	return Bool(UintType == other.Type() && i == other.(Uint))
 }
 
 // Modulo implements traits.Modder.Modulo.

--- a/interpreter/astwalker.go
+++ b/interpreter/astwalker.go
@@ -37,12 +37,10 @@ const (
 // a recursive execution pattern.
 func WalkExpr(expression *exprpb.Expr,
 	metadata Metadata,
-	dispatcher Dispatcher,
 	state MutableEvalState,
 	shortCircuit bool) []Instruction {
 	nextID := maxID(expression)
 	walker := &astWalker{
-		dispatcher:   dispatcher,
 		genSymID:     nextID,
 		genExprID:    nextID,
 		metadata:     metadata,
@@ -54,7 +52,6 @@ func WalkExpr(expression *exprpb.Expr,
 
 // astWalker implementation of the AST walking logic.
 type astWalker struct {
-	dispatcher   Dispatcher
 	genExprID    int64
 	genSymID     int64
 	metadata     Metadata

--- a/interpreter/functions/standard.go
+++ b/interpreter/functions/standard.go
@@ -62,8 +62,9 @@ func StandardOverloads() []*Overload {
 		{Operator: operators.NotEquals,
 			Binary: func(lhs ref.Value, rhs ref.Value) ref.Value {
 				eq := lhs.Equal(rhs)
-				if types.IsBool(eq) {
-					return !eq.(types.Bool)
+				eqBool, isbool := eq.(types.Bool)
+				if isbool {
+					return !eqBool
 				}
 				return eq
 			}},

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -28,7 +28,7 @@ import (
 // Interpreter generates a new Interpretable from a Program.
 type Interpreter interface {
 	// NewInterpretable returns an Interpretable from a Program.
-	NewInterpretable(program Program) Interpretable
+	NewInterpretable(program *Program) Interpretable
 }
 
 // Interpretable can accept a given Activation and produce a value along with
@@ -66,28 +66,36 @@ func NewStandardInterpreter(packager packages.Packager,
 	return NewInterpreter(dispatcher, packager, typeProvider)
 }
 
-func (i *exprInterpreter) NewInterpretable(program Program) Interpretable {
+func (i *exprInterpreter) NewInterpretable(program *Program) Interpretable {
 	// program needs to be pruned with the TypeProvider
 	evalState := NewEvalState(program.MaxInstructionID() + 1)
-	program.Init(i.dispatcher, evalState)
+	intr := &exprInterpreter{
+		dispatcher:   i.dispatcher.Init(evalState),
+		packager:     i.packager,
+		typeProvider: i.typeProvider}
+	program.Init(evalState)
 	return &exprInterpretable{
-		interpreter: i,
+		interpreter: intr,
 		program:     program,
 		state:       evalState}
 }
 
 type exprInterpretable struct {
 	interpreter *exprInterpreter
-	program     Program
+	program     *Program
 	state       MutableEvalState
 }
 
 func (i *exprInterpretable) Eval(activation Activation) (ref.Value, EvalState) {
 	// register machine-like evaluation of the program with the given activation.
 	currActivation := activation
-	stepper := i.program.Begin()
+	// program counter
+	pc := 0
+	end := len(i.program.Instructions)
+	steps := i.program.Instructions
 	var resultID int64
-	for step, hasNext := stepper.Next(); hasNext; step, hasNext = stepper.Next() {
+	for pc < end {
+		step := steps[pc]
 		resultID = step.GetID()
 		switch step.(type) {
 		case *IdentExpr:
@@ -108,11 +116,14 @@ func (i *exprInterpretable) Eval(activation Activation) (ref.Value, EvalState) {
 		case *JumpInst:
 			jmpExpr := step.(*JumpInst)
 			if jmpExpr.OnCondition(i.state) {
-				if !stepper.JumpCount(jmpExpr.Count) {
+				jmpPc := pc + jmpExpr.Count
+				if jmpPc < 0 || jmpPc >= end {
 					// TODO: Error, the jump count should never exceed the
 					// program length.
 					panic("jumped too far")
 				}
+				pc = jmpPc
+				continue
 			}
 			// Special instructions for modifying the activation stack
 		case *PushScopeInst:
@@ -129,6 +140,7 @@ func (i *exprInterpretable) Eval(activation Activation) (ref.Value, EvalState) {
 		case *PopScopeInst:
 			currActivation = currActivation.Parent()
 		}
+		pc++
 	}
 	result := i.value(resultID)
 	if result == nil {
@@ -232,21 +244,17 @@ func (i *exprInterpretable) resolveUnknown(unknown types.Unknown,
 }
 
 func (i *exprInterpretable) evalCall(callExpr *CallExpr, currActivation Activation) {
-	argVals := make([]ref.Value, len(callExpr.Args), len(callExpr.Args))
-	for idx, argID := range callExpr.Args {
-		argVals[idx] = i.value(argID)
-		if callExpr.Strict && types.IsUnknownOrError(argVals[idx]) {
-			i.setValue(callExpr.GetID(), argVals[idx])
-			return
+	if callExpr.Strict {
+		for _, argID := range callExpr.Args {
+			argVal := i.value(argID)
+			argType := argVal.Type()
+			if types.IsUnknownOrError(argType) {
+				i.setValue(callExpr.GetID(), argVal)
+				return
+			}
 		}
 	}
-	ctx := &CallContext{
-		call:       callExpr,
-		activation: currActivation,
-		args:       argVals,
-		metadata:   i.program.Metadata()}
-	result := i.interpreter.dispatcher.Dispatch(ctx)
-	i.setValue(callExpr.GetID(), result)
+	i.interpreter.dispatcher.Dispatch(callExpr)
 }
 
 func (i *exprInterpretable) evalCreateList(listExpr *CreateListExpr) {

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -18,11 +18,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/cel-go/common"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/packages"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
@@ -32,6 +31,12 @@ import (
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
+
+type testCase struct {
+	name string
+	E    string
+	I    map[string]interface{}
+}
 
 func TestExhaustiveInterpreter_ConditionalExpr(t *testing.T) {
 	// a ? b < 1.0 : c == ["hello"]
@@ -448,14 +453,15 @@ func BenchmarkInterpreter_ConditionalExpr(b *testing.B) {
 }
 
 func BenchmarkInterpreter_EqualsCall(b *testing.B) {
-	// type(x) == uint
+	// type(a) == uint
 	activation := NewActivation(map[string]interface{}{
-		"x": types.Uint(20)})
+		"a": types.Uint(20)})
 	d := NewDispatcher()
 	d.Add(functions.StandardOverloads()...)
 	evalState := NewEvalState(4)
+	d = d.Init(evalState)
 	for i := 0; i < b.N; i++ {
-		xRef, _ := activation.ResolveName("x")
+		xRef, _ := activation.ResolveName("a")
 		evalState.SetValue(1, xRef)
 		xRef, _ = evalState.Value(1)
 		typeOfXRef := xRef.ConvertToType(types.TypeType)
@@ -466,46 +472,36 @@ func BenchmarkInterpreter_EqualsCall(b *testing.B) {
 }
 
 func BenchmarkInterpreter_EqualsDispatch(b *testing.B) {
-	// type(x) == uint
+	// type(a) == uint
 	activation := NewActivation(map[string]interface{}{
-		"x": types.Uint(20)})
+		"a": types.Uint(20)})
+	evalState := NewEvalState(4)
 	d := NewDispatcher()
 	d.Add(functions.StandardOverloads()...)
+	d = d.Init(evalState)
 	p := types.NewProvider()
+	uintType, _ := p.FindIdent("uint")
 	callTypeOf := NewCall(2, "type", []int64{1})
 	callEq := NewCall(3, "_==_", []int64{1, 2})
-	evalState := NewEvalState(4)
 	for i := 0; i < b.N; i++ {
-		xRef, _ := activation.ResolveName("x")
+		xRef, _ := activation.ResolveName("a")
 		evalState.SetValue(1, xRef)
-		xRef, _ = evalState.Value(1)
-		ctxType := &CallContext{
-			call:       callTypeOf,
-			args:       []ref.Value{xRef},
-			activation: activation,
-		}
-		evalState.SetValue(callTypeOf.GetID(), d.Dispatch(ctxType))
-		typeOfXRef, _ := evalState.Value(callTypeOf.GetID())
+		d.Dispatch(callTypeOf)
 		// not-found here.
 		activation.ResolveName("uint")
-		uintType, _ := p.FindIdent("uint")
-		ctxEq := &CallContext{
-			call:       callEq,
-			args:       []ref.Value{typeOfXRef, uintType},
-			activation: activation,
-		}
-		evalState.SetValue(callEq.GetID(), d.Dispatch(ctxEq))
+		evalState.SetValue(3, uintType)
+		d.Dispatch(callEq)
 	}
 }
 
 func BenchmarkInterpreter_EqualInstructions(b *testing.B) {
-	// type(x) == uint
+	// type(a) == uint
 	program := NewProgram(
 		test.TypeEquality.Expr,
 		test.TypeEquality.Info(b.Name()))
 	interpretable := interpreter.NewInterpretable(program)
 	activation := NewActivation(map[string]interface{}{
-		"x": types.Uint(20)})
+		"a": types.Uint(20)})
 	for i := 0; i < b.N; i++ {
 		interpretable.Eval(activation)
 	}
@@ -535,11 +531,70 @@ func BenchmarkInterpreter_ComprehensionExprWithInput(b *testing.B) {
 	}
 }
 
+func BenchmarkInterpreter_CanonicalExpressions(b *testing.B) {
+	for _, tst := range testData {
+		s := common.NewTextSource(tst.E)
+		parsed, errors := parser.Parse(s)
+		if len(errors.GetErrors()) != 0 {
+			b.Errorf(errors.ToDisplayString())
+		}
+		program := NewProgram(parsed.GetExpr(), parsed.GetSourceInfo())
+		interpretable := interpreter.NewInterpretable(program)
+		activation := NewActivation(tst.I)
+		b.Run(tst.name, func(bb *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < bb.N; i++ {
+				interpretable.Eval(activation)
+			}
+		})
+	}
+}
+
 var (
 	interpreter = NewStandardInterpreter(
 		packages.DefaultPackage,
 		types.NewProvider(&exprpb.ParsedExpr{}))
+
 	emptyActivation = NewActivation(map[string]interface{}{})
+
+	testData = []testCase{
+		{
+			name: `ExprBench/ok_1st`,
+			E:    `ai == 20 || ar["foo"] == "bar"`,
+			I: map[string]interface{}{
+				"ai": 20,
+				"ar": map[string]string{
+					"foo": "bar",
+				},
+			},
+		},
+		{
+			name: `ExprBench/ok_2nd`,
+			E:    `ai == 20 || ar["foo"] == "bar"`,
+			I: map[string]interface{}{
+				"ai": 2,
+				"ar": map[string]string{
+					"foo": "bar",
+				},
+			},
+		},
+		{
+			name: `ExprBench/not_found`,
+			E:    `ai == 20 || ar["foo"] == "bar"`,
+			I: map[string]interface{}{
+				"ai": 2,
+				"ar": map[string]string{
+					"foo": "baz",
+				},
+			},
+		},
+		{
+			name: `ExprBench/false_2nd`,
+			E:    `true && false`,
+			I:    map[string]interface{}{},
+		},
+	}
 )
 
 func parseExpr(t *testing.T, src string) *exprpb.ParsedExpr {

--- a/interpreter/program_test.go
+++ b/interpreter/program_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/cel-go/interpreter/functions"
 	"github.com/google/cel-go/test"
 )
 
@@ -30,10 +29,7 @@ func TestNewExhaustiveProgram_LogicalOr(t *testing.T) {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
 	state := NewEvalState(program.MaxInstructionID() + 1)
-	program.Init(dispatcher(), state)
-	if _, hasNext := program.Begin().Next(); !hasNext {
-		t.Error("Expected a step in program, but found none")
-	}
+	program.Init(state)
 	fmt.Printf("%s\n%s\n\n", t.Name(), program)
 
 	expected := "TestNewExhaustiveProgram_LogicalOr\n" +
@@ -56,10 +52,7 @@ func TestNewExhaustiveProgram_Conditional(t *testing.T) {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
 	state := NewEvalState(program.MaxInstructionID() + 1)
-	program.Init(dispatcher(), state)
-	if _, hasNext := program.Begin().Next(); !hasNext {
-		t.Error("Expected a step in program, but found none")
-	}
+	program.Init(state)
 	expected := "TestNewExhaustiveProgram_Conditional\n" +
 		"0: local 'a', r1\n" +
 		"1: local 'b', r2\n" +
@@ -83,10 +76,7 @@ func TestNewProgram_Empty(t *testing.T) {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
 	state := NewEvalState(program.MaxInstructionID() + 1)
-	program.Init(dispatcher(), state)
-	if step, hasNext := program.Begin().Next(); hasNext {
-		t.Errorf("Unexpected step in empty program: %v", step)
-	}
+	program.Init(state)
 }
 
 func TestNewProgram_LogicalAnd(t *testing.T) {
@@ -97,10 +87,7 @@ func TestNewProgram_LogicalAnd(t *testing.T) {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
 	state := NewEvalState(program.MaxInstructionID() + 1)
-	program.Init(dispatcher(), state)
-	if _, hasNext := program.Begin().Next(); !hasNext {
-		t.Error("Expected a step in program, but found none")
-	}
+	program.Init(state)
 	fmt.Printf("%s\n%s\n\n", t.Name(), program)
 }
 
@@ -112,10 +99,7 @@ func TestNewProgram_LogicalOr(t *testing.T) {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
 	state := NewEvalState(program.MaxInstructionID() + 1)
-	program.Init(dispatcher(), state)
-	if _, hasNext := program.Begin().Next(); !hasNext {
-		t.Error("Expected a step in program, but found none")
-	}
+	program.Init(state)
 	fmt.Printf("%s\n%s\n\n", t.Name(), program)
 }
 
@@ -127,10 +111,7 @@ func TestNewProgram_Conditional(t *testing.T) {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
 	state := NewEvalState(program.MaxInstructionID() + 1)
-	program.Init(dispatcher(), state)
-	if _, hasNext := program.Begin().Next(); !hasNext {
-		t.Error("Expected a step in program, but found none")
-	}
+	program.Init(state)
 	expected := "TestNewProgram_Conditional\n" +
 		"0: local 'a', r1\n" +
 		"1: jump  8 if cond<r1>\n" +
@@ -157,10 +138,7 @@ func TestNewProgram_Comprehension(t *testing.T) {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
 	state := NewEvalState(program.MaxInstructionID() + 1)
-	program.Init(dispatcher(), state)
-	if _, hasNext := program.Begin().Next(); !hasNext {
-		t.Error("Expected a step in program, but found none")
-	}
+	program.Init(state)
 	fmt.Printf("%s\n%s\n\n", t.Name(), program)
 }
 
@@ -172,15 +150,6 @@ func TestNewProgram_DynMap(t *testing.T) {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
 	state := NewEvalState(program.MaxInstructionID() + 1)
-	program.Init(dispatcher(), state)
-	if _, hasNext := program.Begin().Next(); !hasNext {
-		t.Error("Expected a step in program, but found none")
-	}
+	program.Init(state)
 	fmt.Printf("%s\n%s\n\n", t.Name(), program)
-}
-
-func dispatcher() Dispatcher {
-	dispatcher := NewDispatcher()
-	dispatcher.Add(functions.StandardOverloads()...)
-	return dispatcher
 }

--- a/interpreter/prune.go
+++ b/interpreter/prune.go
@@ -15,10 +15,11 @@
 package interpreter
 
 import (
-	"github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+
+	structpb "github.com/golang/protobuf/ptypes/struct"
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )

--- a/interpreter/prune_test.go
+++ b/interpreter/prune_test.go
@@ -120,6 +120,7 @@ func TestPrune(t *testing.T) {
 		interpretable := interpreter.NewInterpretable(program)
 		_, state := interpretable.Eval(
 			NewActivation(map[string]interface{}{}))
+
 		newExpr := PruneAst(pExpr.Expr, state)
 		actual := debug.ToDebugString(newExpr)
 		if !test.Compare(actual, tst.P) {

--- a/server/server.go
+++ b/server/server.go
@@ -87,7 +87,7 @@ func (s *ConformanceServer) Eval(ctx context.Context, in *exprpb.EvalRequest) (*
 	pkg := packages.NewPackage(in.Container)
 	typeProvider := types.NewProvider()
 	i := interpreter.NewStandardInterpreter(pkg, typeProvider)
-	var prog interpreter.Program
+	var prog *interpreter.Program
 	switch in.ExprKind.(type) {
 	case *exprpb.EvalRequest_ParsedExpr:
 		parsed := in.GetParsedExpr()


### PR DESCRIPTION
The call dispatch has been made in-place meaning that the `Dispatcher` now modifies
loads / stores state directly for function calls rather than create a new `CallContext` and
arg list for each invocation. This reduces allocations and improves performance significantly.

Trivial allocations related to tracking the `Program` instruction counter and checking type
names have been scrubbed.

Below is a table of the before and after benchmarks and deltas:
```
benchmark                                                            old ns/op     new ns/op     delta
BenchmarkInterpreter_ConditionalExpr-12                              2958          1999          -32.42%
BenchmarkInterpreter_EqualsCall-12                                   163           102           -37.42%
BenchmarkInterpreter_EqualsDispatch-12                               743           186           -74.97%
BenchmarkInterpreter_EqualInstructions-12                            1194          486           -59.30%
BenchmarkInterpreter_ComprehensionExpr-12                            5422          3898          -28.11%
BenchmarkInterpreter_ComprehensionExprWithInput-12                   3467          2375          -31.50%
BenchmarkInterpreter_CanonicalExpressions/ExprBench/ok_1st-12        1383          597           -56.83%
BenchmarkInterpreter_CanonicalExpressions/ExprBench/ok_2nd-12        3693          1742          -52.83%
BenchmarkInterpreter_CanonicalExpressions/ExprBench/not_found-12     3497          1728          -50.59%
BenchmarkInterpreter_CanonicalExpressions/ExprBench/false_2nd-12     724           307           -57.60%

benchmark                                                            old allocs     new allocs     delta
BenchmarkInterpreter_ConditionalExpr-12                              17             12             -29.41%
BenchmarkInterpreter_EqualsCall-12                                   1              0              -100.00%
BenchmarkInterpreter_EqualsDispatch-12                               5              0              -100.00%
BenchmarkInterpreter_EqualInstructions-12                            8              0              -100.00%
BenchmarkInterpreter_ComprehensionExpr-12                            22             13             -40.91%
BenchmarkInterpreter_ComprehensionExprWithInput-12                   17             10             -41.18%
BenchmarkInterpreter_CanonicalExpressions/ExprBench/ok_1st-12        7              1              -85.71%
BenchmarkInterpreter_CanonicalExpressions/ExprBench/ok_2nd-12        16             5              -68.75%
BenchmarkInterpreter_CanonicalExpressions/ExprBench/not_found-12     16             5              -68.75%
BenchmarkInterpreter_CanonicalExpressions/ExprBench/false_2nd-12     3              0              -100.00%

benchmark                                                            old bytes     new bytes     delta
BenchmarkInterpreter_ConditionalExpr-12                              416           224           -46.15%
BenchmarkInterpreter_EqualsCall-12                                   16            0             -100.00%
BenchmarkInterpreter_EqualsDispatch-12                               192           0             -100.00%
BenchmarkInterpreter_EqualInstructions-12                            168           0             -100.00%
BenchmarkInterpreter_ComprehensionExpr-12                            1056          720           -31.82%
BenchmarkInterpreter_ComprehensionExprWithInput-12                   800           544           -32.00%
BenchmarkInterpreter_CanonicalExpressions/ExprBench/ok_1st-12        224           8             -96.43%
BenchmarkInterpreter_CanonicalExpressions/ExprBench/ok_2nd-12        528           104           -80.30%
BenchmarkInterpreter_CanonicalExpressions/ExprBench/not_found-12     528           104           -80.30%
BenchmarkInterpreter_CanonicalExpressions/ExprBench/false_2nd-12     112           0             -100.00%
```

Further improvements can be made to reduce the overhead within the `Dispatcher` as well as the
overhead between the `Interpreter` and `Dispatcher` as seen in the `EqualsCall`, `EqualsDispatch`,
and `EqualsInstructions` `ns/op` times.