### PR TITLE
Support function resolution by overload id for custom functions.

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -46,7 +46,7 @@ func Example() {
 		// Function to generate a greeting from one person to another.
 		//    i.greet(you)
 		decls.NewFunction("greet",
-			decls.NewInstanceOverload("greet_string_string",
+			decls.NewInstanceOverload("string_greet_string",
 				[]*exprpb.Type{decls.String, decls.String},
 				decls.String)))
 	e, err := NewEnv(decls)
@@ -67,7 +67,7 @@ func Example() {
 	// Create the program.
 	funcs := Functions(
 		&functions.Overload{
-			Operator: "greet",
+			Operator: "string_greet_string",
 			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
 				return types.String(
 					fmt.Sprintf("Hello %s! Nice to meet you, I'm %s.\n", rhs, lhs))
@@ -104,7 +104,7 @@ func Example_globalOverload() {
 		// Function to generate shake_hands between two people.
 		//    shake_hands(i,you)
 		decls.NewFunction("shake_hands",
-			decls.NewOverload("greet_string_string",
+			decls.NewOverload("shake_hands_string_string",
 				[]*exprpb.Type{decls.String, decls.String},
 				decls.String)))
 	e, err := NewEnv(decls)
@@ -125,7 +125,7 @@ func Example_globalOverload() {
 	// Create the program.
 	funcs := Functions(
 		&functions.Overload{
-			Operator: "shake_hands",
+			Operator: "shake_hands_string_string",
 			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
 				s1, ok := lhs.(types.String)
 				if !ok {

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -254,15 +254,6 @@ func (p *planner) planCall(expr *exprpb.Expr) (Interpretable, error) {
 		len(oRef.GetOverloadId()) == 1 {
 		oName = oRef.GetOverloadId()[0]
 	}
-	// Try to find the specific function by overload id.
-	var fnDef *functions.Overload
-	if oName != "" {
-		fnDef, _ = p.disp.FindOverload(oName)
-	}
-	// If the overload id couldn't resolve the function, try the simple function name.
-	if fnDef == nil {
-		fnDef, _ = p.disp.FindOverload(fnName)
-	}
 
 	// Generate specialized Interpretable operators by function name if possible.
 	switch fnName {
@@ -279,6 +270,15 @@ func (p *planner) planCall(expr *exprpb.Expr) (Interpretable, error) {
 	}
 
 	// Otherwise, generate Interpretable calls specialized by argument count.
+	// Try to find the specific function by overload id.
+	var fnDef *functions.Overload
+	if oName != "" {
+		fnDef, _ = p.disp.FindOverload(oName)
+	}
+	// If the overload id couldn't resolve the function, try the simple function name.
+	if fnDef == nil {
+		fnDef, _ = p.disp.FindOverload(fnName)
+	}
 	switch argCount {
 	case 0:
 		return p.planCallZero(expr, fnName, oName, fnDef)

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -228,7 +228,6 @@ func (p *planner) planSelect(expr *exprpb.Expr) (Interpretable, error) {
 func (p *planner) planCall(expr *exprpb.Expr) (Interpretable, error) {
 	call := expr.GetCallExpr()
 	fnName := call.Function
-	fnDef, _ := p.disp.FindOverload(fnName)
 	argCount := len(call.GetArgs())
 	var offset int
 	if call.Target != nil {
@@ -254,6 +253,15 @@ func (p *planner) planCall(expr *exprpb.Expr) (Interpretable, error) {
 	if oRef, found := p.refMap[expr.Id]; found &&
 		len(oRef.GetOverloadId()) == 1 {
 		oName = oRef.GetOverloadId()[0]
+	}
+	// Try to find the specific function by overload id.
+	var fnDef *functions.Overload
+	if oName != "" {
+		fnDef, _ = p.disp.FindOverload(oName)
+	}
+	// If the overload id couldn't resolve the function, try the simple function name.
+	if fnDef == nil {
+		fnDef, _ = p.disp.FindOverload(fnName)
 	}
 
 	// Generate specialized Interpretable operators by function name if possible.


### PR DESCRIPTION
Update `planner.go` to consider function resolution by overload first, then by function name
as this would be more consistent with the desired behavior and makes custom function
overloading easier:

The `dispatcher.go` errors if more than one custom function has the same name, and reasonably
so, but the function resolution step in the planner was only considering the top-level function name
and not the overload, so it pretty much impossible to implement the overloads separately.

```go
// Desired behavior for overloads of the 'greet' function:
Functions(
  &functions.Overload{
      Operator: "string_greet_string",
      Binary: ...},
  &functions.Overload{
      Operator: "int_greet_int",
      Binary: ...}
)
```

```go
// Previous behavior for overloads of the 'greet' function:
Functions(
  &functions.Overload{
      Operator: "greet",
      Binary: func(...) {
         // type-test and overload internally.
      }},
)
```