### PR TITLE
Commit generated file descriptor for team.proto

### DIFF
--- a/cel/testdata/team.fds
+++ b/cel/testdata/team.fds
@@ -1,0 +1,13 @@
+
+†
+cel/testdata/mutant.protocel.testdata"S
+Mutant
+name (	Rname
+level (Rlevel
+super_power (	R
+superPowerbproto3
+–
+cel/testdata/team.protocel.testdatacel/testdata/mutant.proto"J
+Team
+name (	Rname.
+members (2.cel.testdata.MutantRmembersbproto3


### PR DESCRIPTION
The `cel/testdata/team.fds` file is typically generated during a Bazel build, but in order to make
it easier to get started with just `go test` against the `github.com/google/cel-go/cel` directory, the
generated artifact is being added to the repo.