### PR TITLE
Update the CEL Go Workspace to CEL Spec v0.2.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,7 +36,7 @@ go_repository(
 
 git_repository(
   name = "com_google_cel_spec",
-  tag = "v0.1.0",
+  tag = "v0.2.0",
   remote = "https://github.com/google/cel-spec.git",
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/antlr/antlr4 v0.0.0-20190223165740-dade65a895c2
 	github.com/golang/protobuf v1.3.0
-	github.com/google/cel-spec v0.1.0
+	github.com/google/cel-spec v0.2.0
 	golang.org/x/text v0.3.0
 	google.golang.org/genproto v0.0.0-20190227213309-4f5b463f9597
 	google.golang.org/grpc v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.0 h1:kbxbvI4Un1LUWKxufD+BiE6AEExYYgkQLQmLFqA1LFk=
 github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
-github.com/google/cel-spec v0.1.0 h1:bO1WtpfyGPxISJwaA5eYJuYO/yG5ksyGhisv2rxGGXo=
-github.com/google/cel-spec v0.1.0/go.mod h1:MjQm800JAGhOZXI7vatnVpmIaFTR6L8FHcKk+piiKpI=
+github.com/google/cel-spec v0.2.0 h1:tmJ8gs1R0XuhxKfYPQl1/4xPvSUYHjMRxilAA9M0ZSM=
+github.com/google/cel-spec v0.2.0/go.mod h1:MjQm800JAGhOZXI7vatnVpmIaFTR6L8FHcKk+piiKpI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=


### PR DESCRIPTION
Update the `WORKSPACE` and `go.mod` file prior to tagging the CEL Go v0.2.0 release.