### PR TITLE
Fix for the treatment of enums as ints within CEL.

### DIFF
--- a/common/types/int.go
+++ b/common/types/int.go
@@ -18,9 +18,10 @@ import (
 	"fmt"
 	"reflect"
 
-	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
+
+	structpb "github.com/golang/protobuf/ptypes/struct"
 )
 
 // Int type that implements ref.Value as well as comparison and math operators.

--- a/common/types/int.go
+++ b/common/types/int.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/golang/protobuf/ptypes/struct"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 )
@@ -71,7 +71,7 @@ func (i Int) Compare(other ref.Value) ref.Value {
 func (i Int) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	switch typeDesc.Kind() {
 	case reflect.Int32:
-		return int32(i), nil
+		return reflect.ValueOf(i).Convert(typeDesc).Interface(), nil
 	case reflect.Int64:
 		return int64(i), nil
 	case reflect.Ptr:

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -243,6 +243,12 @@ func NativeToValue(value interface{}) ref.Value {
 			return NewDynamicList(value)
 		case reflect.Map:
 			return NewDynamicMap(value)
+		// Enums are a type alias of int32, so they cannot be asserted as an
+		// int32 value, but rather need to be downcast to int32 before being
+		// converted to an Int representation.
+		case reflect.Int32:
+			intType := reflect.TypeOf(int32(0))
+			return Int(refValue.Convert(intType).Interface().(int32))
 		}
 	}
 	return NewErr("unsupported type conversion for value '%v'", value)

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -384,6 +384,94 @@ func TestInterpreter_BuildObject(t *testing.T) {
 	}
 }
 
+func TestInterpreter_GetObjectEnumField(t *testing.T) {
+	src := common.NewTextSource("a.repeated_nested_enum[0]")
+	parsed, errors := parser.Parse(src)
+	if len(errors.GetErrors()) != 0 {
+		t.Errorf(errors.ToDisplayString())
+	}
+
+	pkgr := packages.NewPackage("google.api.tools.expr.test")
+	provider := types.NewProvider(&test.TestAllTypes{})
+	env := checker.NewStandardEnv(pkgr, provider)
+	env.Add(decls.NewIdent("a", decls.NewObjectType("google.api.tools.expr.test.TestAllTypes"), nil))
+	checked, errors := checker.Check(parsed, src, env)
+	if len(errors.GetErrors()) != 0 {
+		t.Errorf(errors.ToDisplayString())
+	}
+
+	i := NewStandardInterpreter(pkgr, provider)
+	eval := i.NewInterpretable(NewCheckedProgram(checked))
+	a := &test.TestAllTypes{
+		RepeatedNestedEnum: []test.TestAllTypes_NestedEnum{
+			test.TestAllTypes_BAR,
+		},
+	}
+	result, state := eval.Eval(NewActivation(map[string]interface{}{
+		"a": types.NewObject(a),
+	}))
+	expected := int64(1)
+	got, ok := result.(ref.Value).Value().(int64)
+	if !ok {
+		t.Fatalf("cannot cast result to int64: result=%v state=%v", result, state)
+	}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("Could not build object properly. Got '%v', wanted '%v'",
+			result.(ref.Value).Value(),
+			expected)
+	}
+}
+
+func TestInterpreter_SetObjectEnumField(t *testing.T) {
+	// Test the use of enums within object construction, and their equivalence
+	// int values within CEL.
+	src := common.NewTextSource(
+		`TestAllTypes{
+			repeated_nested_enum: [
+				0,
+				TestAllTypes.NestedEnum.BAZ,
+				TestAllTypes.NestedEnum.BAR],
+			repeated_int32: [
+				TestAllTypes.NestedEnum.FOO,
+				TestAllTypes.NestedEnum.BAZ]}`)
+	parsed, errors := parser.Parse(src)
+	if len(errors.GetErrors()) != 0 {
+		t.Errorf(errors.ToDisplayString())
+	}
+
+	pkgr := packages.NewPackage("google.api.tools.expr.test")
+	provider := types.NewProvider(&test.TestAllTypes{})
+	env := checker.NewStandardEnv(pkgr, provider)
+	checked, errors := checker.Check(parsed, src, env)
+	if len(errors.GetErrors()) != 0 {
+		t.Errorf(errors.ToDisplayString())
+	}
+
+	i := NewStandardInterpreter(pkgr, provider)
+	eval := i.NewInterpretable(NewCheckedProgram(checked))
+	expected := &test.TestAllTypes{
+		RepeatedNestedEnum: []test.TestAllTypes_NestedEnum{
+			test.TestAllTypes_FOO,
+			test.TestAllTypes_BAZ,
+			test.TestAllTypes_BAR,
+		},
+		RepeatedInt32: []int32{
+			int32(0),
+			int32(2),
+		},
+	}
+	result, state := eval.Eval(NewActivation(map[string]interface{}{}))
+	got, ok := result.(ref.Value).Value().(*test.TestAllTypes)
+	if !ok {
+		t.Fatalf("cannot cast result to int64: result=%v state=%v", result, state)
+	}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("Could not build object properly. Got '%v', wanted '%v'",
+			result.(ref.Value).Value(),
+			expected)
+	}
+}
+
 func TestInterpreter_ConstantReturnValue(t *testing.T) {
 	parsed, err := parser.Parse(common.NewTextSource("1"))
 	if len(err.GetErrors()) != 0 {


### PR DESCRIPTION
Issue #146 revealed a bug in the treatment of enums in CEL as ints. Since enums are a kind of `Int32`, but they are not actually `int32` values, the conversion logic was incorrect and reflection needed to be introduced to cover the enum types properly. 