### PR TITLE
Perform in-order expression id numbering within the parser.

### DIFF
--- a/parser/helper.go
+++ b/parser/helper.go
@@ -173,10 +173,6 @@ func (p *parserHelper) newComprehension(ctx interface{}, iterVar string,
 }
 
 func (p *parserHelper) newExpr(ctx interface{}) *exprpb.Expr {
-	exp, isExpr := ctx.(*exprpb.Expr)
-	if isExpr {
-		return exp
-	}
 	id, isID := ctx.(int64)
 	if isID {
 		return &exprpb.Expr{Id: id}

--- a/parser/helper.go
+++ b/parser/helper.go
@@ -127,9 +127,9 @@ func (p *parserHelper) newMap(ctx interface{}, entries ...*exprpb.Expr_CreateStr
 	return exprNode
 }
 
-func (p *parserHelper) newMapEntry(ctx interface{}, key *exprpb.Expr, value *exprpb.Expr) *exprpb.Expr_CreateStruct_Entry {
+func (p *parserHelper) newMapEntry(entryID int64, key *exprpb.Expr, value *exprpb.Expr) *exprpb.Expr_CreateStruct_Entry {
 	return &exprpb.Expr_CreateStruct_Entry{
-		Id:      p.id(ctx),
+		Id:      entryID,
 		KeyKind: &exprpb.Expr_CreateStruct_Entry_MapKey{MapKey: key},
 		Value:   value}
 }
@@ -145,9 +145,9 @@ func (p *parserHelper) newObject(ctx interface{},
 	return exprNode
 }
 
-func (p *parserHelper) newObjectField(ctx interface{}, field string, value *exprpb.Expr) *exprpb.Expr_CreateStruct_Entry {
+func (p *parserHelper) newObjectField(fieldID int64, field string, value *exprpb.Expr) *exprpb.Expr_CreateStruct_Entry {
 	return &exprpb.Expr_CreateStruct_Entry{
-		Id:      p.id(ctx),
+		Id:      fieldID,
 		KeyKind: &exprpb.Expr_CreateStruct_Entry_FieldKey{FieldKey: field},
 		Value:   value}
 }
@@ -173,6 +173,10 @@ func (p *parserHelper) newComprehension(ctx interface{}, iterVar string,
 }
 
 func (p *parserHelper) newExpr(ctx interface{}) *exprpb.Expr {
+	exp, isExpr := ctx.(*exprpb.Expr)
+	if isExpr {
+		return exp
+	}
 	id, isID := ctx.(int64)
 	if isID {
 		return &exprpb.Expr{Id: id}
@@ -181,17 +185,20 @@ func (p *parserHelper) newExpr(ctx interface{}) *exprpb.Expr {
 }
 
 func (p *parserHelper) id(ctx interface{}) int64 {
-	var token antlr.Token
+	var location common.Location
 	switch ctx.(type) {
 	case antlr.ParserRuleContext:
-		token = (ctx.(antlr.ParserRuleContext)).GetStart()
+		token := (ctx.(antlr.ParserRuleContext)).GetStart()
+		location = common.NewLocation(token.GetLine(), token.GetColumn())
 	case antlr.Token:
-		token = ctx.(antlr.Token)
+		token := ctx.(antlr.Token)
+		location = common.NewLocation(token.GetLine(), token.GetColumn())
+	case common.Location:
+		location = ctx.(common.Location)
 	default:
 		// This should only happen if the ctx is nil
 		return -1
 	}
-	location := common.NewLocation(token.GetLine(), token.GetColumn())
 	id := p.nextID
 	p.positions[id], _ = p.source.LocationOffset(location)
 	p.nextID++
@@ -269,65 +276,69 @@ func (b *balancer) balancedTree(lo, hi int) *exprpb.Expr {
 
 type exprHelper struct {
 	*parserHelper
-	ctx interface{}
+	id int64
+}
+
+func (e *exprHelper) nextMacroID() int64 {
+	return e.parserHelper.id(e.parserHelper.getLocation(e.id))
 }
 
 // LiteralBool implements the ExprHelper interface method.
 func (e *exprHelper) LiteralBool(value bool) *exprpb.Expr {
-	return e.parserHelper.newLiteralBool(e.ctx, value)
+	return e.parserHelper.newLiteralBool(e.nextMacroID(), value)
 }
 
 // LiteralBytes implements the ExprHelper interface method.
 func (e *exprHelper) LiteralBytes(value []byte) *exprpb.Expr {
-	return e.parserHelper.newLiteralBytes(e.ctx, value)
+	return e.parserHelper.newLiteralBytes(e.nextMacroID(), value)
 }
 
 // LiteralDouble implements the ExprHelper interface method.
 func (e *exprHelper) LiteralDouble(value float64) *exprpb.Expr {
-	return e.parserHelper.newLiteralDouble(e.ctx, value)
+	return e.parserHelper.newLiteralDouble(e.nextMacroID(), value)
 }
 
 // LiteralInt implements the ExprHelper interface method.
 func (e *exprHelper) LiteralInt(value int64) *exprpb.Expr {
-	return e.parserHelper.newLiteralInt(e.ctx, value)
+	return e.parserHelper.newLiteralInt(e.nextMacroID(), value)
 }
 
 // LiteralString implements the ExprHelper interface method.
 func (e *exprHelper) LiteralString(value string) *exprpb.Expr {
-	return e.parserHelper.newLiteralString(e.ctx, value)
+	return e.parserHelper.newLiteralString(e.nextMacroID(), value)
 }
 
 // LiteralUint implements the ExprHelper interface method.
 func (e *exprHelper) LiteralUint(value uint64) *exprpb.Expr {
-	return e.parserHelper.newLiteralUint(e.ctx, value)
+	return e.parserHelper.newLiteralUint(e.nextMacroID(), value)
 }
 
 // NewList implements the ExprHelper interface method.
 func (e *exprHelper) NewList(elems ...*exprpb.Expr) *exprpb.Expr {
-	return e.parserHelper.newList(e.ctx, elems...)
+	return e.parserHelper.newList(e.nextMacroID(), elems...)
 }
 
 // NewMap implements the ExprHelper interface method.
 func (e *exprHelper) NewMap(entries ...*exprpb.Expr_CreateStruct_Entry) *exprpb.Expr {
-	return e.parserHelper.newMap(e.ctx, entries...)
+	return e.parserHelper.newMap(e.nextMacroID(), entries...)
 }
 
 // NewMapEntry implements the ExprHelper interface method.
 func (e *exprHelper) NewMapEntry(key *exprpb.Expr,
 	val *exprpb.Expr) *exprpb.Expr_CreateStruct_Entry {
-	return e.parserHelper.newMapEntry(e.ctx, key, val)
+	return e.parserHelper.newMapEntry(e.nextMacroID(), key, val)
 }
 
 // NewObject implements the ExprHelper interface method.
 func (e *exprHelper) NewObject(typeName string,
 	fieldInits ...*exprpb.Expr_CreateStruct_Entry) *exprpb.Expr {
-	return e.parserHelper.newObject(e.ctx, typeName, fieldInits...)
+	return e.parserHelper.newObject(e.nextMacroID(), typeName, fieldInits...)
 }
 
 // NewObjectFieldInit implements the ExprHelper interface method.
 func (e *exprHelper) NewObjectFieldInit(field string,
 	init *exprpb.Expr) *exprpb.Expr_CreateStruct_Entry {
-	return e.parserHelper.newObjectField(e.ctx, field, init)
+	return e.parserHelper.newObjectField(e.nextMacroID(), field, init)
 }
 
 // Fold implements the ExprHelper interface method.
@@ -339,33 +350,33 @@ func (e *exprHelper) Fold(iterVar string,
 	step *exprpb.Expr,
 	result *exprpb.Expr) *exprpb.Expr {
 	return e.parserHelper.newComprehension(
-		e.ctx, iterVar, iterRange, accuVar, accuInit, condition, step, result)
+		e.nextMacroID(), iterVar, iterRange, accuVar, accuInit, condition, step, result)
 }
 
 // Ident implements the ExprHelper interface method.
 func (e *exprHelper) Ident(name string) *exprpb.Expr {
-	return e.parserHelper.newIdent(e.ctx, name)
+	return e.parserHelper.newIdent(e.nextMacroID(), name)
 }
 
 // GlobalCall implements the ExprHelper interface method.
 func (e *exprHelper) GlobalCall(function string, args ...*exprpb.Expr) *exprpb.Expr {
-	return e.parserHelper.newGlobalCall(e.ctx, function, args...)
+	return e.parserHelper.newGlobalCall(e.nextMacroID(), function, args...)
 }
 
 // ReceiverCall implements the ExprHelper interface method.
 func (e *exprHelper) ReceiverCall(function string,
 	target *exprpb.Expr, args ...*exprpb.Expr) *exprpb.Expr {
-	return e.parserHelper.newReceiverCall(e.ctx, function, target, args...)
+	return e.parserHelper.newReceiverCall(e.nextMacroID(), function, target, args...)
 }
 
 // PresenceTest implements the ExprHelper interface method.
 func (e *exprHelper) PresenceTest(operand *exprpb.Expr, field string) *exprpb.Expr {
-	return e.parserHelper.newPresenceTest(e.ctx, operand, field)
+	return e.parserHelper.newPresenceTest(e.nextMacroID(), operand, field)
 }
 
 // Select implements the ExprHelper interface method.
 func (e *exprHelper) Select(operand *exprpb.Expr, field string) *exprpb.Expr {
-	return e.parserHelper.newSelect(e.ctx, operand, field)
+	return e.parserHelper.newSelect(e.nextMacroID(), operand, field)
 }
 
 // OffsetLocation implements the ExprHelper interface method.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -134,10 +134,10 @@ func (p *parser) VisitExpr(ctx *gen.ExprContext) interface{} {
 	if ctx.GetOp() == nil {
 		return result
 	}
-
+	opExpr := p.helper.newExpr(ctx.GetOp())
 	ifTrue := p.Visit(ctx.GetE1()).(*exprpb.Expr)
 	ifFalse := p.Visit(ctx.GetE2()).(*exprpb.Expr)
-	return p.globalCallOrMacro(ctx.GetOp(), operators.Conditional, result, ifTrue, ifFalse)
+	return p.globalCallOrMacro(opExpr, operators.Conditional, result, ifTrue, ifFalse)
 }
 
 // Visit a parse tree produced by CELParser#conditionalOr.
@@ -179,11 +179,11 @@ func (p *parser) VisitRelation(ctx *gen.RelationContext) interface{} {
 	if ctx.GetOp() != nil {
 		opText = ctx.GetOp().GetText()
 	}
-
 	if op, found := operators.Find(opText); found {
 		lhs := p.Visit(ctx.Relation(0)).(*exprpb.Expr)
+		opExpr := p.helper.newExpr(ctx.GetOp())
 		rhs := p.Visit(ctx.Relation(1)).(*exprpb.Expr)
-		return p.globalCallOrMacro(ctx.GetOp(), op, lhs, rhs)
+		return p.globalCallOrMacro(opExpr, op, lhs, rhs)
 	}
 	return p.reportError(ctx, "operator not found")
 }
@@ -199,8 +199,9 @@ func (p *parser) VisitCalc(ctx *gen.CalcContext) interface{} {
 	}
 	if op, found := operators.Find(opText); found {
 		lhs := p.Visit(ctx.Calc(0)).(*exprpb.Expr)
+		opExpr := p.helper.newExpr(ctx.GetOp())
 		rhs := p.Visit(ctx.Calc(1)).(*exprpb.Expr)
-		return p.globalCallOrMacro(ctx.GetOp(), op, lhs, rhs)
+		return p.globalCallOrMacro(opExpr, op, lhs, rhs)
 	}
 	return p.reportError(ctx, "operator not found")
 }
@@ -229,16 +230,18 @@ func (p *parser) VisitLogicalNot(ctx *gen.LogicalNotContext) interface{} {
 	if len(ctx.GetOps())%2 == 0 {
 		return p.Visit(ctx.Member())
 	}
+	opExpr := p.helper.newExpr(ctx.GetOps()[0])
 	target := p.Visit(ctx.Member()).(*exprpb.Expr)
-	return p.globalCallOrMacro(ctx.GetOps()[0], operators.LogicalNot, target)
+	return p.globalCallOrMacro(opExpr, operators.LogicalNot, target)
 }
 
 func (p *parser) VisitNegate(ctx *gen.NegateContext) interface{} {
 	if len(ctx.GetOps())%2 == 0 {
 		return p.Visit(ctx.Member())
 	}
+	opExpr := p.helper.newExpr(ctx.GetOps()[0])
 	target := p.Visit(ctx.Member()).(*exprpb.Expr)
-	return p.globalCallOrMacro(ctx.GetOps()[0], operators.Negate, target)
+	return p.globalCallOrMacro(opExpr, operators.Negate, target)
 }
 
 // Visit a parse tree produced by CELParser#SelectOrCall.
@@ -250,7 +253,8 @@ func (p *parser) VisitSelectOrCall(ctx *gen.SelectOrCallContext) interface{} {
 	}
 	id := ctx.GetId().GetText()
 	if ctx.GetOpen() != nil {
-		return p.receiverCallOrMacro(ctx.GetOpen(), id, operand, p.visitList(ctx.GetArgs())...)
+		opExpr := p.helper.newExpr(ctx.GetOpen())
+		return p.receiverCallOrMacro(opExpr, id, operand, p.visitList(ctx.GetArgs())...)
 	}
 	return p.helper.newSelect(ctx.GetOp(), operand, id)
 }
@@ -276,18 +280,20 @@ func (p *parser) VisitPrimaryExpr(ctx *gen.PrimaryExprContext) interface{} {
 // Visit a parse tree produced by CELParser#Index.
 func (p *parser) VisitIndex(ctx *gen.IndexContext) interface{} {
 	target := p.Visit(ctx.Member()).(*exprpb.Expr)
+	opExpr := p.helper.newExpr(ctx.GetOp())
 	index := p.Visit(ctx.GetIndex()).(*exprpb.Expr)
-	return p.globalCallOrMacro(ctx.GetOp(), operators.Index, target, index)
+	return p.globalCallOrMacro(opExpr, operators.Index, target, index)
 }
 
 // Visit a parse tree produced by CELParser#CreateMessage.
 func (p *parser) VisitCreateMessage(ctx *gen.CreateMessageContext) interface{} {
 	target := p.Visit(ctx.Member()).(*exprpb.Expr)
+	objExpr := p.helper.newExpr(ctx.GetOp())
 	if messageName, found := p.extractQualifiedName(target); found {
 		entries := p.VisitIFieldInitializerList(ctx.GetEntries()).([]*exprpb.Expr_CreateStruct_Entry)
-		return p.helper.newObject(ctx, messageName, entries...)
+		return p.helper.newObject(objExpr, messageName, entries...)
 	}
-	return p.helper.newExpr(ctx)
+	return objExpr
 }
 
 // Visit a parse tree of field initializers.
@@ -298,8 +304,9 @@ func (p *parser) VisitIFieldInitializerList(ctx gen.IFieldInitializerListContext
 
 	result := make([]*exprpb.Expr_CreateStruct_Entry, len(ctx.GetFields()))
 	for i, f := range ctx.GetFields() {
+		initID := p.helper.id(ctx.GetCols()[i])
 		value := p.Visit(ctx.GetValues()[i]).(*exprpb.Expr)
-		field := p.helper.newObjectField(ctx.GetCols()[i], f.GetText(), value)
+		field := p.helper.newObjectField(initID, f.GetText(), value)
 		result[i] = field
 	}
 	return result
@@ -316,9 +323,9 @@ func (p *parser) VisitIdentOrGlobalCall(ctx *gen.IdentOrGlobalCallContext) inter
 		return p.helper.newExpr(ctx)
 	}
 	identName += ctx.GetId().GetText()
-
 	if ctx.GetOp() != nil {
-		return p.globalCallOrMacro(ctx.GetOp(), identName, p.visitList(ctx.GetArgs())...)
+		opExpr := p.helper.newExpr(ctx.GetOp())
+		return p.globalCallOrMacro(opExpr, identName, p.visitList(ctx.GetArgs())...)
 	}
 	return p.helper.newIdent(ctx.GetId(), identName)
 }
@@ -330,16 +337,18 @@ func (p *parser) VisitNested(ctx *gen.NestedContext) interface{} {
 
 // Visit a parse tree produced by CELParser#CreateList.
 func (p *parser) VisitCreateList(ctx *gen.CreateListContext) interface{} {
-	return p.helper.newList(ctx, p.visitList(ctx.GetElems())...)
+	listExpr := p.helper.newExpr(ctx.GetOp())
+	return p.helper.newList(listExpr, p.visitList(ctx.GetElems())...)
 }
 
 // Visit a parse tree produced by CELParser#CreateStruct.
 func (p *parser) VisitCreateStruct(ctx *gen.CreateStructContext) interface{} {
+	structExpr := p.helper.newExpr(ctx.GetOp())
 	entries := []*exprpb.Expr_CreateStruct_Entry{}
 	if ctx.GetEntries() != nil {
 		entries = p.Visit(ctx.GetEntries()).([]*exprpb.Expr_CreateStruct_Entry)
 	}
-	return p.helper.newMap(ctx.GetStart(), entries...)
+	return p.helper.newMap(structExpr, entries...)
 }
 
 // Visit a parse tree produced by CELParser#ConstantLiteral.
@@ -387,9 +396,10 @@ func (p *parser) VisitMapInitializerList(ctx *gen.MapInitializerListContext) int
 
 	result := make([]*exprpb.Expr_CreateStruct_Entry, len(ctx.GetCols()))
 	for i, col := range ctx.GetCols() {
+		colID := p.helper.id(col)
 		key := p.Visit(ctx.GetKeys()[i]).(*exprpb.Expr)
 		value := p.Visit(ctx.GetValues()[i]).(*exprpb.Expr)
-		entry := p.helper.newMapEntry(col, key, value)
+		entry := p.helper.newMapEntry(colID, key, value)
 		result[i] = entry
 	}
 	return result
@@ -546,21 +556,21 @@ func (p *parser) ReportContextSensitivity(recognizer antlr.Parser, dfa *antlr.DF
 	// Intentional
 }
 
-func (p *parser) globalCallOrMacro(ctx interface{}, function string, args ...*exprpb.Expr) *exprpb.Expr {
-	if expr, found := p.expandMacro(ctx, function, nil, args...); found {
+func (p *parser) globalCallOrMacro(exprNode *exprpb.Expr, function string, args ...*exprpb.Expr) *exprpb.Expr {
+	if expr, found := p.expandMacro(exprNode, function, nil, args...); found {
 		return expr
 	}
-	return p.helper.newGlobalCall(ctx, function, args...)
+	return p.helper.newGlobalCall(exprNode, function, args...)
 }
 
-func (p *parser) receiverCallOrMacro(ctx interface{}, function string, target *exprpb.Expr, args ...*exprpb.Expr) *exprpb.Expr {
-	if expr, found := p.expandMacro(ctx, function, target, args...); found {
+func (p *parser) receiverCallOrMacro(exprNode *exprpb.Expr, function string, target *exprpb.Expr, args ...*exprpb.Expr) *exprpb.Expr {
+	if expr, found := p.expandMacro(exprNode, function, target, args...); found {
 		return expr
 	}
-	return p.helper.newReceiverCall(ctx, function, target, args...)
+	return p.helper.newReceiverCall(exprNode, function, target, args...)
 }
 
-func (p *parser) expandMacro(ctx interface{}, function string, target *exprpb.Expr, args ...*exprpb.Expr) (*exprpb.Expr, bool) {
+func (p *parser) expandMacro(exprNode *exprpb.Expr, function string, target *exprpb.Expr, args ...*exprpb.Expr) (*exprpb.Expr, bool) {
 	macro, found := p.macros[makeMacroKey(function, len(args), target != nil)]
 	if !found {
 		macro, found = p.macros[makeVarArgMacroKey(function, target != nil)]
@@ -571,13 +581,13 @@ func (p *parser) expandMacro(ctx interface{}, function string, target *exprpb.Ex
 	eh := exprHelperPool.Get().(*exprHelper)
 	defer exprHelperPool.Put(eh)
 	eh.parserHelper = p.helper
-	eh.ctx = ctx
+	eh.id = exprNode.Id
 	expr, err := macro.Expander()(eh, target, args)
 	if err != nil {
 		if err.Location != nil {
 			return p.reportError(err.Location, err.Message), true
 		}
-		return p.reportError(ctx, err.Message), true
+		return p.reportError(p.helper.getLocation(exprNode.Id), err.Message), true
 	}
 	return expr, true
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -67,15 +67,15 @@ var testCases = []testInfo{
 		I: `4--4`,
 		P: `_-_(
 			4^#1:*expr.Constant_Int64Value#,
-			-4^#2:*expr.Constant_Int64Value#
-		  )^#3:*expr.Expr_CallExpr#`,
+			-4^#3:*expr.Constant_Int64Value#
+		)^#2:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `4--4.1`,
 		P: `_-_(
 			4^#1:*expr.Constant_Int64Value#,
-			-4.1^#2:*expr.Constant_DoubleValue#
-		  )^#3:*expr.Expr_CallExpr#`,
+			-4.1^#3:*expr.Constant_DoubleValue#
+		)^#2:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `b"abc"`,
@@ -88,8 +88,8 @@ var testCases = []testInfo{
 	{
 		I: `!a`,
 		P: `!_(
-    		  a^#1:*expr.Expr_IdentExpr#
-			)^#2:*expr.Expr_CallExpr#`,
+			a^#2:*expr.Expr_IdentExpr#
+		)^#1:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `null`,
@@ -101,12 +101,11 @@ var testCases = []testInfo{
 	},
 	{
 		I: `a?b:c`,
-		P: `
-			_?_:_(
-    		  a^#1:*expr.Expr_IdentExpr#,
-    		  b^#2:*expr.Expr_IdentExpr#,
-    		  c^#3:*expr.Expr_IdentExpr#
-			)^#4:*expr.Expr_CallExpr#`,
+		P: `_?_:_(
+			a^#1:*expr.Expr_IdentExpr#,
+			b^#3:*expr.Expr_IdentExpr#,
+			c^#4:*expr.Expr_IdentExpr#
+		)^#2:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `a || b`,
@@ -191,86 +190,86 @@ var testCases = []testInfo{
 	{
 		I: `a + b`,
 		P: `_+_(
-    		  a^#1:*expr.Expr_IdentExpr#,
-    		  b^#2:*expr.Expr_IdentExpr#
-			)^#3:*expr.Expr_CallExpr#`,
+			a^#1:*expr.Expr_IdentExpr#,
+			b^#3:*expr.Expr_IdentExpr#
+		)^#2:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `a - b`,
 		P: `_-_(
-    		  a^#1:*expr.Expr_IdentExpr#,
-    		  b^#2:*expr.Expr_IdentExpr#
-			)^#3:*expr.Expr_CallExpr#`,
+			a^#1:*expr.Expr_IdentExpr#,
+			b^#3:*expr.Expr_IdentExpr#
+		)^#2:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `a * b`,
 		P: `_*_(
-    		  a^#1:*expr.Expr_IdentExpr#,
-    		  b^#2:*expr.Expr_IdentExpr#
-			)^#3:*expr.Expr_CallExpr#`,
+			a^#1:*expr.Expr_IdentExpr#,
+			b^#3:*expr.Expr_IdentExpr#
+		)^#2:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `a / b`,
 		P: `_/_(
-    		  a^#1:*expr.Expr_IdentExpr#,
-    		  b^#2:*expr.Expr_IdentExpr#
-			)^#3:*expr.Expr_CallExpr#`,
+			a^#1:*expr.Expr_IdentExpr#,
+			b^#3:*expr.Expr_IdentExpr#
+		)^#2:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `a % b`,
 		P: `_%_(
-    		  a^#1:*expr.Expr_IdentExpr#,
-    		  b^#2:*expr.Expr_IdentExpr#
-			)^#3:*expr.Expr_CallExpr#`,
+			a^#1:*expr.Expr_IdentExpr#,
+			b^#3:*expr.Expr_IdentExpr#
+		)^#2:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `a in b`,
 		P: `@in(
-    		  a^#1:*expr.Expr_IdentExpr#,
-    		  b^#2:*expr.Expr_IdentExpr#
-			)^#3:*expr.Expr_CallExpr#`,
+			a^#1:*expr.Expr_IdentExpr#,
+			b^#3:*expr.Expr_IdentExpr#
+		)^#2:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `a == b`,
 		P: `_==_(
-    		  a^#1:*expr.Expr_IdentExpr#,
-    		  b^#2:*expr.Expr_IdentExpr#
-			)^#3:*expr.Expr_CallExpr#`,
+			a^#1:*expr.Expr_IdentExpr#,
+			b^#3:*expr.Expr_IdentExpr#
+		)^#2:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `a != b`,
-		P: `_!=_(
-    		  a^#1:*expr.Expr_IdentExpr#,
-    		  b^#2:*expr.Expr_IdentExpr#
-			)^#3:*expr.Expr_CallExpr#`,
+		P: ` _!=_(
+			a^#1:*expr.Expr_IdentExpr#,
+			b^#3:*expr.Expr_IdentExpr#
+		)^#2:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `a > b`,
 		P: `_>_(
-    		  a^#1:*expr.Expr_IdentExpr#,
-    		  b^#2:*expr.Expr_IdentExpr#
-			)^#3:*expr.Expr_CallExpr#`,
+			a^#1:*expr.Expr_IdentExpr#,
+			b^#3:*expr.Expr_IdentExpr#
+		)^#2:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `a >= b`,
 		P: `_>=_(
     		  a^#1:*expr.Expr_IdentExpr#,
-    		  b^#2:*expr.Expr_IdentExpr#
-			)^#3:*expr.Expr_CallExpr#`,
+    		  b^#3:*expr.Expr_IdentExpr#
+			)^#2:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `a < b`,
 		P: `_<_(
     		  a^#1:*expr.Expr_IdentExpr#,
-    		  b^#2:*expr.Expr_IdentExpr#
-			)^#3:*expr.Expr_CallExpr#`,
+    		  b^#3:*expr.Expr_IdentExpr#
+			)^#2:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `a <= b`,
 		P: `_<=_(
     		  a^#1:*expr.Expr_IdentExpr#,
-    		  b^#2:*expr.Expr_IdentExpr#
-			)^#3:*expr.Expr_CallExpr#`,
+    		  b^#3:*expr.Expr_IdentExpr#
+			)^#2:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `a.b`,
@@ -283,9 +282,9 @@ var testCases = []testInfo{
 	{
 		I: `a[b]`,
 		P: `_[_](
-    		  a^#1:*expr.Expr_IdentExpr#,
-    		  b^#2:*expr.Expr_IdentExpr#
-			)^#3:*expr.Expr_CallExpr#`,
+			a^#1:*expr.Expr_IdentExpr#,
+			b^#3:*expr.Expr_IdentExpr#
+		)^#2:*expr.Expr_CallExpr#`,
 	},
 
 	// TODO: This is an error.
@@ -303,15 +302,15 @@ var testCases = []testInfo{
 	{
 		I: `foo{ a:b }`,
 		P: `foo{
-    		  a:b^#2:*expr.Expr_IdentExpr#^#3:*expr.Expr_CreateStruct_Entry#
-			}^#4:*expr.Expr_StructExpr#`,
+			a:b^#4:*expr.Expr_IdentExpr#^#3:*expr.Expr_CreateStruct_Entry#
+		}^#2:*expr.Expr_StructExpr#`,
 	},
 	{
 		I: `foo{ a:b, c:d }`,
 		P: `foo{
-    		  a:b^#2:*expr.Expr_IdentExpr#^#3:*expr.Expr_CreateStruct_Entry#,
-    		  c:d^#4:*expr.Expr_IdentExpr#^#5:*expr.Expr_CreateStruct_Entry#
-			}^#6:*expr.Expr_StructExpr#`,
+			a:b^#4:*expr.Expr_IdentExpr#^#3:*expr.Expr_CreateStruct_Entry#,
+			c:d^#6:*expr.Expr_IdentExpr#^#5:*expr.Expr_CreateStruct_Entry#
+		}^#2:*expr.Expr_StructExpr#`,
 	},
 	{
 		I: `{}`,
@@ -321,9 +320,9 @@ var testCases = []testInfo{
 	{
 		I: `{a:b, c:d}`,
 		P: `{
-    		  a^#1:*expr.Expr_IdentExpr#:b^#2:*expr.Expr_IdentExpr#^#3:*expr.Expr_CreateStruct_Entry#,
-    		  c^#4:*expr.Expr_IdentExpr#:d^#5:*expr.Expr_IdentExpr#^#6:*expr.Expr_CreateStruct_Entry#
-			}^#7:*expr.Expr_StructExpr#`,
+			a^#3:*expr.Expr_IdentExpr#:b^#4:*expr.Expr_IdentExpr#^#2:*expr.Expr_CreateStruct_Entry#,
+			c^#6:*expr.Expr_IdentExpr#:d^#7:*expr.Expr_IdentExpr#^#5:*expr.Expr_CreateStruct_Entry#
+		}^#1:*expr.Expr_StructExpr#`,
 	},
 	{
 		I: `[]`,
@@ -332,16 +331,16 @@ var testCases = []testInfo{
 	{
 		I: `[a]`,
 		P: `[
-    		  a^#1:*expr.Expr_IdentExpr#
-			]^#2:*expr.Expr_ListExpr#`,
+			a^#2:*expr.Expr_IdentExpr#
+		]^#1:*expr.Expr_ListExpr#`,
 	},
 	{
 		I: `[a, b, c]`,
 		P: `[
-    		  a^#1:*expr.Expr_IdentExpr#,
-    		  b^#2:*expr.Expr_IdentExpr#,
-    		  c^#3:*expr.Expr_IdentExpr#
-			]^#4:*expr.Expr_ListExpr#`,
+			a^#2:*expr.Expr_IdentExpr#,
+			b^#3:*expr.Expr_IdentExpr#,
+			c^#4:*expr.Expr_IdentExpr#
+		]^#1:*expr.Expr_ListExpr#`,
 	},
 	{
 		I: `(a)`,
@@ -359,14 +358,16 @@ var testCases = []testInfo{
 	{
 		I: `a(b)`,
 		P: `a(
-    		  b^#1:*expr.Expr_IdentExpr#)^#2:*expr.Expr_CallExpr#`,
+			b^#2:*expr.Expr_IdentExpr#
+		)^#1:*expr.Expr_CallExpr#`,
 	},
 
 	{
 		I: `a(b, c)`,
 		P: `a(
-    		  b^#1:*expr.Expr_IdentExpr#,
-    		  c^#2:*expr.Expr_IdentExpr#)^#3:*expr.Expr_CallExpr#`,
+			b^#2:*expr.Expr_IdentExpr#,
+			c^#3:*expr.Expr_IdentExpr#
+		)^#1:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `a.b()`,
@@ -376,10 +377,11 @@ var testCases = []testInfo{
 	{
 		I: `a.b(c)`,
 		P: `a^#1:*expr.Expr_IdentExpr#.b(
-    		  c^#2:*expr.Expr_IdentExpr#)^#3:*expr.Expr_CallExpr#`,
+			c^#3:*expr.Expr_IdentExpr#
+		)^#2:*expr.Expr_CallExpr#`,
 		L: `a^#1[1,0]#.b(
-    		  c^#2[1,4]#
-    		)^#3[1,3]#`,
+    		  c^#3[1,4]#
+    		)^#2[1,3]#`,
 	},
 
 	// Parse error tests
@@ -413,151 +415,150 @@ ERROR: <input>:1:5: Syntax error: extraneous input 'b' expecting <EOF>
 	// Macro tests
 	{
 		I: `has(m.f)`,
-		P: `m^#1:*expr.Expr_IdentExpr#.f~test-only~^#3:*expr.Expr_SelectExpr#`,
-		L: `m^#1[1,4]#.f~test-only~^#3[1,3]#`,
+		P: `m^#2:*expr.Expr_IdentExpr#.f~test-only~^#4:*expr.Expr_SelectExpr#`,
+		L: `m^#2[1,4]#.f~test-only~^#4[1,3]#`,
 	},
 	{
 		I: `m.exists_one(v, f)`,
 		P: `__comprehension__(
-    		  // Variable
-    		  v,
-    		  // Target
-    		  m^#1:*expr.Expr_IdentExpr#,
-    		  // Accumulator
-    		  __result__,
-    		  // Init
-    		  0^#4:*expr.Constant_Int64Value#,
-    		  // LoopCondition
-    		  _<=_(
-    		    __result__^#6:*expr.Expr_IdentExpr#,
-    		    1^#5:*expr.Constant_Int64Value#
-  			  )^#7:*expr.Expr_CallExpr#,
-    		  // LoopStep
-    		  _?_:_(
-    		    f^#3:*expr.Expr_IdentExpr#,
-    		    _+_(
-    		      __result__^#8:*expr.Expr_IdentExpr#,
-    		      1^#5:*expr.Constant_Int64Value#
-				)^#9:*expr.Expr_CallExpr#,
-    		    __result__^#10:*expr.Expr_IdentExpr#
-			  )^#11:*expr.Expr_CallExpr#,
-    		  // Result
-    		  _==_(
-    		    __result__^#12:*expr.Expr_IdentExpr#,
-    		    1^#5:*expr.Constant_Int64Value#
-		      )^#13:*expr.Expr_CallExpr#)^#14:*expr.Expr_ComprehensionExpr#`,
+			// Variable
+			v,
+			// Target
+			m^#1:*expr.Expr_IdentExpr#,
+			// Accumulator
+			__result__,
+			// Init
+			0^#5:*expr.Constant_Int64Value#,
+			// LoopCondition
+			_<=_(
+				__result__^#7:*expr.Expr_IdentExpr#,
+				1^#6:*expr.Constant_Int64Value#
+			)^#8:*expr.Expr_CallExpr#,
+			// LoopStep
+			_?_:_(
+				f^#4:*expr.Expr_IdentExpr#,
+				_+_(
+					__result__^#9:*expr.Expr_IdentExpr#,
+					1^#6:*expr.Constant_Int64Value#
+				)^#10:*expr.Expr_CallExpr#,
+				__result__^#11:*expr.Expr_IdentExpr#
+			)^#12:*expr.Expr_CallExpr#,
+			// Result
+			_==_(
+				__result__^#13:*expr.Expr_IdentExpr#,
+				1^#6:*expr.Constant_Int64Value#
+			)^#14:*expr.Expr_CallExpr#)^#15:*expr.Expr_ComprehensionExpr#`,
 	},
 	{
 		I: `m.map(v, f)`,
 		P: `__comprehension__(
-    		  // Variable
-    		  v,
-    		  // Target
-    		  m^#1:*expr.Expr_IdentExpr#,
-    		  // Accumulator
-    		  __result__,
-    		  // Init
-    		  []^#5:*expr.Expr_ListExpr#,
-    		  // LoopCondition
-    		  true^#6:*expr.Constant_BoolValue#,
-    		  // LoopStep
-    		  _+_(
-    		    __result__^#4:*expr.Expr_IdentExpr#,
-    		    [
-    		      f^#3:*expr.Expr_IdentExpr#
-				]^#7:*expr.Expr_ListExpr#
- 			  )^#8:*expr.Expr_CallExpr#,
-    		  // Result
-    		  __result__^#4:*expr.Expr_IdentExpr#)^#9:*expr.Expr_ComprehensionExpr#`,
+			// Variable
+			v,
+			// Target
+			m^#1:*expr.Expr_IdentExpr#,
+			// Accumulator
+			__result__,
+			// Init
+			[]^#6:*expr.Expr_ListExpr#,
+			// LoopCondition
+			true^#7:*expr.Constant_BoolValue#,
+			// LoopStep
+			_+_(
+				__result__^#5:*expr.Expr_IdentExpr#,
+				[
+					f^#4:*expr.Expr_IdentExpr#
+				]^#8:*expr.Expr_ListExpr#
+			)^#9:*expr.Expr_CallExpr#,
+			// Result
+			__result__^#5:*expr.Expr_IdentExpr#)^#10:*expr.Expr_ComprehensionExpr#`,
 	},
 
 	{
 		I: `m.map(v, p, f)`,
 		P: `__comprehension__(
-    		  // Variable
-    		  v,
-    		  // Target
-    		  m^#1:*expr.Expr_IdentExpr#,
-    		  // Accumulator
-    		  __result__,
-    		  // Init
-    		  []^#6:*expr.Expr_ListExpr#,
-    		  // LoopCondition
-    		  true^#7:*expr.Constant_BoolValue#,
-    		  // LoopStep
-    		  _?_:_(
-    		    p^#3:*expr.Expr_IdentExpr#,
-    		    _+_(
-    		      __result__^#5:*expr.Expr_IdentExpr#,
-    		      [
-    		        f^#4:*expr.Expr_IdentExpr#
-				  ]^#8:*expr.Expr_ListExpr#
-				)^#9:*expr.Expr_CallExpr#,
-    		    __result__^#5:*expr.Expr_IdentExpr#
-                )^#10:*expr.Expr_CallExpr#,
-    		    // Result
-    		    __result__^#5:*expr.Expr_IdentExpr#
-				)^#11:*expr.Expr_ComprehensionExpr#`,
+			// Variable
+			v,
+			// Target
+			m^#1:*expr.Expr_IdentExpr#,
+			// Accumulator
+			__result__,
+			// Init
+			[]^#7:*expr.Expr_ListExpr#,
+			// LoopCondition
+			true^#8:*expr.Constant_BoolValue#,
+			// LoopStep
+			_?_:_(
+				p^#4:*expr.Expr_IdentExpr#,
+				_+_(
+					__result__^#6:*expr.Expr_IdentExpr#,
+					[
+						f^#5:*expr.Expr_IdentExpr#
+					]^#9:*expr.Expr_ListExpr#
+				)^#10:*expr.Expr_CallExpr#,
+				__result__^#6:*expr.Expr_IdentExpr#
+			)^#11:*expr.Expr_CallExpr#,
+			// Result
+			__result__^#6:*expr.Expr_IdentExpr#)^#12:*expr.Expr_ComprehensionExpr#`,
 	},
 
 	{
 		I: `m.filter(v, p)`,
 		P: `__comprehension__(
-    		  // Variable
-    		  v,
-    		  // Target
-    		  m^#1:*expr.Expr_IdentExpr#,
-    		  // Accumulator
-    		  __result__,
-    		  // Init
-    		  []^#5:*expr.Expr_ListExpr#,
-    		  // LoopCondition
-    		  true^#6:*expr.Constant_BoolValue#,
-    		  // LoopStep
-    		  _?_:_(
-    		    p^#3:*expr.Expr_IdentExpr#,
-    		    _+_(
-    		      __result__^#4:*expr.Expr_IdentExpr#,
-    		      [
-    		        v^#2:*expr.Expr_IdentExpr#
-				  ]^#7:*expr.Expr_ListExpr#
-				)^#8:*expr.Expr_CallExpr#,
-    		    __result__^#4:*expr.Expr_IdentExpr#
-  				)^#9:*expr.Expr_CallExpr#,
-    		    // Result
-    		    __result__^#4:*expr.Expr_IdentExpr#)^#10:*expr.Expr_ComprehensionExpr#`,
+			// Variable
+			v,
+			// Target
+			m^#1:*expr.Expr_IdentExpr#,
+			// Accumulator
+			__result__,
+			// Init
+			[]^#6:*expr.Expr_ListExpr#,
+			// LoopCondition
+			true^#7:*expr.Constant_BoolValue#,
+			// LoopStep
+			_?_:_(
+				p^#4:*expr.Expr_IdentExpr#,
+				_+_(
+					__result__^#5:*expr.Expr_IdentExpr#,
+					[
+						v^#3:*expr.Expr_IdentExpr#
+					]^#8:*expr.Expr_ListExpr#
+				)^#9:*expr.Expr_CallExpr#,
+				__result__^#5:*expr.Expr_IdentExpr#
+			)^#10:*expr.Expr_CallExpr#,
+			// Result
+			__result__^#5:*expr.Expr_IdentExpr#)^#11:*expr.Expr_ComprehensionExpr#`,
 	},
 
 	// Tests from Java parser
 	{
 		I: `[] + [1,2,3,] + [4]`,
 		P: `_+_(
-    		  _+_(
-    		    []^#1:*expr.Expr_ListExpr#,
-    		    [
-    		      1^#2:*expr.Constant_Int64Value#,
-    		      2^#3:*expr.Constant_Int64Value#,
-    		      3^#4:*expr.Constant_Int64Value#
-    		    ]^#5:*expr.Expr_ListExpr#
-    		  )^#6:*expr.Expr_CallExpr#,
-    		  [
-    		    4^#7:*expr.Constant_Int64Value#
-    		  ]^#8:*expr.Expr_ListExpr#
-    		)^#9:*expr.Expr_CallExpr#`,
+			_+_(
+				[]^#1:*expr.Expr_ListExpr#,
+				[
+					1^#4:*expr.Constant_Int64Value#,
+					2^#5:*expr.Constant_Int64Value#,
+					3^#6:*expr.Constant_Int64Value#
+				]^#3:*expr.Expr_ListExpr#
+			)^#2:*expr.Expr_CallExpr#,
+			[
+				4^#9:*expr.Constant_Int64Value#
+			]^#8:*expr.Expr_ListExpr#
+		)^#7:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `{1:2u, 2:3u}`,
 		P: `{
-    		  1^#1:*expr.Constant_Int64Value#:2u^#2:*expr.Constant_Uint64Value#^#3:*expr.Expr_CreateStruct_Entry#,
-    		  2^#4:*expr.Constant_Int64Value#:3u^#5:*expr.Constant_Uint64Value#^#6:*expr.Expr_CreateStruct_Entry#
-    		}^#7:*expr.Expr_StructExpr#`,
+			1^#3:*expr.Constant_Int64Value#:2u^#4:*expr.Constant_Uint64Value#^#2:*expr.Expr_CreateStruct_Entry#,
+			2^#6:*expr.Constant_Int64Value#:3u^#7:*expr.Constant_Uint64Value#^#5:*expr.Expr_CreateStruct_Entry#
+		}^#1:*expr.Expr_StructExpr#`,
 	},
 	{
 		I: `TestAllTypes{single_int32: 1, single_int64: 2}`,
 		P: `TestAllTypes{
-    		  single_int32:1^#2:*expr.Constant_Int64Value#^#3:*expr.Expr_CreateStruct_Entry#,
-    		  single_int64:2^#4:*expr.Constant_Int64Value#^#5:*expr.Expr_CreateStruct_Entry#
-    		}^#6:*expr.Expr_StructExpr#`,
+			single_int32:1^#4:*expr.Constant_Int64Value#^#3:*expr.Expr_CreateStruct_Entry#,
+			single_int64:2^#6:*expr.Constant_Int64Value#^#5:*expr.Expr_CreateStruct_Entry#
+		}^#2:*expr.Expr_StructExpr#`,
 	},
 	{
 		I: `TestAllTypes(){single_int32: 1, single_int64: 2}`,
@@ -570,11 +571,11 @@ ERROR: <input>:1:13: expected a qualified name
 	{
 		I: `size(x) == x.size()`,
 		P: `_==_(
-    		  size(
-    		    x^#1:*expr.Expr_IdentExpr#
-    		  )^#2:*expr.Expr_CallExpr#,
-    		  x^#3:*expr.Expr_IdentExpr#.size()^#4:*expr.Expr_CallExpr#
-    		)^#5:*expr.Expr_CallExpr#`,
+			size(
+				x^#2:*expr.Expr_IdentExpr#
+			)^#1:*expr.Expr_CallExpr#,
+			x^#4:*expr.Expr_IdentExpr#.size()^#5:*expr.Expr_CallExpr#
+		)^#3:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `1 + $`,
@@ -603,13 +604,13 @@ ERROR: <input>:2:1: Syntax error: mismatched input '3' expecting <EOF>
 	{
 		I: `[1,3,4][0]`,
 		P: `_[_](
-    		  [
-    		    1^#1:*expr.Constant_Int64Value#,
-    		    3^#2:*expr.Constant_Int64Value#,
-    		    4^#3:*expr.Constant_Int64Value#
-    		  ]^#4:*expr.Expr_ListExpr#,
-    		  0^#5:*expr.Constant_Int64Value#
-    		)^#6:*expr.Expr_CallExpr#`,
+			[
+				1^#2:*expr.Constant_Int64Value#,
+				3^#3:*expr.Constant_Int64Value#,
+				4^#4:*expr.Constant_Int64Value#
+			]^#1:*expr.Expr_ListExpr#,
+			0^#6:*expr.Constant_Int64Value#
+		)^#5:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `1.all(2, 3)`,
@@ -622,64 +623,64 @@ ERROR: <input>:1:7: argument must be a simple name
 	{
 		I: `x["a"].single_int32 == 23`,
 		P: `_==_(
-    		  _[_](
-    		    x^#1:*expr.Expr_IdentExpr#,
-    		    "a"^#2:*expr.Constant_StringValue#
-    		  )^#3:*expr.Expr_CallExpr#.single_int32^#4:*expr.Expr_SelectExpr#,
-    		  23^#5:*expr.Constant_Int64Value#
-    		)^#6:*expr.Expr_CallExpr#`,
+			_[_](
+				x^#1:*expr.Expr_IdentExpr#,
+				"a"^#3:*expr.Constant_StringValue#
+			)^#2:*expr.Expr_CallExpr#.single_int32^#4:*expr.Expr_SelectExpr#,
+			23^#6:*expr.Constant_Int64Value#
+		)^#5:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `x.single_nested_message != null`,
 		P: `_!=_(
-    		  x^#1:*expr.Expr_IdentExpr#.single_nested_message^#2:*expr.Expr_SelectExpr#,
-    		  null^#3:*expr.Constant_NullValue#
-    		)^#4:*expr.Expr_CallExpr#`,
+			x^#1:*expr.Expr_IdentExpr#.single_nested_message^#2:*expr.Expr_SelectExpr#,
+			null^#4:*expr.Constant_NullValue#
+		)^#3:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `false && !true || false ? 2 : 3`,
 		P: `_?_:_(
-    		  _||_(
-    		    _&&_(
-    		      false^#1:*expr.Constant_BoolValue#,
-    		      !_(
-    		        true^#2:*expr.Constant_BoolValue#
-    		      )^#3:*expr.Expr_CallExpr#
-    		    )^#4:*expr.Expr_CallExpr#,
-    		    false^#5:*expr.Constant_BoolValue#
-    		  )^#6:*expr.Expr_CallExpr#,
-    		  2^#7:*expr.Constant_Int64Value#,
-    		  3^#8:*expr.Constant_Int64Value#
-    		)^#9:*expr.Expr_CallExpr#`,
+			_||_(
+				_&&_(
+					false^#1:*expr.Constant_BoolValue#,
+					!_(
+						true^#3:*expr.Constant_BoolValue#
+					)^#2:*expr.Expr_CallExpr#
+				)^#4:*expr.Expr_CallExpr#,
+				false^#5:*expr.Constant_BoolValue#
+			)^#6:*expr.Expr_CallExpr#,
+			2^#8:*expr.Constant_Int64Value#,
+			3^#9:*expr.Constant_Int64Value#
+		)^#7:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `b"abc" + B"def"`,
 		P: `_+_(
-    		  b"abc"^#1:*expr.Constant_BytesValue#,
-    		  b"def"^#2:*expr.Constant_BytesValue#
-    		)^#3:*expr.Expr_CallExpr#`,
+			b"abc"^#1:*expr.Constant_BytesValue#,
+			b"def"^#3:*expr.Constant_BytesValue#
+		)^#2:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `1 + 2 * 3 - 1 / 2 == 6 % 1`,
 		P: `_==_(
-    		  _-_(
-    		    _+_(
-    		      1^#1:*expr.Constant_Int64Value#,
-    		      _*_(
-    		        2^#2:*expr.Constant_Int64Value#,
-    		        3^#3:*expr.Constant_Int64Value#
-    		      )^#4:*expr.Expr_CallExpr#
-    		    )^#5:*expr.Expr_CallExpr#,
-    		    _/_(
-    		      1^#6:*expr.Constant_Int64Value#,
-    		      2^#7:*expr.Constant_Int64Value#
-    		    )^#8:*expr.Expr_CallExpr#
-    		  )^#9:*expr.Expr_CallExpr#,
-    		  _%_(
-    		    6^#10:*expr.Constant_Int64Value#,
-    		    1^#11:*expr.Constant_Int64Value#
-    		  )^#12:*expr.Expr_CallExpr#
-    		)^#13:*expr.Expr_CallExpr#`,
+			_-_(
+				_+_(
+					1^#1:*expr.Constant_Int64Value#,
+					_*_(
+						2^#3:*expr.Constant_Int64Value#,
+						3^#5:*expr.Constant_Int64Value#
+					)^#4:*expr.Expr_CallExpr#
+				)^#2:*expr.Expr_CallExpr#,
+				_/_(
+					1^#7:*expr.Constant_Int64Value#,
+					2^#9:*expr.Constant_Int64Value#
+				)^#8:*expr.Expr_CallExpr#
+			)^#6:*expr.Expr_CallExpr#,
+			_%_(
+				6^#11:*expr.Constant_Int64Value#,
+				1^#13:*expr.Constant_Int64Value#
+			)^#12:*expr.Expr_CallExpr#
+		)^#10:*expr.Expr_CallExpr#`,
 	},
 	{
 		I: `1 + +`,
@@ -695,9 +696,9 @@ ERROR: <input>:1:6: Syntax error: mismatched input '<EOF>' expecting {'[', '{', 
 	{
 		I: `"abc" + "def"`,
 		P: `_+_(
-    		  "abc"^#1:*expr.Constant_StringValue#,
-    		  "def"^#2:*expr.Constant_StringValue#
-    		)^#3:*expr.Expr_CallExpr#`,
+			"abc"^#1:*expr.Constant_StringValue#,
+			"def"^#3:*expr.Constant_StringValue#
+		)^#2:*expr.Expr_CallExpr#`,
 	},
 
 	{
@@ -759,7 +760,7 @@ ERROR: <input>:1:6: Syntax error: mismatched input '<EOF>' expecting {'[', '{', 
 	},
 
 	{
-		I: `      '😁' in ['😁', '😑', '😦'] 
+		I: `      '😁' in ['😁', '😑', '😦']
 			&& in.😁`,
 		E: `ERROR: <input>:2:7: Syntax error: extraneous input 'in' expecting {'[', '{', '(', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}
 		|    && in.😁


### PR DESCRIPTION
Ensure that the expressions are numbered in the same order as the parse elements appear rather than in post-order.