### PR TITLE
Tree-balanced logical ops.

### DIFF
--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -410,43 +410,43 @@ _!=_(_-_(_+_(1~double, _*_(2~double, 3~double)~double^multiply_double)
 		&& z == 1.0`,
 		R: `_&&_(
 			_&&_(
-			  _&&_(
 				_==_(
-				  _[_](
 					_[_](
-					  _[_](
-						x~map(string, dyn)^x,
-						"claims"~string
-					  )~dyn^index_map,
-					  "groups"~string
-					)~list(string)^index_map,
-					0~int
-				  )~string^index_list.name~string,
-				  "dummy"~string
+						_[_](
+							_[_](
+								x~map(string, dyn)^x,
+								"claims"~string
+							)~dyn^index_map,
+							"groups"~string
+						)~list(string)^index_map,
+						0~int
+					)~string^index_list.name~string,
+					"dummy"~string
 				)~bool^equals,
 				_==_(
-				  _[_](
-					x~map(string, dyn)^x.claims~dyn,
-					"exp"~string
-				  )~dyn^index_map,
-				  _[_](
-					y~list(dyn)^y,
-					1~int
-				  )~dyn^index_list.time~dyn
+					_[_](
+						x~map(string, dyn)^x.claims~dyn,
+						"exp"~string
+					)~dyn^index_map,
+					_[_](
+						y~list(dyn)^y,
+						1~int
+					)~dyn^index_list.time~dyn
 				)~bool^equals
-			  )~bool^logical_and,
-			  _==_(
-				x~map(string, dyn)^x.claims~dyn.structured~dyn,
-				{
-				  "key"~string:z~dyn^z
-				}~map(string, dyn)
-			  )~bool^equals
 			)~bool^logical_and,
-			_==_(
-			  z~dyn^z,
-			  1~double
-			)~bool^equals
-		  )~bool^logical_and`,
+			_&&_(
+				_==_(
+					x~map(string, dyn)^x.claims~dyn.structured~dyn,
+					{
+						"key"~string:z~dyn^z
+					}~map(string, dyn)
+				)~bool^equals,
+				_==_(
+					z~dyn^z,
+					1~double
+				)~bool^equals
+			)~bool^logical_and
+		)~bool^logical_and`,
 		Env: env{
 			idents: []*exprpb.Decl{
 				decls.NewIdent("x", decls.NewObjectType("google.protobuf.Struct"), nil),
@@ -895,34 +895,34 @@ ERROR: <input>:1:5: undeclared reference to 'x' (in container '')
 		R: `
 		_||_(
 			_||_(
-			  _||_(
 				_&&_(
-				  _==_(
-					x~any^x,
-					google.protobuf.Any{
-					  type_url:"types.googleapis.com/google.expr.proto3.test.TestAllTypes"~string
-					}~google.protobuf.Any^google.protobuf.Any
-				  )~bool^equals,
-				  _==_(
-					x~any^x.single_nested_message~dyn.bb~dyn,
-					43~int
-				  )~bool^equals
+					_==_(
+						x~any^x,
+						google.protobuf.Any{
+							type_url:"types.googleapis.com/google.expr.proto3.test.TestAllTypes"~string
+						}~google.protobuf.Any^google.protobuf.Any
+					)~bool^equals,
+					_==_(
+						x~any^x.single_nested_message~dyn.bb~dyn,
+						43~int
+					)~bool^equals
 				)~bool^logical_and,
 				_==_(
-				  x~any^x,
-				  google.expr.proto3.test.TestAllTypes{}~google.expr.proto3.test.TestAllTypes^google.expr.proto3.test.TestAllTypes
+					x~any^x,
+					google.expr.proto3.test.TestAllTypes{}~google.expr.proto3.test.TestAllTypes^google.expr.proto3.test.TestAllTypes
 				)~bool^equals
-			  )~bool^logical_or,
-			  _<_(
-				y~wrapper(int)^y,
-				x~any^x
-			  )~bool^less_int64
 			)~bool^logical_or,
-			_>=_(
-			  x~any^x,
-			  x~any^x
-			)~dyn^greater_equals_bool|greater_equals_int64|greater_equals_uint64|greater_equals_double|greater_equals_string|greater_equals_bytes|greater_equals_timestamp|greater_equals_duration
-		  )~bool^logical_or
+			_||_(
+				_<_(
+					y~wrapper(int)^y,
+					x~any^x
+				)~bool^less_int64,
+				_>=_(
+					x~any^x,
+					x~any^x
+				)~dyn^greater_equals_bool|greater_equals_int64|greater_equals_uint64|greater_equals_double|greater_equals_string|greater_equals_bytes|greater_equals_timestamp|greater_equals_duration
+			)~bool^logical_or
+		)~bool^logical_or
 		`,
 		Type: decls.Bool,
 	},

--- a/parser/helper.go
+++ b/parser/helper.go
@@ -157,6 +157,10 @@ func (p *parserHelper) newComprehension(ctx interface{}, iterVar string,
 }
 
 func (p *parserHelper) newExpr(ctx interface{}) *exprpb.Expr {
+	id, isID := ctx.(int64)
+	if isID {
+		return &exprpb.Expr{Id: id}
+	}
 	return &exprpb.Expr{Id: p.id(ctx)}
 }
 
@@ -182,4 +186,67 @@ func (p *parserHelper) getLocation(id int64) common.Location {
 	characterOffset := p.positions[id]
 	location, _ := p.source.OffsetLocation(characterOffset)
 	return location
+}
+
+// balancer performs tree balancing on operators whose arguments are of equal precedence.
+//
+// The purpose of the balancer is to ensure a compact serialization format for the logical &&, ||
+// operators which have a tendency to create long DAGs which are skewed in one direction. Since the
+// operators are commutative re-ordering the terms *must not* affect the evaluation result.
+//
+// Re-balancing the terms is a safe, if somewhat controversial choice. A better solution would be
+// to make these functions variadic and update both the checker and interpreter to understand this;
+// however, this is a more complex change.
+//
+// TODO: Consider replacing tree-balancing with variadic logical &&, || within the parser, checker,
+// and interpreter.
+type balancer struct {
+	helper   *parserHelper
+	function string
+	terms    []*exprpb.Expr
+	ops      []int64
+}
+
+// newBalancer creates a balancer instance bound to a specific function and its first term.
+func newBalancer(h *parserHelper, function string, term *exprpb.Expr) *balancer {
+	return &balancer{
+		helper:   h,
+		function: function,
+		terms:    []*exprpb.Expr{term},
+		ops:      []int64{},
+	}
+}
+
+// addTerm adds an operation identifier and term to the set of terms to be balanced.
+func (b *balancer) addTerm(op int64, term *exprpb.Expr) {
+	b.terms = append(b.terms, term)
+	b.ops = append(b.ops, op)
+}
+
+// balance creates a balanced tree from the sub-terms and returns the final Expr value.
+func (b *balancer) balance() *exprpb.Expr {
+	if len(b.terms) == 1 {
+		return b.terms[0]
+	}
+	return b.balancedTree(0, len(b.ops)-1)
+}
+
+// balancedTree recursively balances the terms provided to a commutative operator.
+func (b *balancer) balancedTree(lo, hi int) *exprpb.Expr {
+	mid := (lo + hi + 1) / 2
+
+	var left *exprpb.Expr
+	if mid == lo {
+		left = b.terms[mid]
+	} else {
+		left = b.balancedTree(lo, mid-1)
+	}
+
+	var right *exprpb.Expr
+	if mid == hi {
+		right = b.terms[mid+1]
+	} else {
+		right = b.balancedTree(mid+1, hi)
+	}
+	return b.helper.newGlobalCall(b.ops[mid], b.function, left, right)
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -145,11 +145,13 @@ func (p *parser) VisitConditionalOr(ctx *gen.ConditionalOrContext) interface{} {
 	if ctx.GetOps() == nil {
 		return result
 	}
+	b := newBalancer(p.helper, operators.LogicalOr, result)
 	for i, op := range ctx.GetOps() {
 		next := p.Visit(ctx.GetE1()[i]).(*exprpb.Expr)
-		result = p.globalCallOrMacro(op, operators.LogicalOr, result, next)
+		opID := p.helper.id(op)
+		b.addTerm(opID, next)
 	}
-	return result
+	return b.balance()
 }
 
 // Visit a parse tree produced by CELParser#conditionalAnd.
@@ -158,11 +160,13 @@ func (p *parser) VisitConditionalAnd(ctx *gen.ConditionalAndContext) interface{}
 	if ctx.GetOps() == nil {
 		return result
 	}
+	b := newBalancer(p.helper, operators.LogicalAnd, result)
 	for i, op := range ctx.GetOps() {
 		next := p.Visit(ctx.GetE1()[i]).(*exprpb.Expr)
-		result = p.globalCallOrMacro(op, operators.LogicalAnd, result, next)
+		opID := p.helper.id(op)
+		b.addTerm(opID, next)
 	}
-	return result
+	return b.balance()
 }
 
 // Visit a parse tree produced by CELParser#relation.

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -116,6 +116,79 @@ var testCases = []testInfo{
 			)^#3:*expr.Expr_CallExpr#`,
 	},
 	{
+		I: `a || b || c || d || e || f `,
+		P: ` _||_(
+			_||_(
+			  _||_(
+				a^#1:*expr.Expr_IdentExpr#,
+				b^#2:*expr.Expr_IdentExpr#
+			  )^#3:*expr.Expr_CallExpr#,
+			  c^#4:*expr.Expr_IdentExpr#
+			)^#5:*expr.Expr_CallExpr#,
+			_||_(
+			  _||_(
+				d^#6:*expr.Expr_IdentExpr#,
+				e^#8:*expr.Expr_IdentExpr#
+			  )^#9:*expr.Expr_CallExpr#,
+			  f^#10:*expr.Expr_IdentExpr#
+			)^#11:*expr.Expr_CallExpr#
+		  )^#7:*expr.Expr_CallExpr#`,
+	},
+	{
+		I: `a && b`,
+		P: `_&&_(
+    		  a^#1:*expr.Expr_IdentExpr#,
+    		  b^#2:*expr.Expr_IdentExpr#
+			)^#3:*expr.Expr_CallExpr#`,
+	},
+	{
+		I: `a && b && c && d && e && f && g`,
+		P: `_&&_(
+			_&&_(
+			  _&&_(
+				a^#1:*expr.Expr_IdentExpr#,
+				b^#2:*expr.Expr_IdentExpr#
+			  )^#3:*expr.Expr_CallExpr#,
+			  _&&_(
+				c^#4:*expr.Expr_IdentExpr#,
+				d^#6:*expr.Expr_IdentExpr#
+			  )^#7:*expr.Expr_CallExpr#
+			)^#5:*expr.Expr_CallExpr#,
+			_&&_(
+			  _&&_(
+				e^#8:*expr.Expr_IdentExpr#,
+				f^#10:*expr.Expr_IdentExpr#
+			  )^#11:*expr.Expr_CallExpr#,
+			  g^#12:*expr.Expr_IdentExpr#
+			)^#13:*expr.Expr_CallExpr#
+		  )^#9:*expr.Expr_CallExpr#`,
+	},
+	{
+		I: `a && b && c && d || e && f && g && h`,
+		P: `_||_(
+			_&&_(
+			  _&&_(
+				a^#1:*expr.Expr_IdentExpr#,
+				b^#2:*expr.Expr_IdentExpr#
+			  )^#3:*expr.Expr_CallExpr#,
+			  _&&_(
+				c^#4:*expr.Expr_IdentExpr#,
+				d^#6:*expr.Expr_IdentExpr#
+			  )^#7:*expr.Expr_CallExpr#
+			)^#5:*expr.Expr_CallExpr#,
+			_&&_(
+			  _&&_(
+				e^#8:*expr.Expr_IdentExpr#,
+				f^#9:*expr.Expr_IdentExpr#
+			  )^#10:*expr.Expr_CallExpr#,
+			  _&&_(
+				g^#11:*expr.Expr_IdentExpr#,
+				h^#13:*expr.Expr_IdentExpr#
+			  )^#14:*expr.Expr_CallExpr#
+			)^#12:*expr.Expr_CallExpr#
+		  )^#15:*expr.Expr_CallExpr#`,
+	},
+	{
 		I: `a + b`,
 		P: `_+_(
     		  a^#1:*expr.Expr_IdentExpr#,


### PR DESCRIPTION
To ensure that ASTs are represented as compactly as possible, the logical `&&`, `||` operator terms
have been tree-balanced. These operators can create highly skewed DAGs for larger expressions
which can result in issues with the recursion limits present during proto-deserialization. While this
is an unconventional approach that may change the order of evaluation of certain terms, it will not
change the evaluation outcome. 

Closes Issue #160 