### PR TITLE
Isolated Type Declarations and Descriptor Declarations

### DIFF
--- a/cel/BUILD.bazel
+++ b/cel/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//common/types/ref:go_default_library",
         "//common/types/traits:go_default_library",
         "//interpreter/functions:go_default_library",
+        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
         "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",
     ],
 )

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -15,16 +15,21 @@
 package cel
 
 import (
+	"bytes"
+	"compress/gzip"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 	"github.com/google/cel-go/interpreter/functions"
 
+	descpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
@@ -203,10 +208,24 @@ func Test_IsolatedTypes(t *testing.T) {
 				Expr{id: 1, ident_expr: Expr.Ident{ name: "a" }},
 				Expr{id: 3, ident_expr: Expr.Ident{ name: "b" }}]
 		}}`
+	gzipped := proto.FileDescriptor("google/api/expr/v1alpha1/syntax.proto")
+        r, err := gzip.NewReader(bytes.NewReader(gzipped))
+        if err != nil {
+                t.Fatal(err)
+        }
+        unzipped, err := ioutil.ReadAll(r)
+        if err != nil {
+                t.Fatal(err)
+        }
+        fd := &descpb.FileDescriptorProto{}
+        if err := proto.Unmarshal(unzipped, fd); err != nil {
+                t.Fatalf("bad gzipped descriptor: %v", err)
+        }
+
 	e, err := NewEnv(
 		Container("google.api.expr.v1alpha1"),
 		IsolateTypes(),
-		Types(&exprpb.Expr{}),
+		Types(fd),
 		Declarations(
 			decls.NewIdent("expr",
 				decls.NewObjectType("google.api.expr.v1alpha1.Expr"), nil)))

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -209,18 +209,18 @@ func Test_IsolatedTypes(t *testing.T) {
 				Expr{id: 3, ident_expr: Expr.Ident{ name: "b" }}]
 		}}`
 	gzipped := proto.FileDescriptor("google/api/expr/v1alpha1/syntax.proto")
