### PR TITLE
Add an `Env.Extend` method.

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -564,6 +564,21 @@ func Benchmark_EvalOptions(b *testing.B) {
 	}
 }
 
+func Test_EnvExtension(t *testing.T) {
+	e, _ := NewEnv(
+		Container("google.api.expr.v1alpha1"),
+		Types(&exprpb.Expr{}),
+		Declarations(
+			decls.NewIdent("expr",
+				decls.NewObjectType("google.api.expr.v1alpha1.Expr"), nil),
+		),
+	)
+	e2, _ := e.Extend()
+	if e == e2 {
+		t.Error("Got object equality, wanted separate objects")
+	}
+}
+
 func Test_ParseAndCheckConcurrently(t *testing.T) {
 	e, _ := NewEnv(
 		Container("google.api.expr.v1alpha1"),

--- a/cel/env.go
+++ b/cel/env.go
@@ -61,6 +61,9 @@ type Ast interface {
 // constants, variables, and functions. The Env interface also defines a method for generating
 // evaluable programs from parsed and checked Asts.
 type Env interface {
+	// Extend the current environment with additional options to produce a new Env.
+	Extend(opts ...EnvOption) (Env, error)
+
 	// Check performs type-checking on the input Ast and yields a checked Ast and/or set of Issues.
 	//
 	// Checking has failed if the returned Issues value and its Issues.Err() value is non-nil.
@@ -118,6 +121,25 @@ func NewEnv(opts ...EnvOption) (Env, error) {
 		enableBuiltins:                 true,
 		enableDynamicAggregateLiterals: true,
 	}
+	return e.configure(opts...)
+}
+
+// Extend the current environment with additional options to produce a new Env.
+func (e *env) Extend(opts ...EnvOption) (Env, error) {
+	ext := &env{
+		declarations:                   e.declarations,
+		macros:                         e.macros,
+		pkg:                            e.pkg,
+		provider:                       e.provider,
+		adapter:                        e.adapter,
+		enableBuiltins:                 e.enableBuiltins,
+		enableDynamicAggregateLiterals: e.enableDynamicAggregateLiterals,
+	}
+	return ext.configure(opts...)
+}
+
+// configure applies a series of EnvOptions to the current environment.
+func (e *env) configure(opts ...EnvOption) (Env, error) {
 	// Customized the environment using the provided EnvOption values. If an error is
 	// generated at any step this, will be returned as a nil Env with a non-nil error.
 	var err error

--- a/cel/env.go
+++ b/cel/env.go
@@ -125,15 +125,9 @@ func NewEnv(opts ...EnvOption) (Env, error) {
 
 // Extend the current environment with additional options to produce a new Env.
 func (e *env) Extend(opts ...EnvOption) (Env, error) {
-	return (&env{
-		declarations:                   e.declarations,
-		macros:                         e.macros,
-		pkg:                            e.pkg,
-		provider:                       e.provider,
-		adapter:                        e.adapter,
-		enableBuiltins:                 e.enableBuiltins,
-		enableDynamicAggregateLiterals: e.enableDynamicAggregateLiterals,
-	}).configure(opts...)
+	ext := &env{}
+	*ext = *e
+	return ext.configure(opts...)
 }
 
 // configure applies a series of EnvOptions to the current environment.

--- a/cel/env.go
+++ b/cel/env.go
@@ -112,7 +112,7 @@ type Issues interface {
 // See the EnvOptions for the options that can be used to configure the environment.
 func NewEnv(opts ...EnvOption) (Env, error) {
 	registry := types.NewRegistry()
-	e := &env{
+	return (&env{
 		declarations:                   checker.StandardDeclarations(),
 		macros:                         parser.AllMacros,
 		pkg:                            packages.DefaultPackage,
@@ -120,13 +120,12 @@ func NewEnv(opts ...EnvOption) (Env, error) {
 		adapter:                        registry,
 		enableBuiltins:                 true,
 		enableDynamicAggregateLiterals: true,
-	}
-	return e.configure(opts...)
+	}).configure(opts...)
 }
 
 // Extend the current environment with additional options to produce a new Env.
 func (e *env) Extend(opts ...EnvOption) (Env, error) {
-	ext := &env{
+	return (&env{
 		declarations:                   e.declarations,
 		macros:                         e.macros,
 		pkg:                            e.pkg,
@@ -134,8 +133,7 @@ func (e *env) Extend(opts ...EnvOption) (Env, error) {
 		adapter:                        e.adapter,
 		enableBuiltins:                 e.enableBuiltins,
 		enableDynamicAggregateLiterals: e.enableDynamicAggregateLiterals,
-	}
-	return ext.configure(opts...)
+	}).configure(opts...)
 }
 
 // configure applies a series of EnvOptions to the current environment.

--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -235,6 +235,9 @@ func TestConcatList_ConvertToNative_Json(t *testing.T) {
 	listC := NewDynamicList(reg, []*dpb.Duration{{Seconds: 100}})
 	listConcat := listA.Add(listC)
 	json, err = listConcat.ConvertToNative(jsonValueType)
+	if err != nil {
+		t.Error(err)
+	}
 	jsonTxt, err = (&jsonpb.Marshaler{}).MarshalToString(json.(proto.Message))
 	if err != nil {
 		t.Error(err)

--- a/test/proto2pb/test_all_types.proto
+++ b/test/proto2pb/test_all_types.proto
@@ -2,13 +2,13 @@
 
 syntax = "proto2";
 
+package google.expr.proto2.test;
+
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
-
-package google.expr.proto2.test;
 
 // This proto includes every type of field in both singular and repeated
 // forms.
@@ -27,21 +27,21 @@ message TestAllTypes {
   }
 
   // Singular
-  optional int32 single_int32 = 1 [ default = -32 ];
-  optional int64 single_int64 = 2 [ default = -64 ];
-  optional uint32 single_uint32 = 3 [ default = 32 ];
-  optional uint64 single_uint64 = 4 [ default = 64 ];
+  optional int32 single_int32 = 1 [default = -32];
+  optional int64 single_int64 = 2 [default = -64];
+  optional uint32 single_uint32 = 3 [default = 32];
+  optional uint64 single_uint64 = 4 [default = 64];
   optional sint32 single_sint32 = 5;
   optional sint64 single_sint64 = 6;
   optional fixed32 single_fixed32 = 7;
   optional fixed64 single_fixed64 = 8;
   optional sfixed32 single_sfixed32 = 9;
   optional sfixed64 single_sfixed64 = 10;
-  optional float single_float = 11 [ default = 3.0 ];
-  optional double single_double = 12 [ default = 6.4 ];
-  optional bool single_bool = 13 [ default = true ];
-  optional string single_string = 14 [ default = "empty" ];
-  optional bytes single_bytes = 15 [ default = "none" ];
+  optional float single_float = 11 [default = 3.0];
+  optional double single_double = 12 [default = 6.4];
+  optional bool single_bool = 13 [default = true];
+  optional string single_string = 14 [default = "empty"];
+  optional bytes single_bytes = 15 [default = "none"];
 
   // Wellknown.
   optional google.protobuf.Any single_any = 100;
@@ -62,7 +62,7 @@ message TestAllTypes {
   // Nested messages
   oneof nested_type {
     NestedMessage single_nested_message = 18;
-    NestedEnum single_nested_enum = 21 [ default = BAR ];
+    NestedEnum single_nested_enum = 21 [default = BAR];
   }
 
   // Repeated

--- a/test/proto3pb/test_all_types.proto
+++ b/test/proto3pb/test_all_types.proto
@@ -2,13 +2,13 @@
 
 syntax = "proto3";
 
+package google.expr.proto3.test;
+
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
-
-package google.expr.proto3.test;
 
 // This proto includes every type of field in both singular and repeated
 // forms.
@@ -58,7 +58,7 @@ message TestAllTypes {
   google.protobuf.StringValue single_string_wrapper = 111;
   google.protobuf.BoolValue single_bool_wrapper = 112;
   google.protobuf.BytesValue single_bytes_wrapper = 113;
-  
+
   // Nested messages
   oneof nested_type {
     NestedMessage single_nested_message = 18;


### PR DESCRIPTION
Introduce a new method to extend a `cel.Env` with additional `cel.EnvOption` options.

Note, the new method clones the current environment before configuring the extended options.