### PR TITLE
Fix for comprehension type-checks against invalid range types.

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -438,6 +438,7 @@ func (c *checker) checkComprehension(e *exprpb.Expr) {
 		varType = decls.Dyn
 	default:
 		c.errors.notAComprehensionRange(c.location(comp.IterRange), rangeType)
+		varType = decls.Dyn
 	}
 
 	// Create a scope for the comprehension since it has a local accumulation variable.

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -438,7 +438,7 @@ func (c *checker) checkComprehension(e *exprpb.Expr) {
 		varType = decls.Dyn
 	default:
 		c.errors.notAComprehensionRange(c.location(comp.IterRange), rangeType)
-		varType = decls.Dyn
+		varType = decls.Error
 	}
 
 	// Create a scope for the comprehension since it has a local accumulation variable.

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -554,28 +554,28 @@ _==_(size(x~google.expr.proto3.test.TestAllTypes^x.map_int64_nested_type
 		},
 		R: `
 		__comprehension__(
-			// Variable
-			y,
-			// Target
-			x~bool^x,
-			// Accumulator
-			__result__,
-			// Init
-			true~bool,
-			// LoopCondition
-			@not_strictly_false(
-			  __result__~bool^__result__
-			)~bool^not_strictly_false,
-			// LoopStep
-			_&&_(
-			  __result__~bool^__result__,
-			  _==_(
-				y~dyn^y,
-				true~bool
-			  )~bool^equals
-			)~bool^logical_and,
-			// Result
-			__result__~bool^__result__)~bool
+		// Variable
+		y,
+		// Target
+		x~bool^x,
+		// Accumulator
+		__result__,
+		// Init
+		true~bool,
+		// LoopCondition
+		@not_strictly_false(
+			__result__~bool^__result__
+		)~bool^not_strictly_false,
+		// LoopStep
+		_&&_(
+			__result__~bool^__result__,
+			_==_(
+			y~!error!^y,
+			true~bool
+			)~bool^equals
+		)~bool^logical_and,
+		// Result
+		__result__~bool^__result__)~bool
 		`,
 		Error: `ERROR: <input>:1:1: expression of type 'bool' cannot be range of a comprehension (must be list, map, or dynamic)
 		| x.all(y, y == true)

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -546,6 +546,42 @@ _==_(size(x~google.expr.proto3.test.TestAllTypes^x.map_int64_nested_type
 		Type: decls.Bool,
 	},
 	{
+		I: `x.all(y, y == true)`,
+		Env: env{
+			idents: []*exprpb.Decl{
+				decls.NewIdent("x", decls.Bool, nil),
+			},
+		},
+		R: `
+		__comprehension__(
+			// Variable
+			y,
+			// Target
+			x~bool^x,
+			// Accumulator
+			__result__,
+			// Init
+			true~bool,
+			// LoopCondition
+			@not_strictly_false(
+			  __result__~bool^__result__
+			)~bool^not_strictly_false,
+			// LoopStep
+			_&&_(
+			  __result__~bool^__result__,
+			  _==_(
+				y~dyn^y,
+				true~bool
+			  )~bool^equals
+			)~bool^logical_and,
+			// Result
+			__result__~bool^__result__)~bool
+		`,
+		Error: `ERROR: <input>:1:1: expression of type 'bool' cannot be range of a comprehension (must be list, map, or dynamic)
+		| x.all(y, y == true)
+		| ^`,
+	},
+	{
 		I: `x.repeated_int64.map(x, double(x))`,
 		Env: env{
 			idents: []*exprpb.Decl{


### PR DESCRIPTION
There comprehension checks make sure that the range specified to the comprehension are one of the supported types; however, when reporting an error, the type was not being marked as an error.