### PR TITLE
Add an option to disable aggregates with dynamic element types.

### DIFF
--- a/cel/BUILD.bazel
+++ b/cel/BUILD.bazel
@@ -45,6 +45,8 @@ go_test(
     ],
     deps = [
         "//checker/decls:go_default_library",
+        "//common/operators:go_default_library",
+        "//common/overloads:go_default_library",
         "//common/types:go_default_library",
         "//common/types/ref:go_default_library",
         "//common/types/traits:go_default_library",

--- a/cel/env.go
+++ b/cel/env.go
@@ -104,11 +104,12 @@ type Issues interface {
 // See the EnvOptions for the options that can be used to configure the environment.
 func NewEnv(opts ...EnvOption) (Env, error) {
 	e := &env{
-		declarations:   checker.StandardDeclarations(),
-		enableBuiltins: true,
-		macros:         parser.AllMacros,
-		pkg:            packages.DefaultPackage,
-		types:          types.NewProvider(),
+		declarations:                   checker.StandardDeclarations(),
+		macros:                         parser.AllMacros,
+		pkg:                            packages.DefaultPackage,
+		types:                          types.NewProvider(),
+		enableBuiltins:                 true,
+		enableDynamicAggregateLiterals: true,
 	}
 	// Customized the environment using the provided EnvOption values. If an error is
 	// generated at any step this, will be returned as a nil Env with a non-nil error.
@@ -161,16 +162,19 @@ func (ast *astValue) Source() Source {
 
 // env is the internal implementation of the Env interface.
 type env struct {
-	declarations   []*exprpb.Decl
-	enableBuiltins bool
-	macros         []parser.Macro
-	pkg            packages.Packager
-	types          ref.TypeProvider
+	declarations []*exprpb.Decl
+	macros       []parser.Macro
+	pkg          packages.Packager
+	types        ref.TypeProvider
+	// environment options, true by default.
+	enableBuiltins                 bool
+	enableDynamicAggregateLiterals bool
 }
 
 // Check implements the Env interface method.
 func (e *env) Check(ast Ast) (Ast, Issues) {
 	ce := checker.NewEnv(e.pkg, e.types)
+	ce.EnableDynamicAggregateLiterals(e.enableDynamicAggregateLiterals)
 	ce.Add(e.declarations...)
 	pe, err := AstToParsedExpr(ast)
 	if err != nil {

--- a/cel/options.go
+++ b/cel/options.go
@@ -83,7 +83,7 @@ func Declarations(decls ...*exprpb.Decl) EnvOption {
 // during type-checking.
 //
 // Note, it is still possible to have heterogeneous aggregates when provided as variables to the
-// expression.
+// expression or with unchecked expressions.
 func HomogeneousAggregateLiterals() EnvOption {
 	return func(e *env) (*env, error) {
 		e.enableDynamicAggregateLiterals = false

--- a/cel/options.go
+++ b/cel/options.go
@@ -83,7 +83,8 @@ func Declarations(decls ...*exprpb.Decl) EnvOption {
 // during type-checking.
 //
 // Note, it is still possible to have heterogeneous aggregates when provided as variables to the
-// expression or with unchecked expressions.
+// expression, as well as via conversion of well-known dynamic types, or with unchecked
+// expressions.
 func HomogeneousAggregateLiterals() EnvOption {
 	return func(e *env) (*env, error) {
 		e.enableDynamicAggregateLiterals = false

--- a/cel/options.go
+++ b/cel/options.go
@@ -79,6 +79,18 @@ func Declarations(decls ...*exprpb.Decl) EnvOption {
 	}
 }
 
+// HomogeneousAggregateLiterals option ensures that list and map literal entry types must agree
+// during type-checking.
+//
+// Note, it is still possible to have heterogeneous aggregates when provided as variables to the
+// expression.
+func HomogeneousAggregateLiterals() EnvOption {
+	return func(e *env) (*env, error) {
+		e.enableDynamicAggregateLiterals = false
+		return e, nil
+	}
+}
+
 // Macros option extends the macro set configured in the environment.
 //
 // Note: This option must be specified after ClearBuiltIns and/or ClearMacros if used together.

--- a/checker/env.go
+++ b/checker/env.go
@@ -28,6 +28,13 @@ import (
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
+type aggregateLiteralElementType int
+
+const (
+	dynElementType aggregateLiteralElementType = iota
+	homogenousElementType aggregateLiteralElementType = 1 << iota
+)
+
 // Env is the environment for type checking.
 // It consists of a Packager, a Type Provider, declarations, and collection of errors encountered
 // during checking.
@@ -36,6 +43,7 @@ type Env struct {
 	typeProvider ref.TypeProvider
 
 	declarations *decls.Scopes
+	aggLitElemType aggregateLiteralElementType
 }
 
 // NewEnv returns a new *Env with the given parameters.
@@ -58,6 +66,15 @@ func NewStandardEnv(packager packages.Packager,
 	if err := e.Add(StandardDeclarations()...); err != nil {
 		// The standard declaration set should never have duplicate declarations.
 		panic(err)
+	}
+	// TODO: isolate standard declarations from the custom set which may be provided layer.
+	return e
+}
+
+func (e *Env) EnableDynamicAggregateLiterals(enabled bool) *Env {
+	e.aggLitElemType = dynElementType
+	if !enabled {
+		e.aggLitElemType = homogenousElementType
 	}
 	return e
 }

--- a/common/types/traits/traits.go
+++ b/common/types/traits/traits.go
@@ -24,7 +24,6 @@ const (
 	ComparerType
 
 	// ContainerType types support 'in' operations.
-
 	ContainerType
 
 	// DividerType types support '/' operations.


### PR DESCRIPTION
This pull closes feature request #144 and will allow users to disable support for aggregate literals with mixed element types. This feature can be enabled via the following top-level option:
```go
env, err := cel.NewEnv(cel.HomogeneousAggregateLiterals())
```    