### PR TITLE
Logical AND / OR fix with error input.

### DIFF
--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -177,8 +177,11 @@ func (or *evalOr) Eval(ctx Activation) ref.Val {
 	if types.IsUnknown(rVal) {
 		return rVal
 	}
-	// if the left-hand side is non-boolean return it as the error.
-	return types.ValOrErr(lVal, "no such overload")
+	// If the left-hand side is non-boolean return it as the error.
+	if types.IsError(lVal) {
+		return types.ValOrErr(lVal, "no such overload")
+	}
+	return types.ValOrErr(rVal, "no such overload")
 }
 
 type evalAnd struct {
@@ -218,8 +221,11 @@ func (and *evalAnd) Eval(ctx Activation) ref.Val {
 	if types.IsUnknown(rVal) {
 		return rVal
 	}
-	// if the left-hand side is non-boolean return it as the error.
-	return types.ValOrErr(lVal, "no such overload")
+	// If the left-hand side is non-boolean return it as the error.
+	if types.IsError(lVal) {
+		return types.ValOrErr(lVal, "no such overload")
+	}
+	return types.ValOrErr(rVal, "no such overload")
 }
 
 type evalConditional struct {
@@ -632,7 +638,11 @@ func (or *evalExhaustiveOr) Eval(ctx Activation) ref.Val {
 	if types.IsUnknown(rVal) {
 		return rVal
 	}
-	return types.ValOrErr(lVal, "no such overload")
+	// If the left-hand side is non-boolean return it as the error.
+	if types.IsError(lVal) {
+		return types.ValOrErr(lVal, "no such overload")
+	}
+	return types.ValOrErr(rVal, "no such overload")
 }
 
 // evalExhaustiveAnd is just like evalAnd, but does not short-circuit argument evaluation.
@@ -668,7 +678,11 @@ func (and *evalExhaustiveAnd) Eval(ctx Activation) ref.Val {
 	if types.IsUnknown(rVal) {
 		return rVal
 	}
-	return types.ValOrErr(lVal, "no such overload")
+	// If the left-hand side is non-boolean return it as the error.
+	if types.IsError(lVal) {
+		return types.ValOrErr(lVal, "no such overload")
+	}
+	return types.ValOrErr(rVal, "no such overload")
 }
 
 // evalExhaustiveConditional is like evalConditional, but does not short-circuit argument

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -179,7 +179,7 @@ func (or *evalOr) Eval(ctx Activation) ref.Val {
 	}
 	// If the left-hand side is non-boolean return it as the error.
 	if types.IsError(lVal) {
-		return types.ValOrErr(lVal, "no such overload")
+		return lVal
 	}
 	return types.ValOrErr(rVal, "no such overload")
 }
@@ -223,7 +223,7 @@ func (and *evalAnd) Eval(ctx Activation) ref.Val {
 	}
 	// If the left-hand side is non-boolean return it as the error.
 	if types.IsError(lVal) {
-		return types.ValOrErr(lVal, "no such overload")
+		return lVal
 	}
 	return types.ValOrErr(rVal, "no such overload")
 }
@@ -638,9 +638,10 @@ func (or *evalExhaustiveOr) Eval(ctx Activation) ref.Val {
 	if types.IsUnknown(rVal) {
 		return rVal
 	}
+	// TODO: Combine the errors into a set in the future.
 	// If the left-hand side is non-boolean return it as the error.
 	if types.IsError(lVal) {
-		return types.ValOrErr(lVal, "no such overload")
+		return lVal
 	}
 	return types.ValOrErr(rVal, "no such overload")
 }
@@ -678,9 +679,10 @@ func (and *evalExhaustiveAnd) Eval(ctx Activation) ref.Val {
 	if types.IsUnknown(rVal) {
 		return rVal
 	}
+	// TODO: Combine the errors into a set in the future.
 	// If the left-hand side is non-boolean return it as the error.
 	if types.IsError(lVal) {
-		return types.ValOrErr(lVal, "no such overload")
+		return lVal
 	}
 	return types.ValOrErr(rVal, "no such overload")
 }


### PR DESCRIPTION
The google/cel-spec defines the logical AND / OR operators as commutative and capable
of absorbing errors. The interpreters do not handle this case correctly and will in some
scenarios produce a faulty result. In the majority of cases the bug is a non-issue, but is out
of conformance with the spec.

Once this test is submitted a conformance test will be written to exercise this case and a point
release created.