### PR TITLE
CEL Interface change to reduce allocations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,11 @@ func main() {
 		log.Fatalf("program creation error: %s\n", err)
 	}
 
-	out, err := prg.Eval(cel.Vars(map[string]interface{}{
+	// Note, the second result, the EvalDetails will be non-nil when using
+	// either cel.OptTrackState or cel.OptExhaustiveEval (not shown). The
+	// details value holds information about the evaluation, rather than the
+	// output of the evaluation itself.
+	out, _, err := prg.Eval(cel.Vars(map[string]interface{}{
 		"i": "CEL",
 		"you": "world"}))
 	if err != nil {
@@ -94,7 +98,7 @@ func main() {
 	}
 
 	// Hello world! I'm CEL.
-	fmt.Println(out.Value())
+	fmt.Println(out)
 }
 ```
 

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -70,8 +70,8 @@ func Example() {
 		log.Fatalf("program creation error: %s\n", err)
 	}
 
-	// Evaluate the program against some inputs.
-	out, err := prg.Eval(Vars(map[string]interface{}{
+	// Evaluate the program against some inputs. Note: the details return is not used.
+	out, _, err := prg.Eval(Vars(map[string]interface{}{
 		// Native values are converted to CEL values under the covers.
 		"i": "CEL",
 		// Values may also be lazily supplied.
@@ -81,7 +81,7 @@ func Example() {
 		log.Fatalf("runtime error: %s\n", err)
 	}
 
-	fmt.Println(out.Value())
+	fmt.Println(out)
 	// Output:Hello world! Nice to meet you, I'm CEL.
 }
 
@@ -110,7 +110,9 @@ func Test_ExampleWithBuiltins(t *testing.T) {
 	if err != nil {
 		t.Fatalf("program creation error: %s\n", err)
 	}
-	out, err := prg.Eval(Vars(map[string]interface{}{
+	// If the Eval() call were provided with cel.EvalOptions(OptTrackState) the details response
+	// (2nd return) would be non-nill
+	out, _, err := prg.Eval(Vars(map[string]interface{}{
 		"i":   "CEL",
 		"you": "world"}))
 	if err != nil {
@@ -118,7 +120,7 @@ func Test_ExampleWithBuiltins(t *testing.T) {
 	}
 
 	// Hello world! I'm CEL.
-	if out.Value().Equal(types.String("Hello world! I'm CEL.")) != types.True {
+	if out.Equal(types.String("Hello world! I'm CEL.")) != types.True {
 		t.Errorf(`Got '%v', wanted "Hello world! I'm CEL."`, out.Value())
 	}
 }
@@ -140,8 +142,8 @@ func Test_DisableStandardEnv(t *testing.T) {
 		p, _ := e.Parse("a.b.c")
 		c, _ := e.Check(p)
 		prg, _ := e.Program(c)
-		out, _ := prg.Eval(Vars(map[string]interface{}{"a.b.c": true}))
-		if !out.Value().Equal(types.True).(types.Bool) {
+		out, _, _ := prg.Eval(Vars(map[string]interface{}{"a.b.c": true}))
+		if !out.Equal(types.True).(types.Bool) {
 			t.Errorf("Got '%v', wanted 'true'", out.Value())
 		}
 	})
@@ -165,7 +167,7 @@ func Test_CustomTypes(t *testing.T) {
 			}}`)
 	c, _ := e.Check(p)
 	prg, _ := e.Program(c)
-	out, _ := prg.Eval(Vars(map[string]interface{}{"expr": &exprpb.Expr{
+	out, _, _ := prg.Eval(Vars(map[string]interface{}{"expr": &exprpb.Expr{
 		Id: 2,
 		ExprKind: &exprpb.Expr_CallExpr{
 			CallExpr: &exprpb.Expr_Call{
@@ -187,7 +189,7 @@ func Test_CustomTypes(t *testing.T) {
 			},
 		},
 	}}))
-	if !out.Value().Equal(types.True).(types.Bool) {
+	if !out.Equal(types.True).(types.Bool) {
 		t.Errorf("Got '%v', wanted 'true'", out.Value())
 	}
 }
@@ -240,26 +242,26 @@ func Test_GlobalVars(t *testing.T) {
 	})))
 
 	t.Run("global_default", func(t *testing.T) {
-		out, _ := prg.Eval(Vars(map[string]interface{}{
+		out, _, _ := prg.Eval(Vars(map[string]interface{}{
 			"attrs": map[string]interface{}{}}))
-		if out.Value().Equal(types.String("third")) != types.True {
+		if out.Equal(types.String("third")) != types.True {
 			t.Errorf("Got '%v', expected 'third'.", out.Value())
 		}
 	})
 
 	t.Run("attrs_alt", func(t *testing.T) {
-		out, _ := prg.Eval(Vars(map[string]interface{}{
+		out, _, _ := prg.Eval(Vars(map[string]interface{}{
 			"attrs": map[string]interface{}{"second": "yep"}}))
-		if out.Value().Equal(types.String("yep")) != types.True {
+		if out.Equal(types.String("yep")) != types.True {
 			t.Errorf("Got '%v', expected 'yep'.", out.Value())
 		}
 	})
 
 	t.Run("local_default", func(t *testing.T) {
-		out, _ := prg.Eval(Vars(map[string]interface{}{
+		out, _, _ := prg.Eval(Vars(map[string]interface{}{
 			"attrs":   map[string]interface{}{},
 			"default": "fourth"}))
-		if out.Value().Equal(types.String("fourth")) != types.True {
+		if out.Equal(types.String("fourth")) != types.True {
 			t.Errorf("Got '%v', expected 'fourth'.", out.Value())
 		}
 	})
@@ -277,17 +279,17 @@ func Test_EvalOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("program creation error: %s\n", err)
 	}
-	out, err := prg.Eval(Vars(map[string]interface{}{"k": "key", "v": true}))
+	out, details, err := prg.Eval(Vars(map[string]interface{}{"k": "key", "v": true}))
 	if err != nil {
 		t.Fatalf("runtime error: %s\n", err)
 	}
-	if out.Value().Equal(types.True) != types.True {
+	if out.Equal(types.True) != types.True {
 		t.Errorf("Got '%v', expected 'true'", out.Value())
 	}
 
 	// Test to see whether 'v != false' was resolved to a value.
 	// With short-circuiting it normally wouldn't be.
-	s := out.State()
+	s := details.State()
 	lhsVal, found := s.Value(p.Expr().GetCallExpr().GetArgs()[0].Id)
 	if !found {
 		t.Error("Got not found, wanted evaluation of left hand side expression.")

--- a/cel/options.go
+++ b/cel/options.go
@@ -168,15 +168,15 @@ type EvalOption int
 
 const (
 	// OptTrackState will cause the runtime to return an immutable EvalState value in the Result.
-	OptTrackState EvalOption = iota + 1
+	OptTrackState EvalOption = 1 << iota
 
 	// OptExhaustiveEval causes the runtime to disable short-circuits and track state.
-	OptExhaustiveEval EvalOption = OptTrackState | iota<<1
+	OptExhaustiveEval EvalOption = 1<<iota | OptTrackState
 
 	// OptFoldConstants evaluates functions and operators with constants as arguments at program
 	// creation time. This flag is useful when the expression will be evaluated repeatedly against
 	// a series of different inputs.
-	OptFoldConstants EvalOption = iota << 1
+	OptFoldConstants EvalOption = 1 << iota
 )
 
 // EvalOptions sets one or more evaluation options which may affect the evaluation or Result.


### PR DESCRIPTION
Remove `cel.Result` from the CEL interface preferring to return an unwrapped `ref.Val`
with a possible non-nil `cel.EvalDetails`. This subtle change reduces allocations in the
common case.