### PR TITLE
Move the internal environment construction out of the Check call.

### DIFF
--- a/cel/env.go
+++ b/cel/env.go
@@ -128,6 +128,7 @@ func NewEnv(opts ...EnvOption) (Env, error) {
 			return nil, err
 		}
 	}
+	// Construct the internal checker env, erroring if there is an issue adding the declarations.
 	ce := checker.NewEnv(e.pkg, e.provider)
 	ce.EnableDynamicAggregateLiterals(e.enableDynamicAggregateLiterals)
 	err = ce.Add(e.declarations...)

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -743,6 +743,17 @@ ERROR: <input>:1:16: found no matching overload for '_!=_' applied to '(int, nul
 		Type: decls.Bool,
 	},
 	{
+		I: `x.repeated_int64.exists(y, y > 10) && y < 5`,
+		Env: env{
+			idents: []*exprpb.Decl{
+				decls.NewIdent("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes"), nil),
+			},
+		},
+		Error: `ERROR: <input>:1:39: undeclared reference to 'y' (in container '')
+		| x.repeated_int64.exists(y, y > 10) && y < 5
+		| ......................................^`,
+	},
+	{
 		I: `x.repeated_int64.all(e, e > 0) && x.repeated_int64.exists(e, e < 0) && x.repeated_int64.exists_one(e, e == 0)`,
 		Env: env{
 			idents: []*exprpb.Decl{

--- a/checker/decls/scopes.go
+++ b/checker/decls/scopes.go
@@ -59,7 +59,7 @@ func (s *Scopes) AddIdent(decl *exprpb.Decl) {
 
 // FindIdent finds the first ident Decl with a matching name in Scopes, or nil if one cannot be
 // found.
-// Note: the search is performed from innermost to outermost.
+// Note: The search is performed from innermost to outermost.
 func (s *Scopes) FindIdent(name string) *exprpb.Decl {
 	if ident, found := s.scopes.idents[name]; found {
 		return ident
@@ -70,8 +70,18 @@ func (s *Scopes) FindIdent(name string) *exprpb.Decl {
 	return nil
 }
 
+// FindIdentInScope finds the first ident Decl with a matching name in the current Scopes value, or
+// nil if one does not exist.
+// Note: The search is only performed on the current scope and does not search outer scopes.
+func (s *Scopes) FindIdentInScope(name string) *exprpb.Decl {
+	if ident, found := s.scopes.idents[name]; found {
+		return ident
+	}
+	return nil
+}
+
 // AddFunction adds the function Decl to the current scope.
-// Note: any previous entry for a function in the current scope with the same name is overwritten.
+// Note: Any previous entry for a function in the current scope with the same name is overwritten.
 func (s *Scopes) AddFunction(fn *exprpb.Decl) {
 	s.scopes.functions[fn.Name] = fn
 }

--- a/checker/decls/scopes.go
+++ b/checker/decls/scopes.go
@@ -16,83 +16,75 @@ package decls
 
 import exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 
-// Scopes represents nested Decl environments.
-// A Scopes structure is a stack of Groups (the highest array index
-// is the top of stack), with the top of the stack being the "innermost"
-// scope, and the bottom being the "outermost" scope.  Each group is a mapping
-// of names to Decls in the ident and function namespaces.
-// Lookups are performed such that bindings in inner scopes shadow those
-// in outer scopes.
+// Scopes represents nested Decl sets where the Scopes value contains a Groups containing all
+// identifiers in scope and an optional parent representing outer scopes.
+// Each Groups value is a mapping of names to Decls in the ident and function namespaces.
+// Lookups are performed such that bindings in inner scopes shadow those in outer scopes.
 type Scopes struct {
-	scopes []*Group
+	parent *Scopes
+	scopes *Group
 }
 
 // NewScopes creates a new, empty Scopes.
 // Some operations can't be safely performed until a Group is added with Push.
 func NewScopes() *Scopes {
 	return &Scopes{
-		scopes: []*Group{},
+		scopes: newGroup(),
 	}
 }
 
-// Push adds an empty Group as the new innermost scope.
-func (s *Scopes) Push() {
-	g := newGroup()
-	s.scopes = append(s.scopes, g)
+// Push creates a new Scopes value which references the current Scope as its parent.
+func (s *Scopes) Push() *Scopes {
+	return &Scopes{
+		parent: s,
+		scopes: newGroup(),
+	}
 }
 
-// Pop removes the innermost Group from Scopes.
-// Scopes should have at least one Group.
-func (s *Scopes) Pop() {
-	s.scopes = s.scopes[:len(s.scopes)-1]
+// Pop returns the parent Scopes value for the current scope, or the current scope if the parent
+// is nil.
+func (s *Scopes) Pop() *Scopes {
+	if s.parent != nil {
+		return s.parent
+	}
+	// TODO: Consider whether this should be an error / panic.
+	return s
 }
 
-// AddIdent adds the ident Decl in the outermost scope.
-// Any previous entry for an ident of the same name is overwritten.
-// Scopes must have at least one group.
+// AddIdent adds the ident Decl in the current scope.
+// Note: If the name collides with an existing identifier in the scope, the Decl is overwritten.
 func (s *Scopes) AddIdent(decl *exprpb.Decl) {
-	s.scopes[0].idents[decl.Name] = decl
+	s.scopes.idents[decl.Name] = decl
 }
 
-// FindIdent finds the first ident Decl with a matching name in Scopes.
-// The search is performed from innermost to outermost.
-// Returns nil if not such ident in Scopes.
+// FindIdent finds the first ident Decl with a matching name in Scopes, or nil if one cannot be
+// found.
+// Note: the search is performed from innermost to outermost.
 func (s *Scopes) FindIdent(name string) *exprpb.Decl {
-	for i := len(s.scopes) - 1; i >= 0; i-- {
-		scope := s.scopes[i]
-		if ident, found := scope.idents[name]; found {
-			return ident
-		}
-	}
-	return nil
-}
-
-// FindIdentInScope returns the named ident binding in the innermost scope.
-// Returns nil if no such binding exists.
-// Scopes must have at least one group.
-func (s *Scopes) FindIdentInScope(name string) *exprpb.Decl {
-	if ident, found := s.scopes[len(s.scopes)-1].idents[name]; found {
+	if ident, found := s.scopes.idents[name]; found {
 		return ident
 	}
+	if s.parent != nil {
+		return s.parent.FindIdent(name)
+	}
 	return nil
 }
 
-// AddFunction adds the function Decl in the outermost scope.
-// Any previous entry for a function of the same name is overwritten.
-// Scopes must have at least one group.
+// AddFunction adds the function Decl to the current scope.
+// Note: any previous entry for a function in the current scope with the same name is overwritten.
 func (s *Scopes) AddFunction(fn *exprpb.Decl) {
-	s.scopes[0].functions[fn.Name] = fn
+	s.scopes.functions[fn.Name] = fn
 }
 
 // FindFunction finds the first function Decl with a matching name in Scopes.
 // The search is performed from innermost to outermost.
 // Returns nil if no such function in Scopes.
 func (s *Scopes) FindFunction(name string) *exprpb.Decl {
-	for i := len(s.scopes) - 1; i >= 0; i-- {
-		scope := s.scopes[i]
-		if fn, found := scope.functions[name]; found {
-			return fn
-		}
+	if fn, found := s.scopes.functions[name]; found {
+		return fn
+	}
+	if s.parent != nil {
+		return s.parent.FindFunction(name)
 	}
 	return nil
 }

--- a/checker/env.go
+++ b/checker/env.go
@@ -39,9 +39,8 @@ const (
 // It consists of a Packager, a Type Provider, declarations, and collection of errors encountered
 // during checking.
 type Env struct {
-	packager packages.Packager
-	provider ref.TypeProvider
-
+	packager       packages.Packager
+	provider       ref.TypeProvider
 	declarations   *decls.Scopes
 	aggLitElemType aggregateLiteralElementType
 }
@@ -289,15 +288,26 @@ func getObjectWellKnownType(t *exprpb.Type) *exprpb.Type {
 	return pb.CheckedWellKnowns[t.GetMessageType()]
 }
 
-// enterScope pushes a new declaration set onto the stack, to ensure variables
-// and function identifiers are appropriately shadowed / enclosed as needed.
-func (e *Env) enterScope() {
-	e.declarations.Push()
+// enterScope creates a new Env instance with a new innermost declaration scope.
+func (e *Env) enterScope() *Env {
+	childDecls := e.declarations.Push()
+	return &Env{
+		declarations:   childDecls,
+		packager:       e.packager,
+		provider:       e.provider,
+		aggLitElemType: e.aggLitElemType,
+	}
 }
 
-// exitScope pops the local declarations of the current frame.
-func (e *Env) exitScope() {
-	e.declarations.Pop()
+// exitScope creates a new Env instance with the nearest outer declaration scope.
+func (e *Env) exitScope() *Env {
+	parentDecls := e.declarations.Pop()
+	return &Env{
+		declarations:   parentDecls,
+		packager:       e.packager,
+		provider:       e.provider,
+		aggLitElemType: e.aggLitElemType,
+	}
 }
 
 // errorMsg is a type alias meant to represent error-based return values which


### PR DESCRIPTION
The internal checker construction is quite expensive and being performed on every
call to the `cel.Env#Check`. This change moves construction of the internal environment
up to the `cel.NewEnv` call where it ought to be.

Also, there was a previously unchecked error on environment construction that's being
surfaced now