### PR TITLE
Missing contains override fix

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -446,8 +446,8 @@ func Benchmark_EvalOptions(b *testing.B) {
 			decls.NewIdent("ar", decls.NewMapType(decls.String, decls.String), nil),
 		),
 	)
-	past, _ := e.Parse("ai == 20 || ar['foo'] == 'bar'")
-	cast, _ := e.Check(past)
+	pAst, _ := e.Parse("ai == 20 || ar['foo'] == 'bar'")
+	cAst, _ := e.Check(pAst)
 	vars := map[string]interface{}{
 		"ai": 2,
 		"ar": map[string]string{
@@ -462,7 +462,7 @@ func Benchmark_EvalOptions(b *testing.B) {
 	}
 	for k, opt := range opts {
 		b.Run(k, func(bb *testing.B) {
-			prg, _ := e.Program(cast, EvalOptions(opt))
+			prg, _ := e.Program(cAst, EvalOptions(opt))
 			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < bb.N; i++ {

--- a/common/types/bool.go
+++ b/common/types/bool.go
@@ -40,12 +40,12 @@ var (
 	True  = Bool(true)
 )
 
-// Compare implements traits.Comparer.Compare.
+// Compare implements the traits.Comparer interface method.
 func (b Bool) Compare(other ref.Val) ref.Val {
-	if BoolType != other.Type() {
+	otherBool, ok := other.(Bool)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	otherBool := other.(Bool)
 	if b == otherBool {
 		return IntZero
 	}
@@ -55,7 +55,7 @@ func (b Bool) Compare(other ref.Val) ref.Val {
 	return IntOne
 }
 
-// ConvertToNative implements ref.Val.ConvertToNative.
+// ConvertToNative implements the ref.Val interface method.
 func (b Bool) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	switch typeDesc.Kind() {
 	case reflect.Bool:
@@ -78,7 +78,7 @@ func (b Bool) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	return nil, fmt.Errorf("type conversion error from bool to '%v'", typeDesc)
 }
 
-// ConvertToType implements ref.Val.ConvertToType.
+// ConvertToType implements the ref.Val interface method.
 func (b Bool) ConvertToType(typeVal ref.Type) ref.Val {
 	switch typeVal {
 	case StringType:
@@ -91,25 +91,26 @@ func (b Bool) ConvertToType(typeVal ref.Type) ref.Val {
 	return NewErr("type conversion error from '%v' to '%v'", BoolType, typeVal)
 }
 
-// Equal implements ref.Val.Equal.
+// Equal implements the ref.Val interface method.
 func (b Bool) Equal(other ref.Val) ref.Val {
-	if BoolType != other.Type() {
+	otherBool, ok := other.(Bool)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return Bool(b == other.(Bool))
+	return Bool(b == otherBool)
 }
 
-// Negate implements traits.Negater.Negate.
+// Negate implements the traits.Negater interface method.
 func (b Bool) Negate() ref.Val {
 	return !b
 }
 
-// Type implements ref.Val.Type.
+// Type implements the ref.Val interface method.
 func (b Bool) Type() ref.Type {
 	return BoolType
 }
 
-// Value implements ref.Val.Value.
+// Value implements the ref.Val interface method.
 func (b Bool) Value() interface{} {
 	return bool(b)
 }

--- a/common/types/bytes.go
+++ b/common/types/bytes.go
@@ -35,23 +35,25 @@ var (
 		traits.SizerType)
 )
 
-// Add implements traits.Adder.Add by concatenating byte sequences.
+// Add implements traits.Adder interface method by concatenating byte sequences.
 func (b Bytes) Add(other ref.Val) ref.Val {
-	if BytesType != other.Type() {
+	otherBytes, ok := other.(Bytes)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return append(b, other.(Bytes)...)
+	return append(b, otherBytes...)
 }
 
-// Compare implments traits.Comparer.Compare by lexicographic ordering.
+// Compare implments traits.Comparer interface method by lexicographic ordering.
 func (b Bytes) Compare(other ref.Val) ref.Val {
-	if BytesType != other.Type() {
+	otherBytes, ok := other.(Bytes)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return Int(bytes.Compare(b, other.(Bytes)))
+	return Int(bytes.Compare(b, otherBytes))
 }
 
-// ConvertToNative implements ref.Val.ConvertToNative.
+// ConvertToNative implements the ref.Val interface method.
 func (b Bytes) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	switch typeDesc.Kind() {
 	case reflect.Array, reflect.Slice:
@@ -66,7 +68,7 @@ func (b Bytes) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	return nil, fmt.Errorf("type conversion error from Bytes to '%v'", typeDesc)
 }
 
-// ConvertToType implements ref.Val.ConvertToType.
+// ConvertToType implements the ref.Val interface method.
 func (b Bytes) ConvertToType(typeVal ref.Type) ref.Val {
 	switch typeVal {
 	case StringType:
@@ -79,25 +81,26 @@ func (b Bytes) ConvertToType(typeVal ref.Type) ref.Val {
 	return NewErr("type conversion error from '%s' to '%s'", BytesType, typeVal)
 }
 
-// Equal implements ref.Val.Equal.
+// Equal implements the ref.Val interface method.
 func (b Bytes) Equal(other ref.Val) ref.Val {
-	if BytesType != other.Type() {
+	otherBytes, ok := other.(Bytes)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return Bool(bytes.Equal(b, other.(Bytes)))
+	return Bool(bytes.Equal(b, otherBytes))
 }
 
-// Size implements traits.Sizer.Size.
+// Size implements the traits.Sizer interface method.
 func (b Bytes) Size() ref.Val {
 	return Int(len(b))
 }
 
-// Type implements ref.Val.Type.
+// Type implements the ref.Val interface method.
 func (b Bytes) Type() ref.Type {
 	return BytesType
 }
 
-// Value implements ref.Val.Value.
+// Value implements the ref.Val interface method.
 func (b Bytes) Value() interface{} {
 	return []byte(b)
 }

--- a/common/types/double.go
+++ b/common/types/double.go
@@ -40,21 +40,23 @@ var (
 
 // Add implements traits.Adder.Add.
 func (d Double) Add(other ref.Val) ref.Val {
-	if DoubleType != other.Type() {
+	otherDouble, ok := other.(Double)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return d + other.(Double)
+	return d + otherDouble
 }
 
 // Compare implements traits.Comparer.Compare.
 func (d Double) Compare(other ref.Val) ref.Val {
-	if DoubleType != other.Type() {
+	otherDouble, ok := other.(Double)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	if d < other.(Double) {
+	if d < otherDouble {
 		return IntNegOne
 	}
-	if d > other.(Double) {
+	if d > otherDouble {
 		return IntOne
 	}
 	return IntZero
@@ -108,27 +110,30 @@ func (d Double) ConvertToType(typeVal ref.Type) ref.Val {
 
 // Divide implements traits.Divider.Divide.
 func (d Double) Divide(other ref.Val) ref.Val {
-	if DoubleType != other.Type() {
+	otherDouble, ok := other.(Double)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return d / other.(Double)
+	return d / otherDouble
 }
 
 // Equal implements ref.Val.Equal.
 func (d Double) Equal(other ref.Val) ref.Val {
-	if DoubleType != other.Type() {
+	otherDouble, ok := other.(Double)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
 	// TODO: Handle NaNs properly.
-	return Bool(d == other.(Double))
+	return Bool(d == otherDouble)
 }
 
 // Multiply implements traits.Multiplier.Multiply.
 func (d Double) Multiply(other ref.Val) ref.Val {
-	if DoubleType != other.Type() {
+	otherDouble, ok := other.(Double)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return d * other.(Double)
+	return d * otherDouble
 }
 
 // Negate implements traits.Negater.Negate.
@@ -138,10 +143,11 @@ func (d Double) Negate() ref.Val {
 
 // Subtract implements traits.Subtractor.Subtract.
 func (d Double) Subtract(subtrahend ref.Val) ref.Val {
-	if DoubleType != subtrahend.Type() {
+	subtraDouble, ok := subtrahend.(Double)
+	if !ok {
 		return ValOrErr(subtrahend, "no such overload")
 	}
-	return d - subtrahend.(Double)
+	return d - subtraDouble
 }
 
 // Type implements ref.Val.Type.

--- a/common/types/duration.go
+++ b/common/types/duration.go
@@ -78,14 +78,15 @@ func (d Duration) Add(other ref.Val) ref.Val {
 
 // Compare implements traits.Comparer.Compare.
 func (d Duration) Compare(other ref.Val) ref.Val {
-	if DurationType != other.Type() {
+	otherDur, ok := other.(Duration)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
 	dur1, err := ptypes.Duration(d.Duration)
 	if err != nil {
 		return &Err{err}
 	}
-	dur2, err := ptypes.Duration(other.(Duration).Duration)
+	dur2, err := ptypes.Duration(otherDur.Duration)
 	if err != nil {
 		return &Err{err}
 	}
@@ -133,10 +134,11 @@ func (d Duration) ConvertToType(typeVal ref.Type) ref.Val {
 
 // Equal implements ref.Val.Equal.
 func (d Duration) Equal(other ref.Val) ref.Val {
-	if DurationType != other.Type() {
+	otherDur, ok := other.(Duration)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return Bool(proto.Equal(d.Duration, other.Value().(proto.Message)))
+	return Bool(proto.Equal(d.Duration, otherDur.Value().(proto.Message)))
 }
 
 // Negate implements traits.Negater.Negate.
@@ -164,10 +166,11 @@ func (d Duration) Receive(function string, overload string, args []ref.Val) ref.
 
 // Subtract implements traits.Subtractor.Subtract.
 func (d Duration) Subtract(subtrahend ref.Val) ref.Val {
-	if DurationType != subtrahend.Type() {
+	subtraDur, ok := subtrahend.(Duration)
+	if !ok {
 		return ValOrErr(subtrahend, "no such overload")
 	}
-	return d.Add(subtrahend.(Duration).Negate())
+	return d.Add(subtraDur.Negate())
 }
 
 // Type implements ref.Val.Type.

--- a/common/types/err.go
+++ b/common/types/err.go
@@ -40,6 +40,9 @@ func NewErr(format string, args ...interface{}) ref.Val {
 // ValOrErr either returns the existing error or create a new one.
 // TODO: Audit the use of this function and standardize the error messages and codes.
 func ValOrErr(val ref.Val, format string, args ...interface{}) ref.Val {
+	if val == nil {
+		return NewErr(format, args...)
+	}
 	switch val.Type() {
 	case ErrType, UnknownType:
 		return val

--- a/common/types/int.go
+++ b/common/types/int.go
@@ -49,21 +49,23 @@ var (
 
 // Add implements traits.Adder.Add.
 func (i Int) Add(other ref.Val) ref.Val {
-	if IntType != other.Type() {
+	otherInt, ok := other.(Int)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return i + other.(Int)
+	return i + otherInt
 }
 
 // Compare implements traits.Comparer.Compare.
 func (i Int) Compare(other ref.Val) ref.Val {
-	if IntType != other.Type() {
+	otherInt, ok := other.(Int)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	if i < other.(Int) {
+	if i < otherInt {
 		return IntNegOne
 	}
-	if i > other.(Int) {
+	if i > otherInt {
 		return IntOne
 	}
 	return IntZero
@@ -117,10 +119,10 @@ func (i Int) ConvertToType(typeVal ref.Type) ref.Val {
 
 // Divide implements traits.Divider.Divide.
 func (i Int) Divide(other ref.Val) ref.Val {
-	if IntType != other.Type() {
+	otherInt, ok := other.(Int)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	otherInt := other.(Int)
 	if otherInt == IntZero {
 		return NewErr("divide by zero")
 	}
@@ -129,18 +131,19 @@ func (i Int) Divide(other ref.Val) ref.Val {
 
 // Equal implements ref.Val.Equal.
 func (i Int) Equal(other ref.Val) ref.Val {
-	if IntType != other.Type() {
+	otherInt, ok := other.(Int)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return Bool(i == other.(Int))
+	return Bool(i == otherInt)
 }
 
 // Modulo implements traits.Modder.Modulo.
 func (i Int) Modulo(other ref.Val) ref.Val {
-	if IntType != other.Type() {
+	otherInt, ok := other.(Int)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	otherInt := other.(Int)
 	if otherInt == IntZero {
 		return NewErr("modulus by zero")
 	}
@@ -149,10 +152,11 @@ func (i Int) Modulo(other ref.Val) ref.Val {
 
 // Multiply implements traits.Multiplier.Multiply.
 func (i Int) Multiply(other ref.Val) ref.Val {
-	if IntType != other.Type() {
+	otherInt, ok := other.(Int)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return i * other.(Int)
+	return i * otherInt
 }
 
 // Negate implements traits.Negater.Negate.
@@ -162,10 +166,11 @@ func (i Int) Negate() ref.Val {
 
 // Subtract implements traits.Subtractor.Subtract.
 func (i Int) Subtract(subtrahend ref.Val) ref.Val {
-	if IntType != subtrahend.Type() {
+	subtraInt, ok := subtrahend.(Int)
+	if !ok {
 		return ValOrErr(subtrahend, "no such overload")
 	}
-	return i - subtrahend.(Int)
+	return i - subtraInt
 }
 
 // Type implements ref.Val.Type.

--- a/common/types/json_list.go
+++ b/common/types/json_list.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	structpb "github.com/golang/protobuf/ptypes/struct"
+
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 )
@@ -66,6 +67,10 @@ func (l *jsonListValue) Contains(elem ref.Val) ref.Val {
 		val := l.Get(i)
 		cmp := elem.Equal(val)
 		b, ok := cmp.(Bool)
+		// When there is an error on the contain check, this is not necessarily terminal.
+		// The contains call could find the element and return True, just as though the user
+		// had written a per-element comparison in an exists() macro or logical ||, e.g.
+		//    list.exists(e, e == elem)
 		if !ok && err == nil {
 			err = ValOrErr(cmp, "no such overload")
 		}

--- a/common/types/json_list.go
+++ b/common/types/json_list.go
@@ -58,10 +58,23 @@ func (l *jsonListValue) Add(other ref.Val) ref.Val {
 }
 
 func (l *jsonListValue) Contains(elem ref.Val) ref.Val {
+	if IsUnknownOrError(elem) {
+		return elem
+	}
+	var err ref.Val
 	for i := Int(0); i < l.Size().(Int); i++ {
-		if l.Get(i).Equal(elem) == True {
+		val := l.Get(i)
+		cmp := elem.Equal(val)
+		b, ok := cmp.(Bool)
+		if !ok && err == nil {
+			err = ValOrErr(cmp, "no such overload")
+		}
+		if b == True {
 			return True
 		}
+	}
+	if err != nil {
+		return err
 	}
 	return False
 }
@@ -133,10 +146,10 @@ func (l *jsonListValue) Equal(other ref.Val) ref.Val {
 }
 
 func (l *jsonListValue) Get(index ref.Val) ref.Val {
-	if IntType != index.Type() {
+	i, ok := index.(Int)
+	if !ok {
 		return ValOrErr(index, "unsupported index type: '%v", index.Type())
 	}
-	i := index.(Int)
 	if i < 0 || i >= l.Size().(Int) {
 		return NewErr("index '%d' out of range in list size '%d'", i, l.Size())
 	}

--- a/common/types/json_list_test.go
+++ b/common/types/json_list_test.go
@@ -48,15 +48,32 @@ func TestJsonListValue_Add(t *testing.T) {
 	}
 }
 
-func TestJsonListValue_Contains(t *testing.T) {
+func TestJsonListValue_Contains_SingleElemType(t *testing.T) {
+	list := NewJSONList(NewRegistry(), &structpb.ListValue{Values: []*structpb.Value{
+		{Kind: &structpb.Value_NumberValue{NumberValue: 3.3}},
+		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
+	if !list.Contains(Double(1)).(Bool) {
+		t.Error("Expected value list to contain number '1'")
+	}
+	if list.Contains(Double(2)).(Bool) {
+		t.Error("Expected value list to not contain number '2'")
+	}
+}
+
+func TestJsonListValue_Contains_MixedElemType(t *testing.T) {
 	list := NewJSONList(NewRegistry(), &structpb.ListValue{Values: []*structpb.Value{
 		{Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 		{Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
 	if !list.Contains(Double(1)).(Bool) {
 		t.Error("Expected value list to contain number '1'", list)
 	}
-	if list.Contains(Double(2)).(Bool) {
-		t.Error("Expected value list to not contain number '2'", list)
+	// Contains is semantically equivalent to unrolling the list and
+	// applying a series of logical ORs between the first input value
+	// each element in the list. When the value is present, the result
+	// can be True. When the value is not present and the list is of
+	// mixed element type, the result is an error.
+	if !IsError(list.Contains(Double(2))) {
+		t.Error("Expected value list to not contain number '2' and error", list)
 	}
 }
 

--- a/common/types/json_list_test.go
+++ b/common/types/json_list_test.go
@@ -20,9 +20,8 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	structpb "github.com/golang/protobuf/ptypes/struct"
-
 	anypb "github.com/golang/protobuf/ptypes/any"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 )
 
 func TestJsonListValue_Add(t *testing.T) {

--- a/common/types/json_struct.go
+++ b/common/types/json_struct.go
@@ -43,6 +43,7 @@ func NewJSONStruct(adapter ref.TypeAdapter, st *structpb.Struct) traits.Mapper {
 }
 
 func (m *jsonStruct) Contains(index ref.Val) ref.Val {
+	// FIXME: This is broken.
 	return Bool(!IsError(m.Get(index)))
 }
 

--- a/common/types/json_struct.go
+++ b/common/types/json_struct.go
@@ -43,6 +43,7 @@ func NewJSONStruct(adapter ref.TypeAdapter, st *structpb.Struct) traits.Mapper {
 	return &jsonStruct{TypeAdapter: adapter, Struct: st}
 }
 
+// Contains implements the traits.Container interface method.
 func (m *jsonStruct) Contains(index ref.Val) ref.Val {
 	val, found := m.Find(index)
 	// When the index is not found and val is non-nil, this is an error or unknown value.
@@ -52,6 +53,7 @@ func (m *jsonStruct) Contains(index ref.Val) ref.Val {
 	return Bool(found)
 }
 
+// ConvertToNative implements the ref.Val interface method.
 func (m *jsonStruct) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	switch typeDesc.Kind() {
 	case reflect.Map:
@@ -100,6 +102,7 @@ func (m *jsonStruct) ConvertToNative(typeDesc reflect.Type) (interface{}, error)
 			" map type: google.protobuf.Struct, native type: %v", typeDesc)
 }
 
+// ConvertToType implements the ref.Val interface method.
 func (m *jsonStruct) ConvertToType(typeVal ref.Type) ref.Val {
 	switch typeVal {
 	case MapType:
@@ -110,6 +113,7 @@ func (m *jsonStruct) ConvertToType(typeVal ref.Type) ref.Val {
 	return NewErr("type conversion error from '%s' to '%s'", MapType, typeVal)
 }
 
+// Equal implements the ref.Val interface method.
 func (m *jsonStruct) Equal(other ref.Val) ref.Val {
 	if MapType != other.Type() {
 		return ValOrErr(other, "no such overload")
@@ -130,13 +134,14 @@ func (m *jsonStruct) Equal(other ref.Val) ref.Val {
 			return ValOrErr(otherVal, "no such overload")
 		}
 		valEq := thisVal.Equal(otherVal)
-		if valEq == False || IsUnknownOrError(valEq) {
+		if valEq != True {
 			return valEq
 		}
 	}
 	return True
 }
 
+// Find implements the traits.Mapper interface method.
 func (m *jsonStruct) Find(key ref.Val) (ref.Val, bool) {
 	strKey, ok := key.(String)
 	if !ok {
@@ -150,6 +155,7 @@ func (m *jsonStruct) Find(key ref.Val) (ref.Val, bool) {
 	return m.NativeToValue(value), found
 }
 
+// Get implements the traits.Indexer interface method.
 func (m *jsonStruct) Get(key ref.Val) ref.Val {
 	v, found := m.Find(key)
 	if !found {
@@ -158,6 +164,7 @@ func (m *jsonStruct) Get(key ref.Val) ref.Val {
 	return v
 }
 
+// Iterator implements the traits.Iterable interface method.
 func (m *jsonStruct) Iterator() traits.Iterator {
 	f := m.GetFields()
 	keys := make([]string, len(m.GetFields()))
@@ -172,14 +179,17 @@ func (m *jsonStruct) Iterator() traits.Iterator {
 		mapKeys:      keys}
 }
 
+// Size implements the traits.Sizer interface method.
 func (m *jsonStruct) Size() ref.Val {
 	return Int(len(m.GetFields()))
 }
 
+// Type implements the ref.Val interface method.
 func (m *jsonStruct) Type() ref.Type {
 	return MapType
 }
 
+// Value implements the ref.Val interface method.
 func (m *jsonStruct) Value() interface{} {
 	return m.Struct
 }
@@ -191,10 +201,12 @@ type jsonValueMapIterator struct {
 	mapKeys []string
 }
 
+// HasNext implements the traits.Iterator interface method.
 func (it *jsonValueMapIterator) HasNext() ref.Val {
 	return Bool(it.cursor < it.len)
 }
 
+// Next implements the traits.Iterator interface method.
 func (it *jsonValueMapIterator) Next() ref.Val {
 	if it.HasNext() == True {
 		index := it.cursor

--- a/common/types/json_struct.go
+++ b/common/types/json_struct.go
@@ -44,8 +44,8 @@ func NewJSONStruct(adapter ref.TypeAdapter, st *structpb.Struct) traits.Mapper {
 }
 
 func (m *jsonStruct) Contains(index ref.Val) ref.Val {
-	// FIXME: This is broken.
 	val, found := m.Find(index)
+	// When the index is not found and val is non-nil, this is an error or unknown value.
 	if !found && val != nil && IsUnknownOrError(val) {
 		return val
 	}
@@ -140,7 +140,7 @@ func (m *jsonStruct) Equal(other ref.Val) ref.Val {
 func (m *jsonStruct) Find(key ref.Val) (ref.Val, bool) {
 	strKey, ok := key.(String)
 	if !ok {
-		return ValOrErr(key, "unsupported key type: '%v", key.Type()), false
+		return ValOrErr(key, "no such overload"), false
 	}
 	fields := m.Struct.GetFields()
 	value, found := fields[string(strKey)]

--- a/common/types/json_struct_test.go
+++ b/common/types/json_struct_test.go
@@ -123,15 +123,6 @@ func TestJsonStruct_Equal(t *testing.T) {
 		&structpb.Struct{Fields: map[string]*structpb.Value{
 			"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
 			"second": {Kind: &structpb.Value_NumberValue{NumberValue: 4}}}})
-
-	otherVal := NewJSONStruct(reg,
-		&structpb.Struct{Fields: map[string]*structpb.Value{
-			"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
-			"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
-	if mapVal.Equal(otherVal) != False {
-		t.Errorf("Got equals 'true', expected 'false' for '%v' == '%v'",
-			mapVal, otherVal)
-	}
 	if mapVal.Equal(mapVal) != True {
 		t.Error("Map was not equal to itself.")
 	}
@@ -140,6 +131,30 @@ func TestJsonStruct_Equal(t *testing.T) {
 	}
 	if !IsError(mapVal.Equal(String(""))) {
 		t.Error("Map equal to a non-map type returned non-error.")
+	}
+
+	other := NewJSONStruct(reg,
+		&structpb.Struct{Fields: map[string]*structpb.Value{
+			"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+			"second": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}}})
+	if mapVal.Equal(other) != False {
+		t.Errorf("Got equals 'true', expected 'false' for '%v' == '%v'",
+			mapVal, other)
+	}
+	other = NewJSONStruct(reg,
+		&structpb.Struct{Fields: map[string]*structpb.Value{
+			"first": {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+			"third": {Kind: &structpb.Value_NumberValue{NumberValue: 4}}}})
+	if mapVal.Equal(other) != False {
+		t.Errorf("Got equals 'true', expected 'false' for '%v' == '%v'",
+			mapVal, other)
+	}
+	mismatch := NewDynamicMap(reg,
+		map[int]interface{}{
+			1: "hello",
+			2: "world"})
+	if !IsError(mapVal.Equal(mismatch)) {
+		t.Error("Key type mismatch did not result in error")
 	}
 }
 

--- a/common/types/json_struct_test.go
+++ b/common/types/json_struct_test.go
@@ -20,9 +20,8 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	structpb "github.com/golang/protobuf/ptypes/struct"
-
 	anypb "github.com/golang/protobuf/ptypes/any"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 )
 
 func TestJsonStruct_Contains(t *testing.T) {

--- a/common/types/list.go
+++ b/common/types/list.go
@@ -83,10 +83,23 @@ func (l *baseList) Add(other ref.Val) ref.Val {
 }
 
 func (l *baseList) Contains(elem ref.Val) ref.Val {
+	if IsUnknownOrError(elem) {
+		return elem
+	}
+	var err ref.Val
 	for i := Int(0); i < l.Size().(Int); i++ {
-		if l.Get(i).Equal(elem) == True {
+		val := l.Get(i)
+		cmp := elem.Equal(val)
+		b, ok := cmp.(Bool)
+		if !ok && err == nil {
+			err = ValOrErr(cmp, "no such overload")
+		}
+		if b == True {
 			return True
 		}
+	}
+	if err != nil {
+		return err
 	}
 	return False
 }
@@ -170,10 +183,10 @@ func (l *baseList) Equal(other ref.Val) ref.Val {
 }
 
 func (l *baseList) Get(index ref.Val) ref.Val {
-	if index.Type() != IntType {
+	i, ok := index.(Int)
+	if !ok {
 		return ValOrErr(index, "unsupported index type '%s' in list", index.Type())
 	}
-	i := index.(Int)
 	if i < 0 || i >= l.Size().(Int) {
 		return NewErr("index '%d' out of range in list size '%d'", i, l.Size())
 	}

--- a/common/types/list.go
+++ b/common/types/list.go
@@ -260,17 +260,23 @@ func (l *concatList) Add(other ref.Val) ref.Val {
 
 // Contains implments the traits.Container interface method.
 func (l *concatList) Contains(elem ref.Val) ref.Val {
+	// The concat list relies on the IsErrorOrUnknown checks against the input element to be
+	// performed by the `prevList` and/or `nextList`.
 	prev := l.prevList.Contains(elem)
+	// Short-circuit the return if the elem was found in the prev list.
 	if prev == True {
 		return prev
 	}
+	// Return if the elem was found in the next list.
 	next := l.nextList.Contains(elem)
 	if next == True {
 		return next
 	}
+	// Handle the case where an error or unknown was encountered before checking next.
 	if IsUnknownOrError(prev) {
 		return prev
 	}
+	// Otherwise, rely on the next value as the representative result.
 	return next
 }
 

--- a/common/types/list.go
+++ b/common/types/list.go
@@ -66,6 +66,7 @@ type baseList struct {
 	refValue reflect.Value
 }
 
+// Add implements the traits.Adder interface method.
 func (l *baseList) Add(other ref.Val) ref.Val {
 	if other.Type() != ListType {
 		return ValOrErr(other, "no such overload")
@@ -82,6 +83,7 @@ func (l *baseList) Add(other ref.Val) ref.Val {
 		nextList:    other.(traits.Lister)}
 }
 
+// Contains implements the traits.Container interface method.
 func (l *baseList) Contains(elem ref.Val) ref.Val {
 	if IsUnknownOrError(elem) {
 		return elem
@@ -91,6 +93,10 @@ func (l *baseList) Contains(elem ref.Val) ref.Val {
 		val := l.Get(i)
 		cmp := elem.Equal(val)
 		b, ok := cmp.(Bool)
+		// When there is an error on the contain check, this is not necessarily terminal.
+		// The contains call could find the element and return True, just as though the user
+		// had written a per-element comparison in an exists() macro or logical ||, e.g.
+		//    list.exists(e, e == elem)
 		if !ok && err == nil {
 			err = ValOrErr(cmp, "no such overload")
 		}
@@ -104,6 +110,7 @@ func (l *baseList) Contains(elem ref.Val) ref.Val {
 	return False
 }
 
+// ConvertToNative implements the ref.Val interface method.
 func (l *baseList) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	// JSON conversions are a special case since the 'native' type is a proto message.
 	if typeDesc == jsonValueType || typeDesc == jsonListValueType {
@@ -153,6 +160,7 @@ func (l *baseList) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	return nativeList.Interface(), nil
 }
 
+// ConvertToType implements the ref.Val interface method.
 func (l *baseList) ConvertToType(typeVal ref.Type) ref.Val {
 	switch typeVal {
 	case ListType:
@@ -163,6 +171,7 @@ func (l *baseList) ConvertToType(typeVal ref.Type) ref.Val {
 	return NewErr("type conversion error from '%s' to '%s'", ListType, typeVal)
 }
 
+// Equal implements the ref.Val interface method.
 func (l *baseList) Equal(other ref.Val) ref.Val {
 	if ListType != other.Type() {
 		return ValOrErr(other, "no such overload")
@@ -182,6 +191,7 @@ func (l *baseList) Equal(other ref.Val) ref.Val {
 	return True
 }
 
+// Get implements the traits.Indexer interface method.
 func (l *baseList) Get(index ref.Val) ref.Val {
 	i, ok := index.(Int)
 	if !ok {
@@ -194,6 +204,7 @@ func (l *baseList) Get(index ref.Val) ref.Val {
 	return l.NativeToValue(elem)
 }
 
+// Iterator implements the traits.Iterable interface method.
 func (l *baseList) Iterator() traits.Iterator {
 	return &listIterator{
 		baseIterator: &baseIterator{},
@@ -202,14 +213,17 @@ func (l *baseList) Iterator() traits.Iterator {
 		len:          l.Size().(Int)}
 }
 
+// Size implements the traits.Sizer interface method.
 func (l *baseList) Size() ref.Val {
 	return Int(l.refValue.Len())
 }
 
+// Type implements the ref.Val interface method.
 func (l *baseList) Type() ref.Type {
 	return ListType
 }
 
+// Value implements the ref.Val interface method.
 func (l *baseList) Value() interface{} {
 	return l.value
 }

--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -45,8 +45,11 @@ func TestBaseList_Add_Error(t *testing.T) {
 
 func TestBaseList_Contains(t *testing.T) {
 	list := NewDynamicList(NewRegistry(), []float32{1.0, 2.0, 3.0})
-	if list.Contains(Int(3)) == True {
+	if !IsError(list.Contains(Int(3))) {
 		t.Error("List contains succeeded with wrong type")
+	}
+	if list.Contains(Double(5)) != False {
+		t.Error("List contains did not return false")
 	}
 	if list.Contains(Double(3)) != True {
 		t.Error("List contains did not succeed")

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -64,6 +64,7 @@ var (
 
 func (m *baseMap) Contains(index ref.Val) ref.Val {
 	val, found := m.Find(index)
+	// When the index is not found and val is non-nil, this is an error or unknown value.
 	if !found && val != nil && IsUnknownOrError(val) {
 		return val
 	}
@@ -72,6 +73,7 @@ func (m *baseMap) Contains(index ref.Val) ref.Val {
 
 func (m *stringMap) Contains(index ref.Val) ref.Val {
 	val, found := m.Find(index)
+	// When the index is not found and val is non-nil, this is an error or unknown value.
 	if !found && val != nil && IsUnknownOrError(val) {
 		return val
 	}

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -62,6 +62,7 @@ var (
 		traits.SizerType)
 )
 
+// Contains implements the traits.Container interface method.
 func (m *baseMap) Contains(index ref.Val) ref.Val {
 	val, found := m.Find(index)
 	// When the index is not found and val is non-nil, this is an error or unknown value.
@@ -71,6 +72,7 @@ func (m *baseMap) Contains(index ref.Val) ref.Val {
 	return Bool(found)
 }
 
+// Contains implements the traits.Container interface method.
 func (m *stringMap) Contains(index ref.Val) ref.Val {
 	val, found := m.Find(index)
 	// When the index is not found and val is non-nil, this is an error or unknown value.
@@ -80,6 +82,7 @@ func (m *stringMap) Contains(index ref.Val) ref.Val {
 	return Bool(found)
 }
 
+// ConvertToNative implements the ref.Val interface method.
 func (m *baseMap) ConvertToNative(refType reflect.Type) (interface{}, error) {
 	// JSON conversion.
 	if refType == jsonValueType || refType == jsonStructType {
@@ -138,6 +141,7 @@ func (m *baseMap) ConvertToNative(refType reflect.Type) (interface{}, error) {
 	return nativeMap.Interface(), nil
 }
 
+// ConvertToNative implements the ref.Val interface method.
 func (m *stringMap) ConvertToNative(refType reflect.Type) (interface{}, error) {
 	if !m.baseMap.refValue.IsValid() {
 		m.baseMap.refValue = reflect.ValueOf(m.value)
@@ -145,6 +149,7 @@ func (m *stringMap) ConvertToNative(refType reflect.Type) (interface{}, error) {
 	return m.baseMap.ConvertToNative(refType)
 }
 
+// ConvertToType implements the ref.Val interface method.
 func (m *baseMap) ConvertToType(typeVal ref.Type) ref.Val {
 	switch typeVal {
 	case MapType:
@@ -155,6 +160,7 @@ func (m *baseMap) ConvertToType(typeVal ref.Type) ref.Val {
 	return NewErr("type conversion error from '%s' to '%s'", MapType, typeVal)
 }
 
+// ConvertToType implements the ref.Val interface method.
 func (m *stringMap) ConvertToType(typeVal ref.Type) ref.Val {
 	switch typeVal {
 	case MapType:
@@ -164,6 +170,7 @@ func (m *stringMap) ConvertToType(typeVal ref.Type) ref.Val {
 	}
 }
 
+// Equal implements the ref.Val interface method.
 func (m *baseMap) Equal(other ref.Val) ref.Val {
 	if MapType != other.Type() {
 		return ValOrErr(other, "no such overload")
@@ -184,13 +191,14 @@ func (m *baseMap) Equal(other ref.Val) ref.Val {
 			return ValOrErr(otherVal, "no such overload")
 		}
 		valEq := thisVal.Equal(otherVal)
-		if valEq == False || IsUnknownOrError(valEq) {
+		if valEq != True {
 			return valEq
 		}
 	}
 	return True
 }
 
+// Equal implements the ref.Val interface method.
 func (m *stringMap) Equal(other ref.Val) ref.Val {
 	if !m.baseMap.refValue.IsValid() {
 		m.baseMap.refValue = reflect.ValueOf(m.value)
@@ -198,6 +206,7 @@ func (m *stringMap) Equal(other ref.Val) ref.Val {
 	return m.baseMap.Equal(other)
 }
 
+// Find implements the traits.Mapper interface method.
 func (m *baseMap) Find(key ref.Val) (ref.Val, bool) {
 	// TODO: There are multiple reasons why a Get could fail. Typically, this is because the key
 	// does not exist in the map; however, it's possible that the value cannot be converted to
@@ -218,6 +227,7 @@ func (m *baseMap) Find(key ref.Val) (ref.Val, bool) {
 	return m.NativeToValue(value.Interface()), true
 }
 
+// Find implements the traits.Mapper interface method.
 func (m *stringMap) Find(key ref.Val) (ref.Val, bool) {
 	strKey, ok := key.(String)
 	if !ok {
@@ -230,6 +240,7 @@ func (m *stringMap) Find(key ref.Val) (ref.Val, bool) {
 	return String(val), true
 }
 
+// Get implements the traits.Indexer interface method.
 func (m *baseMap) Get(key ref.Val) ref.Val {
 	v, found := m.Find(key)
 	if !found {
@@ -238,6 +249,7 @@ func (m *baseMap) Get(key ref.Val) ref.Val {
 	return v
 }
 
+// Get implements the traits.Indexer interface method.
 func (m *stringMap) Get(key ref.Val) ref.Val {
 	v, found := m.Find(key)
 	if !found {
@@ -246,6 +258,7 @@ func (m *stringMap) Get(key ref.Val) ref.Val {
 	return v
 }
 
+// Iterator implements the traits.Iterable interface method.
 func (m *baseMap) Iterator() traits.Iterator {
 	mapKeys := m.refValue.MapKeys()
 	return &mapIterator{
@@ -257,6 +270,7 @@ func (m *baseMap) Iterator() traits.Iterator {
 		len:          int(m.Size().(Int))}
 }
 
+// Iterator implements the traits.Iterable interface method.
 func (m *stringMap) Iterator() traits.Iterator {
 	if !m.baseMap.refValue.IsValid() {
 		m.baseMap.refValue = reflect.ValueOf(m.value)
@@ -264,18 +278,22 @@ func (m *stringMap) Iterator() traits.Iterator {
 	return m.baseMap.Iterator()
 }
 
+// Size implements the traits.Sizer interface method.
 func (m *baseMap) Size() ref.Val {
 	return Int(m.refValue.Len())
 }
 
+// Size implements the traits.Sizer interface method.
 func (m *stringMap) Size() ref.Val {
 	return Int(len(m.mapStrStr))
 }
 
+// Type implements the ref.Val interface method.
 func (m *baseMap) Type() ref.Type {
 	return MapType
 }
 
+// Value implements the ref.Val interface method.
 func (m *baseMap) Value() interface{} {
 	return m.value
 }
@@ -289,10 +307,12 @@ type mapIterator struct {
 	len      int
 }
 
+// HasNext implements the traits.Iterator interface method.
 func (it *mapIterator) HasNext() ref.Val {
 	return Bool(it.cursor < it.len)
 }
 
+// Next implements the traits.Iterator interface method.
 func (it *mapIterator) Next() ref.Val {
 	if it.HasNext() == True {
 		index := it.cursor

--- a/common/types/map_test.go
+++ b/common/types/map_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+
 	"github.com/google/cel-go/common/types/traits"
 )
 
@@ -33,6 +35,25 @@ func TestBaseMap_Contains(t *testing.T) {
 	}
 	if mapValue.Contains(String("unknown")) != False {
 		t.Error("Expected key 'unknown' not contained in map.")
+	}
+	if !IsError(mapValue.Contains(Int(123))) {
+		t.Error("Expected key of Int type would error with 'no such overload'.")
+	}
+	if !reflect.DeepEqual(mapValue.Contains(Unknown{1}), Unknown{1}) {
+		t.Error("Expected Unknown key in would yield Unknown key out.")
+	}
+}
+
+func TestStringMap_Contains(t *testing.T) {
+	reg := NewRegistry()
+	mapValue := NewStringStringMap(reg, map[string]string{
+		"first":  "hello",
+		"second": "world"}).(traits.Mapper)
+	if mapValue.Contains(String("first")) != True {
+		t.Error("Expected key 'first' contained in map.")
+	}
+	if mapValue.Contains(String("third")) != False {
+		t.Error("Expected key 'third' not contained in map.")
 	}
 	if !IsError(mapValue.Contains(Int(123))) {
 		t.Error("Expected key of Int type would error with 'no such overload'.")
@@ -61,7 +82,22 @@ func TestBaseMap_ConvertToNative_Json(t *testing.T) {
 		t.Error(err)
 	}
 	jsonTxt, err := (&jsonpb.Marshaler{}).MarshalToString(json.(proto.Message))
-	if jsonTxt != "{\"nested\":{\"1\":-1}}" {
+	if jsonTxt != `{"nested":{"1":-1}}` {
+		t.Error(jsonTxt)
+	}
+}
+
+func TestStringMap_ConvertToNative_Json(t *testing.T) {
+	reg := NewRegistry()
+	mapValue := NewStringStringMap(reg, map[string]string{
+		"first":  "hello",
+		"second": "world"}).(traits.Mapper)
+	json, err := mapValue.ConvertToNative(jsonStructType)
+	if err != nil {
+		t.Error(err)
+	}
+	jsonTxt, err := (&jsonpb.Marshaler{}).MarshalToString(json.(proto.Message))
+	if jsonTxt != `{"first":"hello","second":"world"}` {
 		t.Error(jsonTxt)
 	}
 }
@@ -69,6 +105,20 @@ func TestBaseMap_ConvertToNative_Json(t *testing.T) {
 func TestBaseMap_ConvertToType(t *testing.T) {
 	reg := NewRegistry()
 	mapValue := NewDynamicMap(reg, map[string]string{"key": "value"})
+	if mapValue.ConvertToType(MapType) != mapValue {
+		t.Error("Map could not be converted to a map.")
+	}
+	if mapValue.ConvertToType(TypeType) != MapType {
+		t.Error("Map type was not listed as a map.")
+	}
+	if !IsError(mapValue.ConvertToType(ListType)) {
+		t.Error("Map conversion to unsupported type was not an error.")
+	}
+}
+
+func TestStringMap_ConvertToType(t *testing.T) {
+	reg := NewRegistry()
+	mapValue := reg.NativeToValue(map[string]string{"key": "value"})
 	if mapValue.ConvertToType(MapType) != mapValue {
 		t.Error("Map could not be converted to a map.")
 	}
@@ -92,20 +142,83 @@ func TestBaseMap_Equal_True(t *testing.T) {
 		t.Error(nestedVal)
 	} else if mapValue.Equal(nestedVal) == True ||
 		nestedVal.Equal(mapValue) == True {
-		t.Error("Same length, but different key names")
+		t.Error("Same length, but different key names did not result in error")
 	}
 }
 
-func TestBaseMap_Equal_False(t *testing.T) {
+func TestStringMap_Equal_True(t *testing.T) {
+	reg := NewRegistry()
+	mapValue := NewStringStringMap(reg, map[string]string{
+		"first":  "hello",
+		"second": "world"})
+	if mapValue.Equal(mapValue) != True {
+		t.Error("Map value was not equal to itself")
+	}
+	equivDyn := NewDynamicMap(reg, map[string]string{
+		"second": "world",
+		"first":  "hello"})
+	if mapValue.Equal(equivDyn) != True {
+		t.Error("Map value equality was key-order dependent")
+	}
+	equivJSON := NewJSONStruct(reg, &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+			"second": {Kind: &structpb.Value_StringValue{StringValue: "world"}},
+		}})
+	if mapValue.Equal(equivJSON) != True && equivJSON.Equal(mapValue) != True {
+		t.Error("Map value was not equivalent to json struct")
+	}
+}
+
+func TestBaseMap_Equal_NotTrue(t *testing.T) {
 	reg := NewRegistry()
 	mapValue := NewDynamicMap(reg, map[string]map[int32]float32{
 		"nested": {1: -1.0, 2: 2.0},
 		"empty":  {}})
-	otherValue := NewDynamicMap(reg, map[string]map[int64]float64{
+	other := NewDynamicMap(reg, map[string]map[int64]float64{
 		"nested": {1: -1.0, 2: 2.0, 3: 3.14},
 		"empty":  {}})
-	if mapValue.Equal(otherValue) != False {
-		t.Error("Inequal maps were deemed equal.")
+	if mapValue.Equal(other) != False {
+		t.Error("Inequal map values were deemed equal.")
+	}
+	other = NewDynamicMap(reg, map[string]map[int64]float64{
+		"nested": {1: -1.0, 2: 2.0, 3: 3.14},
+		"absent": {}})
+	if mapValue.Equal(other) != False {
+		t.Error("Inequal map keys were deemed equal.")
+	}
+}
+
+func TestStringMap_Equal_NotTrue(t *testing.T) {
+	reg := NewRegistry()
+	mapValue := NewStringStringMap(reg, map[string]string{
+		"first":  "hello",
+		"second": "world"})
+	if mapValue.Equal(mapValue) != True {
+		t.Error("Map value was not equal to itself")
+	}
+	other := NewStringStringMap(reg, map[string]string{
+		"second": "world",
+		"first":  "goodbye"})
+	if mapValue.Equal(other) != False {
+		t.Error("Map of same size with same keys and different values not false")
+	}
+	other = NewStringStringMap(reg, map[string]string{
+		"first": "hello"})
+	if mapValue.Equal(other) != False {
+		t.Error("Equality between maps of different size did not return false")
+	}
+	other = NewStringStringMap(reg, map[string]string{
+		"first": "hello",
+		"third": "goodbye"})
+	if mapValue.Equal(other) != False {
+		t.Error("Equality between maps of different size did not return false")
+	}
+	other = NewDynamicMap(reg, map[string]interface{}{
+		"first":  "hello",
+		"second": 1})
+	if !IsError(mapValue.Equal(other)) {
+		t.Error("Equality between maps of different value types did not error")
 	}
 }
 
@@ -121,6 +234,26 @@ func TestBaseMap_Get(t *testing.T) {
 	} else if floatVal.Equal(Double(-1.0)) != True {
 		t.Error("Nested map access of float property not float64")
 	}
+	if !IsError(mapValue.Get(String("absent"))) {
+		t.Error("Got valid result, wanted no such key error.")
+	}
+}
+
+func TestStringMap_Get(t *testing.T) {
+	reg := NewRegistry()
+	mapValue := NewStringStringMap(reg, map[string]string{
+		"first":  "hello",
+		"second": "world"}).(traits.Mapper)
+	val := mapValue.Get(String("first"))
+	if val.Equal(String("hello")) != True {
+		t.Errorf("Got '%v', wanted 'hello'", val)
+	}
+	if !IsError(mapValue.Get(Int(1))) {
+		t.Error("Got real value, wanted error")
+	}
+	if !IsError(mapValue.Get(String("third"))) {
+		t.Error("Got real value, wanted error")
+	}
 }
 
 func TestBaseMap_Iterator(t *testing.T) {
@@ -132,10 +265,11 @@ func TestBaseMap_Iterator(t *testing.T) {
 	var i = 0
 	var fieldNames []interface{}
 	for ; it.HasNext() == True; i++ {
-		if value := mapValue.Get(it.Next()); IsError(value) {
+		fieldName := it.Next()
+		if value := mapValue.Get(fieldName); IsError(value) {
 			t.Error(value)
 		} else {
-			fieldNames = append(fieldNames, value)
+			fieldNames = append(fieldNames, fieldName)
 		}
 	}
 	if len(fieldNames) != 2 {
@@ -143,5 +277,66 @@ func TestBaseMap_Iterator(t *testing.T) {
 	}
 	if it.Next() != nil {
 		t.Error("Iterator ran off the end of the field names")
+	}
+}
+
+func TestStringMap_Iterator(t *testing.T) {
+	reg := NewRegistry()
+	mapValue := NewStringStringMap(reg, map[string]string{
+		"first":  "hello",
+		"second": "world"}).(traits.Mapper)
+	it := mapValue.Iterator()
+	var i = 0
+	var fieldNames []interface{}
+	for ; it.HasNext() == True; i++ {
+		fieldName := it.Next()
+		if value := mapValue.Get(fieldName); IsError(value) {
+			t.Error(value)
+		} else {
+			fieldNames = append(fieldNames, fieldName)
+		}
+	}
+	if len(fieldNames) != 2 {
+		t.Errorf("Did not find the correct number of fields: %v", fieldNames)
+	}
+	fieldsMap := map[string]bool{
+		"first":  false,
+		"second": false,
+	}
+	expectedMap := map[string]bool{
+		"first":  true,
+		"second": true,
+	}
+	for _, fieldName := range fieldNames {
+		key := string(fieldName.(String))
+		if _, found := fieldsMap[key]; found {
+			fieldsMap[key] = true
+		}
+	}
+	if !reflect.DeepEqual(fieldsMap, expectedMap) {
+		t.Errorf("Got '%v', wanted '%v'", fieldsMap, expectedMap)
+	}
+	if it.Next() != nil {
+		t.Error("Iterator ran off the end of the field names")
+	}
+}
+
+func TestBaseMap_Size(t *testing.T) {
+	reg := NewRegistry()
+	mapValue := NewDynamicMap(reg, map[string]int{
+		"first":  1,
+		"second": 2}).(traits.Mapper)
+	if mapValue.Size() != Int(2) {
+		t.Errorf("Got '%v', expected 2", mapValue.Size())
+	}
+}
+
+func TestStringMap_Size(t *testing.T) {
+	reg := NewRegistry()
+	mapValue := NewStringStringMap(reg, map[string]string{
+		"first":  "hello",
+		"second": "world"}).(traits.Mapper)
+	if mapValue.Size() != Int(2) {
+		t.Errorf("Got '%v', expected 2", mapValue.Size())
 	}
 }

--- a/common/types/map_test.go
+++ b/common/types/map_test.go
@@ -32,7 +32,13 @@ func TestBaseMap_Contains(t *testing.T) {
 		t.Error("Expected key 'nested' contained in map.")
 	}
 	if mapValue.Contains(String("unknown")) != False {
-		t.Error("Expected key 'unknown' contained in map.")
+		t.Error("Expected key 'unknown' not contained in map.")
+	}
+	if !IsError(mapValue.Contains(Int(123))) {
+		t.Error("Expected key of Int type would error with 'no such overload'.")
+	}
+	if !reflect.DeepEqual(mapValue.Contains(Unknown{1}), Unknown{1}) {
+		t.Error("Expected Unknown key in would yield Unknown key out.")
 	}
 }
 

--- a/common/types/object.go
+++ b/common/types/object.go
@@ -85,11 +85,12 @@ func (o *protoObj) Equal(other ref.Val) ref.Val {
 
 // IsSet tests whether a field which is defined is set to a non-default value.
 func (o *protoObj) IsSet(field ref.Val) ref.Val {
-	if field.Type() != StringType {
-		return ValOrErr(field, "illegal object field type '%s'", field.Type())
+	protoFieldName, ok := field.(String)
+	if !ok {
+		return ValOrErr(field, "no such overload")
 	}
-	protoFieldName := string(field.(String))
-	if f, found := o.typeDesc.FieldByName(protoFieldName); found {
+	protoFieldStr := string(protoFieldName)
+	if f, found := o.typeDesc.FieldByName(protoFieldStr); found {
 		if !f.IsOneof() {
 			return isFieldSet(o.refValue.Elem().Field(f.Index()))
 		}
@@ -106,11 +107,12 @@ func (o *protoObj) IsSet(field ref.Val) ref.Val {
 }
 
 func (o *protoObj) Get(index ref.Val) ref.Val {
-	if index.Type() != StringType {
-		return ValOrErr(index, "illegal object field type '%s'", index.Type())
+	protoFieldName, ok := index.(String)
+	if !ok {
+		return ValOrErr(index, "no such overload")
 	}
-	protoFieldName := string(index.(String))
-	if f, found := o.typeDesc.FieldByName(protoFieldName); found {
+	protoFieldStr := string(protoFieldName)
+	if f, found := o.typeDesc.FieldByName(protoFieldStr); found {
 		if !f.IsOneof() {
 			return getOrDefaultInstance(o.TypeAdapter, o.refValue.Elem().Field(f.Index()))
 		}

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -364,7 +364,7 @@ func (a *defaultTypeAdapter) NativeToValue(value interface{}) ref.Val {
 	case []string:
 		return NewStringList(a, value.([]string))
 	case map[string]string:
-		return NewStringStringMap(value.(map[string]string))
+		return NewStringStringMap(a, value.(map[string]string))
 	case *dpb.Duration:
 		if ptr := value.(*dpb.Duration); ptr != nil {
 			return Duration{ptr}

--- a/common/types/providers_test.go
+++ b/common/types/providers_test.go
@@ -167,11 +167,11 @@ func TestNativeToValue_Any(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	expected = NewJSONList(reg, &structpb.ListValue{
+	expectedList := NewJSONList(reg, &structpb.ListValue{
 		Values: []*structpb.Value{
 			{Kind: &structpb.Value_StringValue{StringValue: "world"}},
 			{Kind: &structpb.Value_StringValue{StringValue: "five!"}}}})
-	expectNativeToValue(t, anyValue, expected)
+	expectNativeToValue(t, anyValue, expectedList)
 
 	// Object
 	pbMessage := exprpb.ParsedExpr{

--- a/common/types/string.go
+++ b/common/types/string.go
@@ -22,12 +22,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+
 	"github.com/google/cel-go/common/overloads"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
-
-	"github.com/golang/protobuf/ptypes"
-	structpb "github.com/golang/protobuf/ptypes/struct"
 )
 
 // String type implementation which supports addition, comparison, matching,
@@ -52,18 +52,20 @@ var (
 
 // Add implements traits.Adder.Add.
 func (s String) Add(other ref.Val) ref.Val {
-	if StringType != other.Type() {
+	otherString, ok := other.(String)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return s + other.(String)
+	return s + otherString
 }
 
 // Compare implements traits.Comparer.Compare.
 func (s String) Compare(other ref.Val) ref.Val {
-	if StringType != other.Type() {
+	otherString, ok := other.(String)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return Int(strings.Compare(s.Value().(string), other.Value().(string)))
+	return Int(strings.Compare(s.Value().(string), otherString.Value().(string)))
 }
 
 // ConvertToNative implements ref.Val.ConvertToNative.
@@ -131,18 +133,20 @@ func (s String) ConvertToType(typeVal ref.Type) ref.Val {
 
 // Equal implements ref.Val.Equal.
 func (s String) Equal(other ref.Val) ref.Val {
-	if StringType != other.Type() {
+	otherString, ok := other.(String)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return Bool(s == other.(String))
+	return Bool(s == otherString)
 }
 
 // Match implements traits.Matcher.Match.
 func (s String) Match(pattern ref.Val) ref.Val {
-	if pattern.Type() != StringType {
+	pat, ok := pattern.(String)
+	if !ok {
 		return ValOrErr(pattern, "no such overload")
 	}
-	matched, err := regexp.MatchString(pattern.Value().(string), s.Value().(string))
+	matched, err := regexp.MatchString(pat.Value().(string), s.Value().(string))
 	if err != nil {
 		return &Err{err}
 	}

--- a/common/types/timestamp.go
+++ b/common/types/timestamp.go
@@ -21,11 +21,11 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	tpb "github.com/golang/protobuf/ptypes/timestamp"
+
 	"github.com/google/cel-go/common/overloads"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
-
-	tpb "github.com/golang/protobuf/ptypes/timestamp"
 )
 
 // Timestamp type implementation which supports add, compare, and subtract

--- a/common/types/traits/mapper.go
+++ b/common/types/traits/mapper.go
@@ -23,4 +23,11 @@ type Mapper interface {
 	Indexer
 	Iterable
 	Sizer
+
+	// Find a value by key if it exists.
+	//
+	// When the value exists, the result will be non-nil, true. When the value does not exist,
+	// the result will be nil, false. When an error occurs, the value will be non-nil and the
+	// found result false.
+	Find(key ref.Val) (ref.Val, bool)
 }

--- a/common/types/uint.go
+++ b/common/types/uint.go
@@ -45,21 +45,23 @@ const (
 
 // Add implements traits.Adder.Add.
 func (i Uint) Add(other ref.Val) ref.Val {
-	if UintType != other.Type() {
+	otherUint, ok := other.(Uint)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return i + other.(Uint)
+	return i + otherUint
 }
 
 // Compare implements traits.Comparer.Compare.
 func (i Uint) Compare(other ref.Val) ref.Val {
-	if UintType != other.Type() {
+	otherUint, ok := other.(Uint)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	if i < other.(Uint) {
+	if i < otherUint {
 		return IntNegOne
 	}
-	if i > other.(Uint) {
+	if i > otherUint {
 		return IntOne
 	}
 	return IntZero
@@ -114,10 +116,10 @@ func (i Uint) ConvertToType(typeVal ref.Type) ref.Val {
 
 // Divide implements traits.Divider.Divide.
 func (i Uint) Divide(other ref.Val) ref.Val {
-	if UintType != other.Type() {
+	otherUint, ok := other.(Uint)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	otherUint := other.(Uint)
 	if otherUint == uintZero {
 		return NewErr("divide by zero")
 	}
@@ -126,18 +128,19 @@ func (i Uint) Divide(other ref.Val) ref.Val {
 
 // Equal implements ref.Val.Equal.
 func (i Uint) Equal(other ref.Val) ref.Val {
-	if UintType != other.Type() {
+	otherUint, ok := other.(Uint)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return Bool(i == other.(Uint))
+	return Bool(i == otherUint)
 }
 
 // Modulo implements traits.Modder.Modulo.
 func (i Uint) Modulo(other ref.Val) ref.Val {
-	if UintType != other.Type() {
+	otherUint, ok := other.(Uint)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	otherUint := other.(Uint)
 	if otherUint == uintZero {
 		return NewErr("modulus by zero")
 	}
@@ -146,18 +149,20 @@ func (i Uint) Modulo(other ref.Val) ref.Val {
 
 // Multiply implements traits.Multiplier.Multiply.
 func (i Uint) Multiply(other ref.Val) ref.Val {
-	if UintType != other.Type() {
+	otherUint, ok := other.(Uint)
+	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return i * other.(Uint)
+	return i * otherUint
 }
 
 // Subtract implements traits.Subtractor.Subtract.
 func (i Uint) Subtract(subtrahend ref.Val) ref.Val {
-	if UintType != subtrahend.Type() {
+	subtraUint, ok := subtrahend.(Uint)
+	if !ok {
 		return ValOrErr(subtrahend, "no such overload")
 	}
-	return i - subtrahend.(Uint)
+	return i - subtraUint
 }
 
 // Type implements ref.Val.Type.

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -18,8 +18,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/cel-go/common/types/traits"
-
 	"github.com/golang/protobuf/proto"
 
 	"github.com/google/cel-go/checker"
@@ -28,6 +26,7 @@ import (
 	"github.com/google/cel-go/common/packages"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
 	"github.com/google/cel-go/interpreter/functions"
 	"github.com/google/cel-go/parser"
 	"github.com/google/cel-go/test"


### PR DESCRIPTION
Missing override fix for the #208 as well as fixes to the `Contains` semantics for list and map
types. The `Contains` behavior, represented as `in` within CEL, is equivalent to iterating over
the entries in the list or map and determining whether any of the entries is `Equal`.  Since lists
and maps may be heterogeneous, it is possible to encounter errors during evaluation of `Contains`
that must not short-circuit the evaluation.