### PR TITLE
Fix the eval option init values and decorator lists

### DIFF
--- a/cel/options.go
+++ b/cel/options.go
@@ -168,7 +168,7 @@ type EvalOption int
 
 const (
 	// OptTrackState will cause the runtime to return an immutable EvalState value in the Result.
-	OptTrackState EvalOption = iota << 1
+	OptTrackState EvalOption = iota + 1
 
 	// OptExhaustiveEval causes the runtime to disable short-circuits and track state.
 	OptExhaustiveEval EvalOption = OptTrackState | iota<<1

--- a/cel/program.go
+++ b/cel/program.go
@@ -119,14 +119,14 @@ func newProgram(e *env, ast Ast, opts ...ProgramOption) (Program, error) {
 		// State tracking requires that each Eval() call operate on an isolated EvalState
 		// object; hence, the presence of the factory.
 		factory := func(state interpreter.EvalState) (Program, error) {
-			decorators = append(decorators, interpreter.ExhaustiveEval(state))
+			decs := append(decorators, interpreter.ExhaustiveEval(state))
 			clone := &prog{
 				evalOpts:    p.evalOpts,
 				defaultVars: p.defaultVars,
 				env:         e,
 				dispatcher:  disp,
 				interpreter: interp}
-			return initInterpretable(clone, ast, decorators)
+			return initInterpretable(clone, ast, decs)
 		}
 		return &progGen{factory: factory}, nil
 	}
@@ -134,14 +134,14 @@ func newProgram(e *env, ast Ast, opts ...ProgramOption) (Program, error) {
 	// featured than the ExhaustiveEval decorator.
 	if p.evalOpts&OptTrackState == OptTrackState {
 		factory := func(state interpreter.EvalState) (Program, error) {
-			decorators = append(decorators, interpreter.TrackState(state))
+			decs := append(decorators, interpreter.TrackState(state))
 			clone := &prog{
 				evalOpts:    p.evalOpts,
 				defaultVars: p.defaultVars,
 				env:         e,
 				dispatcher:  disp,
 				interpreter: interp}
-			return initInterpretable(clone, ast, decorators)
+			return initInterpretable(clone, ast, decs)
 		}
 		return &progGen{factory: factory}, nil
 	}


### PR DESCRIPTION
Decorator lists were growing indefinitely and the options for the CEL eval modes were incorrectly started at 0 rather than 1 making the state tracking always enabled.