### PR TITLE
Fix ANTLR related data-race.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ go_repository(
 
 go_repository(
   name = "com_github_antlr",
-  commit = "763a1242b7f5fca2c7a06f671ebe757580dacfb2",
+  tag = "4.7.2",
   importpath = "github.com/antlr/antlr4",
 )
 

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1127,6 +1127,7 @@ func TestCheck(t *testing.T) {
 	for i, tst := range testCases {
 		name := fmt.Sprintf("%d %s", i, tst.I)
 		t.Run(name, func(tt *testing.T) {
+			tt.Parallel()
 
 			src := common.NewTextSource(tst.I)
 			expression, errors := parser.Parse(src)

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1127,6 +1127,8 @@ func TestCheck(t *testing.T) {
 	for i, tst := range testCases {
 		name := fmt.Sprintf("%d %s", i, tst.I)
 		t.Run(name, func(tt *testing.T) {
+			// Runs the tests in parallel to ensure that there are no data races
+			// due to shared mutable state across tests.
 			tt.Parallel()
 
 			src := common.NewTextSource(tst.I)

--- a/parser/gen/cel_lexer.go
+++ b/parser/gen/cel_lexer.go
@@ -215,9 +215,6 @@ var serializedLexerAtn = []uint16{
 	336, 338, 350, 352, 363, 373, 386, 401, 408, 415, 420, 422, 3, 2, 3, 2,
 }
 
-var lexerDeserializer = antlr.NewATNDeserializer(nil)
-var lexerAtn = lexerDeserializer.DeserializeFromUInt16(serializedLexerAtn)
-
 var lexerChannelNames = []string{
 	"DEFAULT_TOKEN_CHANNEL", "HIDDEN",
 }
@@ -257,17 +254,15 @@ type CELLexer struct {
 	// TODO: EOF string
 }
 
-var lexerDecisionToDFA = make([]*antlr.DFA, len(lexerAtn.DecisionToState))
-
-func init() {
-	for index, ds := range lexerAtn.DecisionToState {
-		lexerDecisionToDFA[index] = antlr.NewDFA(ds, index)
-	}
-}
-
 func NewCELLexer(input antlr.CharStream) *CELLexer {
 
 	l := new(CELLexer)
+	lexerDeserializer := antlr.NewATNDeserializer(nil)
+	lexerAtn := lexerDeserializer.DeserializeFromUInt16(serializedLexerAtn)
+	lexerDecisionToDFA := make([]*antlr.DFA, len(lexerAtn.DecisionToState))
+	for index, ds := range lexerAtn.DecisionToState {
+		lexerDecisionToDFA[index] = antlr.NewDFA(ds, index)
+	}
 
 	l.BaseLexer = antlr.NewBaseLexer(input)
 	l.Interpreter = antlr.NewLexerATNSimulator(l, lexerAtn, lexerDecisionToDFA, antlr.NewPredictionContextCache())

--- a/parser/gen/cel_parser.go
+++ b/parser/gen/cel_parser.go
@@ -109,8 +109,6 @@ var parserATN = []uint16{
 	2, 2, 29, 37, 44, 52, 63, 75, 77, 84, 90, 93, 103, 106, 116, 119, 121,
 	125, 130, 133, 141, 144, 149, 153, 160, 172, 185, 189, 194, 202,
 }
-var deserializer = antlr.NewATNDeserializer(nil)
-var deserializedATN = deserializer.DeserializeFromUInt16(parserATN)
 
 var literalNames = []string{
 	"", "'in'", "'=='", "'!='", "'<'", "'<='", "'>='", "'>'", "'&&'", "'||'",
@@ -130,13 +128,6 @@ var ruleNames = []string{
 	"unary", "member", "primary", "exprList", "fieldInitializerList", "mapInitializerList",
 	"literal",
 }
-var decisionToDFA = make([]*antlr.DFA, len(deserializedATN.DecisionToState))
-
-func init() {
-	for index, ds := range deserializedATN.DecisionToState {
-		decisionToDFA[index] = antlr.NewDFA(ds, index)
-	}
-}
 
 type CELParser struct {
 	*antlr.BaseParser
@@ -144,7 +135,12 @@ type CELParser struct {
 
 func NewCELParser(input antlr.TokenStream) *CELParser {
 	this := new(CELParser)
-
+	deserializer := antlr.NewATNDeserializer(nil)
+	deserializedATN := deserializer.DeserializeFromUInt16(parserATN)
+	decisionToDFA := make([]*antlr.DFA, len(deserializedATN.DecisionToState))
+	for index, ds := range deserializedATN.DecisionToState {
+		decisionToDFA[index] = antlr.NewDFA(ds, index)
+	}
 	this.BaseParser = antlr.NewBaseParser(input)
 
 	this.Interpreter = antlr.NewParserATNSimulator(this, deserializedATN, decisionToDFA, antlr.NewPredictionContextCache())

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -852,6 +852,8 @@ func TestParse(t *testing.T) {
 	for i, tst := range testCases {
 		name := fmt.Sprintf("%d %s", i, tst.I)
 		t.Run(name, func(tt *testing.T) {
+			// Runs the tests in parallel to ensure that there are no data races
+			// due to shared mutable state across tests.
 			tt.Parallel()
 
 			src := common.NewTextSource(tst.I)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -759,7 +759,7 @@ ERROR: <input>:1:6: Syntax error: mismatched input '<EOF>' expecting {'[', '{', 
 	},
 
 	{
-		I: `      '😁' in ['😁', '😑', '😦'] 
+		I: `      '😁' in ['😁', '😑', '😦']
 			&& in.😁`,
 		E: `ERROR: <input>:2:7: Syntax error: extraneous input 'in' expecting {'[', '{', '(', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}
 		|    && in.😁
@@ -852,6 +852,7 @@ func TestParse(t *testing.T) {
 	for i, tst := range testCases {
 		name := fmt.Sprintf("%d %s", i, tst.I)
 		t.Run(name, func(tt *testing.T) {
+			tt.Parallel()
 
 			src := common.NewTextSource(tst.I)
 			expression, errors := Parse(src)


### PR DESCRIPTION
Issue #175 pointed out a data race within the parser which occurs when the parsing is run in parallel. The issue appears to be related to the [ANTLR Go Codegen](https://github.com/antlr/antlr4/blob/master/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg) which creates mutable global variables during parser generation.

The best available fix, shy of addressing the Go codegen and ANLTR Go runtime libraries, is to make the global state per-instance. This will likely have a performance impact, but it's difficult to characterize at this time.