### PR TITLE
Simple type conversion fix

### DIFF
--- a/common/types/BUILD.bazel
+++ b/common/types/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "//common/types/ref:go_default_library",
         "//common/types/pb:go_default_library",
         "//common/types/traits:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library",
         "@io_bazel_rules_go//proto/wkt:any_go_proto",

--- a/common/types/bool.go
+++ b/common/types/bool.go
@@ -19,9 +19,13 @@ import (
 	"reflect"
 	"strconv"
 
-	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/golang/protobuf/ptypes"
+
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
+
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 )
 
 // Bool type that implements ref.Val and supports comparison and negation.
@@ -32,6 +36,9 @@ var (
 	BoolType = NewTypeValue("bool",
 		traits.ComparerType,
 		traits.NegatorType)
+
+	// boolWrapperType golang reflected type for protobuf bool wrapper type.
+	boolWrapperType = reflect.TypeOf(&wrapperspb.BoolValue{})
 )
 
 // Boolean constants
@@ -61,14 +68,22 @@ func (b Bool) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	case reflect.Bool:
 		return bool(b), nil
 	case reflect.Ptr:
-		if typeDesc == jsonValueType {
+		switch typeDesc {
+		case anyValueType:
+			return ptypes.MarshalAny(&wrapperspb.BoolValue{Value: bool(b)})
+		case boolWrapperType:
+			return &wrapperspb.BoolValue{Value: bool(b)}, nil
+		case jsonValueType:
 			return &structpb.Value{
 				Kind: &structpb.Value_BoolValue{
-					BoolValue: b.Value().(bool)}}, nil
-		}
-		if typeDesc.Elem().Kind() == reflect.Bool {
-			p := bool(b)
-			return &p, nil
+					BoolValue: b.Value().(bool),
+				},
+			}, nil
+		default:
+			if typeDesc.Elem().Kind() == reflect.Bool {
+				p := bool(b)
+				return &p, nil
+			}
 		}
 	case reflect.Interface:
 		if reflect.TypeOf(b).Implements(typeDesc) {

--- a/common/types/bool.go
+++ b/common/types/bool.go
@@ -70,14 +70,14 @@ func (b Bool) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	case reflect.Ptr:
 		switch typeDesc {
 		case anyValueType:
+			// Primitives must be wrapped before being set on an Any field.
 			return ptypes.MarshalAny(&wrapperspb.BoolValue{Value: bool(b)})
 		case boolWrapperType:
+			// Convert the bool to a protobuf.BoolValue.
 			return &wrapperspb.BoolValue{Value: bool(b)}, nil
 		case jsonValueType:
 			return &structpb.Value{
-				Kind: &structpb.Value_BoolValue{
-					BoolValue: b.Value().(bool),
-				},
+				Kind: &structpb.Value_BoolValue{BoolValue: bool(b)},
 			}, nil
 		default:
 			if typeDesc.Elem().Kind() == reflect.Bool {

--- a/common/types/bool_test.go
+++ b/common/types/bool_test.go
@@ -19,7 +19,9 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 	structpb "github.com/golang/protobuf/ptypes/struct"
+	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 )
 
 func TestBool_Compare(t *testing.T) {
@@ -37,6 +39,20 @@ func TestBool_Compare(t *testing.T) {
 	}
 	if !IsError(True.Compare(Uint(0))) {
 		t.Error("Was able to compare uncomparable types.")
+	}
+}
+
+func TestBool_ConvertToNative_Any(t *testing.T) {
+	val, err := True.ConvertToNative(anyValueType)
+	if err != nil {
+		t.Error(err)
+	}
+	pbVal, err := ptypes.MarshalAny(&wrapperspb.BoolValue{Value: true})
+	if err != nil {
+		t.Error(err)
+	}
+	if !proto.Equal(val.(proto.Message), pbVal) {
+		t.Error("Error during conversion to protobuf.Any", val)
 	}
 }
 
@@ -76,6 +92,16 @@ func TestBool_ConvertToNative_Ptr(t *testing.T) {
 		t.Error(err)
 	} else if !*val.(*bool) {
 		t.Error("Error during conversion to *bool", val)
+	}
+}
+
+func TestBool_ConvertToNative_Wrapper(t *testing.T) {
+	val, err := True.ConvertToNative(boolWrapperType)
+	pbVal := &wrapperspb.BoolValue{Value: true}
+	if err != nil {
+		t.Error(err)
+	} else if !proto.Equal(val.(proto.Message), pbVal) {
+		t.Error("Error during conversion to wrapper value type", val)
 	}
 }
 

--- a/common/types/bool_test.go
+++ b/common/types/bool_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 )

--- a/common/types/bytes.go
+++ b/common/types/bytes.go
@@ -78,7 +78,9 @@ func (b Bytes) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 			// Convert the bytes to a protobuf.BytesValue.
 			return &wrapperspb.BytesValue{Value: []byte(b)}, nil
 		case jsonValueType:
-			// proto3 to JSON conversion requires base64 encoding of bytes.
+			// CEL follows the proto3 to JSON conversion by encoding bytes to a string via base64.
+			// The encoding below matches the golang 'encoding/json' behavior during marshaling,
+			// which uses base64.StdEncoding.
 			str := base64.StdEncoding.EncodeToString([]byte(b))
 			return &structpb.Value{
 				Kind: &structpb.Value_StringValue{StringValue: str},

--- a/common/types/bytes.go
+++ b/common/types/bytes.go
@@ -72,16 +72,16 @@ func (b Bytes) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	case reflect.Ptr:
 		switch typeDesc {
 		case anyValueType:
+			// Primitives must be wrapped before being set on an Any field.
 			return ptypes.MarshalAny(&wrapperspb.BytesValue{Value: []byte(b)})
 		case byteWrapperType:
+			// Convert the bytes to a protobuf.BytesValue.
 			return &wrapperspb.BytesValue{Value: []byte(b)}, nil
 		case jsonValueType:
 			// proto3 to JSON conversion requires base64 encoding of bytes.
 			str := base64.StdEncoding.EncodeToString([]byte(b))
 			return &structpb.Value{
-				Kind: &structpb.Value_StringValue{
-					StringValue: str,
-				},
+				Kind: &structpb.Value_StringValue{StringValue: str},
 			}, nil
 		}
 	case reflect.Interface:

--- a/common/types/bytes_test.go
+++ b/common/types/bytes_test.go
@@ -18,6 +18,12 @@ import (
 	"bytes"
 	"reflect"
 	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 )
 
 func TestBytes_Add(t *testing.T) {
@@ -44,6 +50,20 @@ func TestBytes_Compare(t *testing.T) {
 	}
 }
 
+func TestBytes_ConvertToNative_Any(t *testing.T) {
+	val, err := Bytes("123").ConvertToNative(anyValueType)
+	if err != nil {
+		t.Error(err)
+	}
+	want, err := ptypes.MarshalAny(&wrapperspb.BytesValue{Value: []byte("123")})
+	if err != nil {
+		t.Error(err)
+	}
+	if !proto.Equal(val.(proto.Message), want) {
+		t.Errorf("Got %v, wanted %v", val, want)
+	}
+}
+
 func TestBytes_ConvertToNative_ByteSlice(t *testing.T) {
 	val, err := Bytes("123").ConvertToNative(reflect.TypeOf([]byte{}))
 	if err != nil || !bytes.Equal(val.([]byte), []byte{49, 50, 51}) {
@@ -55,6 +75,28 @@ func TestBytes_ConvertToNative_Error(t *testing.T) {
 	val, err := Bytes("123").ConvertToNative(reflect.TypeOf(""))
 	if err == nil {
 		t.Errorf("Got '%v', expected error", val)
+	}
+}
+
+func TestBytes_ConvertToNative_Json(t *testing.T) {
+	val, err := Bytes("123").ConvertToNative(jsonValueType)
+	if err != nil {
+		t.Error(err)
+	}
+	want := &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "MTIz"}}
+	if !proto.Equal(val.(proto.Message), want) {
+		t.Errorf("Got %v, wanted %v", val, want)
+	}
+}
+
+func TestBytes_ConvertToNative_Wrapper(t *testing.T) {
+	val, err := Bytes("123").ConvertToNative(byteWrapperType)
+	if err != nil {
+		t.Error(err)
+	}
+	want := &wrapperspb.BytesValue{Value: []byte("123")}
+	if !proto.Equal(val.(proto.Message), want) {
+		t.Errorf("Got %v, wanted %v", val, want)
 	}
 }
 

--- a/common/types/double.go
+++ b/common/types/double.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/cel-go/common/types/traits"
 
 	"github.com/golang/protobuf/ptypes"
+
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 )

