### PR TITLE
Clarify the evaluation status from Eval

### DIFF
--- a/cel/program.go
+++ b/cel/program.go
@@ -26,8 +26,8 @@ import (
 type Program interface {
 	// Eval returns the result of an evaluation of the Ast and environment against the input vars.
 	//
-	// If the OptTrackState or OptExhaustiveEval is used, the `details` response will be non-nil.
-	// The return state from evaluation will be:
+	// If the `OptTrackState` or `OptExhaustiveEval` flags are used, the `details` response will
+	/// be non-nil. Given this caveat on `details`, the return state from evaluation will be:
 	//
 	// *  `val`, `details`, `nil` - Successful evaluation of a non-error result.
 	// *  `val`, `details`, `err` - Successful evaluation to an error result.


### PR DESCRIPTION
Closes issue #173 by ensuring that the `val` output returned from `program.Eval()` is included even if the evaluation results in an `error`. This allow for disambiguation between errors due to the configuration of the program versus errors related to the evaluation of the program itself.