### PR TITLE
Add a base case for type assignability to prevent infinite recursion.

### DIFF
--- a/checker/types.go
+++ b/checker/types.go
@@ -179,6 +179,11 @@ func isEqualOrLessSpecific(t1 *exprpb.Type, t2 *exprpb.Type) bool {
 
 /// internalIsAssignable returns true if t1 is assignable to t2.
 func internalIsAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) bool {
+	// A type is always assignable to itself.
+	// Early terminate the call to avoid cases of infinite recursion.
+	if proto.Equal(t1, t2) {
+		return true
+	}
 	// Process type parameters.
 	kind1, kind2 := kindOf(t1), kindOf(t2)
 	if kind2 == kindTypeParam {


### PR DESCRIPTION
Ensure that types are always assignable to themselves.

Function argument type comparison can induce the type-checker to compare
a type against itself. When the type is parameterized, this can lead to infinite
recursion with a sufficient nesting of calls without this base case.