--- a/common/types/double_test.go
+++ b/common/types/double_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 )
@@ -118,13 +119,6 @@ func TestDouble_ConvertToNative_Json(t *testing.T) {
 	}
 	val, err = Double(math.Inf(0)).ConvertToNative(jsonValueType)
 	pbVal = &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: math.Inf(0)}}
-	if err != nil {
-		t.Error(err)
-	} else if !proto.Equal(val.(proto.Message), pbVal) {
-		t.Errorf("Got '%v', expected Infinity", val)
-	}
-	val, err = Double(math.Inf(1)).ConvertToNative(jsonValueType)
-	pbVal = &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: math.Inf(1)}}
 	if err != nil {
 		t.Error(err)
 	} else if !proto.Equal(val.(proto.Message), pbVal) {

--- a/common/types/double_test.go
+++ b/common/types/double_test.go
@@ -100,33 +100,35 @@ func TestDouble_ConvertToNative_Json(t *testing.T) {
 	}
 
 	val, err = Double(math.NaN()).ConvertToNative(jsonValueType)
-	pbVal = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "NaN"}}
 	if err != nil {
 		t.Error(err)
-	} else if !proto.Equal(val.(proto.Message), pbVal) {
-		t.Errorf("Got '%v', expected NaN", val)
+	} else {
+		v := val.(*structpb.Value)
+		if !math.IsNaN(v.GetNumberValue()) {
+			t.Errorf("Got '%v', expected NaN", val)
+		}
 	}
 
 	val, err = Double(math.Inf(-1)).ConvertToNative(jsonValueType)
-	pbVal = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "-Infinity"}}
+	pbVal = &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: math.Inf(-1)}}
 	if err != nil {
 		t.Error(err)
 	} else if !proto.Equal(val.(proto.Message), pbVal) {
 		t.Errorf("Got '%v', expected -Infinity", val)
 	}
 	val, err = Double(math.Inf(0)).ConvertToNative(jsonValueType)
-	pbVal = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "Infinity"}}
+	pbVal = &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: math.Inf(0)}}
 	if err != nil {
 		t.Error(err)
 	} else if !proto.Equal(val.(proto.Message), pbVal) {
-		t.Errorf("Got '%v', expected -Infinity", val)
+		t.Errorf("Got '%v', expected Infinity", val)
 	}
 	val, err = Double(math.Inf(1)).ConvertToNative(jsonValueType)
-	pbVal = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "Infinity"}}
+	pbVal = &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: math.Inf(1)}}
 	if err != nil {
 		t.Error(err)
 	} else if !proto.Equal(val.(proto.Message), pbVal) {
-		t.Errorf("Got '%v', expected -Infinity", val)
+		t.Errorf("Got '%v', expected Infinity", val)
 	}
 }
 

--- a/common/types/duration.go
+++ b/common/types/duration.go
@@ -113,7 +113,8 @@ func (d Duration) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 		// Unwrap the CEL value to its underlying proto value.
 		return d.Value(), nil
 	case jsonValueType:
