### PR TITLE
Fix for planner panic.

### DIFF
--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -828,7 +828,7 @@ func TestInterpreter_SetProto2PrimitiveFields(t *testing.T) {
 	}
 }
 
-func TestInterpreter_CustomTypeProvider(t *testing.T) {
+func TestInterpreter_MissingIdentInSelect(t *testing.T) {
 	src := common.NewTextSource(`a.b.c`)
 	parsed, errors := parser.Parse(src)
 	if len(errors.GetErrors()) != 0 {
@@ -847,7 +847,7 @@ func TestInterpreter_CustomTypeProvider(t *testing.T) {
 	i, _ := interp.NewInterpretable(checked)
 	vars := EmptyActivation()
 	result := i.Eval(vars)
-	if !types.IsUnknownOrError(result) {
+	if !types.IsUnknown(result) {
 		t.Errorf("Got %v, wanted unknown", result)
 	}
 }

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -828,6 +828,30 @@ func TestInterpreter_SetProto2PrimitiveFields(t *testing.T) {
 	}
 }
 
+func TestInterpreter_CustomTypeProvider(t *testing.T) {
+	src := common.NewTextSource(`a.b.c`)
+	parsed, errors := parser.Parse(src)
+	if len(errors.GetErrors()) != 0 {
+		t.Fatalf(errors.ToDisplayString())
+	}
+
+	reg := types.NewRegistry()
+	env := checker.NewStandardEnv(packages.DefaultPackage, reg)
+	env.Add(decls.NewIdent("a.b", decls.Dyn, nil))
+	checked, errors := checker.Check(parsed, src, env)
+	if len(errors.GetErrors()) != 0 {
+		t.Fatalf(errors.ToDisplayString())
+	}
+
+	interp := NewStandardInterpreter(packages.NewPackage("test"), reg, reg)
+	i, _ := interp.NewInterpretable(checked)
+	vars := EmptyActivation()
+	result := i.Eval(vars)
+	if !types.IsUnknownOrError(result) {
+		t.Errorf("Got %v, wanted unknown", result)
+	}
+}
+
 func program(tst *testCase, opts ...InterpretableDecorator) (Interpretable, Activation, error) {
 	// Configure the package.
 	pkg := packages.DefaultPackage

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -847,6 +847,7 @@ func TestInterpreter_MissingIdentInSelect(t *testing.T) {
 	i, _ := interp.NewInterpretable(checked)
 	vars := EmptyActivation()
 	result := i.Eval(vars)
+	// TODO: When Issue #190 is fixed, this result should be an error.
 	if !types.IsUnknown(result) {
 		t.Errorf("Got %v, wanted unknown", result)
 	}

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -197,8 +197,9 @@ func (p *planner) planSelect(expr *exprpb.Expr) (Interpretable, error) {
 		}
 		// Otherwise, generate an evalIdent Interpretable.
 		i = &evalIdent{
-			id:   expr.Id,
-			name: idName,
+			id:       expr.Id,
+			name:     idName,
+			provider: p.provider,
 		}
 		p.identMap[idName] = i
 		return i, nil


### PR DESCRIPTION
Fixed a missing `provider` value within the `evalIdent` on the checked expression paths.

Closes #245  