### PR TITLE
syntax error in sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ import(
 	"fmt"
 	"log"
 
-	"github.com/google/cel-go/cel",
+	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker/decls"
 )
 


### PR DESCRIPTION
I ran the sample by copying it into a file `sample.go` and added  `package main`, 
ran with `go run sample.go` and got error:
```
sample.go:7:32: expected ';', found ','
```
after removing the comma it worked fine
