### PR TITLE
Change GCS folder to be full date path; add badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/google/cel-go.svg?branch=master)](https://travis-ci.org/google/cel-go) [![Go Report Card](https://goreportcard.com/badge/github.com/google/cel-go)](https://goreportcard.com/report/github.com/google/cel-go)
 [![GoDoc](https://godoc.org/github.com/google/cel-go?status.svg)][6]
+[![google-cel/cel-go](https://testgrid.k8s.io/q/summary/google-cel/cel-go/tests_status?style=svg)](https://testgrid.k8s.io/google-cel#cel-go)
 
 The Common Expression Language (CEL) is a non-Turing complete language designed
 for simplicity, speed, safety, and portability. CEL's C-like [syntax][1] looks

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
         # at start is recorded and written to a file, then read at the end to ensure monotonically increasing numbers.
         - name: 'ubuntu'
           # stores timestamp in _DATE to use as build id
-          args: ['bash', '-c', 'date +%y%m%d%H%M%S > _DATE' ]
+          args: ['bash', '-c', 'date +%Y%M%D%H%M%S > _DATE' ]
         - name: 'gcr.io/cloud-builders/gsutil'
           # writes _DATE to GCS bucket so it can be used as GCS folder name
           args: ['cp', '-r', '_DATE', 'gs://cel-conformance']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
         # at start is recorded and written to a file, then read at the end to ensure monotonically increasing numbers.
         - name: 'ubuntu'
           # stores timestamp in _DATE to use as build id
-          args: ['bash', '-c', 'date +%Y%M%D%H%M%S > _DATE' ]
+          args: ['bash', '-c', 'date +%Y%m%d%H%M%S > _DATE' ] # Will create folder of format YYYYMMDDHHMMSS
         - name: 'gcr.io/cloud-builders/gsutil'
           # writes _DATE to GCS bucket so it can be used as GCS folder name
           args: ['cp', '-r', '_DATE', 'gs://cel-conformance']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
         # at start is recorded and written to a file, then read at the end to ensure monotonically increasing numbers.
         - name: 'ubuntu'
           # stores timestamp in _DATE to use as build id
-          args: ['bash', '-c', 'date +%s > _DATE' ]
+          args: ['bash', '-c', 'date +%y%m%d%H%M%S > _DATE' ]
         - name: 'gcr.io/cloud-builders/gsutil'
           # writes _DATE to GCS bucket so it can be used as GCS folder name
           args: ['cp', '-r', '_DATE', 'gs://cel-conformance']


### PR DESCRIPTION
UNIX times are hard to read, so folder name is changed to be more human readable, add TestGrid badge

This widget is managed by TestGrid, there is a way to configure our own but I think it would require too much maintenance just to change a name (https://github.com/badges/shields/blob/master/doc/TUTORIAL.md)