-		// Proto3 to JSON conversion requires string-formatted durations.
+		// CEL follows the proto3 to JSON conversion.
+		// Note, using jsonpb would wrap the result in extra double quotes.
 		v := d.ConvertToType(StringType)
 		if IsError(v) {
 			return nil, v.(*Err)

--- a/common/types/duration.go
+++ b/common/types/duration.go
@@ -107,19 +107,19 @@ func (d Duration) Compare(other ref.Val) ref.Val {
 func (d Duration) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	switch typeDesc {
 	case anyValueType:
+		// Pack the underlying proto value into an Any value.
 		return ptypes.MarshalAny(d.Value().(*dpb.Duration))
 	case durationValueType:
+		// Unwrap the CEL value to its underlying proto value.
 		return d.Value(), nil
 	case jsonValueType:
-		// proto3 to JSON conversion requires string-formatted durations
+		// Proto3 to JSON conversion requires string-formatted durations.
 		v := d.ConvertToType(StringType)
 		if IsError(v) {
 			return nil, v.(*Err)
 		}
 		return &structpb.Value{
-			Kind: &structpb.Value_StringValue{
-				StringValue: string(v.(String)),
-			},
+			Kind: &structpb.Value_StringValue{StringValue: string(v.(String))},
 		}, nil
 	}
 	// If the duration is already assignable to the desired type return it.

--- a/common/types/duration_test.go
+++ b/common/types/duration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 
 	dpb "github.com/golang/protobuf/ptypes/duration"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 )
 
 func TestDuration_Add(t *testing.T) {
@@ -61,8 +62,17 @@ func TestDuration_ConvertToNative(t *testing.T) {
 func TestDuration_ConvertToNative_Error(t *testing.T) {
 	val, err := Duration{&dpb.Duration{Seconds: 7506, Nanos: 1000}}.
 		ConvertToNative(jsonValueType)
-	if err == nil {
-		t.Errorf("Got '%v', expected error", val)
+	if err != nil {
+		t.Errorf("Got error: '%v', expected value", err)
+	}
+	json := val.(*structpb.Value)
+	want := &structpb.Value{
+		Kind: &structpb.Value_StringValue{
+			StringValue: "7506.000001s",
+		},
+	}
+	if !proto.Equal(json, want) {
+		t.Errorf("Got %v, wanted %v", json, want)
 	}
 }
 

--- a/common/types/duration_test.go
+++ b/common/types/duration_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+
 	"github.com/google/cel-go/common/overloads"
 	"github.com/google/cel-go/common/types/ref"
 

--- a/common/types/duration_test.go
+++ b/common/types/duration_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/google/cel-go/common/overloads"
 	"github.com/google/cel-go/common/types/ref"
 
@@ -59,6 +60,21 @@ func TestDuration_ConvertToNative(t *testing.T) {
 	}
 }
 
+func TestDuration_ConvertToNative_Any(t *testing.T) {
+	pb := &dpb.Duration{Seconds: 7506, Nanos: 1000}
+	val, err := Duration{pb}.ConvertToNative(anyValueType)
+	if err != nil {
+		t.Error(err)
+	}
+	want, err := ptypes.MarshalAny(pb)
+	if err != nil {
+		t.Error(err)
+	}
+	if !proto.Equal(val.(proto.Message), want) {
+		t.Errorf("Got '%v', wanted %v", val, want)
+	}
+}
+
 func TestDuration_ConvertToNative_Error(t *testing.T) {
 	val, err := Duration{&dpb.Duration{Seconds: 7506, Nanos: 1000}}.
 		ConvertToNative(jsonValueType)
@@ -73,6 +89,17 @@ func TestDuration_ConvertToNative_Error(t *testing.T) {
 	}
 	if !proto.Equal(json, want) {
 		t.Errorf("Got %v, wanted %v", json, want)
+	}
+}
+
+func TestDuration_ConvertToNative_Json(t *testing.T) {
+	val, err := Duration{&dpb.Duration{Seconds: 7506, Nanos: 1000}}.ConvertToNative(jsonValueType)
+	if err != nil {
+		t.Error(err)
+	}
+	want := &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "7506.000001s"}}
+	if !proto.Equal(val.(proto.Message), want) {
+		t.Errorf("Got '%v', wanted %v", val, want)
 	}
 }
 

--- a/common/types/int.go
+++ b/common/types/int.go
@@ -93,20 +93,23 @@ func (i Int) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	case reflect.Ptr:
 		switch typeDesc {
 		case anyValueType:
+			// Primitives must be wrapped before being set on an Any field.
 			return ptypes.MarshalAny(&wrapperspb.Int64Value{Value: int64(i)})
 		case int32WrapperType:
+			// Convert the value to a protobuf.Int32Value (with truncation).
 			return &wrapperspb.Int32Value{Value: int32(i)}, nil
 		case int64WrapperType:
+			// Convert the value to a protobuf.Int64Value.
 			return &wrapperspb.Int64Value{Value: int64(i)}, nil
 		case jsonValueType:
+			// JSON can accurately represent 32-bit ints as floating point values.
 			if i.isInt32() {
 				return &structpb.Value{
-					Kind: &structpb.Value_NumberValue{
-						NumberValue: float64(i),
-					},
+					Kind: &structpb.Value_NumberValue{NumberValue: float64(i)},
 				}, nil
 			}
-			// proto3 to JSON conversion requires string-formatted int64 values.
+			// Proto3 to JSON conversion requires string-formatted int64 values
+			// since the conversion to floating point would result in truncation.
 			return &structpb.Value{
 				Kind: &structpb.Value_StringValue{
 					StringValue: strconv.FormatInt(int64(i), 10),

--- a/common/types/int.go
+++ b/common/types/int.go
@@ -20,10 +20,11 @@ import (
 	"reflect"
 	"strconv"
 
+	"github.com/golang/protobuf/ptypes"
+
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 
-	"github.com/golang/protobuf/ptypes"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 )

--- a/common/types/int_test.go
+++ b/common/types/int_test.go
@@ -75,6 +75,7 @@ func TestInt_ConvertToNative_Int64(t *testing.T) {
 }
 
 func TestInt_ConvertToNative_Json(t *testing.T) {
+	// Value greater than max int32.
 	val, err := Int(4147483648).ConvertToNative(jsonValueType)
 	if err != nil {
 		t.Error(err)

--- a/common/types/int_test.go
+++ b/common/types/int_test.go
@@ -94,20 +94,20 @@ func TestInt_ConvertToNative_Int64(t *testing.T) {
 
 func TestInt_ConvertToNative_Json(t *testing.T) {
 	// Value less than int32.
-	val, err := Int(math.MaxInt32 - 1).ConvertToNative(jsonValueType)
+	val, err := Int(maxIntJSON).ConvertToNative(jsonValueType)
 	if err != nil {
 		t.Error(err)
 	} else if !proto.Equal(val.(proto.Message),
-		&structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: 2147483646.0}}) {
+		&structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: 9007199254740991.0}}) {
 		t.Errorf("Got '%v', expected a json number for a 32-bit int", val)
 	}
 
 	// Value greater than max int32.
-	val, err = Int(math.MaxInt32 + 1).ConvertToNative(jsonValueType)
+	val, err = Int(maxIntJSON + 1).ConvertToNative(jsonValueType)
 	if err != nil {
 		t.Error(err)
 	} else if !proto.Equal(val.(proto.Message),
-		&structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "2147483648"}}) {
+		&structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "9007199254740992"}}) {
 		t.Errorf("Got '%v', expected a json string for a 64-bit int", val)
 	}
 }
@@ -125,11 +125,11 @@ func TestInt_ConvertToNative_Ptr_Int32(t *testing.T) {
 func TestInt_ConvertToNative_Ptr_Int64(t *testing.T) {
 	// Value greater than max int32.
 	ptrType := int64(0)
-	val, err := Int(4147483648).ConvertToNative(reflect.TypeOf(&ptrType))
+	val, err := Int(math.MaxInt32 + 1).ConvertToNative(reflect.TypeOf(&ptrType))
 	if err != nil {
 		t.Error(err)
-	} else if *val.(*int64) != 4147483648 {
-		t.Errorf("Got '%v', expected 4147483648", val)
+	} else if *val.(*int64) != math.MaxInt32+1 {
+		t.Errorf("Got '%v', expected MaxInt32 + 1", val)
 	}
 }
 

--- a/common/types/int_test.go
+++ b/common/types/int_test.go
@@ -93,7 +93,7 @@ func TestInt_ConvertToNative_Int64(t *testing.T) {
 }
 
 func TestInt_ConvertToNative_Json(t *testing.T) {
-	// Value less than int32.
+	// Value can be represented accurately as a JSON number.
 	val, err := Int(maxIntJSON).ConvertToNative(jsonValueType)
 	if err != nil {
 		t.Error(err)
@@ -102,7 +102,7 @@ func TestInt_ConvertToNative_Json(t *testing.T) {
 		t.Errorf("Got '%v', expected a json number for a 32-bit int", val)
 	}
 
-	// Value greater than max int32.
+	// Value converts to a JSON decimal string.
 	val, err = Int(maxIntJSON + 1).ConvertToNative(jsonValueType)
 	if err != nil {
 		t.Error(err)

--- a/common/types/json_list.go
+++ b/common/types/json_list.go
@@ -109,8 +109,8 @@ func (l *jsonListValue) ConvertToNative(typeDesc reflect.Type) (interface{}, err
 			return ptypes.MarshalAny(l.Value().(proto.Message))
 		case jsonValueType:
 			return &structpb.Value{
-				Kind: &structpb.Value_ListValue{
-					ListValue: l.ListValue}}, nil
+				Kind: &structpb.Value_ListValue{ListValue: l.ListValue},
+			}, nil
 		case jsonListValueType:
 			return l.ListValue, nil
 		}

--- a/common/types/json_list.go
+++ b/common/types/json_list.go
@@ -105,14 +105,14 @@ func (l *jsonListValue) ConvertToNative(typeDesc reflect.Type) (interface{}, err
 
 	case reflect.Ptr:
 		switch typeDesc {
+		case anyValueType:
+			return ptypes.MarshalAny(l.Value().(proto.Message))
 		case jsonValueType:
 			return &structpb.Value{
 				Kind: &structpb.Value_ListValue{
 					ListValue: l.ListValue}}, nil
 		case jsonListValueType:
 			return l.ListValue, nil
-		case anyValueType:
-			return ptypes.MarshalAny(l.Value().(proto.Message))
 		}
 
 	case reflect.Interface:

--- a/common/types/json_list_test.go
+++ b/common/types/json_list_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+
 	anypb "github.com/golang/protobuf/ptypes/any"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 )

--- a/common/types/json_struct.go
+++ b/common/types/json_struct.go
@@ -20,10 +20,11 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	structpb "github.com/golang/protobuf/ptypes/struct"
 
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
+
+	structpb "github.com/golang/protobuf/ptypes/struct"
 )
 
 var (
@@ -81,14 +82,14 @@ func (m *jsonStruct) ConvertToNative(typeDesc reflect.Type) (interface{}, error)
 
 	case reflect.Ptr:
 		switch typeDesc {
+		case anyValueType:
+			return ptypes.MarshalAny(m.Value().(proto.Message))
 		case jsonValueType:
 			return &structpb.Value{
 				Kind: &structpb.Value_StructValue{
 					StructValue: m.Struct}}, nil
 		case jsonStructType:
 			return m.Struct, nil
-		case anyValueType:
-			return ptypes.MarshalAny(m.Value().(proto.Message))
 		}
 
 	case reflect.Interface:

--- a/common/types/json_struct.go
+++ b/common/types/json_struct.go
@@ -86,8 +86,8 @@ func (m *jsonStruct) ConvertToNative(typeDesc reflect.Type) (interface{}, error)
 			return ptypes.MarshalAny(m.Value().(proto.Message))
 		case jsonValueType:
 			return &structpb.Value{
-				Kind: &structpb.Value_StructValue{
-					StructValue: m.Struct}}, nil
+				Kind: &structpb.Value_StructValue{StructValue: m.Struct},
+			}, nil
 		case jsonStructType:
 			return m.Struct, nil
 		}

--- a/common/types/json_struct_test.go
+++ b/common/types/json_struct_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+
 	anypb "github.com/golang/protobuf/ptypes/any"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 )

