### PR TITLE
Remove invalid type-param type widening logic

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -422,7 +422,6 @@ func (c *checker) checkComprehension(e *exprpb.Expr) {
 	c.check(comp.AccuInit)
 	accuType := c.getType(comp.AccuInit)
 	rangeType := c.getType(comp.IterRange)
-	rangeType = substitute(c.mappings, rangeType, false)
 	var varType *exprpb.Type
 
 	switch kindOf(rangeType) {

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -422,6 +422,7 @@ func (c *checker) checkComprehension(e *exprpb.Expr) {
 	c.check(comp.AccuInit)
 	accuType := c.getType(comp.AccuInit)
 	rangeType := c.getType(comp.IterRange)
+	rangeType = substitute(c.mappings, rangeType, false)
 	var varType *exprpb.Type
 
 	switch kindOf(rangeType) {

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -34,7 +34,6 @@ import (
 )
 
 var testCases = []testInfo{
-
 	// Const types
 	{
 		I:    `"A"`,
@@ -307,6 +306,36 @@ _!=_(_-_(_+_(1~double, _*_(2~double, 3~double)~double^multiply_double)
 		Type: decls.Bool,
 	},
 
+	{
+		I: `null == null && null != null`,
+		R: `
+		_&&_(
+			_==_(
+				null~null,
+				null~null
+			)~bool^equals,
+			_!=_(
+				null~null,
+				null~null
+			)~bool^not_equals
+		)~bool^logical_and`,
+		Type: decls.Bool,
+	},
+	{
+		I: `1 == 1 && 2 != 1`,
+		R: `
+		_&&_(
+			_==_(
+				1~int,
+				1~int
+			)~bool^equals,
+			_!=_(
+				2~int,
+				1~int
+			)~bool^not_equals
+		)~bool^logical_and`,
+		Type: decls.Bool,
+	},
 	{
 		I:    `1 + 2 * 3 - 1 / 2 == 6 % 1`,
 		R:    ` _==_(_-_(_+_(1~int, _*_(2~int, 3~int)~int^multiply_int64)~int^add_int64, _/_(1~int, 2~int)~int^divide_int64)~int^subtract_int64, _%_(6~int, 1~int)~int^modulo_int64)~bool^equals`,

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 var testCases = []testInfo{
+
 	// Const types
 	{
 		I:    `"A"`,
@@ -861,6 +862,42 @@ ERROR: <input>:1:6: found no matching overload for '_&&_' applied to '(bool, int
  | x.all(e, 0)
  | .....^
 		`,
+	},
+	{
+		I: `lists.filter(x, x > 1.5)`,
+		R: `__comprehension__(
+			// Variable
+			x,
+			// Target
+			lists~dyn^lists,
+			// Accumulator
+			__result__,
+			// Init
+			[]~list(dyn),
+			// LoopCondition
+			true~bool,
+			// LoopStep
+			_?_:_(
+			  _>_(
+				x~dyn^x,
+				1.5~double
+			  )~bool^greater_double,
+			  _+_(
+				__result__~list(dyn)^__result__,
+				[
+				  x~dyn^x
+				]~list(dyn)
+			  )~list(dyn)^add_list,
+			  __result__~list(dyn)^__result__
+			)~list(dyn)^conditional,
+			// Result
+			__result__~list(dyn)^__result__)~list(dyn)`,
+		Type: decls.NewListType(decls.Dyn),
+		Env: env{
+			idents: []*exprpb.Decl{
+				decls.NewIdent("lists", decls.Dyn, nil),
+			},
+		},
 	},
 
 	{

--- a/checker/types.go
+++ b/checker/types.go
@@ -306,7 +306,7 @@ func internalIsAssignableMap(m *mapping, m1 *exprpb.Type_MapType, m2 *exprpb.Typ
 // internalIsAssignableNull returns true if the type is nullable.
 func internalIsAssignableNull(t *exprpb.Type) bool {
 	switch kindOf(t) {
-	case kindAbstract, kindObject, kindWellKnown, kindWrapper:
+	case kindAbstract, kindObject, kindNull, kindWellKnown, kindWrapper:
 		return true
 	default:
 		return false

--- a/checker/types.go
+++ b/checker/types.go
@@ -183,14 +183,6 @@ func internalIsAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) bool {
 	kind1, kind2 := kindOf(t1), kindOf(t2)
 	if kind2 == kindTypeParam {
 		if t2Sub, found := m.find(t2); found {
-			// Adjust the existing substitution to a more common type if possible. This is sound
-			// because any previous substitution will be compatible with the common type. This
-			// deals with the case the we have e.g. A -> int assigned, but now encounter a test
-			// against DYN, and want to widen A to DYN.
-			if isEqualOrLessSpecific(t1, t2Sub) && notReferencedIn(t2, t1) {
-				m.add(t2, t1)
-				return true
-			}
 			// Continue regular process with the assignment for type2.
 			return internalIsAssignable(m, t1, t2Sub)
 		}


### PR DESCRIPTION
An old block of code dealing with type-widening for type-param types was not performing properly and has long since been removed from other implementations. 

The offending code has been removed and tests added.

Closes #232 