### PR TITLE
Add missing lexer rule for 'in'

### DIFF
--- a/parser/gen/CEL.g4
+++ b/parser/gen/CEL.g4
@@ -93,6 +93,7 @@ literal
 
 EQUALS : '==';
 NOT_EQUALS : '!=';
+IN: 'in';
 LESS : '<';
 LESS_EQUALS : '<=';
 GREATER_EQUALS : '>=';


### PR DESCRIPTION
## What
Add a missing lexer rule for 'in'

## Why
Antlr4 reports an error when separating lexer and parser grammars into separate files. This was a necessity for work on a C++ parser.

## Tests
The parser test suite completes without error (ran `bazel test ...`)

Discussed with @TristonianJones.