### PR TITLE
Update duration/timestamp to reflect CEL documentation

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,7 +36,7 @@ go_repository(
 
 git_repository(
   name = "com_google_cel_spec",
-  commit = "eff3d1b97f585251a72ecf7bb53ec2731ab6e17e", #PR #77
+  commit = "3bf57dcb97a51e30c94b0da540325d7035860074", #PR #81
   remote = "https://github.com/google/cel-spec.git",
 )
 

--- a/common/types/duration.go
+++ b/common/types/duration.go
@@ -17,6 +17,7 @@ package types
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -118,7 +119,7 @@ func (d Duration) ConvertToType(typeVal ref.Type) ref.Val {
 	switch typeVal {
 	case StringType:
 		if dur, err := ptypes.Duration(d.Duration); err == nil {
-			return String(dur.String())
+			return String(strconv.FormatFloat(dur.Seconds(), 'f', -1, 64) + "s")
 		}
 	case IntType:
 		if dur, err := ptypes.Duration(d.Duration); err == nil {

--- a/common/types/duration_test.go
+++ b/common/types/duration_test.go
@@ -69,8 +69,8 @@ func TestDuration_ConvertToNative_Error(t *testing.T) {
 func TestDuration_ConvertToType_Identity(t *testing.T) {
 	d := Duration{&dpb.Duration{Seconds: 7506, Nanos: 1000}}
 	str := d.ConvertToType(StringType).(String)
-	if str != "2h5m6.000001s" {
-		t.Errorf("Got '%v', wanted 2h5m6.000001s", str)
+	if str != "7506.000001s" {
+		t.Errorf("Got '%v', wanted 7506.000001s", str)
 	}
 	i := d.ConvertToType(IntType).(Int)
 	if i != Int(7506000001000) {

--- a/common/types/timestamp.go
+++ b/common/types/timestamp.go
@@ -217,7 +217,7 @@ func timestampGetMonth(t time.Time) ref.Val {
 	return Int(t.Month() - 1)
 }
 func timestampGetDayOfYear(t time.Time) ref.Val {
-	return Int(t.YearDay())
+	return Int(t.YearDay() - 1)
 }
 func timestampGetDayOfMonthZeroBased(t time.Time) ref.Val {
 	return Int(t.Day() - 1)

--- a/common/types/timestamp_test.go
+++ b/common/types/timestamp_test.go
@@ -51,6 +51,21 @@ func TestTimestamp_Subtract(t *testing.T) {
 	}
 }
 
+func TestTimestamp_RecieveGetDayOfYear(t *testing.T) {
+	// 1970-01-01T02:05:05Z
+	ts := Timestamp{&tpb.Timestamp{Seconds: 7506}}
+	hr := ts.Receive(overloads.TimeGetDayOfYear, overloads.TimestampToDayOfYear, []ref.Val{})
+	if !hr.Equal(Int(0)).(Bool) {
+		t.Error("Expected 0, got", hr)
+	}
+	// 1969-12-31T19:05:05Z
+	hrTz := ts.Receive(overloads.TimeGetDayOfYear, overloads.TimestampToDayOfYearWithTz,
+		[]ref.Val{String("America/Phoenix")})
+	if !hrTz.Equal(Int(364)).(Bool) {
+		t.Error("Expected 364, got", hrTz)
+	}
+}
+
 func TestTimestamp_ReceiveGetMonth(t *testing.T) {
 	// 1970-01-01T02:05:05Z
 	ts := Timestamp{&tpb.Timestamp{Seconds: 7506}}


### PR DESCRIPTION
timestamp.GetDayOfYear should be 0-based, not 1-based, and string(duration) should return the duration in seconds, not in h/m/s as previously thought.

Depends on google/cel-spec #81