--- a/common/types/list.go
+++ b/common/types/list.go
@@ -122,7 +122,7 @@ func (l *baseList) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	// JSON conversions are a special case since the 'native' type is a proto message.
 	switch typeDesc {
 	case anyValueType:
-		json, err := l.ConvertToNative(jsonValueType)
+		json, err := l.ConvertToNative(jsonListValueType)
 		if err != nil {
 			return nil, err
 		}
@@ -419,7 +419,7 @@ func (l *stringList) ConvertToNative(typeDesc reflect.Type) (interface{}, error)
 	case reflect.Ptr:
 		switch typeDesc {
 		case anyValueType:
-			json, err := l.ConvertToNative(jsonValueType)
+			json, err := l.ConvertToNative(jsonListValueType)
 			if err != nil {
 				return nil, err
 			}

--- a/common/types/list.go
+++ b/common/types/list.go
@@ -18,11 +18,12 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 )
 

--- a/common/types/list.go
+++ b/common/types/list.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"reflect"
 
-	structpb "github.com/golang/protobuf/ptypes/struct"
-
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
+
+	structpb "github.com/golang/protobuf/ptypes/struct"
 )
 
 var (
@@ -115,6 +115,7 @@ func (l *baseList) Contains(elem ref.Val) ref.Val {
 
 // ConvertToNative implements the ref.Val interface method.
 func (l *baseList) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
+	// TODO: Add support for conversion to Any
 	// JSON conversions are a special case since the 'native' type is a proto message.
 	if typeDesc == jsonValueType || typeDesc == jsonListValueType {
 		jsonValues, err :=

--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -18,11 +18,12 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 
-	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/proto"
 	dpb "github.com/golang/protobuf/ptypes/duration"
 )
 

--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -88,7 +88,7 @@ func TestBaseList_ConvertToNative_Any(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	jsonVal := &structpb.Value{}
+	jsonVal := &structpb.ListValue{}
 	if jsonpb.UnmarshalString("[1.0, 2.0]", jsonVal) != nil {
 		t.Error("Unable to unmarshal json")
 	}

--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -20,11 +20,13 @@ import (
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 
 	dpb "github.com/golang/protobuf/ptypes/duration"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 )
 
 func TestBaseList_Add_Empty(t *testing.T) {
@@ -77,6 +79,40 @@ func TestBaseList_ConvertToNative(t *testing.T) {
 		t.Error(err)
 	} else if !reflect.DeepEqual(protoList, []float32{1.0, 2.0}) {
 		t.Errorf("Could not convert to []float32: %v", protoList)
+	}
+}
+
+func TestBaseList_ConvertToNative_Any(t *testing.T) {
+	list := NewDynamicList(NewRegistry(), []float64{1.0, 2.0})
+	val, err := list.ConvertToNative(anyValueType)
+	if err != nil {
+		t.Error(err)
+	}
+	jsonVal := &structpb.Value{}
+	if jsonpb.UnmarshalString("[1.0, 2.0]", jsonVal) != nil {
+		t.Error("Unable to unmarshal json")
+	}
+	want, err := ptypes.MarshalAny(jsonVal)
+	if err != nil {
+		t.Error(err)
+	}
+	if !proto.Equal(val.(proto.Message), want) {
+		t.Errorf("Got %v, wanted %v", val, want)
+	}
+}
+
+func TestBaseList_ConvertToNative_Json(t *testing.T) {
+	list := NewDynamicList(NewRegistry(), []float64{1.0, 2.0})
+	val, err := list.ConvertToNative(jsonListValueType)
+	if err != nil {
+		t.Error(err)
+	}
+	want := &structpb.ListValue{}
+	if jsonpb.UnmarshalString("[1.0, 2.0]", want) != nil {
+		t.Error("Unable to unmarshal json")
+	}
+	if !proto.Equal(val.(proto.Message), want) {
+		t.Errorf("Got %v, wanted %v", val, want)
 	}
 }
 
@@ -195,19 +231,16 @@ func TestConcatList_ConvertToNative_Json(t *testing.T) {
 	if jsonTxt != "[1,2,\"3\"]" {
 		t.Errorf("Got '%v', expected [1,2,\"3\"]", jsonTxt)
 	}
-}
-
-func TestConcatList_ConvertToNative_ElementConversionError(t *testing.T) {
-	reg := NewRegistry()
-	listA := NewDynamicList(reg, []float32{1.0, 2.0})
-	// Duration is serializable to a string form of json, but there is no
-	// concept of a duration literal within CEL, so the serialization to string
-	// is not supported here which should cause the conversion to json to fail.
-	listB := NewDynamicList(reg, []*dpb.Duration{{Seconds: 100}})
-	listConcat := listA.Add(listB)
-	json, err := listConcat.ConvertToNative(jsonValueType)
-	if err == nil {
-		t.Errorf("Got '%v', expected error", json)
+	// Test proto3 to JSON conversion.
+	listC := NewDynamicList(reg, []*dpb.Duration{{Seconds: 100}})
+	listConcat := listA.Add(listC)
+	json, err = listConcat.ConvertToNative(jsonValueType)
+	jsonTxt, err = (&jsonpb.Marshaler{}).MarshalToString(json.(proto.Message))
+	if err != nil {
+		t.Error(err)
+	}
+	if jsonTxt != "[1,2,\"100s\"]" {
+		t.Errorf("Got '%v', expected [1,2,\"100s\"]", jsonTxt)
 	}
 }
 

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -18,11 +18,11 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/google/cel-go/common/types/ref"
-	"github.com/google/cel-go/common/types/traits"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
 
 	structpb "github.com/golang/protobuf/ptypes/struct"
 )

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -90,7 +90,7 @@ func (m *stringMap) Contains(index ref.Val) ref.Val {
 func (m *baseMap) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	switch typeDesc {
 	case anyValueType:
-		json, err := m.ConvertToNative(jsonValueType)
+		json, err := m.ConvertToNative(jsonStructType)
 		if err != nil {
 			return nil, err
 		}
@@ -116,7 +116,7 @@ func (m *baseMap) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 		return nil, fmt.Errorf("type conversion error from map to '%v'", typeDesc)
 	}
 
-	// If the list is already assignable to the desired type return it.
+	// If the map is already assignable to the desired type return it.
 	if reflect.TypeOf(m).AssignableTo(typeDesc) {
 		return m, nil
 	}

--- a/common/types/map_test.go
+++ b/common/types/map_test.go
@@ -20,9 +20,10 @@ import (
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
-	structpb "github.com/golang/protobuf/ptypes/struct"
 
 	"github.com/google/cel-go/common/types/traits"
+
+	structpb "github.com/golang/protobuf/ptypes/struct"
 )
 
 func TestBaseMap_Contains(t *testing.T) {

--- a/common/types/map_test.go
+++ b/common/types/map_test.go
@@ -73,7 +73,7 @@ func TestBaseMap_ConvertToNative_Any(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	jsonMap := &structpb.Value{}
+	jsonMap := &structpb.Struct{}
 	if jsonpb.UnmarshalString(`{"nested":{"1":-1}}`, jsonMap) != nil {
 		t.Error("Unable to unmarshal json to protobuf.Value")
 	}

--- a/common/types/null.go
+++ b/common/types/null.go
@@ -19,8 +19,10 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	structpb "github.com/golang/protobuf/ptypes/struct"
+
 	"github.com/google/cel-go/common/types/ref"
+
+	structpb "github.com/golang/protobuf/ptypes/struct"
 )
 
 // Null type implementation.
@@ -38,16 +40,18 @@ func (n Null) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	switch typeDesc.Kind() {
 	case reflect.Ptr:
 		switch typeDesc {
-		case jsonValueType:
-			return &structpb.Value{
-				Kind: &structpb.Value_NullValue{
-					NullValue: structpb.NullValue_NULL_VALUE}}, nil
 		case anyValueType:
 			pb, err := n.ConvertToNative(jsonValueType)
 			if err != nil {
 				return nil, err
 			}
 			return ptypes.MarshalAny(pb.(proto.Message))
+		case jsonValueType:
+			return &structpb.Value{
+				Kind: &structpb.Value_NullValue{
+					NullValue: structpb.NullValue_NULL_VALUE,
+				},
+			}, nil
 		}
 	case reflect.Interface:
 		if reflect.TypeOf(n).Implements(typeDesc) {

--- a/common/types/null_test.go
+++ b/common/types/null_test.go
@@ -20,9 +20,9 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/struct"
 
 	anypb "github.com/golang/protobuf/ptypes/any"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 )
 
 func TestNull_ConvertToNative(t *testing.T) {

--- a/common/types/object.go
+++ b/common/types/object.go
@@ -21,10 +21,11 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	structpb "github.com/golang/protobuf/ptypes/struct"
 
 	"github.com/google/cel-go/common/types/pb"
 	"github.com/google/cel-go/common/types/ref"
+
+	structpb "github.com/golang/protobuf/ptypes/struct"
 )
 
 type protoObj struct {
@@ -35,8 +36,6 @@ type protoObj struct {
 	typeValue *TypeValue
 	isAny     bool
 }
-
-const ()
 
 // NewObject returns an object based on a proto.Message value which handles
 // conversion between protobuf type values and expression type values.

--- a/common/types/object.go
+++ b/common/types/object.go
@@ -61,6 +61,8 @@ func (o *protoObj) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 		}
 		return ptypes.MarshalAny(pb)
 	case jsonValueType:
+		// Marshal the proto to JSON first, and then rehydrate as protobuf.Value as there is no
+		// support for direct conversion from proto.Message to protobuf.Value.
 		jsonTxt, err := (&jsonpb.Marshaler{}).MarshalToString(pb)
 		if err != nil {
 			return nil, err

--- a/common/types/object.go
+++ b/common/types/object.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+
 	"github.com/google/cel-go/common/types/pb"
 	"github.com/google/cel-go/common/types/ref"
 )
@@ -48,19 +49,20 @@ func NewObject(adapter ref.TypeAdapter,
 		typeValue:   NewObjectTypeValue(typeDesc.Name())}
 }
 
-func (o *protoObj) ConvertToNative(refl reflect.Type) (interface{}, error) {
-	if refl.AssignableTo(o.refValue.Type()) {
+func (o *protoObj) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
+	// TODO: Add support for conversion to JSON
+	if typeDesc.AssignableTo(o.refValue.Type()) {
 		return o.value, nil
 	}
-	if refl == anyValueType {
+	if typeDesc == anyValueType {
 		return ptypes.MarshalAny(o.Value().(proto.Message))
 	}
 	// If the object is already assignable to the desired type return it.
-	if reflect.TypeOf(o).AssignableTo(refl) {
+	if reflect.TypeOf(o).AssignableTo(typeDesc) {
 		return o, nil
 	}
 	return nil, fmt.Errorf("type conversion error from '%v' to '%v'",
-		o.refValue.Type(), refl)
+		o.refValue.Type(), typeDesc)
 }
 
 func (o *protoObj) ConvertToType(typeVal ref.Type) ref.Val {

--- a/common/types/object_test.go
+++ b/common/types/object_test.go
@@ -75,4 +75,11 @@ func TestProtoObj_ConvertToNative(t *testing.T) {
 	if !proto.Equal(unpackedAny.Message, objVal.Value().(proto.Message)) {
 		t.Errorf("Messages were not equal, expect '%v', got '%v'", objVal.Value(), unpackedAny.Message)
 	}
+
+	// JSON
+	json, err := objVal.ConvertToNative(jsonValueType)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Error(json)
 }

--- a/common/types/object_test.go
+++ b/common/types/object_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 
@@ -81,5 +82,12 @@ func TestProtoObj_ConvertToNative(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	t.Error(json)
+	jsonTxt, err := (&jsonpb.Marshaler{}).MarshalToString(json.(proto.Message))
+	if err != nil {
+		t.Error(err)
+	}
+	wantTxt := `{"sourceInfo":{"lineOffsets":[1,2,3]}}`
+	if jsonTxt != wantTxt {
+		t.Errorf("Got %v, wanted %v", jsonTxt, wantTxt)
+	}
 }

--- a/common/types/object_test.go
+++ b/common/types/object_test.go
@@ -20,9 +20,11 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+
 	"github.com/google/cel-go/common/types/traits"
 
 	anypb "github.com/golang/protobuf/ptypes/any"
+
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 

--- a/common/types/providers_test.go
+++ b/common/types/providers_test.go
@@ -27,6 +27,7 @@ import (
 
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
+
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 

--- a/common/types/ref/provider.go
+++ b/common/types/ref/provider.go
@@ -43,8 +43,12 @@ type TypeProvider interface {
 	// Used during type-checking only.
 	FindFieldType(messageType string, fieldName string) (*FieldType, bool)
 
-	// NewValue creates a new type value from a qualified name and a map of
-	// field initializers.
+	// NewValue creates a new type value from a qualified name and map of field
+	// name to value.
+	//
+	// Note, for each value, the Val.ConvertToNative function will be invoked
+	// to convert the Val to the field's native type. If an error occurs during
+	// conversion, the NewValue will be a types.Err.
 	NewValue(typeName string, fields map[string]Val) Val
 }
 

--- a/common/types/string.go
+++ b/common/types/string.go
@@ -80,14 +80,15 @@ func (s String) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	case reflect.Ptr:
 		switch typeDesc {
 		case anyValueType:
+			// Primitives must be wrapped before being set on an Any field.
 			return ptypes.MarshalAny(&wrapperspb.StringValue{Value: string(s)})
 		case jsonValueType:
+			// Convert to a protobuf representation of a JSON String.
 			return &structpb.Value{
-				Kind: &structpb.Value_StringValue{
-					StringValue: string(s),
-				},
+				Kind: &structpb.Value_StringValue{StringValue: string(s)},
 			}, nil
 		case stringWrapperType:
+			// Convert to a protobuf.StringValue.
 			return &wrapperspb.StringValue{Value: string(s)}, nil
 		}
 		if typeDesc.Elem().Kind() == reflect.String {

--- a/common/types/string_test.go
+++ b/common/types/string_test.go
@@ -18,13 +18,13 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
+
 	"github.com/google/cel-go/common/overloads"
 	"github.com/google/cel-go/common/types/ref"
 
-	"github.com/golang/protobuf/proto"
-	structpb "github.com/golang/protobuf/ptypes/struct"
-
 	dpb "github.com/golang/protobuf/ptypes/duration"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	tpb "github.com/golang/protobuf/ptypes/timestamp"
 )
 

--- a/common/types/string_test.go
+++ b/common/types/string_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 
 	"github.com/google/cel-go/common/overloads"
 	"github.com/google/cel-go/common/types/ref"
@@ -26,6 +27,7 @@ import (
 	dpb "github.com/golang/protobuf/ptypes/duration"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	tpb "github.com/golang/protobuf/ptypes/timestamp"
+	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 )
 
 func TestString_Add(t *testing.T) {
@@ -52,6 +54,20 @@ func TestString_Compare(t *testing.T) {
 	}
 	if !IsError(a.Compare(True)) {
 		t.Error("Comparison to a non-string type did not generate an error.")
+	}
+}
+
+func TestString_ConvertToNative_Any(t *testing.T) {
+	val, err := String("hello").ConvertToNative(anyValueType)
+	if err != nil {
+		t.Error(err)
+	}
+	want, err := ptypes.MarshalAny(&wrapperspb.StringValue{Value: "hello"})
+	if err != nil {
+		t.Error(err)
+	}
+	if !proto.Equal(val.(proto.Message), want) {
+		t.Errorf("Got '%v', expected '%v'", val, want)
 	}
 }
 
@@ -88,6 +104,17 @@ func TestString_ConvertToNative_String(t *testing.T) {
 		t.Error(err)
 	} else if val.(string) != "hello" {
 		t.Errorf("Got '%v', expected 'hello'", val)
+	}
+}
+
+func TestString_ConvertToNative_Wrapper(t *testing.T) {
+	val, err := String("hello").ConvertToNative(stringWrapperType)
+	if err != nil {
+		t.Error(err)
+	}
+	want := &wrapperspb.StringValue{Value: "hello"}
+	if !proto.Equal(val.(proto.Message), want) {
+		t.Errorf("Got '%v', expected '%v'", val, want)
 	}
 }
 

--- a/common/types/timestamp.go
+++ b/common/types/timestamp.go
@@ -84,9 +84,9 @@ func (t Timestamp) Compare(other ref.Val) ref.Val {
 func (t Timestamp) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	switch typeDesc {
 	case anyValueType:
-		return ptypes.MarshalAny(t.Value().(proto.Message))
+		return ptypes.MarshalAny(t.Timestamp)
 	case jsonValueType:
-		// proto3 to JSON conversion requires string-formatted timestamps.
+		// proto3 to JSON conversion requires string-formatted timestamps
 		v := t.ConvertToType(StringType)
 		if IsError(v) {
 			return nil, v.(*Err)
@@ -104,7 +104,7 @@ func (t Timestamp) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 		return t, nil
 	}
 	return nil, fmt.Errorf("type conversion error from "+
-		"'google.protobuf.Duration' to '%v'", typeDesc)
+		"'google.protobuf.Timestamp' to '%v'", typeDesc)
 }
 
 // ConvertToType implements ref.Val.ConvertToType.

--- a/common/types/timestamp.go
+++ b/common/types/timestamp.go
@@ -84,19 +84,19 @@ func (t Timestamp) Compare(other ref.Val) ref.Val {
 func (t Timestamp) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	switch typeDesc {
 	case anyValueType:
+		// Pack the underlying protobuf.Timestamp to an Any value.
 		return ptypes.MarshalAny(t.Timestamp)
 	case jsonValueType:
-		// proto3 to JSON conversion requires string-formatted timestamps
+		// Proto3 to JSON conversion requires string-formatted timestamps
 		v := t.ConvertToType(StringType)
 		if IsError(v) {
 			return nil, v.(*Err)
 		}
 		return &structpb.Value{
-			Kind: &structpb.Value_StringValue{
-				StringValue: string(v.(String)),
-			},
+			Kind: &structpb.Value_StringValue{StringValue: string(v.(String))},
 		}, nil
 	case timestampValueType:
+		// Unwrap the underlying protobuf.Timestamp.
 		return t.Value(), nil
 	}
 	// If the timestamp is already assignable to the desired type return it.

--- a/common/types/timestamp.go
+++ b/common/types/timestamp.go
@@ -87,7 +87,8 @@ func (t Timestamp) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 		// Pack the underlying protobuf.Timestamp to an Any value.
 		return ptypes.MarshalAny(t.Timestamp)
 	case jsonValueType:
-		// Proto3 to JSON conversion requires string-formatted timestamps
+		// CEL follows the proto3 to JSON conversion which formats as an RFC 3339 encoded JSON
+		// string.
 		v := t.ConvertToType(StringType)
 		if IsError(v) {
 			return nil, v.(*Err)

--- a/common/types/timestamp_test.go
+++ b/common/types/timestamp_test.go
@@ -17,11 +17,11 @@ package types
 import (
 	"testing"
 
-	"github.com/google/cel-go/common/overloads"
-	"github.com/google/cel-go/common/types/ref"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+
+	"github.com/google/cel-go/common/overloads"
+	"github.com/google/cel-go/common/types/ref"
 
 	dpb "github.com/golang/protobuf/ptypes/duration"
 	structpb "github.com/golang/protobuf/ptypes/struct"

--- a/common/types/timestamp_test.go
+++ b/common/types/timestamp_test.go
@@ -20,7 +20,11 @@ import (
 	"github.com/google/cel-go/common/overloads"
 	"github.com/google/cel-go/common/types/ref"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+
 	dpb "github.com/golang/protobuf/ptypes/duration"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	tpb "github.com/golang/protobuf/ptypes/timestamp"
 )
 
@@ -39,6 +43,52 @@ func TestTimestamp_Add(t *testing.T) {
 	}
 }
 
+func TestTimestamp_ConvertToNative_Any(t *testing.T) {
+	// 1970-01-01T02:05:06Z
+	ts := Timestamp{&tpb.Timestamp{Seconds: 7506}}
+	val, err := ts.ConvertToNative(anyValueType)
+	if err != nil {
+		t.Error(err)
+	}
+	want, err := ptypes.MarshalAny(ts.Timestamp)
+	if err != nil {
+		t.Error(err)
+	}
+	if !proto.Equal(val.(proto.Message), want) {
+		t.Errorf("Got '%v', expected '%v'", val, want)
+	}
+}
+
+func TestTimestamp_ConvertToNative_Json(t *testing.T) {
+	// 1970-01-01T02:05:06Z
+	ts := Timestamp{&tpb.Timestamp{Seconds: 7506}}
+	val, err := ts.ConvertToNative(jsonValueType)
+	if err != nil {
+		t.Error(err)
+	}
+	want := &structpb.Value{
+		Kind: &structpb.Value_StringValue{
+			StringValue: "1970-01-01T02:05:06Z",
+		},
+	}
+	if !proto.Equal(val.(proto.Message), want) {
+		t.Errorf("Got '%v', expected '%v'", val, want)
+	}
+}
+
+func TestTimestamp_ConvertToNative_Timestamp(t *testing.T) {
+	// 1970-01-01T02:05:06Z
+	ts := Timestamp{&tpb.Timestamp{Seconds: 7506}}
+	val, err := ts.ConvertToNative(timestampValueType)
+	if err != nil {
+		t.Error(err)
+	}
+	want := ts.Timestamp
+	if !proto.Equal(val.(proto.Message), want) {
+		t.Errorf("Got '%v', expected '%v'", val, want)
+	}
+}
+
 func TestTimestamp_Subtract(t *testing.T) {
 	ts := Timestamp{&tpb.Timestamp{Seconds: 7506}}
 	val := ts.Subtract(Duration{&dpb.Duration{Seconds: 3600, Nanos: 1000}})
@@ -52,13 +102,13 @@ func TestTimestamp_Subtract(t *testing.T) {
 }
 
 func TestTimestamp_RecieveGetDayOfYear(t *testing.T) {
-	// 1970-01-01T02:05:05Z
+	// 1970-01-01T02:05:06Z
 	ts := Timestamp{&tpb.Timestamp{Seconds: 7506}}
 	hr := ts.Receive(overloads.TimeGetDayOfYear, overloads.TimestampToDayOfYear, []ref.Val{})
 	if !hr.Equal(Int(0)).(Bool) {
 		t.Error("Expected 0, got", hr)
 	}
-	// 1969-12-31T19:05:05Z
+	// 1969-12-31T19:05:06Z
 	hrTz := ts.Receive(overloads.TimeGetDayOfYear, overloads.TimestampToDayOfYearWithTz,
 		[]ref.Val{String("America/Phoenix")})
 	if !hrTz.Equal(Int(364)).(Bool) {
@@ -67,13 +117,13 @@ func TestTimestamp_RecieveGetDayOfYear(t *testing.T) {
 }
 
 func TestTimestamp_ReceiveGetMonth(t *testing.T) {
-	// 1970-01-01T02:05:05Z
+	// 1970-01-01T02:05:06Z
 	ts := Timestamp{&tpb.Timestamp{Seconds: 7506}}
 	hr := ts.Receive(overloads.TimeGetMonth, overloads.TimestampToMonth, []ref.Val{})
 	if !hr.Equal(Int(0)).(Bool) {
 		t.Error("Expected 0, got", hr)
 	}
-	// 1969-12-31T19:05:05Z
+	// 1969-12-31T19:05:06Z
 	hrTz := ts.Receive(overloads.TimeGetMonth, overloads.TimestampToMonthWithTz,
 		[]ref.Val{String("America/Phoenix")})
 	if !hrTz.Equal(Int(11)).(Bool) {
@@ -82,13 +132,13 @@ func TestTimestamp_ReceiveGetMonth(t *testing.T) {
 }
 
 func TestTimestamp_ReceiveGetHours(t *testing.T) {
-	// 1970-01-01T02:05:05Z
+	// 1970-01-01T02:05:06Z
 	ts := Timestamp{&tpb.Timestamp{Seconds: 7506}}
 	hr := ts.Receive(overloads.TimeGetHours, overloads.TimestampToHours, []ref.Val{})
 	if !hr.Equal(Int(2)).(Bool) {
 		t.Error("Expected 2 hours, got", hr)
 	}
-	// 1969-12-31T19:05:05Z
+	// 1969-12-31T19:05:06Z
 	hrTz := ts.Receive(overloads.TimeGetHours, overloads.TimestampToHoursWithTz,
 		[]ref.Val{String("America/Phoenix")})
 	if !hrTz.Equal(Int(19)).(Bool) {
@@ -97,13 +147,13 @@ func TestTimestamp_ReceiveGetHours(t *testing.T) {
 }
 
 func TestTimestamp_ReceiveGetMinutes(t *testing.T) {
-	// 1970-01-01T02:05:05Z
+	// 1970-01-01T02:05:06Z
 	ts := Timestamp{&tpb.Timestamp{Seconds: 7506}}
 	min := ts.Receive(overloads.TimeGetMinutes, overloads.TimestampToMinutes, []ref.Val{})
 	if !min.Equal(Int(5)).(Bool) {
 		t.Error("Expected 5 minutes, got", min)
 	}
-	// 1969-12-31T19:05:05Z
+	// 1969-12-31T19:05:06Z
 	minTz := ts.Receive(overloads.TimeGetMinutes, overloads.TimestampToMinutesWithTz,
 		[]ref.Val{String("America/Phoenix")})
 	if !minTz.Equal(Int(5)).(Bool) {
@@ -112,13 +162,13 @@ func TestTimestamp_ReceiveGetMinutes(t *testing.T) {
 }
 
 func TestTimestamp_ReceiveGetSeconds(t *testing.T) {
-	// 1970-01-01T02:05:05Z
+	// 1970-01-01T02:05:06Z
 	ts := Timestamp{&tpb.Timestamp{Seconds: 7506}}
 	sec := ts.Receive(overloads.TimeGetSeconds, overloads.TimestampToSeconds, []ref.Val{})
 	if !sec.Equal(Int(6)).(Bool) {
 		t.Error("Expected 6 seconds, got", sec)
 	}
-	// 1969-12-31T19:05:05Z
+	// 1969-12-31T19:05:06Z
 	secTz := ts.Receive(overloads.TimeGetSeconds, overloads.TimestampToSecondsWithTz,
 		[]ref.Val{String("America/Phoenix")})
 	if !secTz.Equal(Int(6)).(Bool) {

--- a/common/types/uint.go
+++ b/common/types/uint.go
@@ -16,7 +16,6 @@ package types
 
 import (
 	"fmt"
-	"math"
 	"reflect"
 	"strconv"
 
@@ -90,7 +89,7 @@ func (i Uint) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 			return ptypes.MarshalAny(&wrapperspb.UInt64Value{Value: uint64(i)})
 		case jsonValueType:
 			// JSON can accurately represent 32-bit uints as floating point values.
-			if i.isUint32() {
+			if i.isJSONSafe() {
 				return &structpb.Value{
 					Kind: &structpb.Value_NumberValue{
 						NumberValue: float64(i),
@@ -205,6 +204,7 @@ func (i Uint) Value() interface{} {
 	return uint64(i)
 }
 
-func (i Uint) isUint32() bool {
-	return math.MaxUint32 >= i
+// isJSONSafe indicates whether the uint is safely representable as a floating point value in JSON.
+func (i Uint) isJSONSafe() bool {
+	return i <= maxIntJSON
 }

--- a/common/types/uint.go
+++ b/common/types/uint.go
@@ -20,10 +20,11 @@ import (
 	"reflect"
 	"strconv"
 
+	"github.com/golang/protobuf/ptypes"
+
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 
-	"github.com/golang/protobuf/ptypes"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 )

--- a/common/types/uint_test.go
+++ b/common/types/uint_test.go
@@ -15,10 +15,14 @@
 package types
 
 import (
+	"math"
 	"reflect"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 	structpb "github.com/golang/protobuf/ptypes/struct"
+	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 )
 
 func TestUint_Add(t *testing.T) {
@@ -47,6 +51,20 @@ func TestUint_Compare(t *testing.T) {
 	}
 }
 
+func TestUint_ConvertToNative_Any(t *testing.T) {
+	val, err := Uint(math.MaxUint64).ConvertToNative(anyValueType)
+	if err != nil {
+		t.Error(err)
+	}
+	want, err := ptypes.MarshalAny(&wrapperspb.UInt64Value{Value: math.MaxUint64})
+	if err != nil {
+		t.Error(err)
+	}
+	if !proto.Equal(val.(proto.Message), want) {
+		t.Errorf("Got %v, wanted %v", val, want)
+	}
+}
+
 func TestUint_ConvertToNative_Error(t *testing.T) {
 	val, err := Uint(10000).ConvertToNative(reflect.TypeOf(int(0)))
 	if err == nil {
@@ -55,11 +73,22 @@ func TestUint_ConvertToNative_Error(t *testing.T) {
 }
 
 func TestUint_ConvertToNative_Json(t *testing.T) {
-	val, err := Uint(10000).ConvertToNative(jsonValueType)
+	// Value less than uint32.
+	val, err := Uint(math.MaxUint32 - 1).ConvertToNative(jsonValueType)
 	if err != nil {
 		t.Error(err)
-	} else if val.(*structpb.Value).GetNumberValue() != 10000. {
-		t.Errorf("Error converting uint to json number. Got '%v', expected 10000.", val)
+	} else if !proto.Equal(val.(proto.Message),
+		&structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: 4294967294.0}}) {
+		t.Errorf("Got '%v', expected a json number for a 32-bit uint", val)
+	}
+
+	// Value greater than max uint32.
+	val, err = Int(math.MaxUint32 + 1).ConvertToNative(jsonValueType)
+	if err != nil {
+		t.Error(err)
+	} else if !proto.Equal(val.(proto.Message),
+		&structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "4294967296"}}) {
+		t.Errorf("Got '%v', expected a json string for a 64-bit uint", val)
 	}
 }
 
@@ -80,6 +109,26 @@ func TestUint_ConvertToNative_Ptr_Uint64(t *testing.T) {
 		t.Error(err)
 	} else if *val.(*uint64) != uint64(18446744073709551612) {
 		t.Errorf("Error converting uint to *uint64. Got '%v', expected 18446744073709551612.", val)
+	}
+}
+
+func TestUint_ConvertToNative_Wrapper(t *testing.T) {
+	val, err := Uint(math.MaxUint32).ConvertToNative(uint32WrapperType)
+	if err != nil {
+		t.Error(err)
+	}
+	want := &wrapperspb.UInt32Value{Value: math.MaxUint32}
+	if !proto.Equal(val.(proto.Message), want) {
+		t.Errorf("Got %v, wanted %v", val, want)
+	}
+
+	val, err = Uint(math.MaxUint64).ConvertToNative(uint64WrapperType)
+	if err != nil {
+		t.Error(err)
+	}
+	want2 := &wrapperspb.UInt64Value{Value: math.MaxUint64}
+	if !proto.Equal(val.(proto.Message), want2) {
+		t.Errorf("Got %v, wanted %v", val, want2)
 	}
 }
 

--- a/common/types/uint_test.go
+++ b/common/types/uint_test.go
@@ -74,7 +74,7 @@ func TestUint_ConvertToNative_Error(t *testing.T) {
 }
 
 func TestUint_ConvertToNative_Json(t *testing.T) {
-	// Value less than uint32.
+	// Value can be represented accurately as a JSON number.
 	val, err := Uint(maxIntJSON).ConvertToNative(jsonValueType)
 	if err != nil {
 		t.Error(err)
@@ -83,7 +83,7 @@ func TestUint_ConvertToNative_Json(t *testing.T) {
 		t.Errorf("Got '%v', expected a json number for a 32-bit uint", val)
 	}
 
-	// Value greater than max uint32.
+	// Value converts to a JSON decimal string
 	val, err = Int(maxIntJSON + 1).ConvertToNative(jsonValueType)
 	if err != nil {
 		t.Error(err)

--- a/common/types/uint_test.go
+++ b/common/types/uint_test.go
@@ -75,20 +75,20 @@ func TestUint_ConvertToNative_Error(t *testing.T) {
 
 func TestUint_ConvertToNative_Json(t *testing.T) {
 	// Value less than uint32.
-	val, err := Uint(math.MaxUint32 - 1).ConvertToNative(jsonValueType)
+	val, err := Uint(maxIntJSON).ConvertToNative(jsonValueType)
 	if err != nil {
 		t.Error(err)
 	} else if !proto.Equal(val.(proto.Message),
-		&structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: 4294967294.0}}) {
+		&structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: 9007199254740991.0}}) {
 		t.Errorf("Got '%v', expected a json number for a 32-bit uint", val)
 	}
 
 	// Value greater than max uint32.
-	val, err = Int(math.MaxUint32 + 1).ConvertToNative(jsonValueType)
+	val, err = Int(maxIntJSON + 1).ConvertToNative(jsonValueType)
 	if err != nil {
 		t.Error(err)
 	} else if !proto.Equal(val.(proto.Message),
-		&structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "4294967296"}}) {
+		&structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "9007199254740992"}}) {
 		t.Errorf("Got '%v', expected a json string for a 64-bit uint", val)
 	}
 }

--- a/common/types/uint_test.go
+++ b/common/types/uint_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 )

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -254,6 +254,15 @@ func (p *planner) planCall(expr *exprpb.Expr) (Interpretable, error) {
 		len(oRef.GetOverloadId()) == 1 {
 		oName = oRef.GetOverloadId()[0]
 	}
+	// Try to find the specific function by overload id.
+	var fnDef *functions.Overload
+	if oName != "" {
+		fnDef, _ = p.disp.FindOverload(oName)
+	}
+	// If the overload id couldn't resolve the function, try the simple function name.
+	if fnDef == nil {
+		fnDef, _ = p.disp.FindOverload(fnName)
+	}
 
 	// Generate specialized Interpretable operators by function name if possible.
 	switch fnName {

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -254,15 +254,6 @@ func (p *planner) planCall(expr *exprpb.Expr) (Interpretable, error) {
 		len(oRef.GetOverloadId()) == 1 {
 		oName = oRef.GetOverloadId()[0]
 	}
-	// Try to find the specific function by overload id.
-	var fnDef *functions.Overload
-	if oName != "" {
-		fnDef, _ = p.disp.FindOverload(oName)
-	}
-	// If the overload id couldn't resolve the function, try the simple function name.
-	if fnDef == nil {
-		fnDef, _ = p.disp.FindOverload(fnName)
-	}
 
 	// Generate specialized Interpretable operators by function name if possible.
 	switch fnName {


### PR DESCRIPTION
Add support for the following type conversions:

* [Proto3 to JSON](https://developers.google.com/protocol-buffers/docs/proto3#json) conversions
* Primitives to `google.protobuf.Any`
* Primitives to protobuf wrapper types.

Closes #258 