-        r, err := gzip.NewReader(bytes.NewReader(gzipped))
-        if err != nil {
-                t.Fatal(err)
-        }
-        unzipped, err := ioutil.ReadAll(r)
-        if err != nil {
-                t.Fatal(err)
-        }
-        fd := &descpb.FileDescriptorProto{}
-        if err := proto.Unmarshal(unzipped, fd); err != nil {
-                t.Fatalf("bad gzipped descriptor: %v", err)
-        }
+	r, err := gzip.NewReader(bytes.NewReader(gzipped))
+	if err != nil {
+		t.Fatal(err)
+	}
+	unzipped, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fd := &descpb.FileDescriptorProto{}
+	if err := proto.Unmarshal(unzipped, fd); err != nil {
+		t.Fatalf("bad gzipped descriptor: %v", err)
+	}
 
 	e, err := NewEnv(
 		Container("google.api.expr.v1alpha1"),
@@ -244,7 +244,7 @@ func Test_IsolatedTypes(t *testing.T) {
 		Declarations(
 			decls.NewIdent("expr",
 				decls.NewObjectType("google.api.expr.v1alpha1.Expr"), nil)))
-	p2, _ :=  e2.Parse(src)
+	p2, _ := e2.Parse(src)
 	_, iss = e2.Check(p2)
 	if iss == nil || iss.Err() == nil {
 		t.Errorf("Wanted check failure for unknown message.")

--- a/cel/options.go
+++ b/cel/options.go
@@ -117,7 +117,7 @@ func Types(addTypes ...interface{}) EnvOption {
 		for _, t := range addTypes {
 			switch t.(type) {
 			case proto.Message:
-				fd, err := pb.DescribeFile(t.(proto.Message))
+				fd, err := e.types.pbdb.DescribeFile(t.(proto.Message))
 				if err != nil {
 					return nil, err
 				}

--- a/cel/options.go
+++ b/cel/options.go
@@ -19,8 +19,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cel-go/common/packages"
-	"github.com/google/cel-go/common/types"
-	"github.com/google/cel-go/common/types/pb"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter"
 	"github.com/google/cel-go/interpreter/functions"
@@ -117,15 +115,9 @@ func Types(addTypes ...interface{}) EnvOption {
 		for _, t := range addTypes {
 			switch t.(type) {
 			case proto.Message:
-				fd, err := e.types.pbdb.DescribeFile(t.(proto.Message))
+				err := e.types.RegisterMessage(t.(proto.Message))
 				if err != nil {
 					return nil, err
-				}
-				for _, typeName := range fd.GetTypeNames() {
-					err := e.types.RegisterType(types.NewObjectTypeValue(typeName))
-					if err != nil {
-						return nil, err
-					}
 				}
 			case ref.Type:
 				err := e.types.RegisterType(t.(ref.Type))

--- a/cel/options.go
+++ b/cel/options.go
@@ -100,6 +100,17 @@ func Container(pkg string) EnvOption {
 	}
 }
 
+// IsolateTypes copies the global protobuf registry into a copy private
+// to this Env.  Subsequent Type() calls will modify the protobuf registry
+// in this Env only.  Note that privately-registered protobufs cannot
+// be instantiated with types.NewObject().
+func IsolateTypes() EnvOption {
+	return func(e *env) (*env, error) {
+		e.types.IsolateTypes()
+		return e, nil
+	}
+}
+
 // Types adds one or more type declarations to the environment, allowing for construction of
 // type-literals whose definitions are included in the common expression built-in set.
 //

--- a/common/types/BUILD.bazel
+++ b/common/types/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library",
         "@io_bazel_rules_go//proto/wkt:any_go_proto",
+        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
         "@io_bazel_rules_go//proto/wkt:duration_go_proto",
         "@io_bazel_rules_go//proto/wkt:struct_go_proto",
         "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",

--- a/common/types/object.go
+++ b/common/types/object.go
@@ -37,7 +37,7 @@ type protoObj struct {
 // conversion between protobuf type values and expression type values.
 // Objects support indexing and iteration.
 func NewObject(value proto.Message) ref.Val {
-	typeDesc, err := pb.DescribeValue(value)
+	typeDesc, err := pb.DefaultPbDb.DescribeValue(value)
 	if err != nil {
 		panic(err)
 	}

--- a/common/types/object.go
+++ b/common/types/object.go
@@ -36,21 +36,9 @@ type protoObj struct {
 // NewObject returns an object based on a proto.Message value which handles
 // conversion between protobuf type values and expression type values.
 // Objects support indexing and iteration.
-// DEPRECATED: use ref.TypeProvider.NewObject() instead.
+// Note:  only uses default PbDb.
 func NewObject(value proto.Message) ref.Val {
 	typeDesc, err := pb.DefaultPbDb.DescribeValue(value)
-	if err != nil {
-		panic(err)
-	}
-	return &protoObj{
-		value:     value,
-		refValue:  reflect.ValueOf(value),
-		typeDesc:  typeDesc,
-		typeValue: NewObjectTypeValue(typeDesc.Name())}
-}
-
-func newObjectFromPbDb(value proto.Message, pbdb *pb.PbDb) ref.Val {
-	typeDesc, err := pbdb.DescribeValue(value)
 	if err != nil {
 		panic(err)
 	}

--- a/common/types/object.go
+++ b/common/types/object.go
@@ -36,8 +36,21 @@ type protoObj struct {
 // NewObject returns an object based on a proto.Message value which handles
 // conversion between protobuf type values and expression type values.
 // Objects support indexing and iteration.
+// DEPRECATED: use ref.TypeProvider.NewObject() instead.
 func NewObject(value proto.Message) ref.Val {
 	typeDesc, err := pb.DefaultPbDb.DescribeValue(value)
+	if err != nil {
+		panic(err)
+	}
+	return &protoObj{
+		value:     value,
+		refValue:  reflect.ValueOf(value),
+		typeDesc:  typeDesc,
+		typeValue: NewObjectTypeValue(typeDesc.Name())}
+}
+
+func newObjectFromPbDb(value proto.Message, pbdb *pb.PbDb) ref.Val {
+	typeDesc, err := pbdb.DescribeValue(value)
 	if err != nil {
 		panic(err)
 	}

--- a/common/types/pb/file.go
+++ b/common/types/pb/file.go
@@ -73,7 +73,7 @@ func (fd *FileDescription) Package() string {
 	return fd.desc.GetPackage()
 }
 
-func (fd *FileDescription) indexEnums(pkg string, enumTypes []*descpb.EnumDescriptorProto) {
+func (pbdb *PbDb) indexEnums(fd *FileDescription, pkg string, enumTypes []*descpb.EnumDescriptorProto) {
 	for _, enumType := range enumTypes {
 		for _, enumValue := range enumType.Value {
 			enumValueName := fmt.Sprintf(
@@ -82,12 +82,12 @@ func (fd *FileDescription) indexEnums(pkg string, enumTypes []*descpb.EnumDescri
 				enumName: enumValueName,
 				file:     fd,
 				desc:     enumValue}
-			revFileDescriptorMap[enumValueName] = fd
+			pbdb.revFileDescriptorMap[enumValueName] = fd
 		}
 	}
 }
 
-func (fd *FileDescription) indexTypes(pkg string, msgTypes []*descpb.DescriptorProto) {
+func (pbdb *PbDb) indexTypes(fd *FileDescription, pkg string, msgTypes []*descpb.DescriptorProto) {
 	for _, msgType := range msgTypes {
 		msgName := fmt.Sprintf("%s.%s", pkg, msgType.GetName())
 		td := &TypeDescription{
@@ -97,9 +97,9 @@ func (fd *FileDescription) indexTypes(pkg string, msgTypes []*descpb.DescriptorP
 			fields:       make(map[string]*FieldDescription),
 			fieldIndices: make(map[int][]*FieldDescription)}
 		fd.types[msgName] = td
-		fd.indexTypes(msgName, msgType.NestedType)
-		fd.indexEnums(msgName, msgType.EnumType)
-		revFileDescriptorMap[msgName] = fd
+		pbdb.indexTypes(fd, msgName, msgType.NestedType)
+		pbdb.indexEnums(fd, msgName, msgType.EnumType)
+		pbdb.revFileDescriptorMap[msgName] = fd
 	}
 }
 

--- a/common/types/pb/file_test.go
+++ b/common/types/pb/file_test.go
@@ -6,7 +6,8 @@ import (
 )
 
 func TestFileDescription_GetTypes(t *testing.T) {
-	fd, err := DescribeFile(&testpb.TestAllTypes{})
+	pbdb := NewPbDb()
+	fd, err := pbdb.DescribeFile(&testpb.TestAllTypes{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -46,7 +47,8 @@ func TestFileDescription_GetTypes(t *testing.T) {
 }
 
 func TestFileDescription_GetEnumNames(t *testing.T) {
-	fd, err := DescribeFile(&testpb.TestAllTypes{})
+	pbdb := NewPbDb()
+	fd, err := pbdb.DescribeFile(&testpb.TestAllTypes{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/common/types/pb/pb.go
+++ b/common/types/pb/pb.go
@@ -80,8 +80,8 @@ func (pbdb *PbDb) DescribeFile(message proto.Message) (*FileDescription, error) 
 		return nil, err
 	}
 	pkg := fd.Package()
-	pbdb.indexTypes(fd, pkg, fileDesc.MessageType)
-	pbdb.indexEnums(fd, pkg, fileDesc.EnumType)
+	fd.indexTypes(pkg, fileDesc.MessageType)
+	fd.indexEnums(pkg, fileDesc.EnumType)
 	return fd, nil
 }
 
@@ -107,6 +107,7 @@ func (pbdb *PbDb) DescribeValue(value proto.Message) (*TypeDescription, error) {
 
 func (pbdb *PbDb) describeFileInternal(fileDesc *descpb.FileDescriptorProto) (*FileDescription, error) {
 	fd := &FileDescription{
+		pbdb:  pbdb,
 		desc:  fileDesc,
 		types: make(map[string]*TypeDescription),
 		enums: make(map[string]*EnumDescription)}

--- a/common/types/pb/pb.go
+++ b/common/types/pb/pb.go
@@ -39,15 +39,15 @@ type PbDb struct {
 
 var (
 	DefaultPbDb = &PbDb{
-		revFileDescriptorMap:	make(map[string]*FileDescription),
+		revFileDescriptorMap: make(map[string]*FileDescription),
 	}
 )
 
 func NewPbDb() *PbDb {
 	pbdb := &PbDb{
-		revFileDescriptorMap:	make(map[string]*FileDescription),
+		revFileDescriptorMap: make(map[string]*FileDescription),
 	}
-	for k,v := range DefaultPbDb.revFileDescriptorMap {
+	for k, v := range DefaultPbDb.revFileDescriptorMap {
 		pbdb.revFileDescriptorMap[k] = v
 	}
 	return pbdb

--- a/common/types/pb/pb.go
+++ b/common/types/pb/pb.go
@@ -62,13 +62,7 @@ func (pbdb *PbDb) DescribeEnum(enumName string) (*EnumDescription, error) {
 	return nil, fmt.Errorf("unrecognized enum '%s'", enumName)
 }
 
-// DescribeFile takes a protocol buffer message and indexes all of the message
-// types and enum values contained within the message's file descriptor.
-func (pbdb *PbDb) DescribeFile(message proto.Message) (*FileDescription, error) {
-	if fd, found := pbdb.revFileDescriptorMap[proto.MessageName(message)]; found {
-		return fd, nil
-	}
-	fileDesc, _ := descriptor.ForMessage(message.(descriptor.Message))
+func (pbdb *PbDb) DescribeDescriptor(fileDesc *descpb.FileDescriptorProto) (*FileDescription, error) {
 	fd, err := pbdb.describeFileInternal(fileDesc)
 	if err != nil {
 		return nil, err
@@ -77,6 +71,16 @@ func (pbdb *PbDb) DescribeFile(message proto.Message) (*FileDescription, error) 
 	fd.indexTypes(pkg, fileDesc.MessageType)
 	fd.indexEnums(pkg, fileDesc.EnumType)
 	return fd, nil
+}
+
+// DescribeFile takes a protocol buffer message and indexes all of the message
+// types and enum values contained within the message's file descriptor.
+func (pbdb *PbDb) DescribeFile(message proto.Message) (*FileDescription, error) {
+	if fd, found := pbdb.revFileDescriptorMap[proto.MessageName(message)]; found {
+		return fd, nil
+	}
+	fileDesc, _ := descriptor.ForMessage(message.(descriptor.Message))
+	return pbdb.DescribeDescriptor(fileDesc)
 }
 
 // DescribeType provides a TypeDescription given a qualified type name.

--- a/common/types/pb/pb.go
+++ b/common/types/pb/pb.go
@@ -34,24 +34,18 @@ import (
 
 // map from file / message / enum name to file description.
 type PbDb struct {
-	fileDescriptorMap    map[string]*FileDescription
 	revFileDescriptorMap map[string]*FileDescription
 }
 
 var (
 	DefaultPbDb = &PbDb{
-		fileDescriptorMap:	make(map[string]*FileDescription),
 		revFileDescriptorMap:	make(map[string]*FileDescription),
 	}
 )
 
 func NewPbDb() *PbDb {
 	pbdb := &PbDb{
-		fileDescriptorMap:	make(map[string]*FileDescription),
 		revFileDescriptorMap:	make(map[string]*FileDescription),
-	}
-	for k,v := range DefaultPbDb.fileDescriptorMap {
-		pbdb.fileDescriptorMap[k] = v
 	}
 	for k,v := range DefaultPbDb.revFileDescriptorMap {
 		pbdb.revFileDescriptorMap[k] = v
@@ -111,18 +105,6 @@ func (pbdb *PbDb) describeFileInternal(fileDesc *descpb.FileDescriptorProto) (*F
 		desc:  fileDesc,
 		types: make(map[string]*TypeDescription),
 		enums: make(map[string]*EnumDescription)}
-	pbdb.fileDescriptorMap[fileDesc.GetName()] = fd
-
-	for _, dep := range fileDesc.Dependency {
-		if _, found := pbdb.fileDescriptorMap[dep]; !found {
-			nestedDesc, err := fileDescriptor(dep)
-			if err != nil {
-				panic(err)
-			}
-			pbdb.describeFileInternal(nestedDesc)
-		}
-	}
-
 	return fd, nil
 }
 

--- a/common/types/pb/pb.go
+++ b/common/types/pb/pb.go
@@ -32,10 +32,37 @@ import (
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 )
 
+// map from file / message / enum name to file description.
+type PbDb struct {
+	fileDescriptorMap    map[string]*FileDescription
+	revFileDescriptorMap map[string]*FileDescription
+}
+
+var (
+	DefaultPbDb = &PbDb{
+		fileDescriptorMap:	make(map[string]*FileDescription),
+		revFileDescriptorMap:	make(map[string]*FileDescription),
+	}
+)
+
+func NewPbDb() *PbDb {
+	pbdb := &PbDb{
+		fileDescriptorMap:	make(map[string]*FileDescription),
+		revFileDescriptorMap:	make(map[string]*FileDescription),
+	}
+	for k,v := range DefaultPbDb.fileDescriptorMap {
+		pbdb.fileDescriptorMap[k] = v
+	}
+	for k,v := range DefaultPbDb.revFileDescriptorMap {
+		pbdb.revFileDescriptorMap[k] = v
+	}
+	return pbdb
+}
+
 // DescribeEnum takes a qualified enum name and returns an EnumDescription.
-func DescribeEnum(enumName string) (*EnumDescription, error) {
+func (pbdb *PbDb) DescribeEnum(enumName string) (*EnumDescription, error) {
 	enumName = sanitizeProtoName(enumName)
-	if fd, found := revFileDescriptorMap[enumName]; found {
+	if fd, found := pbdb.revFileDescriptorMap[enumName]; found {
 		return fd.GetEnumDescription(enumName)
 	}
 	return nil, fmt.Errorf("unrecognized enum '%s'", enumName)
@@ -43,25 +70,25 @@ func DescribeEnum(enumName string) (*EnumDescription, error) {
 
 // DescribeFile takes a protocol buffer message and indexes all of the message
 // types and enum values contained within the message's file descriptor.
-func DescribeFile(message proto.Message) (*FileDescription, error) {
-	if fd, found := revFileDescriptorMap[proto.MessageName(message)]; found {
+func (pbdb *PbDb) DescribeFile(message proto.Message) (*FileDescription, error) {
+	if fd, found := pbdb.revFileDescriptorMap[proto.MessageName(message)]; found {
 		return fd, nil
 	}
 	fileDesc, _ := descriptor.ForMessage(message.(descriptor.Message))
-	fd, err := describeFileInternal(fileDesc)
+	fd, err := pbdb.describeFileInternal(fileDesc)
 	if err != nil {
 		return nil, err
 	}
 	pkg := fd.Package()
-	fd.indexTypes(pkg, fileDesc.MessageType)
-	fd.indexEnums(pkg, fileDesc.EnumType)
+	pbdb.indexTypes(fd, pkg, fileDesc.MessageType)
+	pbdb.indexEnums(fd, pkg, fileDesc.EnumType)
 	return fd, nil
 }
 
 // DescribeType provides a TypeDescription given a qualified type name.
-func DescribeType(typeName string) (*TypeDescription, error) {
+func (pbdb *PbDb) DescribeType(typeName string) (*TypeDescription, error) {
 	typeName = sanitizeProtoName(typeName)
-	if fd, found := revFileDescriptorMap[typeName]; found {
+	if fd, found := pbdb.revFileDescriptorMap[typeName]; found {
 		return fd.GetTypeDescription(typeName)
 	}
 	return nil, fmt.Errorf("unrecognized type '%s'", typeName)
@@ -69,8 +96,8 @@ func DescribeType(typeName string) (*TypeDescription, error) {
 
 // DescribeValue takes an instance of a protocol buffer message and returns
 // the associated TypeDescription.
-func DescribeValue(value proto.Message) (*TypeDescription, error) {
-	fd, err := DescribeFile(value)
+func (pbdb *PbDb) DescribeValue(value proto.Message) (*TypeDescription, error) {
+	fd, err := pbdb.DescribeFile(value)
 	if err != nil {
 		return nil, err
 	}
@@ -78,26 +105,20 @@ func DescribeValue(value proto.Message) (*TypeDescription, error) {
 	return fd.GetTypeDescription(typeName)
 }
 
-var (
-	// map from file / message / enum name to file description.
-	fileDescriptorMap    = make(map[string]*FileDescription)
-	revFileDescriptorMap = make(map[string]*FileDescription)
-)
-
-func describeFileInternal(fileDesc *descpb.FileDescriptorProto) (*FileDescription, error) {
+func (pbdb *PbDb) describeFileInternal(fileDesc *descpb.FileDescriptorProto) (*FileDescription, error) {
 	fd := &FileDescription{
 		desc:  fileDesc,
 		types: make(map[string]*TypeDescription),
 		enums: make(map[string]*EnumDescription)}
-	fileDescriptorMap[fileDesc.GetName()] = fd
+	pbdb.fileDescriptorMap[fileDesc.GetName()] = fd
 
 	for _, dep := range fileDesc.Dependency {
-		if _, found := fileDescriptorMap[dep]; !found {
+		if _, found := pbdb.fileDescriptorMap[dep]; !found {
 			nestedDesc, err := fileDescriptor(dep)
 			if err != nil {
 				panic(err)
 			}
-			describeFileInternal(nestedDesc)
+			pbdb.describeFileInternal(nestedDesc)
 		}
 	}
 
@@ -128,9 +149,9 @@ func init() {
 	// The following subset of message types is enough to ensure that all well-known types can
 	// resolved in the runtime, since describing the value results in describing the whole file
 	// where the message is declared.
-	DescribeValue(&anypb.Any{})
-	DescribeValue(&durpb.Duration{})
-	DescribeValue(&tspb.Timestamp{})
-	DescribeValue(&structpb.Value{})
-	DescribeValue(&wrapperspb.BoolValue{})
+	DefaultPbDb.DescribeValue(&anypb.Any{})
+	DefaultPbDb.DescribeValue(&durpb.Duration{})
+	DefaultPbDb.DescribeValue(&tspb.Timestamp{})
+	DefaultPbDb.DescribeValue(&structpb.Value{})
+	DefaultPbDb.DescribeValue(&wrapperspb.BoolValue{})
 }

--- a/common/types/pb/type.go
+++ b/common/types/pb/type.go
@@ -178,9 +178,9 @@ type FieldDescription struct {
 }
 
 // CheckedType returns the type-definition used at type-check time.
-func (fd *FieldDescription) CheckedType() *exprpb.Type {
-	if fd.IsMap() {
-		td, _ := DescribeType(fd.TypeName())
+func (pbdb *PbDb) CheckedType(fd *FieldDescription) *exprpb.Type {
+	if pbdb.IsMap(fd) {
+		td, _ := pbdb.DescribeType(fd.TypeName())
 		key := td.getFieldsAtIndex(0)[0]
 		val := td.getFieldsAtIndex(1)[0]
 		return &exprpb.Type{
@@ -228,11 +228,11 @@ func (fd *FieldDescription) OneofType() reflect.Type {
 }
 
 // IsMap returns true if the field is of map type.
-func (fd *FieldDescription) IsMap() bool {
+func (pbdb *PbDb) IsMap(fd *FieldDescription) bool {
 	if !fd.IsRepeated() || !fd.IsMessage() {
 		return false
 	}
-	td, err := DescribeType(fd.TypeName())
+	td, err := pbdb.DescribeType(fd.TypeName())
 	if err != nil {
 		return false
 	}

--- a/common/types/pb/type.go
+++ b/common/types/pb/type.go
@@ -114,8 +114,8 @@ func (td *TypeDescription) getFieldsInfo() (map[string]*FieldDescription,
 				}
 				desc := fieldDescMap[prop.OrigName]
 				fd := &FieldDescription{
-					tdesc:	td,
-					desc:	desc,
+					tdesc:  td,
+					desc:   desc,
 					index:  i,
 					prop:   prop,
 					proto3: isProto3}

--- a/common/types/pb/type_test.go
+++ b/common/types/pb/type_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestTypeDescription_FieldCount(t *testing.T) {
-	td, err := DescribeValue(&testpb.NestedTestAllTypes{})
+	pbdb := NewPbDb()
+	td, err := pbdb.DescribeValue(&testpb.NestedTestAllTypes{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -21,42 +22,48 @@ func TestTypeDescription_FieldCount(t *testing.T) {
 }
 
 func TestTypeDescription_Any(t *testing.T) {
-	_, err := DescribeType(".google.protobuf.Any")
+	pbdb := NewPbDb()
+	_, err := pbdb.DescribeType(".google.protobuf.Any")
 	if err != nil {
 		t.Error(err)
 	}
 }
 
 func TestTypeDescription_Json(t *testing.T) {
-	_, err := DescribeType(".google.protobuf.Value")
+	pbdb := NewPbDb()
+	_, err := pbdb.DescribeType(".google.protobuf.Value")
 	if err != nil {
 		t.Error(err)
 	}
 }
 
 func TestTypeDescription_JsonNotInTypeInit(t *testing.T) {
-	_, err := DescribeType(".google.protobuf.ListValue")
+	pbdb := NewPbDb()
+	_, err := pbdb.DescribeType(".google.protobuf.ListValue")
 	if err != nil {
 		t.Error(err)
 	}
 }
 
 func TestTypeDescription_Wrapper(t *testing.T) {
-	_, err := DescribeType(".google.protobuf.BoolValue")
+	pbdb := NewPbDb()
+	_, err := pbdb.DescribeType(".google.protobuf.BoolValue")
 	if err != nil {
 		t.Error(err)
 	}
 }
 
 func TestTypeDescription_WrapperNotInTypeInit(t *testing.T) {
-	_, err := DescribeType(".google.protobuf.BytesValue")
+	pbdb := NewPbDb()
+	_, err := pbdb.DescribeType(".google.protobuf.BytesValue")
 	if err != nil {
 		t.Error(err)
 	}
 }
 
 func TestTypeDescription_Field(t *testing.T) {
-	td, err := DescribeValue(&testpb.NestedTestAllTypes{})
+	pbdb := NewPbDb()
+	td, err := pbdb.DescribeValue(&testpb.NestedTestAllTypes{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -76,7 +83,7 @@ func TestTypeDescription_Field(t *testing.T) {
 	if fd.IsOneof() {
 		t.Error("Field payload is listed as a oneof and it is not.")
 	}
-	if fd.IsMap() {
+	if pbdb.IsMap(fd) {
 		t.Error("Field 'payload' is listed as a map and it is not.")
 	}
 	if !fd.IsMessage() {
@@ -91,7 +98,7 @@ func TestTypeDescription_Field(t *testing.T) {
 	if fd.Index() != 1 {
 		t.Error("Field 'payload' was fetched at index 1, but not listed there.")
 	}
-	if !proto.Equal(fd.CheckedType(), &exprpb.Type{
+	if !proto.Equal(pbdb.CheckedType(fd), &exprpb.Type{
 		TypeKind: &exprpb.Type_MessageType{
 			MessageType: "google.expr.proto3.test.TestAllTypes"}}) {
 		t.Error("Field 'payload' had an unexpected checked type.")

--- a/common/types/pb/type_test.go
+++ b/common/types/pb/type_test.go
@@ -83,7 +83,7 @@ func TestTypeDescription_Field(t *testing.T) {
 	if fd.IsOneof() {
 		t.Error("Field payload is listed as a oneof and it is not.")
 	}
-	if pbdb.IsMap(fd) {
+	if fd.IsMap() {
 		t.Error("Field 'payload' is listed as a map and it is not.")
 	}
 	if !fd.IsMessage() {
@@ -98,7 +98,7 @@ func TestTypeDescription_Field(t *testing.T) {
 	if fd.Index() != 1 {
 		t.Error("Field 'payload' was fetched at index 1, but not listed there.")
 	}
-	if !proto.Equal(pbdb.CheckedType(fd), &exprpb.Type{
+	if !proto.Equal(fd.CheckedType(), &exprpb.Type{
 		TypeKind: &exprpb.Type_MessageType{
 			MessageType: "google.expr.proto3.test.TestAllTypes"}}) {
 		t.Error("Field 'payload' had an unexpected checked type.")

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -32,7 +32,7 @@ import (
 
 type protoTypeProvider struct {
 	revTypeMap map[string]ref.Type
-	pbdb *pb.PbDb
+	pbdb       *pb.PbDb
 }
 
 // NewProvider accepts a list of proto message instances and returns a type
@@ -40,8 +40,8 @@ type protoTypeProvider struct {
 // message that proto depends upon in its FileDescriptor.
 func NewProvider(types ...proto.Message) ref.TypeProvider {
 	p := &protoTypeProvider{
-		revTypeMap:	make(map[string]ref.Type),
-		pbdb:		pb.DefaultPbDb,
+		revTypeMap: make(map[string]ref.Type),
+		pbdb:       pb.DefaultPbDb,
 	}
 	p.RegisterType(
 		BoolType,

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -92,7 +92,7 @@ func (p *protoTypeProvider) FindFieldType(t *exprpb.Type,
 			return nil, false
 		}
 		return &ref.FieldType{
-				Type:             p.pbdb.CheckedType(field),
+				Type:             field.CheckedType(),
 				SupportsPresence: field.SupportsPresence()},
 			true
 	}

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -167,8 +167,29 @@ func (p *protoTypeProvider) NewValue(typeName string, fields map[string]ref.Val)
 }
 
 func (p *protoTypeProvider) RegisterDescriptor(fileDesc *descpb.FileDescriptorProto) error {
-	_, err := p.pbdb.DescribeDescriptor(fileDesc)
-	return err
+	fd, err := p.pbdb.DescribeDescriptor(fileDesc)
+	if err != nil {
+		return err
+	}
+	return p.registerAllTypes(fd)
+}
+
+func (p *protoTypeProvider) RegisterMessage(message proto.Message) error {
+	fd, err := p.pbdb.DescribeFile(message)
+	if err != nil {
+		return err
+	}
+	return p.registerAllTypes(fd)
+}
+
+func (p *protoTypeProvider) registerAllTypes(fd *pb.FileDescription) error {
+	for _, typeName := range fd.GetTypeNames() {
+		err := p.RegisterType(NewObjectTypeValue(typeName))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (p *protoTypeProvider) RegisterType(types ...ref.Type) error {

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -41,7 +41,7 @@ type protoTypeProvider struct {
 func NewProvider(types ...proto.Message) ref.TypeProvider {
 	p := &protoTypeProvider{
 		revTypeMap:	make(map[string]ref.Type),
-		pbdb:		pb.NewPbDb(),
+		pbdb:		pb.DefaultPbDb,
 	}
 	p.RegisterType(
 		BoolType,
@@ -123,8 +123,8 @@ func (p *protoTypeProvider) FindType(typeName string) (*exprpb.Type, bool) {
 					MessageType: typeName}}}}, true
 }
 
-func (p *protoTypeProvider) NewObject(value proto.Message) ref.Val {
-	return newObjectFromPbDb(value, p.pbdb)
+func (p *protoTypeProvider) IsolateTypes() {
+	p.pbdb = pb.NewPbDb()
 }
 
 func (p *protoTypeProvider) NewValue(typeName string, fields map[string]ref.Val) ref.Val {

--- a/common/types/ref/BUILD.bazel
+++ b/common/types/ref/BUILD.bazel
@@ -13,6 +13,8 @@ go_library(
     ],
     importpath = "github.com/google/cel-go/common/types/ref",
     deps = [
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
         "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",
     ],
 )

--- a/common/types/ref/provider.go
+++ b/common/types/ref/provider.go
@@ -15,6 +15,9 @@
 package ref
 
 import (
+	"github.com/golang/protobuf/proto"
+
+	descpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
@@ -40,9 +43,18 @@ type TypeProvider interface {
 	// Used during type-checking only.
 	FindFieldType(t *exprpb.Type, fieldName string) (*FieldType, bool)
 
+	// NewObject returns an object based on a proto.Message value which
+	// handles conversion between protobuf type values and expression
+	// type values.  Objects support indexing and iteration.
+	NewObject(value proto.Message) Val
+
 	// NewValue creates a new type value from a qualified name and a map of
 	// field initializers.
 	NewValue(typeName string, fields map[string]Val) Val
+
+	// RegisterDescriptor registers the contents of a protocol
+	// buffer FileDescriptor.
+	RegisterDescriptor(fileDesc *descpb.FileDescriptorProto) error
 
 	// RegisterType registers a type value with the provider which ensures the
 	// provider is aware of how to map the type to an identifier.

--- a/common/types/ref/provider.go
+++ b/common/types/ref/provider.go
@@ -56,6 +56,10 @@ type TypeProvider interface {
 	// buffer FileDescriptor.
 	RegisterDescriptor(fileDesc *descpb.FileDescriptorProto) error
 
+	// RegisterMessage registers a protocol buffer message
+	// and its dependencies.
+	RegisterMessage(message proto.Message) error
+
 	// RegisterType registers a type value with the provider which ensures the
 	// provider is aware of how to map the type to an identifier.
 	//

--- a/common/types/ref/provider.go
+++ b/common/types/ref/provider.go
@@ -43,10 +43,12 @@ type TypeProvider interface {
 	// Used during type-checking only.
 	FindFieldType(t *exprpb.Type, fieldName string) (*FieldType, bool)
 
-	// NewObject returns an object based on a proto.Message value which
-	// handles conversion between protobuf type values and expression
-	// type values.  Objects support indexing and iteration.
-	NewObject(value proto.Message) Val
+	// IsolateTypes copies the global protobuf registry into a copy
+	// private to this TypeProvider.  Subsequent Describe*() calls
+	// will modify the protobuf registry only in this TypeProvider.
+	// Note that privately-registered protobufs cannot be instantiated
+	// with types.NewObject().
+	IsolateTypes()
 
 	// NewValue creates a new type value from a qualified name and a map of
 	// field initializers.


### PR DESCRIPTION
The protocol buffer registry in common/types/pb contains global mutable state.  This state is now pulled into a struct, the PbDb, with a global variable for the default PbDb.  When using "isolated" types, the registry is copied to private state.  Also introduces the ability to provide message declarations via FileDescriptorProto directly.