### PR TITLE
Thread-safe evaluation state

### DIFF
--- a/interpreter/astwalker.go
+++ b/interpreter/astwalker.go
@@ -436,7 +436,7 @@ func (w *astWalker) getID(expr *exprpb.Expr) int64 {
 	id := expr.GetId()
 	if ident := expr.GetIdentExpr(); ident != nil {
 		if altID, found := w.scope.ref(ident.Name); found {
-			w.state.SetRuntimeExpressionID(id, altID)
+			w.state.setRuntimeExpressionID(id, altID)
 			return altID
 		}
 	}

--- a/interpreter/dispatcher.go
+++ b/interpreter/dispatcher.go
@@ -30,25 +30,19 @@ type Dispatcher interface {
 	Add(overloads ...*functions.Overload) error
 
 	// Dispatch a call to its appropriate Overload and set the evaluation
-	// state for the call to the return value.
-	Dispatch(call *CallExpr)
+	// state for the call to the return value. The input state slice is
+	// expected to contain the values indexed by expression id relevant to
+	// the call args and the storage of the result.
+	//
+	// See: evalstate.go
+	Dispatch(state []ref.Value, call *CallExpr)
 
 	// FindOverload returns an Overload definition matching the provided
 	// name.
 	FindOverload(overload string) (*functions.Overload, bool)
-
-	// Init clones the configuration of the current Dispatcher and returns
-	// a new one with its own MutableEvalState sharing the current Dispatcher's
-	// overload map.
-	Init(state MutableEvalState) Dispatcher
 }
 
 // NewDispatcher returns an empty Dispatcher instance.
-//
-// Functions may be added to the Dispatcher via the Add() call. At the
-// creation of a new Interpretable, the Dispatcher is cloned and given an
-// instance of a MutableEvalState for the purpose of gathering call args
-// and recording call responses in-place.
 func NewDispatcher() Dispatcher {
 	return &defaultDispatcher{
 		overloads: make(map[string]*functions.Overload)}
@@ -61,15 +55,6 @@ type overloadMap map[string]*functions.Overload
 // instance used to track call args and return values.
 type defaultDispatcher struct {
 	overloads overloadMap
-	state     MutableEvalState
-}
-
-// Init implements the Dispatcher.Init interface method.
-func (d *defaultDispatcher) Init(state MutableEvalState) Dispatcher {
-	return &defaultDispatcher{
-		overloads: d.overloads,
-		state:     state,
-	}
 }
 
 // Add implements the Dispatcher.Add interface method.
@@ -87,40 +72,38 @@ func (d *defaultDispatcher) Add(overloads ...*functions.Overload) error {
 }
 
 // Dispatcher implements the Dispatcher.Dispatch interface method.
-func (d *defaultDispatcher) Dispatch(call *CallExpr) {
-	s := d.state
+func (d *defaultDispatcher) Dispatch(state []ref.Value, call *CallExpr) {
 	function := call.Function
 	argCount := len(call.Args)
 	if overload, found := d.overloads[function]; found {
 		if argCount == 0 {
-			s.SetValue(call.ID, overload.Function())
+			state[call.ID] = overload.Function()
 			return
 		}
-		arg0, _ := s.Value(call.Args[0])
+		arg0 := state[call.Args[0]]
 		if !arg0.Type().HasTrait(overload.OperandTrait) {
-			s.SetValue(call.ID, types.NewErr("no such overload"))
+			state[call.ID] = types.NewErr("no such overload")
 			return
 		}
 		switch argCount {
 		case 1:
-			s.SetValue(call.ID, overload.Unary(arg0))
+			state[call.ID] = overload.Unary(arg0)
 			return
 		case 2:
-			arg1, _ := s.Value(call.Args[1])
-			s.SetValue(call.ID, overload.Binary(arg0, arg1))
+			arg1 := state[call.Args[1]]
+			state[call.ID] = overload.Binary(arg0, arg1)
 			return
 		case 3:
-			arg1, _ := s.Value(call.Args[1])
-			arg2, _ := s.Value(call.Args[2])
-			s.SetValue(call.ID, overload.Function(arg0, arg1, arg2))
+			arg1 := state[call.Args[1]]
+			arg2 := state[call.Args[2]]
+			state[call.ID] = overload.Function(arg0, arg1, arg2)
 			return
 		default:
 			args := make([]ref.Value, argCount, argCount)
 			for i, argID := range call.Args {
-				val, _ := s.Value(argID)
-				args[i] = val
+				args[i] = state[argID]
 			}
-			s.SetValue(call.ID, overload.Function(args...))
+			state[call.ID] = overload.Function(args...)
 			return
 		}
 	}
@@ -128,10 +111,10 @@ func (d *defaultDispatcher) Dispatch(call *CallExpr) {
 	if argCount == 0 {
 		// If we're here, then there wasn't a zero-arg global function,
 		// and there's definitely no member function without an operand.
-		s.SetValue(call.ID, types.NewErr("no such overload"))
+		state[call.ID] = types.NewErr("no such overload")
 		return
 	}
-	arg0, _ := s.Value(call.Args[0])
+	arg0 := state[call.Args[0]]
 	if arg0.Type().HasTrait(traits.ReceiverType) {
 		overload := call.Overload
 		args := make([]ref.Value, argCount-1, argCount-1)
@@ -139,13 +122,12 @@ func (d *defaultDispatcher) Dispatch(call *CallExpr) {
 			if i == 0 {
 				continue
 			}
-			val, _ := s.Value(argID)
-			args[i] = val
+			args[i] = state[argID]
 		}
-		s.SetValue(call.ID, arg0.(traits.Receiver).Receive(function, overload, args))
+		state[call.ID] = arg0.(traits.Receiver).Receive(function, overload, args)
 		return
 	}
-	s.SetValue(call.ID, types.NewErr("no such overload"))
+	state[call.ID] = types.NewErr("no such overload")
 }
 
 // FindOverload implements the Dispatcher.FindOverload interface method.

--- a/interpreter/dispatcher_test.go
+++ b/interpreter/dispatcher_test.go
@@ -24,11 +24,11 @@ import (
 )
 
 func TestDefaultDispatcher_Dispatch(t *testing.T) {
-	state := NewEvalState(3)
-	state.SetValue(1, types.Int(2))
-	state.SetValue(2, types.Int(2))
+	state := newEvalState(3)
+	state.values[1] = types.Int(1)
+	state.values[2] = types.Int(1)
 	call := NewCall(0, operators.Equals, []int64{1, 2})
-	disp(state).Dispatch(call)
+	disp().Dispatch(state.values, call)
 	res, _ := state.Value(0)
 	if res != types.True {
 		t.Errorf("Got '%v', wanted 'true'", res)
@@ -36,14 +36,14 @@ func TestDefaultDispatcher_Dispatch(t *testing.T) {
 }
 
 func TestDefaultDispatcher_DispatchOverload(t *testing.T) {
-	state := NewEvalState(3)
-	state.SetValue(1, types.Int(100))
-	state.SetValue(2, types.Int(200))
+	state := newEvalState(3)
+	state.values[1] = types.Int(100)
+	state.values[2] = types.Int(200)
 	call := NewCallOverload(0,
 		operators.Equals,
 		[]int64{1, 2},
 		overloads.Equals)
-	disp(state).Dispatch(call)
+	disp().Dispatch(state.values, call)
 	res, _ := state.Value(0)
 	if res != types.False {
 		t.Errorf("Got '%v', wanted 'false'", res)
@@ -52,12 +52,12 @@ func TestDefaultDispatcher_DispatchOverload(t *testing.T) {
 
 func BenchmarkDefaultDispatcher_Dispatch(b *testing.B) {
 	call := NewCall(0, operators.NotEquals, []int64{1, 2})
-	state := NewEvalState(3)
-	state.SetValue(1, types.Int(1))
-	state.SetValue(2, types.Int(2))
-	d := disp(state)
+	state := newEvalState(3)
+	state.values[1] = types.Int(1)
+	state.values[2] = types.Int(2)
+	d := disp()
 	for i := 0; i < b.N; i++ {
-		d.Dispatch(call)
+		d.Dispatch(state.values, call)
 	}
 }
 
@@ -66,17 +66,17 @@ func BenchmarkDefaultDispatcher_DispatchOverload(b *testing.B) {
 		operators.NotEquals,
 		[]int64{1, 2},
 		overloads.NotEquals)
-	state := NewEvalState(3)
-	state.SetValue(1, types.Int(2))
-	state.SetValue(2, types.Int(2))
-	d := disp(state)
+	state := newEvalState(3)
+	state.values[1] = types.Int(1)
+	state.values[2] = types.Int(2)
+	d := disp()
 	for i := 0; i < b.N; i++ {
-		d.Dispatch(call)
+		d.Dispatch(state.values, call)
 	}
 }
 
-func disp(state MutableEvalState) Dispatcher {
+func disp() Dispatcher {
 	dispatcher := NewDispatcher()
 	dispatcher.Add(functions.StandardOverloads()...)
-	return dispatcher.Init(state)
+	return dispatcher
 }

--- a/interpreter/evalstate.go
+++ b/interpreter/evalstate.go
@@ -20,12 +20,9 @@ import (
 
 // EvalState tracks the values associated with expression ids during execution.
 type EvalState interface {
-	// GetRuntimeExpressionID returns the runtime id corresponding to the
-	// expression id from the AST.
+	// GetRuntimeExpressionID returns the runtime id corresponding to the expression id from the
+	// AST.
 	GetRuntimeExpressionID(exprID int64) int64
-
-	// OnlyValue returns the value in the eval state, if only one exists.
-	OnlyValue() (ref.Value, bool)
 
 	// Value of the given expression id, false if not found.
 	Value(int64) (ref.Value, bool)
@@ -46,6 +43,7 @@ func newEvalState(instructionCount int64) *evalState {
 		values:    make([]ref.Value, instructionCount, instructionCount)}
 }
 
+// GetRuntimeExpressionID is an implementation fo the EvalState interface method.
 func (s *evalState) GetRuntimeExpressionID(exprID int64) int64 {
 	if val, ok := s.exprIDMap[exprID]; ok {
 		return val
@@ -53,25 +51,7 @@ func (s *evalState) GetRuntimeExpressionID(exprID int64) int64 {
 	return exprID
 }
 
-func (s *evalState) OnlyValue() (ref.Value, bool) {
-	var result ref.Value
-	i := 0
-	for _, val := range s.values {
-		if val != nil {
-			result = val
-			i++
-		}
-	}
-	if i == 1 {
-		return result, true
-	}
-	return nil, false
-}
-
-func (s *evalState) SetRuntimeExpressionID(exprID int64, runtimeID int64) {
-	s.exprIDMap[exprID] = runtimeID
-}
-
+// Value is an implementation of the EvalState interface method.
 func (s *evalState) Value(exprID int64) (ref.Value, bool) {
 	// TODO: The eval state assumes a dense progrma expression id space. While
 	// this is true of how the cel-go parser generates identifiers, it may not
@@ -83,6 +63,13 @@ func (s *evalState) Value(exprID int64) (ref.Value, bool) {
 	return nil, false
 }
 
+// setRuntimeExpressionID establishes the mapping between an expression id and another equivalent
+// expression with a different id elsewhere in the AST.
+func (s *evalState) setRuntimeExpressionID(exprID int64, runtimeID int64) {
+	s.exprIDMap[exprID] = runtimeID
+}
+
+// copy sets the internal `values` of this eval state instance to the values of the input `src`.
 func (s *evalState) copy(src *evalState) bool {
 	if s.exprCount != src.exprCount {
 		return false

--- a/interpreter/evalstate_test.go
+++ b/interpreter/evalstate_test.go
@@ -21,12 +21,11 @@ import (
 )
 
 func TestGetterSetter(t *testing.T) {
-	var evalState EvalState = NewEvalState(2)
-	if val, found := evalState.Value(1); found && val != nil {
+	evalState := newEvalState(2)
+	if val, found := evalState.Value(1); !found || val != nil {
 		t.Error("Unexpected value found", val)
 	}
-	var mutableState = evalState.(MutableEvalState)
-	mutableState.SetValue(1, types.String("hello"))
+	evalState.values[1] = types.String("hello")
 	if greeting, found := evalState.Value(1); !found || greeting != types.String("hello") {
 		t.Error("Unexpected value found", greeting)
 	}

--- a/interpreter/instructions.go
+++ b/interpreter/instructions.go
@@ -186,7 +186,7 @@ func NewObject(exprID int64, name string,
 type JumpInst struct {
 	*baseInstruction
 	Count       int
-	OnCondition func(EvalState) bool
+	OnCondition func([]ref.Value) bool
 }
 
 // String generates pseudo-assembly for the instruction.
@@ -195,7 +195,7 @@ func (e *JumpInst) String() string {
 }
 
 // NewJump generates a JumpInst.
-func NewJump(exprID int64, instructionCount int, cond func(EvalState) bool) *JumpInst {
+func NewJump(exprID int64, instructionCount int, cond func([]ref.Value) bool) *JumpInst {
 	return &JumpInst{
 		baseInstruction: &baseInstruction{exprID},
 		Count:           instructionCount,

--- a/interpreter/program_test.go
+++ b/interpreter/program_test.go
@@ -28,8 +28,8 @@ func TestNewExhaustiveProgram_LogicalOr(t *testing.T) {
 	if loc, found := program.Metadata().IDLocation(1); found {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
-	state := NewEvalState(program.MaxInstructionID() + 1)
-	program.Init(state)
+	state := newEvalState(program.MaxInstructionID() + 1)
+	program.plan(state)
 	fmt.Printf("%s\n%s\n\n", t.Name(), program)
 
 	expected := "TestNewExhaustiveProgram_LogicalOr\n" +
@@ -51,8 +51,8 @@ func TestNewExhaustiveProgram_Conditional(t *testing.T) {
 	if loc, found := program.Metadata().IDLocation(1); found {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
-	state := NewEvalState(program.MaxInstructionID() + 1)
-	program.Init(state)
+	state := newEvalState(program.MaxInstructionID() + 1)
+	program.plan(state)
 	expected := "TestNewExhaustiveProgram_Conditional\n" +
 		"0: local 'a', r1\n" +
 		"1: local 'b', r2\n" +
@@ -75,8 +75,8 @@ func TestNewProgram_Empty(t *testing.T) {
 	if loc, found := program.Metadata().IDLocation(0); found {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
-	state := NewEvalState(program.MaxInstructionID() + 1)
-	program.Init(state)
+	state := newEvalState(program.MaxInstructionID() + 1)
+	program.plan(state)
 }
 
 func TestNewProgram_LogicalAnd(t *testing.T) {
@@ -86,8 +86,8 @@ func TestNewProgram_LogicalAnd(t *testing.T) {
 	if loc, found := program.Metadata().IDLocation(1); found {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
-	state := NewEvalState(program.MaxInstructionID() + 1)
-	program.Init(state)
+	state := newEvalState(program.MaxInstructionID() + 1)
+	program.plan(state)
 	fmt.Printf("%s\n%s\n\n", t.Name(), program)
 }
 
@@ -98,8 +98,8 @@ func TestNewProgram_LogicalOr(t *testing.T) {
 	if loc, found := program.Metadata().IDLocation(1); found {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
-	state := NewEvalState(program.MaxInstructionID() + 1)
-	program.Init(state)
+	state := newEvalState(program.MaxInstructionID() + 1)
+	program.plan(state)
 	fmt.Printf("%s\n%s\n\n", t.Name(), program)
 }
 
@@ -110,8 +110,8 @@ func TestNewProgram_Conditional(t *testing.T) {
 	if loc, found := program.Metadata().IDLocation(1); found {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
-	state := NewEvalState(program.MaxInstructionID() + 1)
-	program.Init(state)
+	state := newEvalState(program.MaxInstructionID() + 1)
+	program.plan(state)
 	expected := "TestNewProgram_Conditional\n" +
 		"0: local 'a', r1\n" +
 		"1: jump  8 if cond<r1>\n" +
@@ -137,8 +137,8 @@ func TestNewProgram_Comprehension(t *testing.T) {
 	if loc, found := program.Metadata().IDLocation(1); !found {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
-	state := NewEvalState(program.MaxInstructionID() + 1)
-	program.Init(state)
+	state := newEvalState(program.MaxInstructionID() + 1)
+	program.plan(state)
 	fmt.Printf("%s\n%s\n\n", t.Name(), program)
 }
 
@@ -149,7 +149,7 @@ func TestNewProgram_DynMap(t *testing.T) {
 	if loc, found := program.Metadata().IDLocation(1); found {
 		t.Errorf("Unexpected location found: %v", loc)
 	}
-	state := NewEvalState(program.MaxInstructionID() + 1)
-	program.Init(state)
+	state := newEvalState(program.MaxInstructionID() + 1)
+	program.plan(state)
 	fmt.Printf("%s\n%s\n\n", t.Name(), program)
 }

--- a/interpreter/prune_test.go
+++ b/interpreter/prune_test.go
@@ -117,6 +117,7 @@ func TestPrune(t *testing.T) {
 	for _, tst := range testCases {
 		pExpr := &exprpb.ParsedExpr{Expr: tst.E}
 		program := NewProgram(pExpr.Expr, pExpr.SourceInfo)
+		program.flags = programFlagTrackState
 		interpretable := interpreter.NewInterpretable(program)
 		_, state := interpretable.Eval(
 			NewActivation(map[string]interface{}{}))


### PR DESCRIPTION
Thread-safe evaluation state.

The existing implementation shares a single `MutableEvalState` object across all `Eval` calls.
This is incredibly fast, but not thread-safe as concurrent go-routines might clobber each others
evaluation outcomes. Additionally, the output `EvalState` is dirty, thus making it unsuitable for
multiple evaluations within the context of `Program` instances created with
`NewExhaustiveProgram`.

This PR includes the following changes:

*  Removes the `MutableEvalState` interface.
*  Pools runtime state allocations behind a thread-safe `sync.Pool`
*  Adds a `programFlag` concept which specifies behaviors such as state tracking
    and disabling short-circuiting.
*  Optionally returns a non-nil `EvalState` with the evaluation result if state-tracking
    is flag enabled.
