### PR TITLE
Support for parsing embedded CEL expressions within larger files

### DIFF
--- a/cel/env.go
+++ b/cel/env.go
@@ -75,12 +75,18 @@ type Env interface {
 
 	// Parse parses the input expression value `txt` to a Ast and/or a set of Issues.
 	//
+	// This form of Parse creates a common.Source value for the input `txt` and forwards to the
+	// ParseSource method.
+	Parse(txt string) (Ast, Issues)
+
+	// Parse parses the input source to an Ast and/or set of Issues.
+	//
 	// Parsing has failed if the returned Issues value and its Issues.Err() value is non-nil.
 	// Issues should be inspected if they are non-nil, but may not represent a fatal error.
 	//
 	// It is possible to have both non-nil Ast and Issues values returned from this call; however,
 	// the mere presence of an Ast does not imply that it is valid for use.
-	Parse(txt string) (Ast, Issues)
+	ParseSource(src common.Source) (Ast, Issues)
 
 	// Program generates an evaluable instance of the Ast within the environment (Env).
 	Program(ast Ast, opts ...ProgramOption) (Program, error)
@@ -223,6 +229,11 @@ func (e *env) Check(ast Ast) (Ast, Issues) {
 // Parse implements the Env interface method.
 func (e *env) Parse(txt string) (Ast, Issues) {
 	src := common.NewTextSource(txt)
+	return e.ParseSource(src)
+}
+
+// ParseSource implements the Env interface method.
+func (e *env) ParseSource(src common.Source) (Ast, Issues) {
 	res, errs := parser.ParseWithMacros(src, e.macros)
 	if len(errs.GetErrors()) > 0 {
 		return nil, &issues{errs: errs}

--- a/cel/env.go
+++ b/cel/env.go
@@ -78,7 +78,7 @@ type Env interface {
 	// ParseSource method.
 	Parse(txt string) (Ast, *Issues)
 
-	// Parse parses the input source to an Ast and/or set of Issues.
+	// ParseSource parses the input source to an Ast and/or set of Issues.
 	//
 	// Parsing has failed if the returned Issues value and its Issues.Err() value is non-nil.
 	// Issues should be inspected if they are non-nil, but may not represent a fatal error.
@@ -259,10 +259,10 @@ type Issues struct {
 	errs *common.Errors
 }
 
-// NewIssues returns an Issues struct from a common.Source.
-func NewIssues(src common.Source) *Issues {
+// NewIssues returns an Issues struct from a common.Errors object.
+func NewIssues(errs *common.Errors) *Issues {
 	return &Issues{
-		errs: common.NewErrors(src),
+		errs: errs,
 	}
 }
 

--- a/cel/env.go
+++ b/cel/env.go
@@ -16,7 +16,6 @@ package cel
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/checker/decls"
@@ -71,13 +70,13 @@ type Env interface {
 	//
 	// It is possible to have both non-nil Ast and Issues values returned from this call: however,
 	// the mere presence of an Ast does not imply that it is valid for use.
-	Check(ast Ast) (Ast, Issues)
+	Check(ast Ast) (Ast, *Issues)
 
 	// Parse parses the input expression value `txt` to a Ast and/or a set of Issues.
 	//
 	// This form of Parse creates a common.Source value for the input `txt` and forwards to the
 	// ParseSource method.
-	Parse(txt string) (Ast, Issues)
+	Parse(txt string) (Ast, *Issues)
 
 	// Parse parses the input source to an Ast and/or set of Issues.
 	//
@@ -86,7 +85,7 @@ type Env interface {
 	//
 	// It is possible to have both non-nil Ast and Issues values returned from this call; however,
 	// the mere presence of an Ast does not imply that it is valid for use.
-	ParseSource(src common.Source) (Ast, Issues)
+	ParseSource(src common.Source) (Ast, *Issues)
 
 	// Program generates an evaluable instance of the Ast within the environment (Env).
 	Program(ast Ast, opts ...ProgramOption) (Program, error)
@@ -96,19 +95,6 @@ type Env interface {
 
 	// TypeProvider returns the `ref.TypeProvider` configured for the environment.
 	TypeProvider() ref.TypeProvider
-}
-
-// Issues defines methods for inspecting the error details of parse and check calls.
-//
-// Note: in the future, non-fatal warnings and notices may be inspectable via the Issues interface.
-type Issues interface {
-	fmt.Stringer
-
-	// Err returns an error value if the issues list contains one or more errors.
-	Err() error
-
-	// Errors returns the collection of errors encountered in more granular detail.
-	Errors() []common.Error
 }
 
 // NewEnv creates an Env instance suitable for parsing and checking expressions against a set of
@@ -209,12 +195,12 @@ type env struct {
 }
 
 // Check implements the Env interface method.
-func (e *env) Check(ast Ast) (Ast, Issues) {
+func (e *env) Check(ast Ast) (Ast, *Issues) {
 	// Note, errors aren't currently possible on the Ast to ParsedExpr conversion.
 	pe, _ := AstToParsedExpr(ast)
 	res, errs := checker.Check(pe, ast.Source(), e.chk)
 	if len(errs.GetErrors()) > 0 {
-		return nil, &issues{errs: errs}
+		return nil, &Issues{errs: errs}
 	}
 	// Manually create the Ast to ensure that the Ast source information (which may be more
 	// detailed than the information provided by Check), is returned to the caller.
@@ -227,16 +213,16 @@ func (e *env) Check(ast Ast) (Ast, Issues) {
 }
 
 // Parse implements the Env interface method.
-func (e *env) Parse(txt string) (Ast, Issues) {
+func (e *env) Parse(txt string) (Ast, *Issues) {
 	src := common.NewTextSource(txt)
 	return e.ParseSource(src)
 }
 
 // ParseSource implements the Env interface method.
-func (e *env) ParseSource(src common.Source) (Ast, Issues) {
+func (e *env) ParseSource(src common.Source) (Ast, *Issues) {
 	res, errs := parser.ParseWithMacros(src, e.macros)
 	if len(errs.GetErrors()) > 0 {
-		return nil, &issues{errs: errs}
+		return nil, &Issues{errs: errs}
 	}
 	// Manually create the Ast to ensure that the text source information is propagated on
 	// subsequent calls to Check.
@@ -266,25 +252,39 @@ func (e *env) TypeProvider() ref.TypeProvider {
 	return e.provider
 }
 
-// issues is the internal implementation of the Issues interface.
-type issues struct {
+// Issues defines methods for inspecting the error details of parse and check calls.
+//
+// Note: in the future, non-fatal warnings and notices may be inspectable via the Issues struct.
+type Issues struct {
 	errs *common.Errors
 }
 
-// Err implements the Issues interface method.
-func (i *issues) Err() error {
+// NewIssues returns an Issues struct from a common.Source.
+func NewIssues(src common.Source) *Issues {
+	return &Issues{
+		errs: common.NewErrors(src),
+	}
+}
+
+// Err returns an error value if the issues list contains one or more errors.
+func (i *Issues) Err() error {
 	if len(i.errs.GetErrors()) > 0 {
 		return errors.New(i.errs.ToDisplayString())
 	}
 	return nil
 }
 
-// Errors implements the Issues interface method.
-func (i *issues) Errors() []common.Error {
+// Errors returns the collection of errors encountered in more granular detail.
+func (i *Issues) Errors() []common.Error {
 	return i.errs.GetErrors()
 }
 
+// Append collects the issues from another Issues struct into the current object.
+func (i *Issues) Append(other *Issues) {
+	i.errs.Append(other.errs.GetErrors())
+}
+
 // String converts the issues to a suitable display string.
-func (i *issues) String() string {
+func (i *Issues) String() string {
 	return i.errs.ToDisplayString()
 }

--- a/common/errors.go
+++ b/common/errors.go
@@ -45,6 +45,11 @@ func (e *Errors) GetErrors() []Error {
 	return e.errors[:]
 }
 
+// Append takes an Errors object as input and appends its errors to the current Errors object.
+func (e *Errors) Append(errs []Error) {
+	e.errors = append(e.errors, errs...)
+}
+
 // ToDisplayString returns the error set to a newline delimited string.
 func (e *Errors) ToDisplayString() string {
 	var result = ""

--- a/common/source.go
+++ b/common/source.go
@@ -154,7 +154,8 @@ func (s *sourceImpl) Snippet(line int) (string, bool) {
 func (s *sourceImpl) findLineOffset(line int) (int32, bool) {
 	if line == 1 {
 		return 0, true
-	} else if line > 1 && line <= int(len(s.lineOffsets)) {
+	}
+	if line > 1 && line <= int(len(s.lineOffsets)) {
 		offset := s.lineOffsets[line-2]
 		return offset, true
 	}
@@ -180,6 +181,8 @@ func (s *sourceImpl) findLine(characterOffset int32) (int32, int32) {
 	return line, s.lineOffsets[line-2]
 }
 
+// idOffset returns the raw character offset of an expression within the
+// source, or false if the expression cannot be found.
 func (s *sourceImpl) idOffset(exprID int64) (int32, bool) {
 	if offset, found := s.idOffsets[exprID]; found {
 		return offset, true
@@ -187,6 +190,9 @@ func (s *sourceImpl) idOffset(exprID int64) (int32, bool) {
 	return -1, false
 }
 
+// idLocation returns a Location for the given expression id, or false if one
+// cannot be found. It behaves as the composition of idOffset() and
+// offsetLocation().
 func (s *sourceImpl) idLocation(exprID int64) (Location, bool) {
 	if offset, found := s.idOffset(exprID); found {
 		if location, found := s.OffsetLocation(offset); found {

--- a/common/source.go
+++ b/common/source.go
@@ -49,15 +49,6 @@ type Source interface {
 
 	// Snippet returns a line of content and whether the line was found.
 	Snippet(line int) (string, bool)
-
-	// IDOffset returns the raw character offset of an expression within
-	// the source, or false if the expression cannot be found.
-	IDOffset(exprID int64) (int32, bool)
-
-	// IDLocation returns a Location for the given expression id,
-	// or false if one cannot be found.  It behaves as the obvious
-	// composition of IdOffset() and OffsetLocation().
-	IDLocation(exprID int64) (Location, bool)
 }
 
 // The sourceImpl type implementation of the Source interface.
@@ -141,22 +132,6 @@ func (s *sourceImpl) Snippet(line int) (string, bool) {
 	return string(s.contents[charStart:]), true
 }
 
-func (s *sourceImpl) IDOffset(exprID int64) (int32, bool) {
-	if offset, found := s.idOffsets[exprID]; found {
-		return offset, true
-	}
-	return -1, false
-}
-
-func (s *sourceImpl) IDLocation(exprID int64) (Location, bool) {
-	if offset, found := s.IDOffset(exprID); found {
-		if location, found := s.OffsetLocation(offset); found {
-			return location, true
-		}
-	}
-	return NewLocation(1, 0), false
-}
-
 // findLineOffset returns the offset where the (1-indexed) line begins,
 // or false if line doesn't exist.
 func (s *sourceImpl) findLineOffset(line int) (int32, bool) {
@@ -186,4 +161,20 @@ func (s *sourceImpl) findLine(characterOffset int32) (int32, int32) {
 		return line, 0
 	}
 	return line, s.lineOffsets[line-2]
+}
+
+func (s *sourceImpl) idOffset(exprID int64) (int32, bool) {
+	if offset, found := s.idOffsets[exprID]; found {
+		return offset, true
+	}
+	return -1, false
+}
+
+func (s *sourceImpl) idLocation(exprID int64) (Location, bool) {
+	if offset, found := s.idOffset(exprID); found {
+		if location, found := s.OffsetLocation(offset); found {
+			return location, true
+		}
+	}
+	return NewLocation(1, 0), false
 }

--- a/parser/helper.go
+++ b/parser/helper.go
@@ -185,10 +185,10 @@ func (p *parserHelper) id(ctx interface{}) int64 {
 	switch ctx.(type) {
 	case antlr.ParserRuleContext:
 		token := (ctx.(antlr.ParserRuleContext)).GetStart()
-		location = common.NewLocation(token.GetLine(), token.GetColumn())
+		location = p.source.NewLocation(token.GetLine(), token.GetColumn())
 	case antlr.Token:
 		token := ctx.(antlr.Token)
-		location = common.NewLocation(token.GetLine(), token.GetColumn())
+		location = p.source.NewLocation(token.GetLine(), token.GetColumn())
 	case common.Location:
 		location = ctx.(common.Location)
 	default:

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -554,7 +554,7 @@ func (p *parser) reportError(ctx interface{}, format string, args ...interface{}
 // ANTLR Parse listener implementations
 func (p *parser) SyntaxError(recognizer antlr.Recognizer, offendingSymbol interface{}, line, column int, msg string, e antlr.RecognitionException) {
 	// TODO: Snippet
-	l := common.NewLocation(line, column)
+	l := p.helper.source.NewLocation(line, column)
 	p.errors.syntaxError(l, msg)
 }
 


### PR DESCRIPTION
In order to support parsing of CEL expressions within larger source files, the `ParseSource` 
method which accepts a `common.Source` has been added to the `cel.Env` interface.

The `common.Source` value preserves line offsets and provides abstractions for determining
a line and column from an absolute character position. With this change it is possible to embed
CEL expressions within a larger file, e.g. YAML and still refer to the correct line, column for CEL
issues in the embedded expressions.

Note: This is a breaking interface change to `cel.Env`, but future CLs should remove this interface
to ensure better forward compatibility of changes.