### PR TITLE
Fix the 'no such key' error message.

### DIFF
--- a/common/types/json_struct.go
+++ b/common/types/json_struct.go
@@ -159,7 +159,7 @@ func (m *jsonStruct) Find(key ref.Val) (ref.Val, bool) {
 func (m *jsonStruct) Get(key ref.Val) ref.Val {
 	v, found := m.Find(key)
 	if !found {
-		return ValOrErr(v, "no such key: %v", v)
+		return ValOrErr(v, "no such key: %v", key)
 	}
 	return v
 }

--- a/common/types/json_struct_test.go
+++ b/common/types/json_struct_test.go
@@ -161,4 +161,25 @@ func TestJsonStruct_Get(t *testing.T) {
 	if !IsError(NewJSONStruct(NewRegistry(), &structpb.Struct{}).Get(Int(1))) {
 		t.Error("Structs may only have string keys.")
 	}
+
+	reg := NewRegistry()
+	mapVal := NewJSONStruct(reg,
+		&structpb.Struct{Fields: map[string]*structpb.Value{
+			"first":  {Kind: &structpb.Value_StringValue{StringValue: "hello"}},
+			"second": {Kind: &structpb.Value_NumberValue{NumberValue: 4}}}})
+
+	s := mapVal.Get(String("first"))
+	if s.Equal(String("hello")) != True {
+		t.Errorf("Got %v, wanted 'hello'", s)
+	}
+
+	d := mapVal.Get(String("second"))
+	if d.Equal(Double(4.0)) != True {
+		t.Errorf("Got %v, wanted '4.0'", d)
+	}
+
+	e, isError := mapVal.Get(String("third")).(*Err)
+	if !isError || e.Error() != "no such key: third" {
+		t.Errorf("Got %v, wanted no such key: third", e)
+	}
 }

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -244,7 +244,7 @@ func (m *stringMap) Find(key ref.Val) (ref.Val, bool) {
 func (m *baseMap) Get(key ref.Val) ref.Val {
 	v, found := m.Find(key)
 	if !found {
-		return ValOrErr(v, "no such key: %v", v)
+		return ValOrErr(v, "no such key: %v", key)
 	}
 	return v
 }
@@ -253,7 +253,7 @@ func (m *baseMap) Get(key ref.Val) ref.Val {
 func (m *stringMap) Get(key ref.Val) ref.Val {
 	v, found := m.Find(key)
 	if !found {
-		return ValOrErr(v, "no such key: %v", v)
+		return ValOrErr(v, "no such key: %v", key)
 	}
 	return v
 }

--- a/common/types/map_test.go
+++ b/common/types/map_test.go
@@ -234,8 +234,9 @@ func TestBaseMap_Get(t *testing.T) {
 	} else if floatVal.Equal(Double(-1.0)) != True {
 		t.Error("Nested map access of float property not float64")
 	}
-	if !IsError(mapValue.Get(String("absent"))) {
-		t.Error("Got valid result, wanted no such key error.")
+	e, isError := mapValue.Get(String("absent")).(*Err)
+	if !isError || e.Error() != "no such key: absent" {
+		t.Errorf("Got %v, wanted no such key: absent.", e)
 	}
 }
 


### PR DESCRIPTION
Ensure the missing key is properly mentioned in the `no such key` error messages.