### PR TITLE
Conformance tests and use server library.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,7 @@
 workspace(name = "cel_go")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
 
 http_archive(
     name = "io_bazel_rules_go",
@@ -31,6 +32,67 @@ go_repository(
   name = "com_github_antlr",
   commit = "763a1242b7f5fca2c7a06f671ebe757580dacfb2",
   importpath = "github.com/antlr/antlr4",
+)
+
+git_repository(
+  name = "com_google_cel_spec",
+  # PR #37
+  commit = "2f58390677f9ffcb9a36420dcee18fcd9caeff27",
+  remote = "https://github.com/google/cel-spec.git",
+)
+
+# Required to use embedded BUILD.bazel file in googleapis/google/rpc
+git_repository(
+    name = "io_grpc_grpc_java",
+    remote = "https://github.com/grpc/grpc-java.git",
+    tag = "v1.13.1",
+)
+
+new_git_repository(
+    name = "com_google_googleapis",
+    remote = "https://github.com/googleapis/googleapis.git",
+    commit = "980cdfa876e54b1db4395617e14037612af25466",
+    build_file_content = """
+load('@io_bazel_rules_go//proto:def.bzl', 'go_proto_library')
+
+cc_proto_library(
+    name = 'cc_rpc_status',
+    deps = ['//google/rpc:status_proto'],
+    visibility = ['//visibility:public'],
+)
+
+cc_proto_library(
+    name = 'cc_rpc_code',
+    deps = ['//google/rpc:code_proto'],
+    visibility = ['//visibility:public'],
+)
+
+cc_proto_library(
+    name = 'cc_expr_v1beta1',
+    deps = [
+        '//google/api/expr/v1beta1/eval_proto',
+        '//google/api/expr/v1beta1/value_proto',
+    ],
+    visibility = ['//visibility:public'],
+)
+
+go_proto_library(
+    name = 'rpc_status_go_proto',
+    # TODO: Switch to the correct import path when bazel rules fixed.
+    #importpath = 'google.golang.org/genproto/googleapis/rpc/status',
+    importpath = 'github.com/googleapis/googleapis/google/rpc',
+    proto = '//google/rpc:status_proto',
+    visibility = ['//visibility:public'],
+)
+
+go_proto_library(
+    name = 'expr_v1beta1_go_proto',
+    importpath = 'google.golang.org/genproto/googleapis/api/expr/v1beta1',
+    proto = '//google/api/expr/v1beta1',
+    visibility = ['//visibility:public'],
+    deps = ['@com_google_googleapis//:rpc_status_go_proto'],
+)
+"""
 )
 
 go_repository(

--- a/conformance/BUILD.bazel
+++ b/conformance/BUILD.bazel
@@ -1,0 +1,14 @@
+sh_test(
+    name = "ct",
+    srcs = ["@com_google_cel_spec//tests:conftest.sh"],
+    args = [
+        "$(location @com_google_cel_spec//tests/simple:simple_test)",
+        "--server=$(location //server/main:cel_server)",
+        "$(location @com_google_cel_spec//tests/simple:testdata/basic.textproto)",
+    ],
+    data = [
+        "@com_google_cel_spec//tests/simple:simple_test",
+        "//server/main:cel_server",
+        "@com_google_cel_spec//tests/simple:testdata/basic.textproto",
+    ],
+)

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -40,8 +40,9 @@ go_test(
         "//checker/decls:go_default_library",
         "//common/operators:go_default_library",
         "//test:go_default_library",
+        "@com_google_cel_spec//tools/celrpc:go_default_library",
         "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",
         "@org_golang_google_genproto//googleapis/rpc/status:go_default_library",
-        "@org_golang_google_grpc//:go_default_library",
-    ]
+    ],
+    visibility = ["//visibility:public"],
 )

--- a/server/ct.sh
+++ b/server/ct.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$@"

--- a/server/main/BUILD.bazel
+++ b/server/main/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -10,9 +10,7 @@ go_binary(
     srcs = ["main.go"],
     deps = [
         "//server:go_default_library",
-        "@org_golang_google_grpc//:go_default_library",
-        "@org_golang_google_grpc//reflection:go_default_library",
-        "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",
+        "@com_google_cel_spec//tools/celrpc:go_default_library",
     ],
     out = "cel_server",
 )

--- a/server/main/main.go
+++ b/server/main/main.go
@@ -2,42 +2,10 @@
 package main
 
 import (
-	"fmt"
-	"log"
-	"net"
-	"os"
-
 	"github.com/google/cel-go/server"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/reflection"
-
-	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	"github.com/google/cel-spec/tools/celrpc"
 )
 
 func main() {
-	log.Println("Server opening listening port")
-	lis, err := net.Listen("tcp4", "127.0.0.1:")
-	if err != nil {
-		lis, err = net.Listen("tcp6", "[::1]:0")
-		if err != nil {
-			log.Fatalf("failed to listen: %v", err)
-		}
-	}
-	log.Println("Server opened port ", lis.Addr())
-
-	// Must print to stdout, so the client can find the port.
-	// So, no, this must be 'fmt', not 'log'.
-	fmt.Printf("Listening on %v\n", lis.Addr())
-	os.Stdout.Sync()
-	log.Println("Server wrote address")
-
-	log.Println("Server registering service on port")
-	s := grpc.NewServer()
-	exprpb.RegisterConformanceServiceServer(s, &server.ConformanceServer{})
-	log.Println("Server calling Register")
-	reflection.Register(s)
-	log.Println("Server calling Serve")
-	if err := s.Serve(lis); err != nil {
-		log.Fatalf("failed to serve: %v", err)
-	}
+	celrpc.RunServer(&server.ConformanceServer{})
 }


### PR DESCRIPTION
Conformance tests and use server library.

Run the cel-spec conformance tests against our conformance service server.  Simplify the server by using the provided library for handling launch of the server for testing.