### PR TITLE
Speculative optimization: Use custom string serializer for Type

### DIFF
--- a/checker/types.go
+++ b/checker/types.go
@@ -475,5 +475,5 @@ func substitute(m *mapping, t *exprpb.Type, typeParamToDyn bool) *exprpb.Type {
 }
 
 func typeKey(t *exprpb.Type) string {
-	return fmt.Sprintf("%v:%v", kindOf(t), t.String())
+	return FormatCheckedType(t)
 }


### PR DESCRIPTION
It seems that the generic text proto CompactStringMarshal is more expensive that hand-made one.
Looking for feedback. I think we probably want to use a Struct as a hashmap key, but that would require building a new family of structs mirroring Types, since using proto Type does not seem to work.