### PR TITLE
Optimize 'in' operations on homogeneous list literals as set membership tests.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,8 +11,8 @@ http_archive(
 
 http_archive(
     name = "bazel_gazelle",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.15.0/bazel-gazelle-0.15.0.tar.gz"],
-    sha256 = "6e875ab4b6bf64a38c352887760f21203ab054676d9c1b274963907e0768740d",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz"],
+    sha256 = "3c681998538231a2d24d0c07ed5a7658cb72bfb5fd4bf9911157c0e9ac6a2687",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -485,7 +485,7 @@ func Benchmark_EvalOptions(b *testing.B) {
 	opts := map[string]EvalOption{
 		"track-state":     OptTrackState,
 		"exhaustive-eval": OptExhaustiveEval,
-		"fold-constants":  OptFoldConstants,
+		"optimize":        OptOptimize,
 	}
 	for k, opt := range opts {
 		b.Run(k, func(bb *testing.B) {

--- a/cel/options.go
+++ b/cel/options.go
@@ -232,10 +232,10 @@ const (
 	// OptExhaustiveEval causes the runtime to disable short-circuits and track state.
 	OptExhaustiveEval EvalOption = 1<<iota | OptTrackState
 
-	// OptFoldConstants evaluates functions and operators with constants as arguments at program
+	// OptOptimize precomputes functions and operators with constants as arguments at program
 	// creation time. This flag is useful when the expression will be evaluated repeatedly against
 	// a series of different inputs.
-	OptFoldConstants EvalOption = 1 << iota
+	OptOptimize EvalOption = 1 << iota
 )
 
 // EvalOptions sets one or more evaluation options which may affect the evaluation or Result.

--- a/cel/program.go
+++ b/cel/program.go
@@ -111,8 +111,8 @@ func newProgram(e *env, ast Ast, opts ...ProgramOption) (Program, error) {
 	// Translate the EvalOption flags into InterpretableDecorator instances.
 	decorators := []interpreter.InterpretableDecorator{}
 	// Enable constant folding first.
-	if p.evalOpts&OptFoldConstants == OptFoldConstants {
-		decorators = append(decorators, interpreter.FoldConstants())
+	if p.evalOpts&OptOptimize == OptOptimize {
+		decorators = append(decorators, interpreter.Optimize())
 	}
 	// Enable exhaustive eval over state tracking since it offers a superset of features.
 	if p.evalOpts&OptExhaustiveEval == OptExhaustiveEval {

--- a/common/types/util.go
+++ b/common/types/util.go
@@ -18,11 +18,20 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 )
 
-// IsUnknownOrError returns whether the input element ref.Type or ref.Val is an ErrType or
-// UnknonwType.
+// IsUnknownOrError returns whether the input element ref.Val is an ErrType or UnknonwType.
 func IsUnknownOrError(val ref.Val) bool {
 	switch val.Type() {
 	case UnknownType, ErrType:
+		return true
+	}
+	return false
+}
+
+// IsPrimitiveType returns whether the input element ref.Val is a primitive type.
+// Note, primitive types do not include well-known types such as Duration and Timestamp.
+func IsPrimitiveType(val ref.Val) bool {
+	switch val.Type() {
+	case BoolType, BytesType, DoubleType, IntType, StringType, UintType:
 		return true
 	}
 	return false

--- a/conformance/BUILD.bazel
+++ b/conformance/BUILD.bazel
@@ -11,6 +11,7 @@ sh_test(
         "$(location @com_google_cel_spec//tests/simple:testdata/fp_math.textproto)",
         "$(location @com_google_cel_spec//tests/simple:testdata/integer_math.textproto)",
         "$(location @com_google_cel_spec//tests/simple:testdata/logic.textproto)",
+        "$(location @com_google_cel_spec//tests/simple:testdata/macros.textproto)",
         "$(location @com_google_cel_spec//tests/simple:testdata/string.textproto)",
     ],
     data = [
@@ -23,6 +24,7 @@ sh_test(
         "@com_google_cel_spec//tests/simple:testdata/fp_math.textproto",
         "@com_google_cel_spec//tests/simple:testdata/integer_math.textproto",
         "@com_google_cel_spec//tests/simple:testdata/logic.textproto",
+        "@com_google_cel_spec//tests/simple:testdata/macros.textproto",
         "@com_google_cel_spec//tests/simple:testdata/string.textproto",
     ],
 )

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -82,10 +82,10 @@ func ExhaustiveEval(state EvalState) InterpretableDecorator {
 	}
 }
 
-// FoldConstants will pre-compute list and map literals comprised entirely of constant entries.
-// This optimization will increase the set of constant fold operations over time.
-func FoldConstants() InterpretableDecorator {
-	return decFoldConstants()
+// Optimize will pre-compute operations such as list and map construction and optimize
+// call arguments to set membership tests. The set of optimizations will increase over time.
+func Optimize() InterpretableDecorator {
+	return decOptimize()
 }
 
 type exprInterpreter struct {

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -592,7 +592,7 @@ func TestInterpreter_SetObjectEnumField(t *testing.T) {
 	}
 
 	i := NewStandardInterpreter(pkgr, reg, reg)
-	eval, _ := i.NewInterpretable(checked, FoldConstants())
+	eval, _ := i.NewInterpretable(checked, Optimize())
 	expected := &proto3pb.TestAllTypes{
 		RepeatedNestedEnum: []proto3pb.TestAllTypes_NestedEnum{
 			proto3pb.TestAllTypes_FOO,
@@ -645,7 +645,7 @@ func TestInterpreter_BuildMap(t *testing.T) {
 	if len(err.GetErrors()) != 0 {
 		t.Error(err)
 	}
-	i, _ := interpreter.NewUncheckedInterpretable(parsed.GetExpr(), FoldConstants())
+	i, _ := interpreter.NewUncheckedInterpretable(parsed.GetExpr(), Optimize())
 	vars, _ := NewActivation(map[string]interface{}{
 		"name": types.String("tristan")})
 	res := i.Eval(vars)
@@ -706,7 +706,7 @@ func BenchmarkInterpreter_ComprehensionExpr(b *testing.B) {
 	// [1, 1u, 1.0].exists(x, type(x) == uint)
 	interpretable, _ := interpreter.NewUncheckedInterpretable(
 		test.Exists.Expr,
-		FoldConstants())
+		Optimize())
 	noargs := EmptyActivation()
 	for i := 0; i < b.N; i++ {
 		interpretable.Eval(noargs)
@@ -744,7 +744,7 @@ func BenchmarkInterpreter_CanonicalExpressions(b *testing.B) {
 		checked, _ := checker.Check(parsed, s, env)
 		disp := NewDispatcher()
 		disp.Add(functions.StandardOverloads()...)
-		prg, _ := interpreter.NewInterpretable(checked, FoldConstants())
+		prg, _ := interpreter.NewInterpretable(checked, Optimize())
 		activation, _ := NewActivation(tst.I)
 		b.Run(tst.name, func(bb *testing.B) {
 			b.ResetTimer()


### PR DESCRIPTION
When CEL evaluates the following expression, the developer's intent is to test whether an element exists within an enumerated value space:

```javascript
elem in ['a', 'b', 'c', 'd']
```

Currently the `in` operator is implemented as a per-element comparison between the `elem` and each value in the list. This is rather inefficient. When the list elements are all of the same type and the list literal is composed of constant values, this expression can be converted to a map key existence test where the value in the list becomes a key in the map.

This optimization only works for primitive types and only when the list literal is defined in CEL. Additionally, this feature must be enabled with the `cel.OptOptimize` flag and a new canonical benchmark was added to demonstrate the overall performance.

**Before**
```
ExprBench/complex-12    1000000    1172 ns/op	152 B/op    10 allocs/op
```

**After**
```
ExprBench/complex-12    2000000     871 ns/op    144 B/op     9 allocs/op
```