### PR TITLE
Type provider proto isolation

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -78,8 +78,8 @@ func Example() {
 
 	// Evaluate the program against some inputs. Note: the details return is not used.
 	out, _, err := prg.Eval(map[string]interface{}{
-		// CEL values may be supplied directly.
-		"i": types.String("CEL"),
+		// Native values are converted to CEL values under the covers.
+		"i": "CEL",
 		// Values may also be lazily supplied.
 		"you": func() ref.Val { return types.String("world") },
 	})
@@ -120,8 +120,8 @@ func Test_ExampleWithBuiltins(t *testing.T) {
 	// If the Eval() call were provided with cel.EvalOptions(OptTrackState) the details response
 	// (2nd return) would be non-nil.
 	out, _, err := prg.Eval(map[string]interface{}{
-		"i":   types.String("CEL"),
-		"you": types.String("world")})
+		"i":   "CEL",
+		"you": "world"})
 	if err != nil {
 		t.Fatalf("runtime error: %s\n", err)
 	}
@@ -149,7 +149,7 @@ func Test_DisableStandardEnv(t *testing.T) {
 		p, _ := e.Parse("a.b.c")
 		c, _ := e.Check(p)
 		prg, _ := e.Program(c)
-		out, _, _ := prg.Eval(map[string]interface{}{"a.b.c": types.True})
+		out, _, _ := prg.Eval(map[string]interface{}{"a.b.c": true})
 		if out != types.True {
 			t.Errorf("Got '%v', wanted 'true'", out.Value())
 		}
@@ -208,7 +208,7 @@ func Test_HomogeneousAggregateLiterals(t *testing.T) {
 			t.Fatalf("Got issue: %v, expected successful check.", iss.Err())
 		}
 		prg, _ := e.Program(c, funcs)
-		out, _, err := prg.Eval(Vars(map[string]interface{}{"name": "world"}))
+		out, _, err := prg.Eval(map[string]interface{}{"name": "world"})
 		if err != nil {
 			t.Fatalf("Got err: %v, wanted result", err)
 		}
@@ -223,7 +223,7 @@ func Test_HomogeneousAggregateLiterals(t *testing.T) {
 			t.Fatalf("Got issue: %v, expected successful check.", iss.Err())
 		}
 		prg, _ := e.Program(c, funcs)
-		out, _, err := prg.Eval(Vars(map[string]interface{}{"name": "world"}))
+		out, _, err := prg.Eval(map[string]interface{}{"name": "world"})
 		if err != nil {
 			t.Fatalf("Got err: %v, wanted result", err)
 		}
@@ -363,7 +363,7 @@ func Test_GlobalVars(t *testing.T) {
 
 	// Global variables can be configured as a ProgramOption and optionally overridden on Eval.
 	prg, _ := e.Program(c, funcs, Globals(map[string]interface{}{
-		"default": types.String("third"),
+		"default": "third",
 	}))
 
 	t.Run("global_default", func(t *testing.T) {
@@ -409,8 +409,8 @@ func Test_EvalOptions(t *testing.T) {
 	}
 	out, details, err := prg.Eval(
 		map[string]interface{}{
-			"k": types.String("key"),
-			"v": types.True})
+			"k": "key",
+			"v": true})
 	if err != nil {
 		t.Fatalf("runtime error: %s\n", err)
 	}

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -77,12 +77,12 @@ func Example() {
 	}
 
 	// Evaluate the program against some inputs. Note: the details return is not used.
-	out, _, err := prg.Eval(Vars(map[string]interface{}{
-		// Native values are converted to CEL values under the covers.
-		"i": "CEL",
+	out, _, err := prg.Eval(map[string]interface{}{
+		// CEL values may be supplied directly.
+		"i": types.String("CEL"),
 		// Values may also be lazily supplied.
 		"you": func() ref.Val { return types.String("world") },
-	}))
+	})
 	if err != nil {
 		log.Fatalf("runtime error: %s\n", err)
 	}
@@ -119,9 +119,9 @@ func Test_ExampleWithBuiltins(t *testing.T) {
 
 	// If the Eval() call were provided with cel.EvalOptions(OptTrackState) the details response
 	// (2nd return) would be non-nil.
-	out, _, err := prg.Eval(Vars(map[string]interface{}{
-		"i":   "CEL",
-		"you": "world"}))
+	out, _, err := prg.Eval(map[string]interface{}{
+		"i":   types.String("CEL"),
+		"you": types.String("world")})
 	if err != nil {
 		t.Fatalf("runtime error: %s\n", err)
 	}
@@ -149,7 +149,7 @@ func Test_DisableStandardEnv(t *testing.T) {
 		p, _ := e.Parse("a.b.c")
 		c, _ := e.Check(p)
 		prg, _ := e.Program(c)
-		out, _, _ := prg.Eval(Vars(map[string]interface{}{"a.b.c": true}))
+		out, _, _ := prg.Eval(map[string]interface{}{"a.b.c": types.True})
 		if out != types.True {
 			t.Errorf("Got '%v', wanted 'true'", out.Value())
 		}
@@ -251,7 +251,7 @@ func Test_CustomTypes(t *testing.T) {
 			}}`)
 	c, _ := e.Check(p)
 	prg, _ := e.Program(c)
-	out, _, _ := prg.Eval(Vars(map[string]interface{}{"expr": &exprpb.Expr{
+	vars := map[string]interface{}{"expr": &exprpb.Expr{
 		Id: 2,
 		ExprKind: &exprpb.Expr_CallExpr{
 			CallExpr: &exprpb.Expr_Call{
@@ -272,7 +272,8 @@ func Test_CustomTypes(t *testing.T) {
 				},
 			},
 		},
-	}}))
+	}}
+	out, _, _ := prg.Eval(vars)
 	if out != types.True {
 		t.Errorf("Got '%v', wanted 'true'", out.Value())
 	}
@@ -289,7 +290,6 @@ func Test_IsolatedTypes(t *testing.T) {
 	}
 
 	e, err := NewEnv(
-		IsolateTypes(),
 		TypeDescs(&fds),
 		Declarations(
 			decls.NewIdent("myteam",
@@ -362,30 +362,33 @@ func Test_GlobalVars(t *testing.T) {
 			}})
 
 	// Global variables can be configured as a ProgramOption and optionally overridden on Eval.
-	prg, _ := e.Program(c, funcs, Globals(Vars(map[string]interface{}{
-		"default": "third",
-	})))
+	prg, _ := e.Program(c, funcs, Globals(map[string]interface{}{
+		"default": types.String("third"),
+	}))
 
 	t.Run("global_default", func(t *testing.T) {
-		out, _, _ := prg.Eval(Vars(map[string]interface{}{
-			"attrs": map[string]interface{}{}}))
+		vars := map[string]interface{}{
+			"attrs": map[string]interface{}{}}
+		out, _, _ := prg.Eval(vars)
 		if out.Equal(types.String("third")) != types.True {
 			t.Errorf("Got '%v', expected 'third'.", out.Value())
 		}
 	})
 
 	t.Run("attrs_alt", func(t *testing.T) {
-		out, _, _ := prg.Eval(Vars(map[string]interface{}{
-			"attrs": map[string]interface{}{"second": "yep"}}))
+		vars := map[string]interface{}{
+			"attrs": map[string]interface{}{"second": "yep"}}
+		out, _, _ := prg.Eval(vars)
 		if out.Equal(types.String("yep")) != types.True {
 			t.Errorf("Got '%v', expected 'yep'.", out.Value())
 		}
 	})
 
 	t.Run("local_default", func(t *testing.T) {
-		out, _, _ := prg.Eval(Vars(map[string]interface{}{
+		vars := map[string]interface{}{
 			"attrs":   map[string]interface{}{},
-			"default": "fourth"}))
+			"default": "fourth"}
+		out, _, _ := prg.Eval(vars)
 		if out.Equal(types.String("fourth")) != types.True {
 			t.Errorf("Got '%v', expected 'fourth'.", out.Value())
 		}
@@ -404,7 +407,10 @@ func Test_EvalOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("program creation error: %s\n", err)
 	}
-	out, details, err := prg.Eval(Vars(map[string]interface{}{"k": "key", "v": true}))
+	out, details, err := prg.Eval(
+		map[string]interface{}{
+			"k": types.String("key"),
+			"v": types.True})
 	if err != nil {
 		t.Fatalf("runtime error: %s\n", err)
 	}
@@ -442,12 +448,12 @@ func Benchmark_EvalOptions(b *testing.B) {
 	)
 	past, _ := e.Parse("ai == 20 || ar['foo'] == 'bar'")
 	cast, _ := e.Check(past)
-	vars := Vars(map[string]interface{}{
+	vars := map[string]interface{}{
 		"ai": 2,
 		"ar": map[string]string{
 			"foo": "bar",
 		},
-	})
+	}
 
 	opts := map[string]EvalOption{
 		"track-state":     OptTrackState,

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -279,7 +279,7 @@ func Test_CustomTypes(t *testing.T) {
 	}
 }
 
-func Test_IsolatedTypes(t *testing.T) {
+func Test_TypeIsolation(t *testing.T) {
 	b, err := ioutil.ReadFile("testdata/team.fds")
 	if err != nil {
 		t.Fatal("Can't read fds file: ", err)

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -278,7 +278,7 @@ func Test_CustomTypes(t *testing.T) {
 	}
 }
 
-func TestIsolatedTypes(t *testing.T) {
+func Test_IsolatedTypes(t *testing.T) {
 	b, err := ioutil.ReadFile("testdata/team.fds")
 	if err != nil {
 		t.Fatal("Can't read fds file: ", err)

--- a/cel/env.go
+++ b/cel/env.go
@@ -103,11 +103,14 @@ type Issues interface {
 //
 // See the EnvOptions for the options that can be used to configure the environment.
 func NewEnv(opts ...EnvOption) (Env, error) {
+	types := types.NewProvider()
+	adapter := types
 	e := &env{
 		declarations:                   checker.StandardDeclarations(),
 		macros:                         parser.AllMacros,
 		pkg:                            packages.DefaultPackage,
-		types:                          types.NewProvider(),
+		types:                          types,
+		adapter:                        adapter,
 		enableBuiltins:                 true,
 		enableDynamicAggregateLiterals: true,
 	}
@@ -166,6 +169,7 @@ type env struct {
 	macros       []parser.Macro
 	pkg          packages.Packager
 	types        ref.TypeProvider
+	adapter      ref.TypeAdapter
 	// environment options, true by default.
 	enableBuiltins                 bool
 	enableDynamicAggregateLiterals bool
@@ -219,14 +223,6 @@ func (e *env) Program(ast Ast, opts ...ProgramOption) (Program, error) {
 			opts...)
 	}
 	return newProgram(e, ast, opts...)
-}
-
-func (e *env) TypeAdapter() ref.TypeAdapter {
-	adapter, isAdapter := e.types.(ref.TypeAdapter)
-	if isAdapter {
-		return adapter
-	}
-	return nil
 }
 
 // issues is the internal implementation of the Issues interface.

--- a/cel/env.go
+++ b/cel/env.go
@@ -221,6 +221,14 @@ func (e *env) Program(ast Ast, opts ...ProgramOption) (Program, error) {
 	return newProgram(e, ast, opts...)
 }
 
+func (e *env) TypeAdapter() ref.TypeAdapter {
+	adapter, isAdapter := e.types.(ref.TypeAdapter)
+	if isAdapter {
+		return adapter
+	}
+	return nil
+}
+
 // issues is the internal implementation of the Issues interface.
 type issues struct {
 	errs *common.Errors

--- a/cel/options.go
+++ b/cel/options.go
@@ -59,7 +59,7 @@ func ClearMacros() EnvOption {
 
 // CustomTypeAdapter swaps the default ref.TypeAdapter implementation with a custom one.
 //
-// Note: This option must be specified before the Types option when used together.
+// Note: This option must be specified before the Types and TypeDescs options when used together.
 func CustomTypeAdapter(adapter ref.TypeAdapter) EnvOption {
 	return func(e *env) (*env, error) {
 		e.adapter = adapter
@@ -69,7 +69,7 @@ func CustomTypeAdapter(adapter ref.TypeAdapter) EnvOption {
 
 // CustomTypeProvider swaps the default ref.TypeProvider implementation with a custom one.
 //
-// Note: This option must be specified before the Types option when used together.
+// Note: This option must be specified before the Types and TypeDescs options when used together.
 func CustomTypeProvider(provider ref.TypeProvider) EnvOption {
 	return func(e *env) (*env, error) {
 		e.provider = provider

--- a/cel/options.go
+++ b/cel/options.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cel-go/common/packages"
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter"
 	"github.com/google/cel-go/interpreter/functions"
@@ -63,13 +64,11 @@ func ClearMacros() EnvOption {
 func CustomTypeProvider(provider ref.TypeProvider) EnvOption {
 	return func(e *env) (*env, error) {
 		e.types = provider
+		e.adapter = types.DefaultTypeAdapter
 		adapter, isAdapter := provider.(ref.TypeAdapter)
 		if isAdapter {
 			e.adapter = adapter
-		} else {
-			// TODO: implement GoTypeAdapter.
-			e.adapter = nil // types.GoTypeAdapter
-		}
+		} 
 		return e, nil
 	}
 }

--- a/cel/program.go
+++ b/cel/program.go
@@ -88,7 +88,7 @@ type progGen struct {
 func newProgram(e *env, ast Ast, opts ...ProgramOption) (Program, error) {
 	// Build the dispatcher, interpreter, and default program value.
 	disp := interpreter.NewDispatcher()
-	interp := interpreter.NewInterpreter(disp, e.pkg, e.types, e.adapter)
+	interp := interpreter.NewInterpreter(disp, e.pkg, e.provider, e.adapter)
 	p := &prog{
 		env:         e,
 		dispatcher:  disp,

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -190,7 +190,10 @@ func (c *checker) checkSelect(e *exprpb.Expr) {
 		// Objects yield their field type declaration as the selection result type, but only if
 		// the field is defined.
 		messageType := targetType
-		if fieldType, found := c.lookupFieldType(c.location(e), messageType, sel.Field); found {
+		if fieldType, found := c.lookupFieldType(
+			c.location(e),
+			messageType.GetMessageType(),
+			sel.Field); found {
 			resultType = fieldType.Type
 			// In proto3, primitive field types can't support presence testing, so the has()
 			// style operation would be invalid in this instance.
@@ -402,11 +405,15 @@ func (c *checker) checkCreateMessage(e *exprpb.Expr) {
 		c.check(value)
 
 		fieldType := decls.Error
-		if t, found := c.lookupFieldType(c.locationByID(ent.Id), messageType, field); found {
+		if t, found := c.lookupFieldType(
+			c.locationByID(ent.Id),
+			messageType.GetMessageType(),
+			field); found {
 			fieldType = t.Type
 		}
 		if !c.isAssignable(fieldType, c.getType(value)) {
-			c.errors.fieldTypeMismatch(c.locationByID(ent.Id), field, fieldType, c.getType(value))
+			c.errors.fieldTypeMismatch(
+				c.locationByID(ent.Id), field, fieldType, c.getType(value))
 		}
 	}
 }
@@ -494,10 +501,10 @@ func (c *checker) isAssignableList(l1 []*exprpb.Type, l2 []*exprpb.Type) bool {
 	return false
 }
 
-func (c *checker) lookupFieldType(l common.Location, messageType *exprpb.Type, fieldName string) (*ref.FieldType, bool) {
-	if _, found := c.env.typeProvider.FindType(messageType.GetMessageType()); !found {
+func (c *checker) lookupFieldType(l common.Location, messageType string, fieldName string) (*ref.FieldType, bool) {
+	if _, found := c.env.typeProvider.FindType(messageType); !found {
 		// This should not happen, anyway, report an error.
-		c.errors.unexpectedFailedResolution(l, messageType.GetMessageType())
+		c.errors.unexpectedFailedResolution(l, messageType)
 		return nil, false
 	}
 

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -502,13 +502,13 @@ func (c *checker) isAssignableList(l1 []*exprpb.Type, l2 []*exprpb.Type) bool {
 }
 
 func (c *checker) lookupFieldType(l common.Location, messageType string, fieldName string) (*ref.FieldType, bool) {
-	if _, found := c.env.typeProvider.FindType(messageType); !found {
+	if _, found := c.env.provider.FindType(messageType); !found {
 		// This should not happen, anyway, report an error.
 		c.errors.unexpectedFailedResolution(l, messageType)
 		return nil, false
 	}
 
-	if ft, found := c.env.typeProvider.FindFieldType(messageType, fieldName); found {
+	if ft, found := c.env.provider.FindFieldType(messageType, fieldName); found {
 		return ft, found
 	}
 

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1159,10 +1159,10 @@ _&&_(_==_(list~type(list(dyn))^list,
 	},
 }
 
-var typeProvider = initTypeProvider()
+var reg = initTypeRegistry()
 
-func initTypeProvider() ref.TypeProvider {
-	return types.NewProvider(&proto3pb.NestedTestAllTypes{}, &proto3pb.TestAllTypes{})
+func initTypeRegistry() ref.TypeRegistry {
+	return types.NewRegistry(&proto3pb.NestedTestAllTypes{}, &proto3pb.TestAllTypes{})
 }
 
 var testEnvs = map[string]env{
@@ -1235,6 +1235,7 @@ func TestCheck(t *testing.T) {
 				return
 			}
 
+<<<<<<< HEAD
 			pkg := packages.NewPackage(tc.Container)
 			env := NewStandardEnv(pkg, typeProvider)
 			if tc.DisableStdEnv {
@@ -1245,6 +1246,12 @@ func TestCheck(t *testing.T) {
 			}
 			if tc.Env.idents != nil {
 				for _, ident := range tc.Env.idents {
+=======
+			pkg := packages.NewPackage(tst.Container)
+			env := NewStandardEnv(pkg, reg)
+			if tst.Env.idents != nil {
+				for _, ident := range tst.Env.idents {
+>>>>>>> Updates to the review feedback.
 					env.Add(ident)
 				}
 			}

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1225,7 +1225,7 @@ func TestCheck(t *testing.T) {
 		t.Run(name, func(tt *testing.T) {
 			// Runs the tests in parallel to ensure that there are no data races
 			// due to shared mutable state across tests.
-			// tt.Parallel()
+			tt.Parallel()
 
 			src := common.NewTextSource(tc.I)
 			expression, errors := parser.Parse(src)

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1235,23 +1235,16 @@ func TestCheck(t *testing.T) {
 				return
 			}
 
-<<<<<<< HEAD
 			pkg := packages.NewPackage(tc.Container)
-			env := NewStandardEnv(pkg, typeProvider)
+			env := NewStandardEnv(pkg, reg)
 			if tc.DisableStdEnv {
-				env = NewEnv(pkg, typeProvider)
+				env = NewEnv(pkg, reg)
 			}
 			if tc.HomogeneousAggregateLiterals {
 				env.EnableDynamicAggregateLiterals(!tc.HomogeneousAggregateLiterals)
 			}
 			if tc.Env.idents != nil {
 				for _, ident := range tc.Env.idents {
-=======
-			pkg := packages.NewPackage(tst.Container)
-			env := NewStandardEnv(pkg, reg)
-			if tst.Env.idents != nil {
-				for _, ident := range tst.Env.idents {
->>>>>>> Updates to the review feedback.
 					env.Add(ident)
 				}
 			}

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1225,7 +1225,7 @@ func TestCheck(t *testing.T) {
 		t.Run(name, func(tt *testing.T) {
 			// Runs the tests in parallel to ensure that there are no data races
 			// due to shared mutable state across tests.
-			tt.Parallel()
+			// tt.Parallel()
 
 			src := common.NewTextSource(tc.I)
 			expression, errors := parser.Parse(src)

--- a/checker/env.go
+++ b/checker/env.go
@@ -39,30 +39,28 @@ const (
 // It consists of a Packager, a Type Provider, declarations, and collection of errors encountered
 // during checking.
 type Env struct {
-	packager     packages.Packager
-	typeProvider ref.TypeProvider
+	packager packages.Packager
+	provider ref.TypeProvider
 
 	declarations *decls.Scopes
 	aggLitElemType aggregateLiteralElementType
 }
 
 // NewEnv returns a new *Env with the given parameters.
-func NewEnv(packager packages.Packager,
-	typeProvider ref.TypeProvider) *Env {
+func NewEnv(packager packages.Packager, provider ref.TypeProvider) *Env {
 	declarations := decls.NewScopes()
 	declarations.Push()
 
 	return &Env{
 		packager:     packager,
-		typeProvider: typeProvider,
+		provider:     provider,
 		declarations: declarations,
 	}
 }
 
 // NewStandardEnv returns a new *Env with the given params plus standard declarations.
-func NewStandardEnv(packager packages.Packager,
-	typeProvider ref.TypeProvider) *Env {
-	e := NewEnv(packager, typeProvider)
+func NewStandardEnv(packager packages.Packager, provider ref.TypeProvider) *Env {
+	e := NewEnv(packager, provider)
 	if err := e.Add(StandardDeclarations()...); err != nil {
 		// The standard declaration set should never have duplicate declarations.
 		panic(err)
@@ -105,7 +103,7 @@ func (e *Env) LookupIdent(typeName string) *exprpb.Decl {
 		// Next try to import the name as a reference to a message type. If found,
 		// the declaration is added to the outest (global) scope of the
 		// environment, so next time we can access it faster.
-		if t, found := e.typeProvider.FindType(candidate); found {
+		if t, found := e.provider.FindType(candidate); found {
 			decl := decls.NewIdent(candidate, t, nil)
 			e.declarations.AddIdent(decl)
 			return decl
@@ -113,7 +111,7 @@ func (e *Env) LookupIdent(typeName string) *exprpb.Decl {
 
 		// Next try to import this as an enum value by splitting the name in a type prefix and
 		// the enum inside.
-		if enumValue := e.typeProvider.EnumValue(candidate); enumValue.Type() != types.ErrType {
+		if enumValue := e.provider.EnumValue(candidate); enumValue.Type() != types.ErrType {
 			decl := decls.NewIdent(candidate,
 				decls.Int,
 				&exprpb.Constant{

--- a/checker/env.go
+++ b/checker/env.go
@@ -31,7 +31,7 @@ import (
 type aggregateLiteralElementType int
 
 const (
-	dynElementType aggregateLiteralElementType = iota
+	dynElementType        aggregateLiteralElementType = iota
 	homogenousElementType aggregateLiteralElementType = 1 << iota
 )
 
@@ -42,7 +42,7 @@ type Env struct {
 	packager packages.Packager
 	provider ref.TypeProvider
 
-	declarations *decls.Scopes
+	declarations   *decls.Scopes
 	aggLitElemType aggregateLiteralElementType
 }
 
@@ -69,6 +69,9 @@ func NewStandardEnv(packager packages.Packager, provider ref.TypeProvider) *Env 
 	return e
 }
 
+// EnableDynamicAggregateLiterals detmerines whether list and map literals may support mixed
+// element types at check-time. This does not preclude the presence of a dynamic list or map
+// somewhere in the CEL evaluation process.
 func (e *Env) EnableDynamicAggregateLiterals(enabled bool) *Env {
 	e.aggLitElemType = dynElementType
 	if !enabled {

--- a/checker/env_test.go
+++ b/checker/env_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestOverlappingIdentifier(t *testing.T) {
-	env := NewStandardEnv(packages.DefaultPackage, types.NewProvider())
+	env := NewStandardEnv(packages.DefaultPackage, types.NewRegistry())
 	err := env.Add(
 		decls.NewIdent("int", decls.NewTypeType(nil), nil))
 	if err == nil {
@@ -37,7 +37,7 @@ func TestOverlappingIdentifier(t *testing.T) {
 }
 
 func TestOverlappingMacro(t *testing.T) {
-	env := NewStandardEnv(packages.DefaultPackage, types.NewProvider())
+	env := NewStandardEnv(packages.DefaultPackage, types.NewRegistry())
 	err := env.Add(decls.NewFunction("has",
 		decls.NewOverload("has", []*exprpb.Type{decls.String}, decls.Bool)))
 	if err == nil {
@@ -48,7 +48,7 @@ func TestOverlappingMacro(t *testing.T) {
 }
 
 func TestOverlappingOverload(t *testing.T) {
-	env := NewStandardEnv(packages.DefaultPackage, types.NewProvider())
+	env := NewStandardEnv(packages.DefaultPackage, types.NewRegistry())
 	paramA := decls.NewTypeParamType("A")
 	typeParamAList := []string{"A"}
 	err := env.Add(decls.NewFunction(overloads.TypeConvertDyn,

--- a/common/types/iterator.go
+++ b/common/types/iterator.go
@@ -29,12 +29,10 @@ var (
 
 // baseIterator is the basis for list, map, and object iterators.
 //
-// An iterator in and of itself should not be a valid value for comparison, but
-// must implement the ref.Val methods in order to be well-supported within
-// instruction arguments processed by the interpreter.
-type baseIterator struct {
-	ref.TypeAdapter
-}
+// An iterator in and of itself should not be a valid value for comparison, but must implement the
+// `ref.Val` methods in order to be well-supported within instruction arguments processed by the
+// interpreter.
+type baseIterator struct{}
 
 func (it *baseIterator) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	return nil, fmt.Errorf("type conversion on iterators not supported")

--- a/common/types/iterator.go
+++ b/common/types/iterator.go
@@ -32,7 +32,9 @@ var (
 // An iterator in and of itself should not be a valid value for comparison, but
 // must implement the ref.Val methods in order to be well-supported within
 // instruction arguments processed by the interpreter.
-type baseIterator struct{}
+type baseIterator struct {
+	ref.TypeAdapter
+}
 
 func (it *baseIterator) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	return nil, fmt.Errorf("type conversion on iterators not supported")

--- a/common/types/json_list.go
+++ b/common/types/json_list.go
@@ -34,8 +34,10 @@ type jsonListValue struct {
 	ref.TypeAdapter
 }
 
-// NewJSONList creates a traits.Lister implementation backed by a JSON list
-// that has been encoded in protocol buffer form.
+// NewJSONList creates a traits.Lister implementation backed by a JSON list that has been encoded
+// in protocol buffer form. 
+// 
+// The `adapter` argument provides type adaptation capabilities from proto to CEL.
 func NewJSONList(adapter ref.TypeAdapter, l *structpb.ListValue) traits.Lister {
 	return &jsonListValue{TypeAdapter: adapter, ListValue: l}
 }
@@ -144,7 +146,8 @@ func (l *jsonListValue) Get(index ref.Val) ref.Val {
 
 func (l *jsonListValue) Iterator() traits.Iterator {
 	return &jsonValueListIterator{
-		baseIterator: &baseIterator{TypeAdapter: l.TypeAdapter},
+		baseIterator: &baseIterator{},
+		TypeAdapter: l.TypeAdapter,
 		elems:        l.GetValues(),
 		len:          len(l.GetValues())}
 }
@@ -163,6 +166,7 @@ func (l *jsonListValue) Value() interface{} {
 
 type jsonValueListIterator struct {
 	*baseIterator
+	ref.TypeAdapter
 	cursor int
 	elems  []*structpb.Value
 	len    int

--- a/common/types/json_list_test.go
+++ b/common/types/json_list_test.go
@@ -26,10 +26,10 @@ import (
 )
 
 func TestJsonListValue_Add(t *testing.T) {
-	listA := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
+	listA := NewJSONList(NewRegistry(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
-	listB := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
+	listB := NewJSONList(NewRegistry(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_NumberValue{NumberValue: 2}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 3}}}})
 	list := listA.Add(listB)
@@ -49,7 +49,7 @@ func TestJsonListValue_Add(t *testing.T) {
 }
 
 func TestJsonListValue_Contains(t *testing.T) {
-	list := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
+	list := NewJSONList(NewRegistry(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	if !list.Contains(Double(1)).(Bool) {
@@ -61,7 +61,7 @@ func TestJsonListValue_Contains(t *testing.T) {
 }
 
 func TestJsonListValue_ConvertToNative_Json(t *testing.T) {
-	list := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
+	list := NewJSONList(NewRegistry(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	listVal, err := list.ConvertToNative(jsonListValueType)
@@ -84,7 +84,7 @@ func TestJsonListValue_ConvertToNative_Json(t *testing.T) {
 }
 
 func TestJsonListValue_ConvertToNative_Slice(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	list := NewJSONList(p, &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
@@ -101,7 +101,7 @@ func TestJsonListValue_ConvertToNative_Slice(t *testing.T) {
 }
 
 func TestJsonListValue_ConvertToNative_Any(t *testing.T) {
-	list := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
+	list := NewJSONList(NewRegistry(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	anyVal, err := list.ConvertToNative(anyValueType)
@@ -119,7 +119,7 @@ func TestJsonListValue_ConvertToNative_Any(t *testing.T) {
 }
 
 func TestJsonListValue_ConvertToType(t *testing.T) {
-	list := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
+	list := NewJSONList(NewRegistry(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	if list.ConvertToType(TypeType) != ListType {
@@ -134,10 +134,10 @@ func TestJsonListValue_ConvertToType(t *testing.T) {
 }
 
 func TestJsonListValue_Equal(t *testing.T) {
-	listA := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
+	listA := NewJSONList(NewRegistry(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_NumberValue{NumberValue: -3}},
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}}}})
-	listB := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
+	listB := NewJSONList(NewRegistry(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_NumberValue{NumberValue: 2}},
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}}}})
 	if listA.Equal(listB).(Bool) || listB.Equal(listA).(Bool) {
@@ -155,7 +155,7 @@ func TestJsonListValue_Equal(t *testing.T) {
 }
 
 func TestJsonListValue_Get_OutOfRange(t *testing.T) {
-	list := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
+	list := NewJSONList(NewRegistry(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	if !IsError(list.Get(Int(-1))) {
@@ -170,7 +170,7 @@ func TestJsonListValue_Get_OutOfRange(t *testing.T) {
 }
 
 func TestJsonListValue_Iterator(t *testing.T) {
-	list := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
+	list := NewJSONList(NewRegistry(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 2}},

--- a/common/types/json_list_test.go
+++ b/common/types/json_list_test.go
@@ -84,8 +84,8 @@ func TestJsonListValue_ConvertToNative_Json(t *testing.T) {
 }
 
 func TestJsonListValue_ConvertToNative_Slice(t *testing.T) {
-	p := NewRegistry()
-	list := NewJSONList(p, &structpb.ListValue{Values: []*structpb.Value{
+	reg := NewRegistry()
+	list := NewJSONList(reg, &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	listVal, err := list.ConvertToNative(reflect.TypeOf([]*structpb.Value{}))
@@ -93,7 +93,7 @@ func TestJsonListValue_ConvertToNative_Slice(t *testing.T) {
 		t.Error(err)
 	}
 	for i, v := range listVal.([]*structpb.Value) {
-		if !list.Get(Int(i)).Equal(p.NativeToValue(v)).(Bool) {
+		if !list.Get(Int(i)).Equal(reg.NativeToValue(v)).(Bool) {
 			t.Errorf("elem[%d] Got '%v', expected '%v'",
 				i, v, list.Get(Int(i)))
 		}

--- a/common/types/json_list_test.go
+++ b/common/types/json_list_test.go
@@ -26,10 +26,10 @@ import (
 )
 
 func TestJsonListValue_Add(t *testing.T) {
-	listA := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+	listA := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
-	listB := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+	listB := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_NumberValue{NumberValue: 2}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 3}}}})
 	list := listA.Add(listB)
@@ -49,7 +49,7 @@ func TestJsonListValue_Add(t *testing.T) {
 }
 
 func TestJsonListValue_Contains(t *testing.T) {
-	list := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+	list := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	if !list.Contains(Double(1)).(Bool) {
@@ -61,7 +61,7 @@ func TestJsonListValue_Contains(t *testing.T) {
 }
 
 func TestJsonListValue_ConvertToNative_Json(t *testing.T) {
-	list := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+	list := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	listVal, err := list.ConvertToNative(jsonListValueType)
@@ -84,7 +84,8 @@ func TestJsonListValue_ConvertToNative_Json(t *testing.T) {
 }
 
 func TestJsonListValue_ConvertToNative_Slice(t *testing.T) {
-	list := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+	p := NewProvider()
+	list := NewJSONList(p, &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	listVal, err := list.ConvertToNative(reflect.TypeOf([]*structpb.Value{}))
@@ -92,7 +93,7 @@ func TestJsonListValue_ConvertToNative_Slice(t *testing.T) {
 		t.Error(err)
 	}
 	for i, v := range listVal.([]*structpb.Value) {
-		if !list.Get(Int(i)).Equal(NativeToValue(v)).(Bool) {
+		if !list.Get(Int(i)).Equal(p.NativeToValue(v)).(Bool) {
 			t.Errorf("elem[%d] Got '%v', expected '%v'",
 				i, v, list.Get(Int(i)))
 		}
@@ -100,7 +101,7 @@ func TestJsonListValue_ConvertToNative_Slice(t *testing.T) {
 }
 
 func TestJsonListValue_ConvertToNative_Any(t *testing.T) {
-	list := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+	list := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	anyVal, err := list.ConvertToNative(anyValueType)
@@ -118,7 +119,7 @@ func TestJsonListValue_ConvertToNative_Any(t *testing.T) {
 }
 
 func TestJsonListValue_ConvertToType(t *testing.T) {
-	list := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+	list := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	if list.ConvertToType(TypeType) != ListType {
@@ -133,10 +134,10 @@ func TestJsonListValue_ConvertToType(t *testing.T) {
 }
 
 func TestJsonListValue_Equal(t *testing.T) {
-	listA := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+	listA := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_NumberValue{NumberValue: -3}},
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}}}})
-	listB := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+	listB := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_NumberValue{NumberValue: 2}},
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}}}})
 	if listA.Equal(listB).(Bool) || listB.Equal(listA).(Bool) {
@@ -154,7 +155,7 @@ func TestJsonListValue_Equal(t *testing.T) {
 }
 
 func TestJsonListValue_Get_OutOfRange(t *testing.T) {
-	list := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+	list := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	if !IsError(list.Get(Int(-1))) {
@@ -169,7 +170,7 @@ func TestJsonListValue_Get_OutOfRange(t *testing.T) {
 }
 
 func TestJsonListValue_Iterator(t *testing.T) {
-	list := NewJSONList(&structpb.ListValue{Values: []*structpb.Value{
+	list := NewJSONList(NewProvider(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 2}},

--- a/common/types/json_struct.go
+++ b/common/types/json_struct.go
@@ -34,8 +34,10 @@ type jsonStruct struct {
 	*structpb.Struct
 }
 
-// NewJSONStruct creates a traits.Mapper implementation backed by a JSON struct
-// that has been encoded in protocol buffer form.
+// NewJSONStruct creates a traits.Mapper implementation backed by a JSON struct that has been
+// encoded in protocol buffer form.
+//
+// The `adapter` argument provides type adaptation capabilities from proto to CEL.
 func NewJSONStruct(adapter ref.TypeAdapter, st *structpb.Struct) traits.Mapper {
 	return &jsonStruct{TypeAdapter: adapter, Struct: st}
 }
@@ -148,7 +150,7 @@ func (m *jsonStruct) Iterator() traits.Iterator {
 		i++
 	}
 	return &jsonValueMapIterator{
-		baseIterator: &baseIterator{m.TypeAdapter},
+		baseIterator: &baseIterator{},
 		len:          len(keys),
 		mapKeys:      keys}
 }

--- a/common/types/json_struct.go
+++ b/common/types/json_struct.go
@@ -30,13 +30,14 @@ var (
 )
 
 type jsonStruct struct {
+	ref.TypeAdapter
 	*structpb.Struct
 }
 
 // NewJSONStruct creates a traits.Mapper implementation backed by a JSON struct
 // that has been encoded in protocol buffer form.
-func NewJSONStruct(st *structpb.Struct) traits.Mapper {
-	return &jsonStruct{st}
+func NewJSONStruct(adapter ref.TypeAdapter, st *structpb.Struct) traits.Mapper {
+	return &jsonStruct{TypeAdapter: adapter, Struct: st}
 }
 
 func (m *jsonStruct) Contains(index ref.Val) ref.Val {
@@ -135,7 +136,7 @@ func (m *jsonStruct) Get(key ref.Val) ref.Val {
 	if !found {
 		return NewErr("no such key: '%v'", key)
 	}
-	return NativeToValue(value)
+	return m.NativeToValue(value)
 }
 
 func (m *jsonStruct) Iterator() traits.Iterator {
@@ -147,7 +148,7 @@ func (m *jsonStruct) Iterator() traits.Iterator {
 		i++
 	}
 	return &jsonValueMapIterator{
-		baseIterator: &baseIterator{},
+		baseIterator: &baseIterator{m.TypeAdapter},
 		len:          len(keys),
 		mapKeys:      keys}
 }

--- a/common/types/json_struct_test.go
+++ b/common/types/json_struct_test.go
@@ -118,13 +118,13 @@ func TestJsonStruct_ConvertToType(t *testing.T) {
 }
 
 func TestJsonStruct_Equal(t *testing.T) {
-	p := NewRegistry()
-	mapVal := NewJSONStruct(p,
+	reg := NewRegistry()
+	mapVal := NewJSONStruct(reg,
 		&structpb.Struct{Fields: map[string]*structpb.Value{
 			"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 			"second": {Kind: &structpb.Value_NumberValue{NumberValue: 4}}}})
 
-	otherVal := NewJSONStruct(p,
+	otherVal := NewJSONStruct(reg,
 		&structpb.Struct{Fields: map[string]*structpb.Value{
 			"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 			"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
@@ -135,7 +135,7 @@ func TestJsonStruct_Equal(t *testing.T) {
 	if mapVal.Equal(mapVal) != True {
 		t.Error("Map was not equal to itself.")
 	}
-	if mapVal.Equal(NewJSONStruct(p, &structpb.Struct{})) != False {
+	if mapVal.Equal(NewJSONStruct(reg, &structpb.Struct{})) != False {
 		t.Error("Map with key-value pairs was equal to empty map")
 	}
 	if !IsError(mapVal.Equal(String(""))) {

--- a/common/types/json_struct_test.go
+++ b/common/types/json_struct_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestJsonStruct_Contains(t *testing.T) {
-	mapVal := NewJSONStruct(&structpb.Struct{Fields: map[string]*structpb.Value{
+	mapVal := NewJSONStruct(NewProvider(), &structpb.Struct{Fields: map[string]*structpb.Value{
 		"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	if !mapVal.Contains(String("first")).(Bool) {
@@ -38,7 +38,7 @@ func TestJsonStruct_Contains(t *testing.T) {
 }
 
 func TestJsonStruct_ConvertToNative_Error(t *testing.T) {
-	val, err := NewJSONStruct(&structpb.Struct{}).ConvertToNative(jsonListValueType)
+	val, err := NewJSONStruct(NewProvider(), &structpb.Struct{}).ConvertToNative(jsonListValueType)
 	if err == nil {
 		t.Errorf("Unsupported type conversion succeeded. "+
 			"Got '%v', expected error", val)
@@ -49,7 +49,7 @@ func TestJsonStruct_ConvertToNative_Json(t *testing.T) {
 	structVal := &structpb.Struct{Fields: map[string]*structpb.Value{
 		"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}}
-	mapVal := NewJSONStruct(structVal)
+	mapVal := NewJSONStruct(NewProvider(), structVal)
 	val, err := mapVal.ConvertToNative(jsonValueType)
 	if err != nil {
 		t.Error(err)
@@ -73,7 +73,7 @@ func TestJsonStruct_ConvertToNative_Any(t *testing.T) {
 		Fields: map[string]*structpb.Value{
 			"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 			"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}}
-	mapVal := NewJSONStruct(structVal)
+	mapVal := NewJSONStruct(NewProvider(), structVal)
 	anyVal, err := mapVal.ConvertToNative(anyValueType)
 	if err != nil {
 		t.Error(err)
@@ -91,7 +91,7 @@ func TestJsonStruct_ConvertToNative_Map(t *testing.T) {
 	structVal := &structpb.Struct{Fields: map[string]*structpb.Value{
 		"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		"second": {Kind: &structpb.Value_StringValue{StringValue: "world"}}}}
-	mapVal := NewJSONStruct(structVal)
+	mapVal := NewJSONStruct(NewProvider(), structVal)
 	val, err := mapVal.ConvertToNative(reflect.TypeOf(map[string]string{}))
 	if err != nil {
 		t.Error(err)
@@ -102,9 +102,10 @@ func TestJsonStruct_ConvertToNative_Map(t *testing.T) {
 }
 
 func TestJsonStruct_ConvertToType(t *testing.T) {
-	mapVal := NewJSONStruct(&structpb.Struct{Fields: map[string]*structpb.Value{
-		"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
-		"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
+	mapVal := NewJSONStruct(NewProvider(),
+		&structpb.Struct{Fields: map[string]*structpb.Value{
+			"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+			"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	if mapVal.ConvertToType(MapType) != mapVal {
 		t.Error("Map could not be converted to a map.")
 	}
@@ -117,13 +118,16 @@ func TestJsonStruct_ConvertToType(t *testing.T) {
 }
 
 func TestJsonStruct_Equal(t *testing.T) {
-	mapVal := NewJSONStruct(&structpb.Struct{Fields: map[string]*structpb.Value{
-		"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
-		"second": {Kind: &structpb.Value_NumberValue{NumberValue: 4}}}})
+	p := NewProvider()
+	mapVal := NewJSONStruct(p,
+		&structpb.Struct{Fields: map[string]*structpb.Value{
+			"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+			"second": {Kind: &structpb.Value_NumberValue{NumberValue: 4}}}})
 
-	otherVal := NewJSONStruct(&structpb.Struct{Fields: map[string]*structpb.Value{
-		"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
-		"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
+	otherVal := NewJSONStruct(p,
+		&structpb.Struct{Fields: map[string]*structpb.Value{
+			"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+			"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	if mapVal.Equal(otherVal) != False {
 		t.Errorf("Got equals 'true', expected 'false' for '%v' == '%v'",
 			mapVal, otherVal)
@@ -131,7 +135,7 @@ func TestJsonStruct_Equal(t *testing.T) {
 	if mapVal.Equal(mapVal) != True {
 		t.Error("Map was not equal to itself.")
 	}
-	if mapVal.Equal(NewJSONStruct(&structpb.Struct{})) != False {
+	if mapVal.Equal(NewJSONStruct(p, &structpb.Struct{})) != False {
 		t.Error("Map with key-value pairs was equal to empty map")
 	}
 	if !IsError(mapVal.Equal(String(""))) {
@@ -140,7 +144,7 @@ func TestJsonStruct_Equal(t *testing.T) {
 }
 
 func TestJsonStruct_Get(t *testing.T) {
-	if !IsError(NewJSONStruct(&structpb.Struct{}).Get(Int(1))) {
+	if !IsError(NewJSONStruct(NewProvider(), &structpb.Struct{}).Get(Int(1))) {
 		t.Error("Structs may only have string keys.")
 	}
 }

--- a/common/types/json_struct_test.go
+++ b/common/types/json_struct_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestJsonStruct_Contains(t *testing.T) {
-	mapVal := NewJSONStruct(NewProvider(), &structpb.Struct{Fields: map[string]*structpb.Value{
+	mapVal := NewJSONStruct(NewRegistry(), &structpb.Struct{Fields: map[string]*structpb.Value{
 		"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	if !mapVal.Contains(String("first")).(Bool) {
@@ -38,7 +38,7 @@ func TestJsonStruct_Contains(t *testing.T) {
 }
 
 func TestJsonStruct_ConvertToNative_Error(t *testing.T) {
-	val, err := NewJSONStruct(NewProvider(), &structpb.Struct{}).ConvertToNative(jsonListValueType)
+	val, err := NewJSONStruct(NewRegistry(), &structpb.Struct{}).ConvertToNative(jsonListValueType)
 	if err == nil {
 		t.Errorf("Unsupported type conversion succeeded. "+
 			"Got '%v', expected error", val)
@@ -49,7 +49,7 @@ func TestJsonStruct_ConvertToNative_Json(t *testing.T) {
 	structVal := &structpb.Struct{Fields: map[string]*structpb.Value{
 		"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}}
-	mapVal := NewJSONStruct(NewProvider(), structVal)
+	mapVal := NewJSONStruct(NewRegistry(), structVal)
 	val, err := mapVal.ConvertToNative(jsonValueType)
 	if err != nil {
 		t.Error(err)
@@ -73,7 +73,7 @@ func TestJsonStruct_ConvertToNative_Any(t *testing.T) {
 		Fields: map[string]*structpb.Value{
 			"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 			"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}}
-	mapVal := NewJSONStruct(NewProvider(), structVal)
+	mapVal := NewJSONStruct(NewRegistry(), structVal)
 	anyVal, err := mapVal.ConvertToNative(anyValueType)
 	if err != nil {
 		t.Error(err)
@@ -91,7 +91,7 @@ func TestJsonStruct_ConvertToNative_Map(t *testing.T) {
 	structVal := &structpb.Struct{Fields: map[string]*structpb.Value{
 		"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		"second": {Kind: &structpb.Value_StringValue{StringValue: "world"}}}}
-	mapVal := NewJSONStruct(NewProvider(), structVal)
+	mapVal := NewJSONStruct(NewRegistry(), structVal)
 	val, err := mapVal.ConvertToNative(reflect.TypeOf(map[string]string{}))
 	if err != nil {
 		t.Error(err)
@@ -102,7 +102,7 @@ func TestJsonStruct_ConvertToNative_Map(t *testing.T) {
 }
 
 func TestJsonStruct_ConvertToType(t *testing.T) {
-	mapVal := NewJSONStruct(NewProvider(),
+	mapVal := NewJSONStruct(NewRegistry(),
 		&structpb.Struct{Fields: map[string]*structpb.Value{
 			"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 			"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
@@ -118,7 +118,7 @@ func TestJsonStruct_ConvertToType(t *testing.T) {
 }
 
 func TestJsonStruct_Equal(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	mapVal := NewJSONStruct(p,
 		&structpb.Struct{Fields: map[string]*structpb.Value{
 			"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
@@ -144,7 +144,7 @@ func TestJsonStruct_Equal(t *testing.T) {
 }
 
 func TestJsonStruct_Get(t *testing.T) {
-	if !IsError(NewJSONStruct(NewProvider(), &structpb.Struct{}).Get(Int(1))) {
+	if !IsError(NewJSONStruct(NewRegistry(), &structpb.Struct{}).Get(Int(1))) {
 		t.Error("Structs may only have string keys.")
 	}
 }

--- a/common/types/list.go
+++ b/common/types/list.go
@@ -58,7 +58,8 @@ func NewValueList(adapter ref.TypeAdapter, elems []ref.Val) traits.Lister {
 }
 
 // baseList points to a list containing elements of any type.
-// value is an array of native values, and refValue is its reflection object.
+// The `value` is an array of native values, and refValue is its reflection object.
+// The `ref.TypeAdapter` enables native type to CEL type conversions.
 type baseList struct {
 	ref.TypeAdapter
 	value    interface{}
@@ -91,8 +92,7 @@ func (l *baseList) Contains(elem ref.Val) ref.Val {
 }
 
 func (l *baseList) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
-	// JSON conversions are a special case since the 'native' type in this case
-	// actually a protocol buffer message rather than a list.
+	// JSON conversions are a special case since the 'native' type is a proto message.
 	if typeDesc == jsonValueType || typeDesc == jsonListValueType {
 		jsonValues, err :=
 			l.ConvertToNative(reflect.TypeOf([]*structpb.Value{}))
@@ -126,8 +126,7 @@ func (l *baseList) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	if otherElemKind == thisElemKind {
 		return l.value, nil
 	}
-	// Allow the element ConvertToNative() function to determine whether
-	// conversion is possible.
+	// Allow the element ConvertToNative() function to determine whether conversion is possible.
 	elemCount := int(l.Size().(Int))
 	nativeList := reflect.MakeSlice(typeDesc, elemCount, elemCount)
 	for i := 0; i < elemCount; i++ {
@@ -184,7 +183,7 @@ func (l *baseList) Get(index ref.Val) ref.Val {
 
 func (l *baseList) Iterator() traits.Iterator {
 	return &listIterator{
-		baseIterator: &baseIterator{l.TypeAdapter},
+		baseIterator: &baseIterator{},
 		listValue:    l,
 		cursor:       0,
 		len:          l.Size().(Int)}
@@ -203,6 +202,7 @@ func (l *baseList) Value() interface{} {
 }
 
 // concatList combines two list implementations together into a view.
+// The `ref.TypeAdapter` enables native type to CEL type conversions.
 type concatList struct {
 	ref.TypeAdapter
 	value    interface{}
@@ -281,7 +281,7 @@ func (l *concatList) Get(index ref.Val) ref.Val {
 
 func (l *concatList) Iterator() traits.Iterator {
 	return &listIterator{
-		baseIterator: &baseIterator{l.TypeAdapter},
+		baseIterator: &baseIterator{},
 		listValue:    l,
 		cursor:       0,
 		len:          l.Size().(Int)}

--- a/common/types/list.go
+++ b/common/types/list.go
@@ -36,27 +36,31 @@ var (
 // NewDynamicList returns a traits.Lister with heterogenous elements.
 // value should be an array of "native" types, i.e. any type that
 // NativeToValue() can convert to a ref.Val.
-func NewDynamicList(value interface{}) traits.Lister {
-	return &baseList{value, reflect.ValueOf(value)}
+func NewDynamicList(adapter ref.TypeAdapter, value interface{}) traits.Lister {
+	return &baseList{
+		TypeAdapter: adapter,
+		value:       value,
+		refValue:    reflect.ValueOf(value)}
 }
 
 // NewStringList returns a traits.Lister containing only strings.
-func NewStringList(elems []string) traits.Lister {
+func NewStringList(adapter ref.TypeAdapter, elems []string) traits.Lister {
 	return &stringList{
-		baseList: NewDynamicList(elems).(*baseList),
+		baseList: NewDynamicList(adapter, elems).(*baseList),
 		elems:    elems}
 }
 
 // NewValueList returns a traits.Lister with ref.Val elements.
-func NewValueList(elems []ref.Val) traits.Lister {
+func NewValueList(adapter ref.TypeAdapter, elems []ref.Val) traits.Lister {
 	return &valueList{
-		baseList: NewDynamicList(elems).(*baseList),
+		baseList: NewDynamicList(adapter, elems).(*baseList),
 		elems:    elems}
 }
 
 // baseList points to a list containing elements of any type.
 // value is an array of native values, and refValue is its reflection object.
 type baseList struct {
+	ref.TypeAdapter
 	value    interface{}
 	refValue reflect.Value
 }
@@ -72,8 +76,9 @@ func (l *baseList) Add(other ref.Val) ref.Val {
 		return l
 	}
 	return &concatList{
-		prevList: l,
-		nextList: other.(traits.Lister)}
+		TypeAdapter: l.TypeAdapter,
+		prevList:    l,
+		nextList:    other.(traits.Lister)}
 }
 
 func (l *baseList) Contains(elem ref.Val) ref.Val {
@@ -174,12 +179,12 @@ func (l *baseList) Get(index ref.Val) ref.Val {
 		return NewErr("index '%d' out of range in list size '%d'", i, l.Size())
 	}
 	elem := l.refValue.Index(int(i)).Interface()
-	return NativeToValue(elem)
+	return l.NativeToValue(elem)
 }
 
 func (l *baseList) Iterator() traits.Iterator {
 	return &listIterator{
-		baseIterator: &baseIterator{},
+		baseIterator: &baseIterator{l.TypeAdapter},
 		listValue:    l,
 		cursor:       0,
 		len:          l.Size().(Int)}
@@ -199,6 +204,7 @@ func (l *baseList) Value() interface{} {
 
 // concatList combines two list implementations together into a view.
 type concatList struct {
+	ref.TypeAdapter
 	value    interface{}
 	prevList traits.Lister
 	nextList traits.Lister
@@ -215,8 +221,9 @@ func (l *concatList) Add(other ref.Val) ref.Val {
 		return l
 	}
 	return &concatList{
-		prevList: l,
-		nextList: other.(traits.Lister)}
+		TypeAdapter: l.TypeAdapter,
+		prevList:    l,
+		nextList:    other.(traits.Lister)}
 }
 
 func (l *concatList) Contains(elem ref.Val) ref.Val {
@@ -226,8 +233,9 @@ func (l *concatList) Contains(elem ref.Val) ref.Val {
 
 func (l *concatList) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	combined := &baseList{
-		value:    l.Value(),
-		refValue: reflect.ValueOf(l.Value())}
+		TypeAdapter: l.TypeAdapter,
+		value:       l.Value(),
+		refValue:    reflect.ValueOf(l.Value())}
 	return combined.ConvertToNative(typeDesc)
 }
 
@@ -273,7 +281,7 @@ func (l *concatList) Get(index ref.Val) ref.Val {
 
 func (l *concatList) Iterator() traits.Iterator {
 	return &listIterator{
-		baseIterator: &baseIterator{},
+		baseIterator: &baseIterator{l.TypeAdapter},
 		listValue:    l,
 		cursor:       0,
 		len:          l.Size().(Int)}
@@ -324,11 +332,12 @@ func (l *stringList) Add(other ref.Val) ref.Val {
 	switch other.(type) {
 	case *stringList:
 		concatElems := append(l.elems, other.(*stringList).elems...)
-		return NewStringList(concatElems)
+		return NewStringList(l.TypeAdapter, concatElems)
 	}
 	return &concatList{
-		prevList: l.baseList,
-		nextList: other.(traits.Lister)}
+		TypeAdapter: l.TypeAdapter,
+		prevList:    l.baseList,
+		nextList:    other.(traits.Lister)}
 }
 
 func (l *stringList) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
@@ -388,8 +397,9 @@ func (l *valueList) Add(other ref.Val) ref.Val {
 		return ValOrErr(other, "no such overload")
 	}
 	return &concatList{
-		prevList: l,
-		nextList: other.(traits.Lister)}
+		TypeAdapter: l.TypeAdapter,
+		prevList:    l,
+		nextList:    other.(traits.Lister)}
 }
 
 func (l *valueList) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {

--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -27,12 +27,12 @@ import (
 )
 
 func TestBaseList_Add_Empty(t *testing.T) {
-	p := NewRegistry()
-	list := NewDynamicList(p, []bool{true})
-	if list.Add(NewDynamicList(p, []bool{})) != list {
+	reg := NewRegistry()
+	list := NewDynamicList(reg, []bool{true})
+	if list.Add(NewDynamicList(reg, []bool{})) != list {
 		t.Error("Adding an empty list created new list.")
 	}
-	if NewDynamicList(p, []string{}).Add(list) != list {
+	if NewDynamicList(reg, []string{}).Add(list) != list {
 		t.Error("Adding list to empty created a new list.")
 	}
 }
@@ -137,24 +137,24 @@ func validateIterator123(t *testing.T, list traits.Lister) {
 }
 
 func TestBaseList_NestedList(t *testing.T) {
-	p := NewRegistry()
+	reg := NewRegistry()
 	listUint32 := []uint32{1, 2}
-	nestedUint32 := NewDynamicList(p, []interface{}{listUint32})
+	nestedUint32 := NewDynamicList(reg, []interface{}{listUint32})
 	listUint64 := []uint64{1, 2}
-	nestedUint64 := NewDynamicList(p, []interface{}{listUint64})
+	nestedUint64 := NewDynamicList(reg, []interface{}{listUint64})
 	if nestedUint32.Equal(nestedUint64) != True {
 		t.Error("Could not find nested list")
 	}
-	if nestedUint32.Contains(NewDynamicList(p, listUint64)) != True ||
-		nestedUint64.Contains(NewDynamicList(p, listUint32)) != True {
+	if nestedUint32.Contains(NewDynamicList(reg, listUint64)) != True ||
+		nestedUint64.Contains(NewDynamicList(reg, listUint32)) != True {
 		t.Error("Could not find type compatible nested lists")
 	}
 }
 
 func TestBaseList_Size(t *testing.T) {
-	p := NewRegistry()
+	reg := NewRegistry()
 	listUint32 := []uint32{1, 2}
-	nestedUint32 := NewDynamicList(p, []interface{}{listUint32})
+	nestedUint32 := NewDynamicList(reg, []interface{}{listUint32})
 	if nestedUint32.Size() != IntOne {
 		t.Error("List indicates the incorrect size.")
 	}
@@ -164,9 +164,9 @@ func TestBaseList_Size(t *testing.T) {
 }
 
 func TestConcatList_Add(t *testing.T) {
-	p := NewRegistry()
-	listA := NewDynamicList(p, []float32{1.0, 2.0})
-	listB := NewStringList(p, []string{"3"})
+	reg := NewRegistry()
+	listA := NewDynamicList(reg, []float32{1.0, 2.0})
+	listB := NewStringList(reg, []string{"3"})
 	list := listA.Add(listB).(traits.Lister).Add(listA).
 		Value().([]interface{})
 	expected := []interface{}{
@@ -188,9 +188,9 @@ func TestConcatList_Add(t *testing.T) {
 }
 
 func TestConcatList_ConvertToNative_Json(t *testing.T) {
-	p := NewRegistry()
-	listA := NewDynamicList(p, []float32{1.0, 2.0})
-	listB := NewDynamicList(p, []string{"3"})
+	reg := NewRegistry()
+	listA := NewDynamicList(reg, []float32{1.0, 2.0})
+	listB := NewDynamicList(reg, []string{"3"})
 	list := listA.Add(listB)
 	json, err := list.ConvertToNative(jsonValueType)
 	if err != nil {
@@ -206,12 +206,12 @@ func TestConcatList_ConvertToNative_Json(t *testing.T) {
 }
 
 func TestConcatList_ConvertToNative_ElementConversionError(t *testing.T) {
-	p := NewRegistry()
-	listA := NewDynamicList(p, []float32{1.0, 2.0})
+	reg := NewRegistry()
+	listA := NewDynamicList(reg, []float32{1.0, 2.0})
 	// Duration is serializable to a string form of json, but there is no
 	// concept of a duration literal within CEL, so the serialization to string
 	// is not supported here which should cause the conversion to json to fail.
-	listB := NewDynamicList(p, []*dpb.Duration{{Seconds: 100}})
+	listB := NewDynamicList(reg, []*dpb.Duration{{Seconds: 100}})
 	listConcat := listA.Add(listB)
 	json, err := listConcat.ConvertToNative(jsonValueType)
 	if err == nil {
@@ -220,9 +220,9 @@ func TestConcatList_ConvertToNative_ElementConversionError(t *testing.T) {
 }
 
 func TestConcatList_ConvertToType(t *testing.T) {
-	p := NewRegistry()
-	listA := NewDynamicList(p, []float32{1.0, 2.0})
-	listB := NewDynamicList(p, []*dpb.Duration{{Seconds: 100}})
+	reg := NewRegistry()
+	listA := NewDynamicList(reg, []float32{1.0, 2.0})
+	listB := NewDynamicList(reg, []*dpb.Duration{{Seconds: 100}})
 	list := listA.Add(listB)
 	if list.ConvertToType(ListType) != list {
 		t.Error("List conversion to list failed.")
@@ -236,12 +236,12 @@ func TestConcatList_ConvertToType(t *testing.T) {
 }
 
 func TestConcatListValue_Equal(t *testing.T) {
-	p := NewRegistry()
-	listA := NewDynamicList(p, []float32{1.0, 2.0})
-	listB := NewDynamicList(p, []float64{3.0})
+	reg := NewRegistry()
+	listA := NewDynamicList(reg, []float32{1.0, 2.0})
+	listB := NewDynamicList(reg, []float64{3.0})
 	list := listA.Add(listB)
 	// Note the internal type of list raw and concat list are slightly different.
-	listRaw := NewDynamicList(p, []interface{}{
+	listRaw := NewDynamicList(reg, []interface{}{
 		float32(1.0), float64(2.0), float64(3.0)})
 	if listRaw.Equal(list) != True ||
 		list.Equal(listRaw) != True {
@@ -256,9 +256,9 @@ func TestConcatListValue_Equal(t *testing.T) {
 }
 
 func TestConcatListValue_Get(t *testing.T) {
-	p := NewRegistry()
-	listA := NewDynamicList(p, []float32{1.0, 2.0})
-	listB := NewDynamicList(p, []float64{3.0})
+	reg := NewRegistry()
+	listA := NewDynamicList(reg, []float32{1.0, 2.0})
+	listB := NewDynamicList(reg, []float64{3.0})
 	list := listA.Add(listB).(traits.Lister)
 	if getElem(t, list, 0) != Double(1.0) ||
 		getElem(t, list, 1) != Double(2.0) ||
@@ -274,9 +274,9 @@ func TestConcatListValue_Get(t *testing.T) {
 }
 
 func TestConcatListValue_Iterator(t *testing.T) {
-	p := NewRegistry()
-	listA := NewDynamicList(p, []float32{1.0, 2.0})
-	listB := NewDynamicList(p, []float64{3.0})
+	reg := NewRegistry()
+	listA := NewDynamicList(reg, []float32{1.0, 2.0})
+	listB := NewDynamicList(reg, []float64{3.0})
 	list := listA.Add(listB).(traits.Lister)
 	it := list.Iterator()
 	var i = int64(0)
@@ -296,27 +296,27 @@ func TestConcatListValue_Iterator(t *testing.T) {
 }
 
 func TestStringList_Add_Empty(t *testing.T) {
-	p := NewRegistry()
-	list := NewStringList(p, []string{"hello"})
-	if list.Add(NewStringList(p, []string{})) != list {
+	reg := NewRegistry()
+	list := NewStringList(reg, []string{"hello"})
+	if list.Add(NewStringList(reg, []string{})) != list {
 		t.Error("Adding empty lists resulted in new list creation.")
 	}
-	if NewStringList(p, []string{}).Add(list) != list {
+	if NewStringList(reg, []string{}).Add(list) != list {
 		t.Error("Adding empty lists resulted in new list creation.")
 	}
 }
 
 func TestStringList_Add_Error(t *testing.T) {
-	p := NewRegistry()
-	if !IsError(NewStringList(p, []string{}).Add(True)) {
+	reg := NewRegistry()
+	if !IsError(NewStringList(reg, []string{}).Add(True)) {
 		t.Error("Got list, expected error.")
 	}
 }
 
 func TestStringList_Add_Heterogenous(t *testing.T) {
-	p := NewRegistry()
-	listA := NewStringList(p, []string{"hello"})
-	listB := NewDynamicList(p, []int32{1, 2, 3})
+	reg := NewRegistry()
+	listA := NewStringList(reg, []string{"hello"})
+	listB := NewDynamicList(reg, []int32{1, 2, 3})
 	list := listA.Add(listB).(traits.Lister).Value().([]interface{})
 	expected := []interface{}{"hello", int32(1), int32(2), int32(3)}
 	if len(list) != len(expected) {
@@ -330,9 +330,9 @@ func TestStringList_Add_Heterogenous(t *testing.T) {
 }
 
 func TestStringList_Add_StringLists(t *testing.T) {
-	p := NewRegistry()
-	listA := NewStringList(p, []string{"hello"})
-	listB := NewStringList(p, []string{"world", "!"})
+	reg := NewRegistry()
+	listA := NewStringList(reg, []string{"hello"})
+	listB := NewStringList(reg, []string{"world", "!"})
 	list := listA.Add(listB).(traits.Lister)
 	if list.Size() != Int(3) {
 		t.Error("Combined list did not have correct size.")
@@ -346,8 +346,8 @@ func TestStringList_Add_StringLists(t *testing.T) {
 }
 
 func TestStringList_ConvertToNative(t *testing.T) {
-	p := NewRegistry()
-	list := NewStringList(p, []string{"h", "e", "l", "p"})
+	reg := NewRegistry()
+	list := NewStringList(reg, []string{"h", "e", "l", "p"})
 	val, err := list.ConvertToNative(reflect.TypeOf([]string{}))
 	if err != nil {
 		t.Error("Unable to convert string list to itself.")
@@ -358,8 +358,8 @@ func TestStringList_ConvertToNative(t *testing.T) {
 }
 
 func TestStringList_ConvertToNative_Error(t *testing.T) {
-	p := NewRegistry()
-	list := NewStringList(p, []string{"h", "e", "l", "p"})
+	reg := NewRegistry()
+	list := NewStringList(reg, []string{"h", "e", "l", "p"})
 	_, err := list.ConvertToNative(jsonStructType)
 	if err == nil {
 		t.Error("Conversion of list to unsupported type did not error.")
@@ -367,8 +367,8 @@ func TestStringList_ConvertToNative_Error(t *testing.T) {
 }
 
 func TestStringList_ConvertToNative_Json(t *testing.T) {
-	p := NewRegistry()
-	list := NewStringList(p, []string{"h", "e", "l", "p"})
+	reg := NewRegistry()
+	list := NewStringList(reg, []string{"h", "e", "l", "p"})
 	json, err := list.ConvertToNative(jsonValueType)
 	if err != nil {
 		t.Errorf("Got '%v', expected '%v'", err, json)
@@ -392,8 +392,8 @@ func TestStringList_ConvertToNative_Json(t *testing.T) {
 }
 
 func TestStringList_Get_OutOfRange(t *testing.T) {
-	p := NewRegistry()
-	list := NewStringList(p, []string{"hello", "world"})
+	reg := NewRegistry()
+	list := NewStringList(reg, []string{"hello", "world"})
 	if !IsError(list.Get(Int(-1))) {
 		t.Error("Negative index did not return error.")
 	}

--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -27,23 +27,24 @@ import (
 )
 
 func TestBaseList_Add_Empty(t *testing.T) {
-	list := NewDynamicList([]bool{true})
-	if list.Add(NewDynamicList([]bool{})) != list {
+	p := NewProvider()
+	list := NewDynamicList(p, []bool{true})
+	if list.Add(NewDynamicList(p, []bool{})) != list {
 		t.Error("Adding an empty list created new list.")
 	}
-	if NewDynamicList([]string{}).Add(list) != list {
+	if NewDynamicList(p, []string{}).Add(list) != list {
 		t.Error("Adding list to empty created a new list.")
 	}
 }
 
 func TestBaseList_Add_Error(t *testing.T) {
-	if !IsError(NewDynamicList([]bool{}).Add(String("error"))) {
+	if !IsError(NewDynamicList(NewProvider(), []bool{}).Add(String("error"))) {
 		t.Error("Addind a non-list value to a list unexpected succeeds.")
 	}
 }
 
 func TestBaseList_Contains(t *testing.T) {
-	list := NewDynamicList([]float32{1.0, 2.0, 3.0})
+	list := NewDynamicList(NewProvider(), []float32{1.0, 2.0, 3.0})
 	if list.Contains(Int(3)) == True {
 		t.Error("List contains succeeded with wrong type")
 	}
@@ -53,7 +54,7 @@ func TestBaseList_Contains(t *testing.T) {
 }
 
 func TestBaseList_ConvertToNative(t *testing.T) {
-	list := NewDynamicList([]float64{1.0, 2.0})
+	list := NewDynamicList(NewProvider(), []float64{1.0, 2.0})
 	if protoList, err := list.ConvertToNative(reflect.TypeOf([]float32{})); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(protoList, []float32{1.0, 2.0}) {
@@ -62,7 +63,7 @@ func TestBaseList_ConvertToNative(t *testing.T) {
 }
 
 func TestBaseList_ConvertToType(t *testing.T) {
-	list := NewDynamicList([]string{"h", "e", "l", "l", "o"})
+	list := NewDynamicList(NewProvider(), []string{"h", "e", "l", "l", "o"})
 	if list.ConvertToType(ListType) != list {
 		t.Error("List was not convertible to itself.")
 	}
@@ -75,27 +76,27 @@ func TestBaseList_ConvertToType(t *testing.T) {
 }
 
 func TestBaseList_Equal(t *testing.T) {
-	listA := NewDynamicList([]string{"h", "e", "l", "l", "o"})
-	listB := NewDynamicList([]string{"h", "e", "l", "p", "!"})
+	listA := NewDynamicList(NewProvider(), []string{"h", "e", "l", "l", "o"})
+	listB := NewDynamicList(NewProvider(), []string{"h", "e", "l", "p", "!"})
 	if listA.Equal(listB) != False {
 		t.Error("Lists with different contents returned equal.")
 	}
 }
 
 func TestBaseList_Get(t *testing.T) {
-	validateList123(t, NewDynamicList([]int32{1, 2, 3}).(traits.Lister))
+	validateList123(t, NewDynamicList(NewProvider(), []int32{1, 2, 3}).(traits.Lister))
 }
 
 func TestValueList_Get(t *testing.T) {
-	validateList123(t, NewValueList([]ref.Val{Int(1), Int(2), Int(3)}))
+	validateList123(t, NewValueList(NewProvider(), []ref.Val{Int(1), Int(2), Int(3)}))
 }
 
 func TestBaseList_Iterator(t *testing.T) {
-	validateIterator123(t, NewDynamicList([]int32{1, 2, 3}).(traits.Lister))
+	validateIterator123(t, NewDynamicList(NewProvider(), []int32{1, 2, 3}).(traits.Lister))
 }
 
 func TestValueListValue_Iterator(t *testing.T) {
-	validateIterator123(t, NewValueList([]ref.Val{Int(1), Int(2), Int(3)}))
+	validateIterator123(t, NewValueList(NewProvider(), []ref.Val{Int(1), Int(2), Int(3)}))
 }
 
 func validateList123(t *testing.T, list traits.Lister) {
@@ -136,22 +137,24 @@ func validateIterator123(t *testing.T, list traits.Lister) {
 }
 
 func TestBaseList_NestedList(t *testing.T) {
+	p := NewProvider()
 	listUint32 := []uint32{1, 2}
-	nestedUint32 := NewDynamicList([]interface{}{listUint32})
+	nestedUint32 := NewDynamicList(p, []interface{}{listUint32})
 	listUint64 := []uint64{1, 2}
-	nestedUint64 := NewDynamicList([]interface{}{listUint64})
+	nestedUint64 := NewDynamicList(p, []interface{}{listUint64})
 	if nestedUint32.Equal(nestedUint64) != True {
 		t.Error("Could not find nested list")
 	}
-	if nestedUint32.Contains(NewDynamicList(listUint64)) != True ||
-		nestedUint64.Contains(NewDynamicList(listUint32)) != True {
+	if nestedUint32.Contains(NewDynamicList(p, listUint64)) != True ||
+		nestedUint64.Contains(NewDynamicList(p, listUint32)) != True {
 		t.Error("Could not find type compatible nested lists")
 	}
 }
 
 func TestBaseList_Size(t *testing.T) {
+	p := NewProvider()
 	listUint32 := []uint32{1, 2}
-	nestedUint32 := NewDynamicList([]interface{}{listUint32})
+	nestedUint32 := NewDynamicList(p, []interface{}{listUint32})
 	if nestedUint32.Size() != IntOne {
 		t.Error("List indicates the incorrect size.")
 	}
@@ -161,8 +164,9 @@ func TestBaseList_Size(t *testing.T) {
 }
 
 func TestConcatList_Add(t *testing.T) {
-	listA := NewDynamicList([]float32{1.0, 2.0})
-	listB := NewStringList([]string{"3"})
+	p := NewProvider()
+	listA := NewDynamicList(p, []float32{1.0, 2.0})
+	listB := NewStringList(p, []string{"3"})
 	list := listA.Add(listB).(traits.Lister).Add(listA).
 		Value().([]interface{})
 	expected := []interface{}{
@@ -184,8 +188,9 @@ func TestConcatList_Add(t *testing.T) {
 }
 
 func TestConcatList_ConvertToNative_Json(t *testing.T) {
-	listA := NewDynamicList([]float32{1.0, 2.0})
-	listB := NewDynamicList([]string{"3"})
+	p := NewProvider()
+	listA := NewDynamicList(p, []float32{1.0, 2.0})
+	listB := NewDynamicList(p, []string{"3"})
 	list := listA.Add(listB)
 	json, err := list.ConvertToNative(jsonValueType)
 	if err != nil {
@@ -201,11 +206,12 @@ func TestConcatList_ConvertToNative_Json(t *testing.T) {
 }
 
 func TestConcatList_ConvertToNative_ElementConversionError(t *testing.T) {
-	listA := NewDynamicList([]float32{1.0, 2.0})
+	p := NewProvider()
+	listA := NewDynamicList(p, []float32{1.0, 2.0})
 	// Duration is serializable to a string form of json, but there is no
 	// concept of a duration literal within CEL, so the serialization to string
 	// is not supported here which should cause the conversion to json to fail.
-	listB := NewDynamicList([]*dpb.Duration{{Seconds: 100}})
+	listB := NewDynamicList(p, []*dpb.Duration{{Seconds: 100}})
 	listConcat := listA.Add(listB)
 	json, err := listConcat.ConvertToNative(jsonValueType)
 	if err == nil {
@@ -214,8 +220,9 @@ func TestConcatList_ConvertToNative_ElementConversionError(t *testing.T) {
 }
 
 func TestConcatList_ConvertToType(t *testing.T) {
-	listA := NewDynamicList([]float32{1.0, 2.0})
-	listB := NewDynamicList([]*dpb.Duration{{Seconds: 100}})
+	p := NewProvider()
+	listA := NewDynamicList(p, []float32{1.0, 2.0})
+	listB := NewDynamicList(p, []*dpb.Duration{{Seconds: 100}})
 	list := listA.Add(listB)
 	if list.ConvertToType(ListType) != list {
 		t.Error("List conversion to list failed.")
@@ -229,11 +236,12 @@ func TestConcatList_ConvertToType(t *testing.T) {
 }
 
 func TestConcatListValue_Equal(t *testing.T) {
-	listA := NewDynamicList([]float32{1.0, 2.0})
-	listB := NewDynamicList([]float64{3.0})
+	p := NewProvider()
+	listA := NewDynamicList(p, []float32{1.0, 2.0})
+	listB := NewDynamicList(p, []float64{3.0})
 	list := listA.Add(listB)
 	// Note the internal type of list raw and concat list are slightly different.
-	listRaw := NewDynamicList([]interface{}{
+	listRaw := NewDynamicList(p, []interface{}{
 		float32(1.0), float64(2.0), float64(3.0)})
 	if listRaw.Equal(list) != True ||
 		list.Equal(listRaw) != True {
@@ -248,8 +256,9 @@ func TestConcatListValue_Equal(t *testing.T) {
 }
 
 func TestConcatListValue_Get(t *testing.T) {
-	listA := NewDynamicList([]float32{1.0, 2.0})
-	listB := NewDynamicList([]float64{3.0})
+	p := NewProvider()
+	listA := NewDynamicList(p, []float32{1.0, 2.0})
+	listB := NewDynamicList(p, []float64{3.0})
 	list := listA.Add(listB).(traits.Lister)
 	if getElem(t, list, 0) != Double(1.0) ||
 		getElem(t, list, 1) != Double(2.0) ||
@@ -265,8 +274,9 @@ func TestConcatListValue_Get(t *testing.T) {
 }
 
 func TestConcatListValue_Iterator(t *testing.T) {
-	listA := NewDynamicList([]float32{1.0, 2.0})
-	listB := NewDynamicList([]float64{3.0})
+	p := NewProvider()
+	listA := NewDynamicList(p, []float32{1.0, 2.0})
+	listB := NewDynamicList(p, []float64{3.0})
 	list := listA.Add(listB).(traits.Lister)
 	it := list.Iterator()
 	var i = int64(0)
@@ -286,24 +296,27 @@ func TestConcatListValue_Iterator(t *testing.T) {
 }
 
 func TestStringList_Add_Empty(t *testing.T) {
-	list := NewStringList([]string{"hello"})
-	if list.Add(NewStringList([]string{})) != list {
+	p := NewProvider()
+	list := NewStringList(p, []string{"hello"})
+	if list.Add(NewStringList(p, []string{})) != list {
 		t.Error("Adding empty lists resulted in new list creation.")
 	}
-	if NewStringList([]string{}).Add(list) != list {
+	if NewStringList(p, []string{}).Add(list) != list {
 		t.Error("Adding empty lists resulted in new list creation.")
 	}
 }
 
 func TestStringList_Add_Error(t *testing.T) {
-	if !IsError(NewStringList([]string{}).Add(True)) {
+	p := NewProvider()
+	if !IsError(NewStringList(p, []string{}).Add(True)) {
 		t.Error("Got list, expected error.")
 	}
 }
 
 func TestStringList_Add_Heterogenous(t *testing.T) {
-	listA := NewStringList([]string{"hello"})
-	listB := NewDynamicList([]int32{1, 2, 3})
+	p := NewProvider()
+	listA := NewStringList(p, []string{"hello"})
+	listB := NewDynamicList(p, []int32{1, 2, 3})
 	list := listA.Add(listB).(traits.Lister).Value().([]interface{})
 	expected := []interface{}{"hello", int32(1), int32(2), int32(3)}
 	if len(list) != len(expected) {
@@ -317,8 +330,9 @@ func TestStringList_Add_Heterogenous(t *testing.T) {
 }
 
 func TestStringList_Add_StringLists(t *testing.T) {
-	listA := NewStringList([]string{"hello"})
-	listB := NewStringList([]string{"world", "!"})
+	p := NewProvider()
+	listA := NewStringList(p, []string{"hello"})
+	listB := NewStringList(p, []string{"world", "!"})
 	list := listA.Add(listB).(traits.Lister)
 	if list.Size() != Int(3) {
 		t.Error("Combined list did not have correct size.")
@@ -332,7 +346,8 @@ func TestStringList_Add_StringLists(t *testing.T) {
 }
 
 func TestStringList_ConvertToNative(t *testing.T) {
-	list := NewStringList([]string{"h", "e", "l", "p"})
+	p := NewProvider()
+	list := NewStringList(p, []string{"h", "e", "l", "p"})
 	val, err := list.ConvertToNative(reflect.TypeOf([]string{}))
 	if err != nil {
 		t.Error("Unable to convert string list to itself.")
@@ -343,7 +358,8 @@ func TestStringList_ConvertToNative(t *testing.T) {
 }
 
 func TestStringList_ConvertToNative_Error(t *testing.T) {
-	list := NewStringList([]string{"h", "e", "l", "p"})
+	p := NewProvider()
+	list := NewStringList(p, []string{"h", "e", "l", "p"})
 	_, err := list.ConvertToNative(jsonStructType)
 	if err == nil {
 		t.Error("Conversion of list to unsupported type did not error.")
@@ -351,7 +367,8 @@ func TestStringList_ConvertToNative_Error(t *testing.T) {
 }
 
 func TestStringList_ConvertToNative_Json(t *testing.T) {
-	list := NewStringList([]string{"h", "e", "l", "p"})
+	p := NewProvider()
+	list := NewStringList(p, []string{"h", "e", "l", "p"})
 	json, err := list.ConvertToNative(jsonValueType)
 	if err != nil {
 		t.Errorf("Got '%v', expected '%v'", err, json)
@@ -375,7 +392,8 @@ func TestStringList_ConvertToNative_Json(t *testing.T) {
 }
 
 func TestStringList_Get_OutOfRange(t *testing.T) {
-	list := NewStringList([]string{"hello", "world"})
+	p := NewProvider()
+	list := NewStringList(p, []string{"hello", "world"})
 	if !IsError(list.Get(Int(-1))) {
 		t.Error("Negative index did not return error.")
 	}

--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestBaseList_Add_Empty(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	list := NewDynamicList(p, []bool{true})
 	if list.Add(NewDynamicList(p, []bool{})) != list {
 		t.Error("Adding an empty list created new list.")
@@ -38,13 +38,13 @@ func TestBaseList_Add_Empty(t *testing.T) {
 }
 
 func TestBaseList_Add_Error(t *testing.T) {
-	if !IsError(NewDynamicList(NewProvider(), []bool{}).Add(String("error"))) {
+	if !IsError(NewDynamicList(NewRegistry(), []bool{}).Add(String("error"))) {
 		t.Error("Addind a non-list value to a list unexpected succeeds.")
 	}
 }
 
 func TestBaseList_Contains(t *testing.T) {
-	list := NewDynamicList(NewProvider(), []float32{1.0, 2.0, 3.0})
+	list := NewDynamicList(NewRegistry(), []float32{1.0, 2.0, 3.0})
 	if list.Contains(Int(3)) == True {
 		t.Error("List contains succeeded with wrong type")
 	}
@@ -54,7 +54,7 @@ func TestBaseList_Contains(t *testing.T) {
 }
 
 func TestBaseList_ConvertToNative(t *testing.T) {
-	list := NewDynamicList(NewProvider(), []float64{1.0, 2.0})
+	list := NewDynamicList(NewRegistry(), []float64{1.0, 2.0})
 	if protoList, err := list.ConvertToNative(reflect.TypeOf([]float32{})); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(protoList, []float32{1.0, 2.0}) {
@@ -63,7 +63,7 @@ func TestBaseList_ConvertToNative(t *testing.T) {
 }
 
 func TestBaseList_ConvertToType(t *testing.T) {
-	list := NewDynamicList(NewProvider(), []string{"h", "e", "l", "l", "o"})
+	list := NewDynamicList(NewRegistry(), []string{"h", "e", "l", "l", "o"})
 	if list.ConvertToType(ListType) != list {
 		t.Error("List was not convertible to itself.")
 	}
@@ -76,27 +76,27 @@ func TestBaseList_ConvertToType(t *testing.T) {
 }
 
 func TestBaseList_Equal(t *testing.T) {
-	listA := NewDynamicList(NewProvider(), []string{"h", "e", "l", "l", "o"})
-	listB := NewDynamicList(NewProvider(), []string{"h", "e", "l", "p", "!"})
+	listA := NewDynamicList(NewRegistry(), []string{"h", "e", "l", "l", "o"})
+	listB := NewDynamicList(NewRegistry(), []string{"h", "e", "l", "p", "!"})
 	if listA.Equal(listB) != False {
 		t.Error("Lists with different contents returned equal.")
 	}
 }
 
 func TestBaseList_Get(t *testing.T) {
-	validateList123(t, NewDynamicList(NewProvider(), []int32{1, 2, 3}).(traits.Lister))
+	validateList123(t, NewDynamicList(NewRegistry(), []int32{1, 2, 3}).(traits.Lister))
 }
 
 func TestValueList_Get(t *testing.T) {
-	validateList123(t, NewValueList(NewProvider(), []ref.Val{Int(1), Int(2), Int(3)}))
+	validateList123(t, NewValueList(NewRegistry(), []ref.Val{Int(1), Int(2), Int(3)}))
 }
 
 func TestBaseList_Iterator(t *testing.T) {
-	validateIterator123(t, NewDynamicList(NewProvider(), []int32{1, 2, 3}).(traits.Lister))
+	validateIterator123(t, NewDynamicList(NewRegistry(), []int32{1, 2, 3}).(traits.Lister))
 }
 
 func TestValueListValue_Iterator(t *testing.T) {
-	validateIterator123(t, NewValueList(NewProvider(), []ref.Val{Int(1), Int(2), Int(3)}))
+	validateIterator123(t, NewValueList(NewRegistry(), []ref.Val{Int(1), Int(2), Int(3)}))
 }
 
 func validateList123(t *testing.T, list traits.Lister) {
@@ -137,7 +137,7 @@ func validateIterator123(t *testing.T, list traits.Lister) {
 }
 
 func TestBaseList_NestedList(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	listUint32 := []uint32{1, 2}
 	nestedUint32 := NewDynamicList(p, []interface{}{listUint32})
 	listUint64 := []uint64{1, 2}
@@ -152,7 +152,7 @@ func TestBaseList_NestedList(t *testing.T) {
 }
 
 func TestBaseList_Size(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	listUint32 := []uint32{1, 2}
 	nestedUint32 := NewDynamicList(p, []interface{}{listUint32})
 	if nestedUint32.Size() != IntOne {
@@ -164,7 +164,7 @@ func TestBaseList_Size(t *testing.T) {
 }
 
 func TestConcatList_Add(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	listA := NewDynamicList(p, []float32{1.0, 2.0})
 	listB := NewStringList(p, []string{"3"})
 	list := listA.Add(listB).(traits.Lister).Add(listA).
@@ -188,7 +188,7 @@ func TestConcatList_Add(t *testing.T) {
 }
 
 func TestConcatList_ConvertToNative_Json(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	listA := NewDynamicList(p, []float32{1.0, 2.0})
 	listB := NewDynamicList(p, []string{"3"})
 	list := listA.Add(listB)
@@ -206,7 +206,7 @@ func TestConcatList_ConvertToNative_Json(t *testing.T) {
 }
 
 func TestConcatList_ConvertToNative_ElementConversionError(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	listA := NewDynamicList(p, []float32{1.0, 2.0})
 	// Duration is serializable to a string form of json, but there is no
 	// concept of a duration literal within CEL, so the serialization to string
@@ -220,7 +220,7 @@ func TestConcatList_ConvertToNative_ElementConversionError(t *testing.T) {
 }
 
 func TestConcatList_ConvertToType(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	listA := NewDynamicList(p, []float32{1.0, 2.0})
 	listB := NewDynamicList(p, []*dpb.Duration{{Seconds: 100}})
 	list := listA.Add(listB)
@@ -236,7 +236,7 @@ func TestConcatList_ConvertToType(t *testing.T) {
 }
 
 func TestConcatListValue_Equal(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	listA := NewDynamicList(p, []float32{1.0, 2.0})
 	listB := NewDynamicList(p, []float64{3.0})
 	list := listA.Add(listB)
@@ -256,7 +256,7 @@ func TestConcatListValue_Equal(t *testing.T) {
 }
 
 func TestConcatListValue_Get(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	listA := NewDynamicList(p, []float32{1.0, 2.0})
 	listB := NewDynamicList(p, []float64{3.0})
 	list := listA.Add(listB).(traits.Lister)
@@ -274,7 +274,7 @@ func TestConcatListValue_Get(t *testing.T) {
 }
 
 func TestConcatListValue_Iterator(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	listA := NewDynamicList(p, []float32{1.0, 2.0})
 	listB := NewDynamicList(p, []float64{3.0})
 	list := listA.Add(listB).(traits.Lister)
@@ -296,7 +296,7 @@ func TestConcatListValue_Iterator(t *testing.T) {
 }
 
 func TestStringList_Add_Empty(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	list := NewStringList(p, []string{"hello"})
 	if list.Add(NewStringList(p, []string{})) != list {
 		t.Error("Adding empty lists resulted in new list creation.")
@@ -307,14 +307,14 @@ func TestStringList_Add_Empty(t *testing.T) {
 }
 
 func TestStringList_Add_Error(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	if !IsError(NewStringList(p, []string{}).Add(True)) {
 		t.Error("Got list, expected error.")
 	}
 }
 
 func TestStringList_Add_Heterogenous(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	listA := NewStringList(p, []string{"hello"})
 	listB := NewDynamicList(p, []int32{1, 2, 3})
 	list := listA.Add(listB).(traits.Lister).Value().([]interface{})
@@ -330,7 +330,7 @@ func TestStringList_Add_Heterogenous(t *testing.T) {
 }
 
 func TestStringList_Add_StringLists(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	listA := NewStringList(p, []string{"hello"})
 	listB := NewStringList(p, []string{"world", "!"})
 	list := listA.Add(listB).(traits.Lister)
@@ -346,7 +346,7 @@ func TestStringList_Add_StringLists(t *testing.T) {
 }
 
 func TestStringList_ConvertToNative(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	list := NewStringList(p, []string{"h", "e", "l", "p"})
 	val, err := list.ConvertToNative(reflect.TypeOf([]string{}))
 	if err != nil {
@@ -358,7 +358,7 @@ func TestStringList_ConvertToNative(t *testing.T) {
 }
 
 func TestStringList_ConvertToNative_Error(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	list := NewStringList(p, []string{"h", "e", "l", "p"})
 	_, err := list.ConvertToNative(jsonStructType)
 	if err == nil {
@@ -367,7 +367,7 @@ func TestStringList_ConvertToNative_Error(t *testing.T) {
 }
 
 func TestStringList_ConvertToNative_Json(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	list := NewStringList(p, []string{"h", "e", "l", "p"})
 	json, err := list.ConvertToNative(jsonValueType)
 	if err != nil {
@@ -392,7 +392,7 @@ func TestStringList_ConvertToNative_Json(t *testing.T) {
 }
 
 func TestStringList_Get_OutOfRange(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	list := NewStringList(p, []string{"hello", "world"})
 	if !IsError(list.Get(Int(-1))) {
 		t.Error("Negative index did not return error.")

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -25,6 +25,7 @@ import (
 
 // baseMap is a reflection based map implementation designed to handle a variety of map-like types.
 type baseMap struct {
+	ref.TypeAdapter
 	value    interface{}
 	refValue reflect.Value
 }
@@ -37,8 +38,11 @@ type stringMap struct {
 }
 
 // NewDynamicMap returns a traits.Mapper value with dynamic key, value pairs.
-func NewDynamicMap(value interface{}) traits.Mapper {
-	return &baseMap{value, reflect.ValueOf(value)}
+func NewDynamicMap(adapter ref.TypeAdapter, value interface{}) traits.Mapper {
+	return &baseMap{
+		TypeAdapter: adapter,
+		value:       value,
+		refValue:    reflect.ValueOf(value)}
 }
 
 // NewStringStringMap returns a specialized traits.Mapper with string keys and values.
@@ -186,7 +190,7 @@ func (m *baseMap) Get(key ref.Val) ref.Val {
 	if !value.IsValid() {
 		return NewErr("no such key: '%v'", nativeKey)
 	}
-	return NativeToValue(value.Interface())
+	return m.NativeToValue(value.Interface())
 }
 
 func (m *stringMap) Get(key ref.Val) ref.Val {
@@ -204,7 +208,7 @@ func (m *stringMap) Get(key ref.Val) ref.Val {
 func (m *baseMap) Iterator() traits.Iterator {
 	mapKeys := m.refValue.MapKeys()
 	return &mapIterator{
-		baseIterator: &baseIterator{},
+		baseIterator: &baseIterator{TypeAdapter: m.TypeAdapter},
 		mapValue:     m,
 		mapKeys:      mapKeys,
 		cursor:       0,
@@ -251,7 +255,7 @@ func (it *mapIterator) Next() ref.Val {
 		index := it.cursor
 		it.cursor++
 		refKey := it.mapKeys[index]
-		return NativeToValue(refKey.Interface())
+		return it.NativeToValue(refKey.Interface())
 	}
 	return nil
 }

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -208,7 +208,8 @@ func (m *stringMap) Get(key ref.Val) ref.Val {
 func (m *baseMap) Iterator() traits.Iterator {
 	mapKeys := m.refValue.MapKeys()
 	return &mapIterator{
-		baseIterator: &baseIterator{TypeAdapter: m.TypeAdapter},
+		baseIterator: &baseIterator{},
+		TypeAdapter:  m.TypeAdapter,
 		mapValue:     m,
 		mapKeys:      mapKeys,
 		cursor:       0,
@@ -240,6 +241,7 @@ func (m *baseMap) Value() interface{} {
 
 type mapIterator struct {
 	*baseIterator
+	ref.TypeAdapter
 	mapValue traits.Mapper
 	mapKeys  []reflect.Value
 	cursor   int

--- a/common/types/map_test.go
+++ b/common/types/map_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestBaseMap_Contains(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	mapValue := NewDynamicMap(p, map[string]map[int32]float32{
 		"nested": {1: -1.0, 2: 2.0},
 		"empty":  {}}).(traits.Mapper)
@@ -37,7 +37,7 @@ func TestBaseMap_Contains(t *testing.T) {
 }
 
 func TestBaseMap_ConvertToNative_Error(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	mapValue := NewDynamicMap(p, map[string]map[string]float32{
 		"nested": {"1": -1.0}})
 	val, err := mapValue.ConvertToNative(reflect.TypeOf(""))
@@ -47,7 +47,7 @@ func TestBaseMap_ConvertToNative_Error(t *testing.T) {
 }
 
 func TestBaseMap_ConvertToNative_Json(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	mapValue := NewDynamicMap(p, map[string]map[string]float32{
 		"nested": {"1": -1.0}})
 	json, err := mapValue.ConvertToNative(jsonValueType)
@@ -61,7 +61,7 @@ func TestBaseMap_ConvertToNative_Json(t *testing.T) {
 }
 
 func TestBaseMap_ConvertToType(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	mapValue := NewDynamicMap(p, map[string]string{"key": "value"})
 	if mapValue.ConvertToType(MapType) != mapValue {
 		t.Error("Map could not be converted to a map.")
@@ -75,7 +75,7 @@ func TestBaseMap_ConvertToType(t *testing.T) {
 }
 
 func TestBaseMap_Equal_True(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	mapValue := NewDynamicMap(p, map[string]map[int32]float32{
 		"nested": {1: -1.0, 2: 2.0},
 		"empty":  {}})
@@ -91,7 +91,7 @@ func TestBaseMap_Equal_True(t *testing.T) {
 }
 
 func TestBaseMap_Equal_False(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	mapValue := NewDynamicMap(p, map[string]map[int32]float32{
 		"nested": {1: -1.0, 2: 2.0},
 		"empty":  {}})
@@ -104,7 +104,7 @@ func TestBaseMap_Equal_False(t *testing.T) {
 }
 
 func TestBaseMap_Get(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	mapValue := NewDynamicMap(p, map[string]map[int32]float32{
 		"nested": {1: -1.0, 2: 2.0},
 		"empty":  {}}).(traits.Mapper)
@@ -118,7 +118,7 @@ func TestBaseMap_Get(t *testing.T) {
 }
 
 func TestBaseMap_Iterator(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	mapValue := NewDynamicMap(p, map[string]map[int32]float32{
 		"nested": {1: -1.0, 2: 2.0},
 		"empty":  {}}).(traits.Mapper)

--- a/common/types/map_test.go
+++ b/common/types/map_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 func TestBaseMap_Contains(t *testing.T) {
-	p := NewRegistry()
-	mapValue := NewDynamicMap(p, map[string]map[int32]float32{
+	reg := NewRegistry()
+	mapValue := NewDynamicMap(reg, map[string]map[int32]float32{
 		"nested": {1: -1.0, 2: 2.0},
 		"empty":  {}}).(traits.Mapper)
 	if mapValue.Contains(String("nested")) != True {
@@ -37,8 +37,8 @@ func TestBaseMap_Contains(t *testing.T) {
 }
 
 func TestBaseMap_ConvertToNative_Error(t *testing.T) {
-	p := NewRegistry()
-	mapValue := NewDynamicMap(p, map[string]map[string]float32{
+	reg := NewRegistry()
+	mapValue := NewDynamicMap(reg, map[string]map[string]float32{
 		"nested": {"1": -1.0}})
 	val, err := mapValue.ConvertToNative(reflect.TypeOf(""))
 	if err == nil {
@@ -47,8 +47,8 @@ func TestBaseMap_ConvertToNative_Error(t *testing.T) {
 }
 
 func TestBaseMap_ConvertToNative_Json(t *testing.T) {
-	p := NewRegistry()
-	mapValue := NewDynamicMap(p, map[string]map[string]float32{
+	reg := NewRegistry()
+	mapValue := NewDynamicMap(reg, map[string]map[string]float32{
 		"nested": {"1": -1.0}})
 	json, err := mapValue.ConvertToNative(jsonValueType)
 	if err != nil {
@@ -61,8 +61,8 @@ func TestBaseMap_ConvertToNative_Json(t *testing.T) {
 }
 
 func TestBaseMap_ConvertToType(t *testing.T) {
-	p := NewRegistry()
-	mapValue := NewDynamicMap(p, map[string]string{"key": "value"})
+	reg := NewRegistry()
+	mapValue := NewDynamicMap(reg, map[string]string{"key": "value"})
 	if mapValue.ConvertToType(MapType) != mapValue {
 		t.Error("Map could not be converted to a map.")
 	}
@@ -75,8 +75,8 @@ func TestBaseMap_ConvertToType(t *testing.T) {
 }
 
 func TestBaseMap_Equal_True(t *testing.T) {
-	p := NewRegistry()
-	mapValue := NewDynamicMap(p, map[string]map[int32]float32{
+	reg := NewRegistry()
+	mapValue := NewDynamicMap(reg, map[string]map[int32]float32{
 		"nested": {1: -1.0, 2: 2.0},
 		"empty":  {}})
 	if mapValue.Equal(mapValue) != True {
@@ -91,11 +91,11 @@ func TestBaseMap_Equal_True(t *testing.T) {
 }
 
 func TestBaseMap_Equal_False(t *testing.T) {
-	p := NewRegistry()
-	mapValue := NewDynamicMap(p, map[string]map[int32]float32{
+	reg := NewRegistry()
+	mapValue := NewDynamicMap(reg, map[string]map[int32]float32{
 		"nested": {1: -1.0, 2: 2.0},
 		"empty":  {}})
-	otherValue := NewDynamicMap(p, map[string]map[int64]float64{
+	otherValue := NewDynamicMap(reg, map[string]map[int64]float64{
 		"nested": {1: -1.0, 2: 2.0, 3: 3.14},
 		"empty":  {}})
 	if mapValue.Equal(otherValue) != False {
@@ -104,8 +104,8 @@ func TestBaseMap_Equal_False(t *testing.T) {
 }
 
 func TestBaseMap_Get(t *testing.T) {
-	p := NewRegistry()
-	mapValue := NewDynamicMap(p, map[string]map[int32]float32{
+	reg := NewRegistry()
+	mapValue := NewDynamicMap(reg, map[string]map[int32]float32{
 		"nested": {1: -1.0, 2: 2.0},
 		"empty":  {}}).(traits.Mapper)
 	if nestedVal := mapValue.Get(String("nested")); IsError(nestedVal) {
@@ -118,8 +118,8 @@ func TestBaseMap_Get(t *testing.T) {
 }
 
 func TestBaseMap_Iterator(t *testing.T) {
-	p := NewRegistry()
-	mapValue := NewDynamicMap(p, map[string]map[int32]float32{
+	reg := NewRegistry()
+	mapValue := NewDynamicMap(reg, map[string]map[int32]float32{
 		"nested": {1: -1.0, 2: 2.0},
 		"empty":  {}}).(traits.Mapper)
 	it := mapValue.Iterator()

--- a/common/types/map_test.go
+++ b/common/types/map_test.go
@@ -24,7 +24,8 @@ import (
 )
 
 func TestBaseMap_Contains(t *testing.T) {
-	mapValue := NewDynamicMap(map[string]map[int32]float32{
+	p := NewProvider()
+	mapValue := NewDynamicMap(p, map[string]map[int32]float32{
 		"nested": {1: -1.0, 2: 2.0},
 		"empty":  {}}).(traits.Mapper)
 	if mapValue.Contains(String("nested")) != True {
@@ -36,7 +37,8 @@ func TestBaseMap_Contains(t *testing.T) {
 }
 
 func TestBaseMap_ConvertToNative_Error(t *testing.T) {
-	mapValue := NewDynamicMap(map[string]map[string]float32{
+	p := NewProvider()
+	mapValue := NewDynamicMap(p, map[string]map[string]float32{
 		"nested": {"1": -1.0}})
 	val, err := mapValue.ConvertToNative(reflect.TypeOf(""))
 	if err == nil {
@@ -45,7 +47,8 @@ func TestBaseMap_ConvertToNative_Error(t *testing.T) {
 }
 
 func TestBaseMap_ConvertToNative_Json(t *testing.T) {
-	mapValue := NewDynamicMap(map[string]map[string]float32{
+	p := NewProvider()
+	mapValue := NewDynamicMap(p, map[string]map[string]float32{
 		"nested": {"1": -1.0}})
 	json, err := mapValue.ConvertToNative(jsonValueType)
 	if err != nil {
@@ -58,7 +61,8 @@ func TestBaseMap_ConvertToNative_Json(t *testing.T) {
 }
 
 func TestBaseMap_ConvertToType(t *testing.T) {
-	mapValue := NewDynamicMap(map[string]string{"key": "value"})
+	p := NewProvider()
+	mapValue := NewDynamicMap(p, map[string]string{"key": "value"})
 	if mapValue.ConvertToType(MapType) != mapValue {
 		t.Error("Map could not be converted to a map.")
 	}
@@ -71,7 +75,8 @@ func TestBaseMap_ConvertToType(t *testing.T) {
 }
 
 func TestBaseMap_Equal_True(t *testing.T) {
-	mapValue := NewDynamicMap(map[string]map[int32]float32{
+	p := NewProvider()
+	mapValue := NewDynamicMap(p, map[string]map[int32]float32{
 		"nested": {1: -1.0, 2: 2.0},
 		"empty":  {}})
 	if mapValue.Equal(mapValue) != True {
@@ -86,10 +91,11 @@ func TestBaseMap_Equal_True(t *testing.T) {
 }
 
 func TestBaseMap_Equal_False(t *testing.T) {
-	mapValue := NewDynamicMap(map[string]map[int32]float32{
+	p := NewProvider()
+	mapValue := NewDynamicMap(p, map[string]map[int32]float32{
 		"nested": {1: -1.0, 2: 2.0},
 		"empty":  {}})
-	otherValue := NewDynamicMap(map[string]map[int64]float64{
+	otherValue := NewDynamicMap(p, map[string]map[int64]float64{
 		"nested": {1: -1.0, 2: 2.0, 3: 3.14},
 		"empty":  {}})
 	if mapValue.Equal(otherValue) != False {
@@ -98,7 +104,8 @@ func TestBaseMap_Equal_False(t *testing.T) {
 }
 
 func TestBaseMap_Get(t *testing.T) {
-	mapValue := NewDynamicMap(map[string]map[int32]float32{
+	p := NewProvider()
+	mapValue := NewDynamicMap(p, map[string]map[int32]float32{
 		"nested": {1: -1.0, 2: 2.0},
 		"empty":  {}}).(traits.Mapper)
 	if nestedVal := mapValue.Get(String("nested")); IsError(nestedVal) {
@@ -111,7 +118,8 @@ func TestBaseMap_Get(t *testing.T) {
 }
 
 func TestBaseMap_Iterator(t *testing.T) {
-	mapValue := NewDynamicMap(map[string]map[int32]float32{
+	p := NewProvider()
+	mapValue := NewDynamicMap(p, map[string]map[int32]float32{
 		"nested": {1: -1.0, 2: 2.0},
 		"empty":  {}}).(traits.Mapper)
 	it := mapValue.Iterator()

--- a/common/types/object.go
+++ b/common/types/object.go
@@ -129,7 +129,7 @@ func (o *protoObj) Get(index ref.Val) ref.Val {
 
 func (o *protoObj) Iterator() traits.Iterator {
 	return &msgIterator{
-		baseIterator: &baseIterator{TypeAdapter: o.TypeAdapter},
+		baseIterator: &baseIterator{},
 		refValue:     o.refValue,
 		typeDesc:     o.typeDesc,
 		cursor:       0}

--- a/common/types/object.go
+++ b/common/types/object.go
@@ -49,19 +49,19 @@ func NewObject(adapter ref.TypeAdapter,
 		typeValue:   NewObjectTypeValue(typeDesc.Name())}
 }
 
-func (o *protoObj) ConvertToNative(refType reflect.Type) (interface{}, error) {
-	if refType.AssignableTo(o.refValue.Type()) {
+func (o *protoObj) ConvertToNative(refl reflect.Type) (interface{}, error) {
+	if refl.AssignableTo(o.refValue.Type()) {
 		return o.value, nil
 	}
-	if refType == anyValueType {
+	if refl == anyValueType {
 		return ptypes.MarshalAny(o.Value().(proto.Message))
 	}
 	// If the object is already assignable to the desired type return it.
-	if reflect.TypeOf(o).AssignableTo(refType) {
+	if reflect.TypeOf(o).AssignableTo(refl) {
 		return o, nil
 	}
 	return nil, fmt.Errorf("type conversion error from '%v' to '%v'",
-		o.refValue.Type(), refType)
+		o.refValue.Type(), refl)
 }
 
 func (o *protoObj) ConvertToType(typeVal ref.Type) ref.Val {

--- a/common/types/object.go
+++ b/common/types/object.go
@@ -26,6 +26,7 @@ import (
 )
 
 type protoObj struct {
+	ref.TypeAdapter
 	value     proto.Message
 	refValue  reflect.Value
 	typeDesc  *pb.TypeDescription
@@ -37,32 +38,30 @@ type protoObj struct {
 // conversion between protobuf type values and expression type values.
 // Objects support indexing and iteration.
 // Note:  only uses default Db.
-func NewObject(value proto.Message) ref.Val {
-	typeName := proto.MessageName(value)
-	typeDesc, err := pb.DefaultDb.DescribeType(typeName)
-	if err != nil {
-		return NewErr("unknown type: %s", typeName)
-	}
+func NewObject(adapter ref.TypeAdapter,
+	typeDesc *pb.TypeDescription,
+	value proto.Message) ref.Val {
 	return &protoObj{
-		value:     value,
-		refValue:  reflect.ValueOf(value),
-		typeDesc:  typeDesc,
-		typeValue: NewObjectTypeValue(typeDesc.Name())}
+		TypeAdapter: adapter,
+		value:       value,
+		refValue:    reflect.ValueOf(value),
+		typeDesc:    typeDesc,
+		typeValue:   NewObjectTypeValue(typeDesc.Name())}
 }
 
-func (o *protoObj) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
-	if typeDesc.AssignableTo(o.refValue.Type()) {
+func (o *protoObj) ConvertToNative(refType reflect.Type) (interface{}, error) {
+	if refType.AssignableTo(o.refValue.Type()) {
 		return o.value, nil
 	}
-	if typeDesc == anyValueType {
+	if refType == anyValueType {
 		return ptypes.MarshalAny(o.Value().(proto.Message))
 	}
 	// If the object is already assignable to the desired type return it.
-	if reflect.TypeOf(o).AssignableTo(typeDesc) {
+	if reflect.TypeOf(o).AssignableTo(refType) {
 		return o, nil
 	}
 	return nil, fmt.Errorf("type conversion error from '%v' to '%v'",
-		o.refValue.Type(), typeDesc)
+		o.refValue.Type(), refType)
 }
 
 func (o *protoObj) ConvertToType(typeVal ref.Type) ref.Val {
@@ -114,14 +113,14 @@ func (o *protoObj) Get(index ref.Val) ref.Val {
 	protoFieldName := string(index.(String))
 	if f, found := o.typeDesc.FieldByName(protoFieldName); found {
 		if !f.IsOneof() {
-			return getOrDefaultInstance(o.refValue.Elem().Field(f.Index()))
+			return getOrDefaultInstance(o.TypeAdapter, o.refValue.Elem().Field(f.Index()))
 		}
 
 		getter := o.refValue.MethodByName(f.GetterName())
 		if getter.IsValid() {
 			refField := getter.Call([]reflect.Value{})[0]
 			if refField.IsValid() {
-				return getOrDefaultInstance(refField)
+				return getOrDefaultInstance(o.TypeAdapter, refField)
 			}
 		}
 	}
@@ -130,7 +129,7 @@ func (o *protoObj) Get(index ref.Val) ref.Val {
 
 func (o *protoObj) Iterator() traits.Iterator {
 	return &msgIterator{
-		baseIterator: &baseIterator{},
+		baseIterator: &baseIterator{TypeAdapter: o.TypeAdapter},
 		refValue:     o.refValue,
 		typeDesc:     o.typeDesc,
 		cursor:       0}
@@ -176,22 +175,22 @@ func isFieldSet(refVal reflect.Value) ref.Val {
 	return True
 }
 
-func getOrDefaultInstance(refVal reflect.Value) ref.Val {
+func getOrDefaultInstance(adapter ref.TypeAdapter, refVal reflect.Value) ref.Val {
 	if isFieldSet(refVal) == True {
 		value := refVal.Interface()
-		return NativeToValue(value)
+		return adapter.NativeToValue(value)
 	}
-	return getDefaultInstance(refVal.Type())
+	return getDefaultInstance(adapter, refVal.Type())
 }
 
-func getDefaultInstance(refType reflect.Type) ref.Val {
+func getDefaultInstance(adapter ref.TypeAdapter, refType reflect.Type) ref.Val {
 	if refType.Kind() == reflect.Ptr {
 		refType = refType.Elem()
 	}
 	if defaultValue, found := protoDefaultInstanceMap[refType]; found {
 		return defaultValue
 	}
-	defaultValue := NativeToValue(reflect.New(refType).Interface())
+	defaultValue := adapter.NativeToValue(reflect.New(refType).Interface())
 	protoDefaultInstanceMap[refType] = defaultValue
 	return defaultValue
 }

--- a/common/types/object.go
+++ b/common/types/object.go
@@ -38,9 +38,10 @@ type protoObj struct {
 // Objects support indexing and iteration.
 // Note:  only uses default Db.
 func NewObject(value proto.Message) ref.Val {
-	typeDesc, err := pb.DefaultDb.DescribeValue(value)
+	typeName := proto.MessageName(value)
+	typeDesc, err := pb.DefaultDb.DescribeType(typeName)
 	if err != nil {
-		panic(err)
+		return NewErr("unknown type: %s", typeName)
 	}
 	return &protoObj{
 		value:     value,

--- a/common/types/object_test.go
+++ b/common/types/object_test.go
@@ -29,13 +29,12 @@ import (
 )
 
 func TestNewProtoObject(t *testing.T) {
-	p := NewProvider()
+	p := NewRegistry()
 	parsedExpr := &exprpb.ParsedExpr{
 		SourceInfo: &exprpb.SourceInfo{
 			LineOffsets: []int32{1, 2, 3}}}
 	p.RegisterMessage(parsedExpr)
-	td, _ := p.pbdb.DescribeType(proto.MessageName(parsedExpr))
-	obj := NewObject(p, td, parsedExpr).(traits.Indexer)
+	obj := p.NativeToValue(parsedExpr).(traits.Indexer)
 	si := obj.Get(String("source_info")).(traits.Indexer)
 	lo := si.Get(String("line_offsets")).(traits.Indexer)
 	if lo.Get(Int(2)).Equal(Int(3)) != True {
@@ -49,9 +48,8 @@ func TestNewProtoObject(t *testing.T) {
 }
 
 func TestProtoObject_Iterator(t *testing.T) {
-	p := NewProvider(&exprpb.Expr{})
-	td, _ := p.pbdb.DescribeType(proto.MessageName(test.Exists.Expr))
-	existsMsg := NewObject(p, td, test.Exists.Expr).(traits.Iterable)
+	p := NewRegistry(&exprpb.Expr{})
+	existsMsg := p.NativeToValue(test.Exists.Expr).(traits.Iterable)
 	it := existsMsg.Iterator()
 	var fields []ref.Val
 	for it.HasNext() == True {
@@ -63,12 +61,11 @@ func TestProtoObject_Iterator(t *testing.T) {
 }
 
 func TestProtoObj_ConvertToNative(t *testing.T) {
-	p := NewProvider(&exprpb.Expr{})
+	p := NewRegistry(&exprpb.Expr{})
 	pbMessage := &exprpb.ParsedExpr{
 		SourceInfo: &exprpb.SourceInfo{
 			LineOffsets: []int32{1, 2, 3}}}
-	td, _ := p.pbdb.DescribeType(proto.MessageName(pbMessage))
-	objVal := NewObject(p, td, pbMessage)
+	objVal := p.NativeToValue(pbMessage)
 
 	// Proto Message
 	val, err := objVal.ConvertToNative(reflect.TypeOf(&exprpb.ParsedExpr{}))

--- a/common/types/object_test.go
+++ b/common/types/object_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/google/cel-go/common/types/pb"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 	"github.com/google/cel-go/test"
@@ -32,6 +33,7 @@ func TestNewProtoObject(t *testing.T) {
 	parsedExpr := &exprpb.ParsedExpr{
 		SourceInfo: &exprpb.SourceInfo{
 			LineOffsets: []int32{1, 2, 3}}}
+	pb.DefaultDb.RegisterMessage(parsedExpr)
 	obj := NewObject(parsedExpr).(traits.Indexer)
 	si := obj.Get(String("source_info")).(traits.Indexer)
 	lo := si.Get(String("line_offsets")).(traits.Indexer)

--- a/common/types/object_test.go
+++ b/common/types/object_test.go
@@ -29,12 +29,12 @@ import (
 )
 
 func TestNewProtoObject(t *testing.T) {
-	p := NewRegistry()
+	reg := NewRegistry()
 	parsedExpr := &exprpb.ParsedExpr{
 		SourceInfo: &exprpb.SourceInfo{
 			LineOffsets: []int32{1, 2, 3}}}
-	p.RegisterMessage(parsedExpr)
-	obj := p.NativeToValue(parsedExpr).(traits.Indexer)
+	reg.RegisterMessage(parsedExpr)
+	obj := reg.NativeToValue(parsedExpr).(traits.Indexer)
 	si := obj.Get(String("source_info")).(traits.Indexer)
 	lo := si.Get(String("line_offsets")).(traits.Indexer)
 	if lo.Get(Int(2)).Equal(Int(3)) != True {
@@ -48,8 +48,8 @@ func TestNewProtoObject(t *testing.T) {
 }
 
 func TestProtoObject_Iterator(t *testing.T) {
-	p := NewRegistry(&exprpb.Expr{})
-	existsMsg := p.NativeToValue(test.Exists.Expr).(traits.Iterable)
+	reg := NewRegistry(&exprpb.Expr{})
+	existsMsg := reg.NativeToValue(test.Exists.Expr).(traits.Iterable)
 	it := existsMsg.Iterator()
 	var fields []ref.Val
 	for it.HasNext() == True {
@@ -61,11 +61,11 @@ func TestProtoObject_Iterator(t *testing.T) {
 }
 
 func TestProtoObj_ConvertToNative(t *testing.T) {
-	p := NewRegistry(&exprpb.Expr{})
+	reg := NewRegistry(&exprpb.Expr{})
 	pbMessage := &exprpb.ParsedExpr{
 		SourceInfo: &exprpb.SourceInfo{
 			LineOffsets: []int32{1, 2, 3}}}
-	objVal := p.NativeToValue(pbMessage)
+	objVal := reg.NativeToValue(pbMessage)
 
 	// Proto Message
 	val, err := objVal.ConvertToNative(reflect.TypeOf(&exprpb.ParsedExpr{}))

--- a/common/types/pb/file_test.go
+++ b/common/types/pb/file_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestFileDescription_GetTypes(t *testing.T) {
 	pbdb := NewDb()
-	fd, err := pbdb.DescribeFile(&proto3pb.TestAllTypes{})
+	fd, err := pbdb.RegisterMessage(&proto3pb.TestAllTypes{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -49,7 +49,7 @@ func TestFileDescription_GetTypes(t *testing.T) {
 
 func TestFileDescription_GetEnumNames(t *testing.T) {
 	pbdb := NewDb()
-	fd, err := pbdb.DescribeFile(&proto3pb.TestAllTypes{})
+	fd, err := pbdb.RegisterMessage(&proto3pb.TestAllTypes{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/common/types/pb/pb.go
+++ b/common/types/pb/pb.go
@@ -55,17 +55,8 @@ func NewDb() *Db {
 	return pbdb
 }
 
-// DescribeEnum takes a qualified enum name and returns an EnumDescription.
-func (pbdb *Db) DescribeEnum(enumName string) (*EnumDescription, error) {
-	enumName = sanitizeProtoName(enumName)
-	if fd, found := pbdb.revFileDescriptorMap[enumName]; found {
-		return fd.GetEnumDescription(enumName)
-	}
-	return nil, fmt.Errorf("unrecognized enum '%s'", enumName)
-}
-
-// DescribeDescriptor produces a FileDescription from a FileDescriptorProto.
-func (pbdb *Db) DescribeDescriptor(fileDesc *descpb.FileDescriptorProto) (*FileDescription, error) {
+// RegisterDescriptor produces a FileDescription from a FileDescriptorProto.
+func (pbdb *Db) RegisterDescriptor(fileDesc *descpb.FileDescriptorProto) (*FileDescription, error) {
 	fd, err := pbdb.describeFileInternal(fileDesc)
 	if err != nil {
 		return nil, err
@@ -76,14 +67,32 @@ func (pbdb *Db) DescribeDescriptor(fileDesc *descpb.FileDescriptorProto) (*FileD
 	return fd, nil
 }
 
-// DescribeFile takes a protocol buffer message and indexes all of the message
-// types and enum values contained within the message's file descriptor.
-func (pbdb *Db) DescribeFile(message proto.Message) (*FileDescription, error) {
-	if fd, found := pbdb.revFileDescriptorMap[proto.MessageName(message)]; found {
+func (pbdb *Db) RegisterMessage(message proto.Message) (*FileDescription, error) {
+	typeName := sanitizeProtoName(proto.MessageName(message))
+	if fd, found := pbdb.revFileDescriptorMap[typeName]; found {
 		return fd, nil
 	}
 	fileDesc, _ := descriptor.ForMessage(message.(descriptor.Message))
-	return pbdb.DescribeDescriptor(fileDesc)
+	return pbdb.RegisterDescriptor(fileDesc)
+}
+
+// DescribeFile takes a protocol buffer message and indexes all of the message
+// types and enum values contained within the message's file descriptor.
+func (pbdb *Db) DescribeFile(message proto.Message) (*FileDescription, error) {
+	typeName := sanitizeProtoName(proto.MessageName(message))
+	if fd, found := pbdb.revFileDescriptorMap[typeName]; found {
+		return fd, nil
+	}
+	return nil, fmt.Errorf("unrecognized proto type name '%s'", typeName)
+}
+
+// DescribeEnum takes a qualified enum name and returns an EnumDescription.
+func (pbdb *Db) DescribeEnum(enumName string) (*EnumDescription, error) {
+	enumName = sanitizeProtoName(enumName)
+	if fd, found := pbdb.revFileDescriptorMap[enumName]; found {
+		return fd.GetEnumDescription(enumName)
+	}
+	return nil, fmt.Errorf("unrecognized enum '%s'", enumName)
 }
 
 // DescribeType provides a TypeDescription given a qualified type name.
@@ -93,17 +102,6 @@ func (pbdb *Db) DescribeType(typeName string) (*TypeDescription, error) {
 		return fd.GetTypeDescription(typeName)
 	}
 	return nil, fmt.Errorf("unrecognized type '%s'", typeName)
-}
-
-// DescribeValue takes an instance of a protocol buffer message and returns
-// the associated TypeDescription.
-func (pbdb *Db) DescribeValue(value proto.Message) (*TypeDescription, error) {
-	fd, err := pbdb.DescribeFile(value)
-	if err != nil {
-		return nil, err
-	}
-	typeName := proto.MessageName(value)
-	return fd.GetTypeDescription(typeName)
 }
 
 func (pbdb *Db) describeFileInternal(fileDesc *descpb.FileDescriptorProto) (*FileDescription, error) {
@@ -139,9 +137,9 @@ func init() {
 	// The following subset of message types is enough to ensure that all well-known types can
 	// resolved in the runtime, since describing the value results in describing the whole file
 	// where the message is declared.
-	DefaultDb.DescribeValue(&anypb.Any{})
-	DefaultDb.DescribeValue(&durpb.Duration{})
-	DefaultDb.DescribeValue(&tspb.Timestamp{})
-	DefaultDb.DescribeValue(&structpb.Value{})
-	DefaultDb.DescribeValue(&wrapperspb.BoolValue{})
+	DefaultDb.RegisterMessage(&anypb.Any{})
+	DefaultDb.RegisterMessage(&durpb.Duration{})
+	DefaultDb.RegisterMessage(&tspb.Timestamp{})
+	DefaultDb.RegisterMessage(&structpb.Value{})
+	DefaultDb.RegisterMessage(&wrapperspb.BoolValue{})
 }

--- a/common/types/pb/pb.go
+++ b/common/types/pb/pb.go
@@ -44,7 +44,7 @@ var (
 	}
 )
 
-// NewDb creates a new Db with an empty type name to file description map.
+// NewDb creates a new `pb.Db` with an empty type name to file description map.
 func NewDb() *Db {
 	pbdb := &Db{
 		revFileDescriptorMap: make(map[string]*FileDescription),
@@ -55,7 +55,8 @@ func NewDb() *Db {
 	return pbdb
 }
 
-// RegisterDescriptor produces a FileDescription from a FileDescriptorProto.
+// RegisterDescriptor produces a `FileDescription` from a `FileDescriptorProto` and registers the
+// message and enum types into the `pb.Db`.
 func (pbdb *Db) RegisterDescriptor(fileDesc *descpb.FileDescriptorProto) (*FileDescription, error) {
 	fd, err := pbdb.describeFileInternal(fileDesc)
 	if err != nil {
@@ -67,6 +68,8 @@ func (pbdb *Db) RegisterDescriptor(fileDesc *descpb.FileDescriptorProto) (*FileD
 	return fd, nil
 }
 
+// RegisterMessage produces a `FileDescription` from a `message` and registers the message and all
+// other definitions within the message file into the `pb.Db`.
 func (pbdb *Db) RegisterMessage(message proto.Message) (*FileDescription, error) {
 	typeName := sanitizeProtoName(proto.MessageName(message))
 	if fd, found := pbdb.revFileDescriptorMap[typeName]; found {
@@ -76,8 +79,7 @@ func (pbdb *Db) RegisterMessage(message proto.Message) (*FileDescription, error)
 	return pbdb.RegisterDescriptor(fileDesc)
 }
 
-// DescribeFile takes a protocol buffer message and indexes all of the message
-// types and enum values contained within the message's file descriptor.
+// DescribeFile gets the `FileDescription` for the `message` type if it exists in the `pb.Db`.
 func (pbdb *Db) DescribeFile(message proto.Message) (*FileDescription, error) {
 	typeName := sanitizeProtoName(proto.MessageName(message))
 	if fd, found := pbdb.revFileDescriptorMap[typeName]; found {
@@ -86,7 +88,8 @@ func (pbdb *Db) DescribeFile(message proto.Message) (*FileDescription, error) {
 	return nil, fmt.Errorf("unrecognized proto type name '%s'", typeName)
 }
 
-// DescribeEnum takes a qualified enum name and returns an EnumDescription.
+// DescribeEnum takes a qualified enum name and returns an `EnumDescription` if it exists in the
+// `pb.Db`.
 func (pbdb *Db) DescribeEnum(enumName string) (*EnumDescription, error) {
 	enumName = sanitizeProtoName(enumName)
 	if fd, found := pbdb.revFileDescriptorMap[enumName]; found {
@@ -95,7 +98,7 @@ func (pbdb *Db) DescribeEnum(enumName string) (*EnumDescription, error) {
 	return nil, fmt.Errorf("unrecognized enum '%s'", enumName)
 }
 
-// DescribeType provides a TypeDescription given a qualified type name.
+// DescribeType returns a `TypeDescription` for the `typeName` if it exists in the `pb.Db`.
 func (pbdb *Db) DescribeType(typeName string) (*TypeDescription, error) {
 	typeName = sanitizeProtoName(typeName)
 	if fd, found := pbdb.revFileDescriptorMap[typeName]; found {

--- a/common/types/pb/type_test.go
+++ b/common/types/pb/type_test.go
@@ -11,7 +11,8 @@ import (
 
 func TestTypeDescription_FieldCount(t *testing.T) {
 	pbdb := NewDb()
-	td, err := pbdb.DescribeValue(&proto3pb.NestedTestAllTypes{})
+	pbdb.RegisterMessage(&proto3pb.NestedTestAllTypes{})
+	td, err := pbdb.DescribeType(proto.MessageName(&proto3pb.NestedTestAllTypes{}))
 	if err != nil {
 		t.Error(err)
 	}
@@ -63,10 +64,11 @@ func TestTypeDescription_WrapperNotInTypeInit(t *testing.T) {
 
 func TestTypeDescription_Field(t *testing.T) {
 	pbdb := NewDb()
-	td, err := pbdb.DescribeValue(&proto3pb.NestedTestAllTypes{})
+	_, err := pbdb.RegisterMessage(&proto3pb.NestedTestAllTypes{})
 	if err != nil {
 		t.Error(err)
 	}
+	td, err := pbdb.DescribeType(proto.MessageName(&proto3pb.NestedTestAllTypes{}))
 	fd, found := td.FieldByName("payload")
 	if !found {
 		t.Error("Field 'payload' not found")

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -191,9 +191,79 @@ func (p *protoTypeProvider) registerAllTypes(fd *pb.FileDescription) error {
 	return nil
 }
 
-// NativeToValue converts various "native" types to ref.Val.
-// It should be the inverse of ref.Val.ConvertToNative.
+// NativeToValue converts various "native" types to ref.Val with this specific implementation
+// providing support for custom proto-based types.
+//
+// This method should be the inverse of ref.Val.ConvertToNative.
 func (p *protoTypeProvider) NativeToValue(value interface{}) ref.Val {
+	switch value.(type) {
+	case ref.Val:
+		return value.(ref.Val)
+	// Adapt common types and aggregate specializations using the DefaultTypeAdapter.
+	case bool, *bool,
+		float32, *float32, float64, *float64,
+		int, *int, int32, *int32, int64, *int64,		
+		string, *string,
+		uint, *uint, uint32, *uint32, uint64, *uint64,
+		[]byte,
+		[]string,
+		map[string]string:
+		return DefaultTypeAdapter.NativeToValue(value)
+	// Adapt well-known proto-types using the DefaultTypeAdapter.
+	case *dpb.Duration,
+		*tpb.Timestamp,
+		*structpb.ListValue,
+		structpb.NullValue,
+		*structpb.Struct,
+		*structpb.Value:
+		return DefaultTypeAdapter.NativeToValue(value)
+	// Override the Any type by ensuring that custom proto-types are considered on recursive calls.
+	case *anypb.Any:
+		val := value.(*anypb.Any)
+		unpackedAny := ptypes.DynamicAny{}
+		if ptypes.UnmarshalAny(val, &unpackedAny) != nil {
+			NewErr("Fail to unmarshal any.")
+		}
+		return p.NativeToValue(unpackedAny.Message)
+	// Convert custom proto types to CEL values based on type's presence within the pb.Db.
+	case proto.Message:
+		pbVal := value.(proto.Message)
+		typeName := proto.MessageName(pbVal)
+		td, err := p.pbdb.DescribeType(typeName)
+		if err != nil {
+			return NewErr("unknown type '%s'", typeName)
+		}
+		return NewObject(p, td, pbVal)
+	// Override default handling for list and maps to ensure that blends of Go + proto types
+	// are appropriately adapted on recursive calls or subsequent inspection of the aggregate
+	// value.
+	default:
+		refValue := reflect.ValueOf(value)
+		if refValue.Kind() == reflect.Ptr {
+			refValue = refValue.Elem()
+		}
+		refKind := refValue.Kind()
+		switch refKind {
+		case reflect.Array, reflect.Slice:
+			return NewDynamicList(p, value)
+		case reflect.Map:
+			return NewDynamicMap(p, value)
+		}
+	}
+	// By default return the default type adapter's conversion to CEL.
+	return DefaultTypeAdapter.NativeToValue(value)
+}
+
+// defaultTypeAdapter converts go native types to CEL values.
+type defaultTypeAdapter struct{}
+
+var (
+	// DefaultTypeAdapter adapts canonical CEL types from their equivalent Go values.
+	DefaultTypeAdapter = &defaultTypeAdapter{}
+)
+
+// NativeToValue implements the ref.TypeAdapter interface.
+func (a *defaultTypeAdapter) NativeToValue(value interface{}) ref.Val {
 	switch value.(type) {
 	case ref.Val:
 		return value.(ref.Val)
@@ -240,32 +310,32 @@ func (p *protoTypeProvider) NativeToValue(value interface{}) ref.Val {
 	case []byte:
 		return Bytes(value.([]byte))
 	case []string:
-		return NewStringList(p, value.([]string))
+		return NewStringList(a, value.([]string))
 	case map[string]string:
 		return NewStringStringMap(value.(map[string]string))
 	case *dpb.Duration:
 		return Duration{value.(*dpb.Duration)}
 	case *structpb.ListValue:
-		return NewJSONList(p, value.(*structpb.ListValue))
+		return NewJSONList(a, value.(*structpb.ListValue))
 	case structpb.NullValue:
 		return NullValue
 	case *structpb.Struct:
-		return NewJSONStruct(p, value.(*structpb.Struct))
+		return NewJSONStruct(a, value.(*structpb.Struct))
 	case *structpb.Value:
 		v := value.(*structpb.Value)
 		switch v.Kind.(type) {
 		case *structpb.Value_BoolValue:
-			return p.NativeToValue(v.GetBoolValue())
+			return a.NativeToValue(v.GetBoolValue())
 		case *structpb.Value_ListValue:
-			return p.NativeToValue(v.GetListValue())
+			return a.NativeToValue(v.GetListValue())
 		case *structpb.Value_NullValue:
 			return NullValue
 		case *structpb.Value_NumberValue:
-			return p.NativeToValue(v.GetNumberValue())
+			return a.NativeToValue(v.GetNumberValue())
 		case *structpb.Value_StringValue:
-			return p.NativeToValue(v.GetStringValue())
+			return a.NativeToValue(v.GetStringValue())
 		case *structpb.Value_StructValue:
-			return p.NativeToValue(v.GetStructValue())
+			return a.NativeToValue(v.GetStructValue())
 		}
 	case *tpb.Timestamp:
 		return Timestamp{value.(*tpb.Timestamp)}
@@ -275,15 +345,7 @@ func (p *protoTypeProvider) NativeToValue(value interface{}) ref.Val {
 		if ptypes.UnmarshalAny(val, &unpackedAny) != nil {
 			NewErr("Fail to unmarshal any.")
 		}
-		return p.NativeToValue(unpackedAny.Message)
-	case proto.Message:
-		pbVal := value.(proto.Message)
-		typeName := proto.MessageName(pbVal)
-		td, err := p.pbdb.DescribeType(typeName)
-		if err != nil {
-			return NewErr("unknown type '%s'", typeName)
-		}
-		return NewObject(p, td, pbVal)
+		return a.NativeToValue(unpackedAny.Message)
 	default:
 		refValue := reflect.ValueOf(value)
 		if refValue.Kind() == reflect.Ptr {
@@ -292,15 +354,29 @@ func (p *protoTypeProvider) NativeToValue(value interface{}) ref.Val {
 		refKind := refValue.Kind()
 		switch refKind {
 		case reflect.Array, reflect.Slice:
-			return NewDynamicList(p, value)
+			return NewDynamicList(a, value)
 		case reflect.Map:
-			return NewDynamicMap(p, value)
-		// Enums are a type alias of int32, so they cannot be asserted as an
-		// int32 value, but rather need to be downcast to int32 before being
-		// converted to an Int representation.
+			return NewDynamicMap(a, value)
+		// type aliases of primitive types cannot be asserted as that type, but rather need
+		// to be downcast to int32 before being converted to a CEL representation.
 		case reflect.Int32:
 			intType := reflect.TypeOf(int32(0))
 			return Int(refValue.Convert(intType).Interface().(int32))
+		case reflect.Int64:
+			intType := reflect.TypeOf(int64(0))
+			return Int(refValue.Convert(intType).Interface().(int64))
+		case reflect.Uint32:
+			uintType := reflect.TypeOf(uint32(0))
+			return Uint(refValue.Convert(uintType).Interface().(uint32))
+		case reflect.Uint64:
+			uintType := reflect.TypeOf(uint64(0))
+			return Uint(refValue.Convert(uintType).Interface().(uint64))
+		case reflect.Float32:
+			doubleType := reflect.TypeOf(float32(0))
+			return Double(refValue.Convert(doubleType).Interface().(float32))
+		case reflect.Float64:
+			doubleType := reflect.TypeOf(float64(0))
+			return Double(refValue.Convert(doubleType).Interface().(float64))
 		}
 	}
 	return NewErr("unsupported type conversion for value '%v'", value)

--- a/common/types/providers_test.go
+++ b/common/types/providers_test.go
@@ -28,19 +28,19 @@ import (
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
-func TestTypeProvider_NewValue(t *testing.T) {
-	tp := NewRegistry(&exprpb.ParsedExpr{})
-	if sourceInfo := tp.NewValue(
+func TestTypeRegistry_NewValue(t *testing.T) {
+	reg := NewRegistry(&exprpb.ParsedExpr{})
+	if sourceInfo := reg.NewValue(
 		"google.api.expr.v1alpha1.SourceInfo",
 		map[string]ref.Val{
-			"location":     String("TestTypeProvider_NewValue"),
-			"line_offsets": NewDynamicList(tp, []int64{0, 2}),
-			"positions":    NewDynamicMap(tp, map[int64]int64{1: 2, 2: 4}),
+			"location":     String("TestTypeRegistry_NewValue"),
+			"line_offsets": NewDynamicList(reg, []int64{0, 2}),
+			"positions":    NewDynamicMap(reg, map[int64]int64{1: 2, 2: 4}),
 		}); IsError(sourceInfo) {
 		t.Error(sourceInfo)
 	} else {
 		info := sourceInfo.Value().(*exprpb.SourceInfo)
-		if info.Location != "TestTypeProvider_NewValue" ||
+		if info.Location != "TestTypeRegistry_NewValue" ||
 			!reflect.DeepEqual(info.LineOffsets, []int32{0, 2}) ||
 			!reflect.DeepEqual(info.Positions, map[int64]int32{1: 2, 2: 4}) {
 			t.Errorf("Source info not properly configured: %v", info)
@@ -48,12 +48,12 @@ func TestTypeProvider_NewValue(t *testing.T) {
 	}
 }
 
-func TestTypeProvider_NewValue_OneofFields(t *testing.T) {
-	tp := NewRegistry(&exprpb.ParsedExpr{})
-	if exp := tp.NewValue(
+func TestTypeRegistry_NewValue_OneofFields(t *testing.T) {
+	reg := NewRegistry(&exprpb.ParsedExpr{})
+	if exp := reg.NewValue(
 		"google.api.expr.v1alpha1.Expr",
 		map[string]ref.Val{
-			"const_expr": tp.NativeToValue(
+			"const_expr": reg.NativeToValue(
 				&exprpb.Constant{
 					ConstantKind: &exprpb.Constant_StringValue{
 						StringValue: "oneof"}}),
@@ -67,28 +67,28 @@ func TestTypeProvider_NewValue_OneofFields(t *testing.T) {
 	}
 }
 
-func TestTypeProvider_Getters(t *testing.T) {
-	typeProvider := NewRegistry(&exprpb.ParsedExpr{})
-	if sourceInfo := typeProvider.NewValue(
+func TestTypeRegistry_Getters(t *testing.T) {
+	reg := NewRegistry(&exprpb.ParsedExpr{})
+	if sourceInfo := reg.NewValue(
 		"google.api.expr.v1alpha1.SourceInfo",
 		map[string]ref.Val{
-			"location":     String("TestTypeProvider_GetFieldValue"),
-			"line_offsets": NewDynamicList(typeProvider, []int64{0, 2}),
-			"positions":    NewDynamicMap(typeProvider, map[int64]int64{1: 2, 2: 4}),
+			"location":     String("TestTypeRegistry_GetFieldValue"),
+			"line_offsets": NewDynamicList(reg, []int64{0, 2}),
+			"positions":    NewDynamicMap(reg, map[int64]int64{1: 2, 2: 4}),
 		}); IsError(sourceInfo) {
 		t.Error(sourceInfo)
 	} else {
 		si := sourceInfo.(traits.Indexer)
 		if loc := si.Get(String("location")); IsError(loc) {
 			t.Error(loc)
-		} else if loc.(String) != "TestTypeProvider_GetFieldValue" {
+		} else if loc.(String) != "TestTypeRegistry_GetFieldValue" {
 			t.Errorf("Expected %s, got %s",
-				"TestTypeProvider_GetFieldValue",
+				"TestTypeRegistry_GetFieldValue",
 				loc)
 		}
 		if pos := si.Get(String("positions")); IsError(pos) {
 			t.Error(pos)
-		} else if pos.Equal(NewDynamicMap(typeProvider, map[int64]int32{1: 2, 2: 4})) != True {
+		} else if pos.Equal(NewDynamicMap(reg, map[int64]int32{1: 2, 2: 4})) != True {
 			t.Errorf("Expected map[int64]int32, got %v", pos)
 		} else if posKeyVal := pos.(traits.Indexer).Get(Int(1)); IsError(posKeyVal) {
 			t.Error(posKeyVal)
@@ -106,7 +106,7 @@ func TestTypeProvider_Getters(t *testing.T) {
 }
 
 func TestValue_ConvertToNative(t *testing.T) {
-	p := NewRegistry(&exprpb.ParsedExpr{})
+	reg := NewRegistry(&exprpb.ParsedExpr{})
 	// Core type conversion tests.
 	expectValueToNative(t, True, true)
 	expectValueToNative(t, Int(-1), int32(-1))
@@ -117,9 +117,9 @@ func TestValue_ConvertToNative(t *testing.T) {
 	expectValueToNative(t, Double(-5.5), float64(-5.5))
 	expectValueToNative(t, String("hello"), "hello")
 	expectValueToNative(t, Bytes("world"), []byte("world"))
-	expectValueToNative(t, NewDynamicList(p,
+	expectValueToNative(t, NewDynamicList(reg,
 		[]int64{1, 2, 3}), []int32{1, 2, 3})
-	expectValueToNative(t, NewDynamicMap(p,
+	expectValueToNative(t, NewDynamicMap(reg,
 		map[int64]int64{1: 1, 2: 1, 3: 1}),
 		map[int32]int32{1: 1, 2: 1, 3: 1})
 
@@ -128,11 +128,11 @@ func TestValue_ConvertToNative(t *testing.T) {
 
 	// Proto conversion tests.
 	parsedExpr := &exprpb.ParsedExpr{}
-	expectValueToNative(t, p.NativeToValue(parsedExpr), parsedExpr)
+	expectValueToNative(t, reg.NativeToValue(parsedExpr), parsedExpr)
 }
 
 func TestNativeToValue_Any(t *testing.T) {
-	p := NewRegistry(&exprpb.ParsedExpr{})
+	reg := NewRegistry(&exprpb.ParsedExpr{})
 	// NullValue
 	anyValue, err := NullValue.ConvertToNative(anyValueType)
 	if err != nil {
@@ -150,7 +150,7 @@ func TestNativeToValue_Any(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	expected := NewJSONStruct(p, &structpb.Struct{
+	expected := NewJSONStruct(reg, &structpb.Struct{
 		Fields: map[string]*structpb.Value{
 			"a": {Kind: &structpb.Value_StringValue{StringValue: "world"}},
 			"b": {Kind: &structpb.Value_StringValue{StringValue: "five!"}}}})
@@ -166,7 +166,7 @@ func TestNativeToValue_Any(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	expected = NewJSONList(p, &structpb.ListValue{
+	expected = NewJSONList(reg, &structpb.ListValue{
 		Values: []*structpb.Value{
 			{Kind: &structpb.Value_StringValue{StringValue: "world"}},
 			{Kind: &structpb.Value_StringValue{StringValue: "five!"}}}})
@@ -180,11 +180,11 @@ func TestNativeToValue_Any(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	expectNativeToValue(t, anyValue, p.NativeToValue(&pbMessage))
+	expectNativeToValue(t, anyValue, reg.NativeToValue(&pbMessage))
 }
 
 func TestNativeToValue_Json(t *testing.T) {
-	p := NewRegistry(&exprpb.ParsedExpr{})
+	reg := NewRegistry(&exprpb.ParsedExpr{})
 	// Json primitive conversion test.
 	expectNativeToValue(t,
 		&structpb.Value{Kind: &structpb.Value_BoolValue{}},
@@ -208,7 +208,7 @@ func TestNativeToValue_Json(t *testing.T) {
 					Values: []*structpb.Value{
 						{Kind: &structpb.Value_StringValue{StringValue: "world"}},
 						{Kind: &structpb.Value_StringValue{StringValue: "five!"}}}}}},
-		NewJSONList(p, &structpb.ListValue{
+		NewJSONList(reg, &structpb.ListValue{
 			Values: []*structpb.Value{
 				{Kind: &structpb.Value_StringValue{StringValue: "world"}},
 				{Kind: &structpb.Value_StringValue{StringValue: "five!"}}}}))
@@ -221,18 +221,18 @@ func TestNativeToValue_Json(t *testing.T) {
 					Fields: map[string]*structpb.Value{
 						"a": {Kind: &structpb.Value_StringValue{StringValue: "world"}},
 						"b": {Kind: &structpb.Value_StringValue{StringValue: "five!"}}}}}},
-		NewJSONStruct(p, &structpb.Struct{
+		NewJSONStruct(reg, &structpb.Struct{
 			Fields: map[string]*structpb.Value{
 				"a": {Kind: &structpb.Value_StringValue{StringValue: "world"}},
 				"b": {Kind: &structpb.Value_StringValue{StringValue: "five!"}}}}))
 
 	// Proto conversion test.
 	parsedExpr := &exprpb.ParsedExpr{}
-	expectNativeToValue(t, parsedExpr, p.NativeToValue(parsedExpr))
+	expectNativeToValue(t, parsedExpr, reg.NativeToValue(parsedExpr))
 }
 
 func TestNativeToValue_Primitive(t *testing.T) {
-	p := NewRegistry()
+	reg := NewRegistry()
 	// Core type conversions.
 	expectNativeToValue(t, true, True)
 	expectNativeToValue(t, int32(-1), Int(-1))
@@ -243,16 +243,16 @@ func TestNativeToValue_Primitive(t *testing.T) {
 	expectNativeToValue(t, float64(-5.5), Double(-5.5))
 	expectNativeToValue(t, "hello", String("hello"))
 	expectNativeToValue(t, []byte("world"), Bytes("world"))
-	expectNativeToValue(t, []int32{1, 2, 3}, NewDynamicList(p, []int32{1, 2, 3}))
+	expectNativeToValue(t, []int32{1, 2, 3}, NewDynamicList(reg, []int32{1, 2, 3}))
 	expectNativeToValue(t, map[int32]int32{1: 1, 2: 1, 3: 1},
-		NewDynamicMap(p, map[int32]int32{1: 1, 2: 1, 3: 1}))
+		NewDynamicMap(reg, map[int32]int32{1: 1, 2: 1, 3: 1}))
 	// Null conversion test.
 	expectNativeToValue(t, structpb.NullValue_NULL_VALUE, Null(structpb.NullValue_NULL_VALUE))
 }
 
 func TestUnsupportedConversion(t *testing.T) {
-	p := NewRegistry()
-	if val := p.NativeToValue(nonConvertible{}); !IsError(val) {
+	reg := NewRegistry()
+	if val := reg.NativeToValue(nonConvertible{}); !IsError(val) {
 		t.Error("Expected error when converting non-proto struct to proto", val)
 	}
 }
@@ -282,8 +282,8 @@ func expectValueToNative(t *testing.T, in ref.Val, out interface{}) {
 
 func expectNativeToValue(t *testing.T, in interface{}, out ref.Val) {
 	t.Helper()
-	p := NewRegistry(&exprpb.ParsedExpr{})
-	if val := p.NativeToValue(in); IsError(val) {
+	reg := NewRegistry(&exprpb.ParsedExpr{})
+	if val := reg.NativeToValue(in); IsError(val) {
 		t.Error(val)
 	} else {
 		if val.Equal(out) != True {
@@ -298,14 +298,14 @@ type nonConvertible struct {
 }
 
 func BenchmarkTypeProvider_NewValue(b *testing.B) {
-	p := NewRegistry(&exprpb.ParsedExpr{})
+	reg := NewRegistry(&exprpb.ParsedExpr{})
 	for i := 0; i < b.N; i++ {
-		p.NewValue(
+		reg.NewValue(
 			"google.api.expr.v1.SourceInfo",
 			map[string]ref.Val{
 				"Location":    String("BenchmarkTypeProvider_NewValue"),
-				"LineOffsets": NewDynamicList(p, []int64{0, 2}),
-				"Positions":   NewDynamicMap(p, map[int64]int64{1: 2, 2: 4}),
+				"LineOffsets": NewDynamicList(reg, []int64{0, 2}),
+				"Positions":   NewDynamicMap(reg, map[int64]int64{1: 2, 2: 4}),
 			})
 	}
 }

--- a/common/types/providers_test.go
+++ b/common/types/providers_test.go
@@ -34,8 +34,8 @@ func TestTypeProvider_NewValue(t *testing.T) {
 		"google.api.expr.v1alpha1.SourceInfo",
 		map[string]ref.Val{
 			"location":     String("TestTypeProvider_NewValue"),
-			"line_offsets": NewDynamicList([]int64{0, 2}),
-			"positions":    NewDynamicMap(map[int64]int64{1: 2, 2: 4}),
+			"line_offsets": NewDynamicList(typeProvider, []int64{0, 2}),
+			"positions":    NewDynamicMap(typeProvider, map[int64]int64{1: 2, 2: 4}),
 		}); IsError(sourceInfo) {
 		t.Error(sourceInfo)
 	} else {
@@ -49,11 +49,14 @@ func TestTypeProvider_NewValue(t *testing.T) {
 }
 
 func TestTypeProvider_NewValue_OneofFields(t *testing.T) {
-	typeProvider := NewProvider(&exprpb.ParsedExpr{})
-	if exp := typeProvider.NewValue(
+	tp := NewProvider(&exprpb.ParsedExpr{})
+	if exp := tp.NewValue(
 		"google.api.expr.v1alpha1.Expr",
 		map[string]ref.Val{
-			"const_expr": NewObject(&exprpb.Constant{ConstantKind: &exprpb.Constant_StringValue{StringValue: "oneof"}}),
+			"const_expr": tp.NativeToValue(
+				&exprpb.Constant{
+					ConstantKind: &exprpb.Constant_StringValue{
+						StringValue: "oneof"}}),
 		}); IsError(exp) {
 		t.Error(exp)
 	} else {
@@ -70,8 +73,8 @@ func TestTypeProvider_Getters(t *testing.T) {
 		"google.api.expr.v1alpha1.SourceInfo",
 		map[string]ref.Val{
 			"location":     String("TestTypeProvider_GetFieldValue"),
-			"line_offsets": NewDynamicList([]int64{0, 2}),
-			"positions":    NewDynamicMap(map[int64]int64{1: 2, 2: 4}),
+			"line_offsets": NewDynamicList(typeProvider, []int64{0, 2}),
+			"positions":    NewDynamicMap(typeProvider, map[int64]int64{1: 2, 2: 4}),
 		}); IsError(sourceInfo) {
 		t.Error(sourceInfo)
 	} else {
@@ -85,7 +88,7 @@ func TestTypeProvider_Getters(t *testing.T) {
 		}
 		if pos := si.Get(String("positions")); IsError(pos) {
 			t.Error(pos)
-		} else if pos.Equal(NewDynamicMap(map[int64]int32{1: 2, 2: 4})) != True {
+		} else if pos.Equal(NewDynamicMap(typeProvider, map[int64]int32{1: 2, 2: 4})) != True {
 			t.Errorf("Expected map[int64]int32, got %v", pos)
 		} else if posKeyVal := pos.(traits.Indexer).Get(Int(1)); IsError(posKeyVal) {
 			t.Error(posKeyVal)
@@ -103,6 +106,7 @@ func TestTypeProvider_Getters(t *testing.T) {
 }
 
 func TestValue_ConvertToNative(t *testing.T) {
+	p := NewProvider(&exprpb.ParsedExpr{})
 	// Core type conversion tests.
 	expectValueToNative(t, True, true)
 	expectValueToNative(t, Int(-1), int32(-1))
@@ -113,8 +117,10 @@ func TestValue_ConvertToNative(t *testing.T) {
 	expectValueToNative(t, Double(-5.5), float64(-5.5))
 	expectValueToNative(t, String("hello"), "hello")
 	expectValueToNative(t, Bytes("world"), []byte("world"))
-	expectValueToNative(t, NewDynamicList([]int64{1, 2, 3}), []int32{1, 2, 3})
-	expectValueToNative(t, NewDynamicMap(map[int64]int64{1: 1, 2: 1, 3: 1}),
+	expectValueToNative(t, NewDynamicList(p,
+		[]int64{1, 2, 3}), []int32{1, 2, 3})
+	expectValueToNative(t, NewDynamicMap(p,
+		map[int64]int64{1: 1, 2: 1, 3: 1}),
 		map[int32]int32{1: 1, 2: 1, 3: 1})
 
 	// Null conversion tests.
@@ -122,10 +128,11 @@ func TestValue_ConvertToNative(t *testing.T) {
 
 	// Proto conversion tests.
 	parsedExpr := &exprpb.ParsedExpr{}
-	expectValueToNative(t, NewObject(parsedExpr), parsedExpr)
+	expectValueToNative(t, p.NativeToValue(parsedExpr), parsedExpr)
 }
 
 func TestNativeToValue_Any(t *testing.T) {
+	p := NewProvider(&exprpb.ParsedExpr{})
 	// NullValue
 	anyValue, err := NullValue.ConvertToNative(anyValueType)
 	if err != nil {
@@ -143,7 +150,7 @@ func TestNativeToValue_Any(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	expected := NewJSONStruct(&structpb.Struct{
+	expected := NewJSONStruct(p, &structpb.Struct{
 		Fields: map[string]*structpb.Value{
 			"a": {Kind: &structpb.Value_StringValue{StringValue: "world"}},
 			"b": {Kind: &structpb.Value_StringValue{StringValue: "five!"}}}})
@@ -159,7 +166,7 @@ func TestNativeToValue_Any(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	expected = NewJSONList(&structpb.ListValue{
+	expected = NewJSONList(p, &structpb.ListValue{
 		Values: []*structpb.Value{
 			{Kind: &structpb.Value_StringValue{StringValue: "world"}},
 			{Kind: &structpb.Value_StringValue{StringValue: "five!"}}}})
@@ -173,10 +180,11 @@ func TestNativeToValue_Any(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	expectNativeToValue(t, anyValue, NewObject(&pbMessage))
+	expectNativeToValue(t, anyValue, p.NativeToValue(&pbMessage))
 }
 
 func TestNativeToValue_Json(t *testing.T) {
+	p := NewProvider(&exprpb.ParsedExpr{})
 	// Json primitive conversion test.
 	expectNativeToValue(t,
 		&structpb.Value{Kind: &structpb.Value_BoolValue{}},
@@ -200,7 +208,7 @@ func TestNativeToValue_Json(t *testing.T) {
 					Values: []*structpb.Value{
 						{Kind: &structpb.Value_StringValue{StringValue: "world"}},
 						{Kind: &structpb.Value_StringValue{StringValue: "five!"}}}}}},
-		NewJSONList(&structpb.ListValue{
+		NewJSONList(p, &structpb.ListValue{
 			Values: []*structpb.Value{
 				{Kind: &structpb.Value_StringValue{StringValue: "world"}},
 				{Kind: &structpb.Value_StringValue{StringValue: "five!"}}}}))
@@ -213,17 +221,18 @@ func TestNativeToValue_Json(t *testing.T) {
 					Fields: map[string]*structpb.Value{
 						"a": {Kind: &structpb.Value_StringValue{StringValue: "world"}},
 						"b": {Kind: &structpb.Value_StringValue{StringValue: "five!"}}}}}},
-		NewJSONStruct(&structpb.Struct{
+		NewJSONStruct(p, &structpb.Struct{
 			Fields: map[string]*structpb.Value{
 				"a": {Kind: &structpb.Value_StringValue{StringValue: "world"}},
 				"b": {Kind: &structpb.Value_StringValue{StringValue: "five!"}}}}))
 
 	// Proto conversion test.
 	parsedExpr := &exprpb.ParsedExpr{}
-	expectNativeToValue(t, parsedExpr, NewObject(parsedExpr))
+	expectNativeToValue(t, parsedExpr, p.NativeToValue(parsedExpr))
 }
 
 func TestNativeToValue_Primitive(t *testing.T) {
+	p := NewProvider()
 	// Core type conversions.
 	expectNativeToValue(t, true, True)
 	expectNativeToValue(t, int32(-1), Int(-1))
@@ -234,15 +243,16 @@ func TestNativeToValue_Primitive(t *testing.T) {
 	expectNativeToValue(t, float64(-5.5), Double(-5.5))
 	expectNativeToValue(t, "hello", String("hello"))
 	expectNativeToValue(t, []byte("world"), Bytes("world"))
-	expectNativeToValue(t, []int32{1, 2, 3}, NewDynamicList([]int32{1, 2, 3}))
+	expectNativeToValue(t, []int32{1, 2, 3}, NewDynamicList(p, []int32{1, 2, 3}))
 	expectNativeToValue(t, map[int32]int32{1: 1, 2: 1, 3: 1},
-		NewDynamicMap(map[int32]int32{1: 1, 2: 1, 3: 1}))
+		NewDynamicMap(p, map[int32]int32{1: 1, 2: 1, 3: 1}))
 	// Null conversion test.
 	expectNativeToValue(t, structpb.NullValue_NULL_VALUE, Null(structpb.NullValue_NULL_VALUE))
 }
 
 func TestUnsupportedConversion(t *testing.T) {
-	if val := NativeToValue(nonConvertible{}); !IsError(val) {
+	p := NewProvider()
+	if val := p.NativeToValue(nonConvertible{}); !IsError(val) {
 		t.Error("Expected error when converting non-proto struct to proto", val)
 	}
 }
@@ -272,7 +282,8 @@ func expectValueToNative(t *testing.T, in ref.Val, out interface{}) {
 
 func expectNativeToValue(t *testing.T, in interface{}, out ref.Val) {
 	t.Helper()
-	if val := NativeToValue(in); IsError(val) {
+	p := NewProvider(&exprpb.ParsedExpr{})
+	if val := p.NativeToValue(in); IsError(val) {
 		t.Error(val)
 	} else {
 		if val.Equal(out) != True {
@@ -293,8 +304,8 @@ func BenchmarkTypeProvider_NewValue(b *testing.B) {
 			"google.api.expr.v1.SourceInfo",
 			map[string]ref.Val{
 				"Location":    String("BenchmarkTypeProvider_NewValue"),
-				"LineOffsets": NewDynamicList([]int64{0, 2}),
-				"Positions":   NewDynamicMap(map[int64]int64{1: 2, 2: 4}),
+				"LineOffsets": NewDynamicList(typeProvider, []int64{0, 2}),
+				"Positions":   NewDynamicMap(typeProvider, map[int64]int64{1: 2, 2: 4}),
 			})
 	}
 }

--- a/common/types/ref/provider.go
+++ b/common/types/ref/provider.go
@@ -41,7 +41,7 @@ type TypeProvider interface {
 	// false if the field could not be found.
 	//
 	// Used during type-checking only.
-	FindFieldType(t *exprpb.Type, fieldName string) (*FieldType, bool)
+	FindFieldType(messageType string, fieldName string) (*FieldType, bool)
 
 	// NewValue creates a new type value from a qualified name and a map of
 	// field initializers.
@@ -51,12 +51,6 @@ type TypeProvider interface {
 // TypeRegistry allows third-parties to registry custom types. Not all TypeProvider
 // implementations support type-customization, so these features are optional.
 type TypeRegistry interface {
-	// IsolateTypes copies the global protobuf registry into a copy private to this
-	// TypeProvider. Subsequent Describe*() calls will modify the protobuf registry
-	// only in this TypeProvider. Note that privately-registered protobufs cannot be
-	// instantiated with types.NewObject().
-	IsolateTypes()
-
 	// RegisterDescriptor registers the contents of a protocol buffer FileDescriptor.
 	RegisterDescriptor(fileDesc *descpb.FileDescriptorProto) error
 
@@ -69,6 +63,10 @@ type TypeRegistry interface {
 	// If a type is provided more than once with an alternative definition, the
 	// call will result in an error.
 	RegisterType(types ...Type) error
+}
+
+type TypeAdapter interface {
+	NativeToValue(value interface{}) Val
 }
 
 // FieldType represents a field's type value and whether that field supports

--- a/common/types/ref/provider.go
+++ b/common/types/ref/provider.go
@@ -43,23 +43,24 @@ type TypeProvider interface {
 	// Used during type-checking only.
 	FindFieldType(t *exprpb.Type, fieldName string) (*FieldType, bool)
 
-	// IsolateTypes copies the global protobuf registry into a copy
-	// private to this TypeProvider.  Subsequent Describe*() calls
-	// will modify the protobuf registry only in this TypeProvider.
-	// Note that privately-registered protobufs cannot be instantiated
-	// with types.NewObject().
-	IsolateTypes()
-
 	// NewValue creates a new type value from a qualified name and a map of
 	// field initializers.
 	NewValue(typeName string, fields map[string]Val) Val
+}
 
-	// RegisterDescriptor registers the contents of a protocol
-	// buffer FileDescriptor.
+// TypeRegistry allows third-parties to registry custom types. Not all TypeProvider
+// implementations support type-customization, so these features are optional.
+type TypeRegistry interface {
+	// IsolateTypes copies the global protobuf registry into a copy private to this
+	// TypeProvider. Subsequent Describe*() calls will modify the protobuf registry
+	// only in this TypeProvider. Note that privately-registered protobufs cannot be
+	// instantiated with types.NewObject().
+	IsolateTypes()
+
+	// RegisterDescriptor registers the contents of a protocol buffer FileDescriptor.
 	RegisterDescriptor(fileDesc *descpb.FileDescriptorProto) error
 
-	// RegisterMessage registers a protocol buffer message
-	// and its dependencies.
+	// RegisterMessage registers a protocol buffer message and its dependencies.
 	RegisterMessage(message proto.Message) error
 
 	// RegisterType registers a type value with the provider which ensures the

--- a/common/types/ref/provider.go
+++ b/common/types/ref/provider.go
@@ -65,7 +65,9 @@ type TypeRegistry interface {
 	RegisterType(types ...Type) error
 }
 
+// TypeAdapter converts native Go values of varying type and complexity to equivalent CEL values.
 type TypeAdapter interface {
+	// NativeToValue converts the input `value` to a CEL `ref.Val`.
 	NativeToValue(value interface{}) Val
 }
 

--- a/common/types/ref/provider.go
+++ b/common/types/ref/provider.go
@@ -54,7 +54,7 @@ type TypeAdapter interface {
 	NativeToValue(value interface{}) Val
 }
 
-// TypeRegistry allows third-parties to registry custom types. Not all `TypeProvider`
+// TypeRegistry allows third-parties to add custom types to CEL. Not all `TypeProvider`
 // implementations support type-customization, so these features are optional. However, a
 // `TypeRegistry` should be a `TypeProvider` and a `TypeAdapter` to ensure that types
 // which are registered can be converted to CEL representations.

--- a/common/types/ref/provider.go
+++ b/common/types/ref/provider.go
@@ -48,10 +48,21 @@ type TypeProvider interface {
 	NewValue(typeName string, fields map[string]Val) Val
 }
 
-// TypeRegistry allows third-parties to registry custom types. Not all TypeProvider
-// implementations support type-customization, so these features are optional.
+// TypeAdapter converts native Go values of varying type and complexity to equivalent CEL values.
+type TypeAdapter interface {
+	// NativeToValue converts the input `value` to a CEL `ref.Val`.
+	NativeToValue(value interface{}) Val
+}
+
+// TypeRegistry allows third-parties to registry custom types. Not all `TypeProvider`
+// implementations support type-customization, so these features are optional. However, a
+// `TypeRegistry` should be a `TypeProvider` and a `TypeAdapter` to ensure that types
+// which are registered can be converted to CEL representations.
 type TypeRegistry interface {
-	// RegisterDescriptor registers the contents of a protocol buffer FileDescriptor.
+	TypeAdapter
+	TypeProvider
+
+	// RegisterDescriptor registers the contents of a protocol buffer `FileDescriptor`.
 	RegisterDescriptor(fileDesc *descpb.FileDescriptorProto) error
 
 	// RegisterMessage registers a protocol buffer message and its dependencies.
@@ -63,12 +74,6 @@ type TypeRegistry interface {
 	// If a type is provided more than once with an alternative definition, the
 	// call will result in an error.
 	RegisterType(types ...Type) error
-}
-
-// TypeAdapter converts native Go values of varying type and complexity to equivalent CEL values.
-type TypeAdapter interface {
-	// NativeToValue converts the input `value` to a CEL `ref.Val`.
-	NativeToValue(value interface{}) Val
 }
 
 // FieldType represents a field's type value and whether that field supports

--- a/interpreter/activation.go
+++ b/interpreter/activation.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 )
 
@@ -47,10 +48,9 @@ func EmptyActivation() Activation {
 // The input `bindings` may either be of type `Activation` or `map[string]interface{}`.
 //
 // When the bindings are a `map` form whose values are not of `ref.Val` type, the values will be
-// converted to CEL values (if possible) using the `types.GoTypeAdapter`.
+// converted to CEL values (if possible) using the `types.DefaultTypeAdapter`.
 func NewActivation(bindings interface{}) (Activation, error) {
-	// TODO: implement types.GoTypeAdapter.
-	return NewAdaptingActivation(nil, bindings)
+	return NewAdaptingActivation(types.DefaultTypeAdapter, bindings)
 }
 
 // NewAdaptingActivation returns an actvation which is capable of adapting `bindings` from native

--- a/interpreter/activation.go
+++ b/interpreter/activation.go
@@ -62,8 +62,7 @@ func NewActivation(bindings interface{}) (Activation, error) {
 //   - `ref.Val`: a CEL value instance.
 //   - `func() ref.Val`: a CEL value supplier.
 //   - other: a native value which must be converted to a CEL `ref.Val` by the `adapter`.
-func NewAdaptingActivation(adapter ref.TypeAdapter,
-	bindings interface{}) (Activation, error) {
+func NewAdaptingActivation(adapter ref.TypeAdapter, bindings interface{}) (Activation, error) {
 	a, isActivation := bindings.(Activation)
 	if isActivation {
 		return a, nil

--- a/interpreter/activation_test.go
+++ b/interpreter/activation_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestNewActivation(t *testing.T) {
-	activation := NewActivation(map[string]interface{}{"a": true})
+	activation, _ := NewActivation(map[string]interface{}{"a": types.True})
 	if val, found := activation.ResolveName("a"); !found || val != types.True {
 		t.Error("Activation failed to resolve 'a'")
 	}
@@ -29,9 +29,15 @@ func TestNewActivation(t *testing.T) {
 
 func TestHierarchicalActivation(t *testing.T) {
 	// compose a parent with more properties than the child
-	parent := NewActivation(map[string]interface{}{"a": "world", "b": -42})
+	parent, _ := NewActivation(map[string]interface{}{
+		"a": types.String("world"),
+		"b": types.Int(-42),
+	})
 	// compose the child such that it shadows the parent
-	child := NewActivation(map[string]interface{}{"a": true, "c": "universe"})
+	child, _ := NewActivation(map[string]interface{}{
+		"a": types.True,
+		"c": types.String("universe"),
+	})
 	combined := NewHierarchicalActivation(parent, child)
 
 	// Resolve the shadowed child value.

--- a/interpreter/decorators.go
+++ b/interpreter/decorators.go
@@ -90,7 +90,7 @@ func decFoldConstants() InterpretableDecorator {
 					return i, nil
 				}
 			}
-			val := l.Eval(emptyActivation)
+			val := l.Eval(EmptyActivation())
 			return &evalConst{
 				id:  l.id,
 				val: val,
@@ -107,7 +107,7 @@ func decFoldConstants() InterpretableDecorator {
 					return i, nil
 				}
 			}
-			val := mp.Eval(emptyActivation)
+			val := mp.Eval(EmptyActivation())
 			return &evalConst{
 				id:  mp.id,
 				val: val,
@@ -285,7 +285,3 @@ func (fold *evalExhaustiveFold) Eval(ctx Activation) ref.Val {
 	varActivationPool.Put(accuCtx)
 	return res
 }
-
-var (
-	emptyActivation = NewActivation(map[string]interface{}{})
-)

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -89,34 +89,31 @@ func FoldConstants() InterpretableDecorator {
 }
 
 type exprInterpreter struct {
-	dispatcher   Dispatcher
-	packager     packages.Packager
-	typeProvider ref.TypeProvider
-	adapter      ref.TypeAdapter
+	dispatcher Dispatcher
+	packager   packages.Packager
+	provider   ref.TypeProvider
+	adapter    ref.TypeAdapter
 }
 
-// NewInterpreter builds an Interpreter from a Dispatcher and TypeProvider
-// which will be used throughout the Eval of all Interpretable instances
-// gerenated from it.
-func NewInterpreter(dispatcher Dispatcher,
-	packager packages.Packager,
-	typeProvider ref.TypeProvider,
+// NewInterpreter builds an Interpreter from a Dispatcher and TypeProvider which will be used
+// throughout the Eval of all Interpretable instances gerenated from it.
+func NewInterpreter(dispatcher Dispatcher, packager packages.Packager,
+	provider ref.TypeProvider,
 	adapter ref.TypeAdapter) Interpreter {
 	return &exprInterpreter{
-		dispatcher:   dispatcher,
-		packager:     packager,
-		typeProvider: typeProvider,
-		adapter:      adapter}
+		dispatcher: dispatcher,
+		packager:   packager,
+		provider:   provider,
+		adapter:    adapter}
 }
 
-// NewStandardInterpreter builds a Dispatcher and TypeProvider with support
-// for all of the CEL builtins defined in the language definition.
-func NewStandardInterpreter(packager packages.Packager,
-	typeProvider ref.TypeProvider,
+// NewStandardInterpreter builds a Dispatcher and TypeProvider with support for all of the CEL
+// builtins defined in the language definition.
+func NewStandardInterpreter(packager packages.Packager, provider ref.TypeProvider,
 	adapter ref.TypeAdapter) Interpreter {
 	dispatcher := NewDispatcher()
 	dispatcher.Add(functions.StandardOverloads()...)
-	return NewInterpreter(dispatcher, packager, typeProvider, adapter)
+	return NewInterpreter(dispatcher, packager, provider, adapter)
 }
 
 // NewIntepretable implements the Interpreter interface method.
@@ -125,7 +122,7 @@ func (i *exprInterpreter) NewInterpretable(
 	decorators ...InterpretableDecorator) (Interpretable, error) {
 	p := newPlanner(
 		i.dispatcher,
-		i.typeProvider,
+		i.provider,
 		i.adapter,
 		i.packager,
 		checked,
@@ -139,7 +136,7 @@ func (i *exprInterpreter) NewUncheckedInterpretable(
 	decorators ...InterpretableDecorator) (Interpretable, error) {
 	p := newUncheckedPlanner(
 		i.dispatcher,
-		i.typeProvider,
+		i.provider,
 		i.adapter,
 		i.packager,
 		decorators...)

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -230,7 +230,7 @@ func TestInterpreter_FieldAccess(t *testing.T) {
 }
 
 func TestInterpreter_SubsumedFieldAccess(t *testing.T) {
-	vars := NewActivation(map[string]interface{}{
+	vars, _ := NewActivation(map[string]interface{}{
 		"a.b":   map[string]types.Int{"c": types.Int(9)},
 		"a.b.c": types.Int(10),
 	})

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -48,7 +48,7 @@ func TestExhaustiveInterpreter_ConditionalExpr(t *testing.T) {
 	// Operator "_==_" is at Expr 6, should be evaluated in exhaustive mode
 	// even though "a" is true
 	state := NewEvalState()
-	tp := types.NewProvider(&exprpb.ParsedExpr{})
+	tp := types.NewRegistry(&exprpb.ParsedExpr{})
 	intr := NewStandardInterpreter(packages.DefaultPackage, tp, tp)
 	interpretable, _ := intr.NewUncheckedInterpretable(
 		test.Conditional.Expr,
@@ -104,7 +104,7 @@ func TestExhaustiveInterpreter_LogicalOrEquals(t *testing.T) {
 
 	// TODO: make the type identifiers part of the standard declaration set.
 	state := NewEvalState()
-	tp := types.NewProvider(&exprpb.Expr{})
+	tp := types.NewRegistry(&exprpb.Expr{})
 	interp := NewStandardInterpreter(packages.NewPackage("test"), tp, tp)
 	i, _ := interp.NewUncheckedInterpretable(test.LogicalOrEquals.Expr,
 		ExhaustiveEval(state))
@@ -124,7 +124,7 @@ func TestExhaustiveInterpreter_LogicalOrEquals(t *testing.T) {
 }
 
 func TestInterpreter_CallExpr(t *testing.T) {
-	tp := types.NewProvider(&exprpb.ParsedExpr{})
+	tp := types.NewRegistry(&exprpb.ParsedExpr{})
 	intr := NewStandardInterpreter(packages.NewPackage("google.api.expr"), tp, tp)
 	state := NewEvalState()
 	interpretable, _ := intr.NewUncheckedInterpretable(test.Equality.Expr,
@@ -289,7 +289,7 @@ func TestInterpreter_ZeroArityCall(t *testing.T) {
 			return types.IntZero
 		},
 	})
-	tp := types.NewProvider()
+	tp := types.NewRegistry()
 	interp := NewInterpreter(disp, packages.DefaultPackage, tp, tp)
 	i, _ := interp.NewUncheckedInterpretable(p.Expr)
 	result := i.Eval(EmptyActivation())
@@ -312,7 +312,7 @@ func TestInterpreter_VarArgsCall(t *testing.T) {
 			return val
 		},
 	})
-	tp := types.NewProvider()
+	tp := types.NewRegistry()
 	interp := NewInterpreter(disp, packages.DefaultPackage, tp, tp)
 	i, _ := interp.NewUncheckedInterpretable(p.Expr)
 	vars, _ := NewActivation(
@@ -363,7 +363,7 @@ func TestInterpreter_LogicalAndMissingType(t *testing.T) {
 
 func TestInterpreter_LogicalOr(t *testing.T) {
 	// {c: false}.c || a
-	tp := types.NewProvider(&exprpb.Expr{})
+	tp := types.NewRegistry(&exprpb.Expr{})
 	intr := NewStandardInterpreter(packages.NewPackage("test"), tp, tp)
 	i, _ := intr.NewUncheckedInterpretable(test.LogicalOr.Expr)
 	vars, _ := NewActivation(map[string]interface{}{"a": types.True})
@@ -377,7 +377,7 @@ func TestInterpreter_LogicalOrEquals(t *testing.T) {
 	// a || b == "b"
 	// Operator "==" is at Expr 4, should not be evaluated since "a" is true)
 	// TODO: make the type identifiers part of the standard declaration set.
-	tp := types.NewProvider(&exprpb.Expr{})
+	tp := types.NewRegistry(&exprpb.Expr{})
 	i := NewStandardInterpreter(packages.NewPackage("test"), tp, tp)
 	interpretable, _ := i.NewUncheckedInterpretable(test.LogicalOrEquals.Expr)
 	vars, _ := NewActivation(map[string]interface{}{
@@ -401,7 +401,7 @@ func TestInterpreter_BuildObject(t *testing.T) {
 	}
 
 	pkgr := packages.NewPackage("google.api.expr")
-	tp := types.NewProvider(&exprpb.Expr{})
+	tp := types.NewRegistry(&exprpb.Expr{})
 	env := checker.NewStandardEnv(pkgr, tp)
 	checked, errors := checker.Check(parsed, src, env)
 	if len(errors.GetErrors()) != 0 {
@@ -438,7 +438,7 @@ func TestInterpreter_GetProto2PrimitiveFields(t *testing.T) {
 	}
 
 	pkgr := packages.NewPackage("google.expr.proto2.test")
-	tp := types.NewProvider(&proto2pb.TestAllTypes{})
+	tp := types.NewRegistry(&proto2pb.TestAllTypes{})
 	env := checker.NewStandardEnv(pkgr, tp)
 	env.Add(decls.NewIdent("a", decls.NewObjectType("google.expr.proto2.test.TestAllTypes"), nil))
 	checked, errors := checker.Check(parsed, src, env)
@@ -484,7 +484,7 @@ func TestInterpreter_SetProto2PrimitiveFields(t *testing.T) {
 	}
 
 	pkgr := packages.NewPackage("google.expr.proto2.test")
-	tp := types.NewProvider(&proto2pb.TestAllTypes{})
+	tp := types.NewRegistry(&proto2pb.TestAllTypes{})
 	env := checker.NewStandardEnv(pkgr, tp)
 	env.Add(decls.NewIdent("input", decls.NewObjectType("google.expr.proto2.test.TestAllTypes"), nil))
 	checked, errors := checker.Check(parsed, src, env)
@@ -536,7 +536,7 @@ func TestInterpreter_GetObjectEnumField(t *testing.T) {
 	}
 
 	pkgr := packages.NewPackage("google.expr.proto3.test")
-	tp := types.NewProvider(&proto3pb.TestAllTypes{})
+	tp := types.NewRegistry(&proto3pb.TestAllTypes{})
 	env := checker.NewStandardEnv(pkgr, tp)
 	env.Add(decls.NewIdent("a", decls.NewObjectType("google.expr.proto3.test.TestAllTypes"), nil))
 	checked, errors := checker.Check(parsed, src, env)
@@ -585,7 +585,7 @@ func TestInterpreter_SetObjectEnumField(t *testing.T) {
 	}
 
 	pkgr := packages.NewPackage("google.expr.proto3.test")
-	tp := types.NewProvider(&proto3pb.TestAllTypes{})
+	tp := types.NewRegistry(&proto3pb.TestAllTypes{})
 	env := checker.NewStandardEnv(pkgr, tp)
 	checked, errors := checker.Check(parsed, src, env)
 	if len(errors.GetErrors()) != 0 {
@@ -733,7 +733,7 @@ func BenchmarkInterpreter_CanonicalExpressions(b *testing.B) {
 			b.Errorf(errors.ToDisplayString())
 		}
 
-		types := types.NewProvider()
+		types := types.NewRegistry()
 		pkg := packages.DefaultPackage
 		env := checker.NewStandardEnv(pkg, types)
 		env.Add(
@@ -755,9 +755,9 @@ func BenchmarkInterpreter_CanonicalExpressions(b *testing.B) {
 }
 
 var (
-	tp          = types.NewProvider(&exprpb.ParsedExpr{})
+	tp          = types.NewRegistry(&exprpb.ParsedExpr{})
 	interpreter = NewStandardInterpreter(packages.DefaultPackage, tp, tp)
-	testData = []testCase{
+	testData    = []testCase{
 		{
 			name: `ExprBench/ok_1st`,
 			E:    `ai == 20 || ar["foo"] == "bar"`,
@@ -826,7 +826,7 @@ func compileExpr(t *testing.T, src string, decls ...*exprpb.Decl) *exprpb.Checke
 		t.Error(errors.ToDisplayString())
 		return nil
 	}
-	env := checker.NewStandardEnv(packages.DefaultPackage, types.NewProvider())
+	env := checker.NewStandardEnv(packages.DefaultPackage, types.NewRegistry())
 	env.Add(decls...)
 	checked, errors := checker.Check(parsed, s, env)
 	if len(errors.GetErrors()) != 0 {

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -39,13 +39,14 @@ type interpretablePlanner interface {
 // needs to be done once and may be semi-expensive to compute.
 func newPlanner(disp Dispatcher,
 	types ref.TypeProvider,
+	adapter ref.TypeAdapter,
 	pkg packages.Packager,
 	checked *exprpb.CheckedExpr,
 	decorators ...InterpretableDecorator) interpretablePlanner {
 	return &planner{
 		disp:       disp,
 		types:      types,
-		adapter:    types.(ref.TypeAdapter),
+		adapter:    adapter,
 		pkg:        pkg,
 		identMap:   make(map[string]Interpretable),
 		refMap:     checked.GetReferenceMap(),
@@ -59,12 +60,13 @@ func newPlanner(disp Dispatcher,
 // present in Select expressions are resolved lazily at evaluation time.
 func newUncheckedPlanner(disp Dispatcher,
 	types ref.TypeProvider,
+	adapter ref.TypeAdapter,
 	pkg packages.Packager,
 	decorators ...InterpretableDecorator) interpretablePlanner {
 	return &planner{
 		disp:       disp,
 		types:      types,
-		adapter:    types.(ref.TypeAdapter),
+		adapter:    adapter,
 		pkg:        pkg,
 		identMap:   make(map[string]Interpretable),
 		refMap:     make(map[int64]*exprpb.Reference),

--- a/interpreter/prune_test.go
+++ b/interpreter/prune_test.go
@@ -120,7 +120,7 @@ func TestPrune(t *testing.T) {
 		interpretable, _ := interpreter.NewUncheckedInterpretable(
 			pExpr.Expr,
 			ExhaustiveEval(state))
-		interpretable.Eval(NewActivation(map[string]interface{}{}))
+		interpretable.Eval(EmptyActivation())
 		newExpr := PruneAst(pExpr.Expr, state)
 		actual := debug.ToDebugString(newExpr)
 		if !test.Compare(actual, tst.P) {

--- a/server/server.go
+++ b/server/server.go
@@ -94,10 +94,7 @@ func (s *ConformanceServer) Check(ctx context.Context, in *exprpb.CheckRequest) 
 
 // Eval implements ConformanceService.Eval.
 func (s *ConformanceServer) Eval(ctx context.Context, in *exprpb.EvalRequest) (*exprpb.EvalResponse, error) {
-	tp := types.NewProvider()
-	env, _ := cel.NewEnv(
-		cel.Container(in.Container),
-		cel.CustomTypeProvider(tp))
+	env, _ := cel.NewEnv(cel.Container(in.Container))
 	var prg cel.Program
 	var err error
 	switch in.ExprKind.(type) {
@@ -119,7 +116,7 @@ func (s *ConformanceServer) Eval(ctx context.Context, in *exprpb.EvalRequest) (*
 	}
 	args := make(map[string]interface{})
 	for name, exprValue := range in.Bindings {
-		refVal, err := ExprValueToRefValue(tp, exprValue)
+		refVal, err := ExprValueToRefValue(env.TypeAdapter(), exprValue)
 		if err != nil {
 			return nil, fmt.Errorf("can't convert binding %s: %s", name, err)
 		}


### PR DESCRIPTION
Provide strict isolation between the `types.Provider` instances to make it possible to run multiple CEL expressions together using different environments, etc. This should fix #180 and address issues raised in #175.

Minor changes have also been made to the top-level interface to make sure it is easy to adapt native inputs to CEL types.