### PR TITLE
Remove support for proto field iteration.

### DIFF
--- a/common/types/object.go
+++ b/common/types/object.go
@@ -22,7 +22,6 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/cel-go/common/types/pb"
 	"github.com/google/cel-go/common/types/ref"
-	"github.com/google/cel-go/common/types/traits"
 )
 
 type protoObj struct {
@@ -127,41 +126,12 @@ func (o *protoObj) Get(index ref.Val) ref.Val {
 	return NewErr("no such field '%s'", index)
 }
 
-func (o *protoObj) Iterator() traits.Iterator {
-	return &msgIterator{
-		baseIterator: &baseIterator{},
-		refValue:     o.refValue,
-		typeDesc:     o.typeDesc,
-		cursor:       0}
-}
-
 func (o *protoObj) Type() ref.Type {
 	return o.typeValue
 }
 
 func (o *protoObj) Value() interface{} {
 	return o.value
-}
-
-type msgIterator struct {
-	*baseIterator
-	refValue reflect.Value
-	typeDesc *pb.TypeDescription
-	cursor   int
-	len      int
-}
-
-func (it *msgIterator) HasNext() ref.Val {
-	return Bool(it.cursor < it.typeDesc.FieldCount())
-}
-
-func (it *msgIterator) Next() ref.Val {
-	if it.HasNext() == False {
-		return nil
-	}
-	fieldName, _ := it.typeDesc.FieldNameAtIndex(it.cursor, it.refValue)
-	it.cursor++
-	return String(fieldName)
 }
 
 var (

--- a/common/types/object_test.go
+++ b/common/types/object_test.go
@@ -20,9 +20,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
-	"github.com/google/cel-go/test"
 
 	anypb "github.com/golang/protobuf/ptypes/any"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
@@ -44,19 +42,6 @@ func TestNewProtoObject(t *testing.T) {
 	call := expr.Get(String("call_expr")).(traits.Indexer)
 	if call.Get(String("function")).Equal(String("")) != True {
 		t.Errorf("Could not traverse through default values for unset fields")
-	}
-}
-
-func TestProtoObject_Iterator(t *testing.T) {
-	reg := NewRegistry(&exprpb.Expr{})
-	existsMsg := reg.NativeToValue(test.Exists.Expr).(traits.Iterable)
-	it := existsMsg.Iterator()
-	var fields []ref.Val
-	for it.HasNext() == True {
-		fields = append(fields, it.Next())
-	}
-	if !reflect.DeepEqual(fields, []ref.Val{String("id"), String("comprehension_expr")}) {
-		t.Errorf("Got %v, wanted %v", fields, []interface{}{"id", "comprehension_expr"})
 	}
 }
 

--- a/common/types/type.go
+++ b/common/types/type.go
@@ -49,8 +49,7 @@ func NewTypeValue(name string, traits ...int) *TypeValue {
 func NewObjectTypeValue(name string) *TypeValue {
 	return NewTypeValue(name,
 		traits.FieldTesterType,
-		traits.IndexerType,
-		traits.IterableType)
+		traits.IndexerType)
 }
 
 // ConvertToNative implements ref.Val.ConvertToNative.


### PR DESCRIPTION
Proto field iteration was a feature of limited use which was not possible to represent
within the `checker.go` implementation. Removing this complicated bit of code that was
only ever partially implemented.