### PR TITLE
Improve type conversion support for lists and maps

### DIFF
--- a/common/types/list.go
+++ b/common/types/list.go
@@ -416,6 +416,13 @@ func (l *stringList) ConvertToNative(typeDesc reflect.Type) (interface{}, error)
 		if typeDesc.Elem().Kind() == reflect.String {
 			return l.elems, nil
 		}
+		if typeDesc.Elem().Kind() == reflect.Interface {
+			iface := make([]interface{}, len(l.elems), len(l.elems))
+			for i, str := range l.elems {
+				iface[i] = str
+			}
+			return iface, nil
+		}
 	case reflect.Ptr:
 		switch typeDesc {
 		case anyValueType:

--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -423,7 +423,7 @@ func TestStringList_ConvertToNative(t *testing.T) {
 		t.Error("Unable to convert string list to itself.")
 	}
 	if !reflect.DeepEqual(val, []string{"h", "e", "l", "p"}) {
-		t.Errorf("Got %v, expected ['h', 'e', 'l', 'p']", val)
+		t.Errorf(`Got %v, expected ["h", "e", "l", "p"]`, val)
 	}
 }
 
@@ -435,7 +435,7 @@ func TestStringList_ConvertToNative_ListInterface(t *testing.T) {
 		t.Error("Unable to convert string list to itself.")
 	}
 	if !reflect.DeepEqual(val, []interface{}{"h", "e", "l", "p"}) {
-		t.Errorf("Got %v, expected ['h', 'e', 'l', 'p']", val)
+		t.Errorf(`Got %v, expected ["h", "e", "l", "p"]`, val)
 	}
 }
 

--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -247,6 +247,20 @@ func TestConcatList_ConvertToNative_Json(t *testing.T) {
 	}
 }
 
+func TestConcatList_ConvertToNative_ListInterface(t *testing.T) {
+	reg := NewRegistry()
+	listA := NewDynamicList(reg, []float32{1.0, 2.0})
+	listB := NewStringList(reg, []string{"3.0"})
+	list := listA.Add(listB)
+	iface, err := list.ConvertToNative(reflect.TypeOf([]interface{}{}))
+	if err != nil {
+		t.Errorf("Got '%v', expected '%v'", err, list)
+	}
+	if !reflect.DeepEqual(iface, []interface{}{1.0, 2.0, "3.0"}) {
+		t.Errorf("Got '%v', expected '%v'", iface, []interface{}{1.0, 2.0, "3.0"})
+	}
+}
+
 func TestConcatList_ConvertToType(t *testing.T) {
 	reg := NewRegistry()
 	listA := NewDynamicList(reg, []float32{1.0, 2.0})
@@ -409,6 +423,18 @@ func TestStringList_ConvertToNative(t *testing.T) {
 		t.Error("Unable to convert string list to itself.")
 	}
 	if !reflect.DeepEqual(val, []string{"h", "e", "l", "p"}) {
+		t.Errorf("Got %v, expected ['h', 'e', 'l', 'p']", val)
+	}
+}
+
+func TestStringList_ConvertToNative_ListInterface(t *testing.T) {
+	reg := NewRegistry()
+	list := NewStringList(reg, []string{"h", "e", "l", "p"})
+	val, err := list.ConvertToNative(reflect.TypeOf([]interface{}{}))
+	if err != nil {
+		t.Error("Unable to convert string list to itself.")
+	}
+	if !reflect.DeepEqual(val, []interface{}{"h", "e", "l", "p"}) {
 		t.Errorf("Got %v, expected ['h', 'e', 'l', 'p']", val)
 	}
 }

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -176,7 +177,14 @@ func (m *baseMap) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 			key := it.Next()
 			// Ensure the field name being referenced is exported.
 			fieldName := string(key.ConvertToType(StringType).(String))
-			fieldName = strings.ToUpper(fieldName[0:1]) + fieldName[1:]
+			switch len(fieldName) {
+			case 0:
+				return nil, errors.New("type conversion error, unsupported empty field")
+			case 1:
+				fieldName = strings.ToUpper(fieldName)
+			default:
+				fieldName = strings.ToUpper(fieldName[0:1]) + fieldName[1:]
+			}
 			fieldRef := nativeStruct.FieldByName(fieldName)
 			if !fieldRef.IsValid() {
 				return nil, fmt.Errorf(

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -116,13 +116,12 @@ func (m *baseMap) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	// Unwrap pointers, but track their use.
 	isPtr := false
 	if typeDesc.Kind() == reflect.Ptr {
+		tk := typeDesc
 		typeDesc = typeDesc.Elem()
+		if typeDesc.Kind() == reflect.Ptr {
+			return nil, fmt.Errorf("unsupported type conversion to '%v'", tk)
+		}
 		isPtr = true
-	}
-
-	// Non-map conversion.
-	if typeDesc.Kind() != reflect.Map && typeDesc.Kind() != reflect.Struct {
-		return nil, fmt.Errorf("type conversion error from map to '%v'", typeDesc)
 	}
 
 	// If the map is already assignable to the desired type return it, e.g. interfaces and

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -175,6 +175,8 @@ func (m *baseMap) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 		for it.HasNext() == True {
 			key := it.Next()
 			// Ensure the field name being referenced is exported.
+			// Only exported (public) field names can be set by reflection, where the name
+			// must be at least one character in length and start with an upper-case letter.
 			fieldName := string(key.ConvertToType(StringType).(String))
 			switch len(fieldName) {
 			case 0:

--- a/common/types/map_test.go
+++ b/common/types/map_test.go
@@ -148,6 +148,19 @@ func TestBaseMap_ConvertToNative_StructPtr(t *testing.T) {
 	}
 }
 
+func TestBaseMap_ConvertToNative_StructPtrPtr(t *testing.T) {
+	reg := NewRegistry()
+	mapValue := NewDynamicMap(reg, map[string]interface{}{
+		"m":       "hello",
+		"details": []string{"world", "universe"},
+	})
+	ptr := &testStruct{}
+	ts, err := mapValue.ConvertToNative(reflect.TypeOf(&ptr))
+	if err == nil {
+		t.Errorf("Got %v, wanted error", ts)
+	}
+}
+
 func TestBaseMap_ConvertToNative_Struct_InvalidFieldError(t *testing.T) {
 	reg := NewRegistry()
 	mapValue := NewDynamicMap(reg, map[string]interface{}{

--- a/common/types/map_test.go
+++ b/common/types/map_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 type testStruct struct {
-	Message string
+	M       string
 	Details []string
 	private string
 }
@@ -119,14 +119,14 @@ func TestBaseMap_ConvertToNative_Json(t *testing.T) {
 func TestBaseMap_ConvertToNative_Struct(t *testing.T) {
 	reg := NewRegistry()
 	mapValue := NewDynamicMap(reg, map[string]interface{}{
-		"message": "hello",
+		"m":       "hello",
 		"details": []string{"world", "universe"},
 	})
 	ts, err := mapValue.ConvertToNative(reflect.TypeOf(testStruct{}))
 	if err != nil {
 		t.Error(err)
 	}
-	want := testStruct{Message: "hello", Details: []string{"world", "universe"}}
+	want := testStruct{M: "hello", Details: []string{"world", "universe"}}
 	if !reflect.DeepEqual(ts, want) {
 		t.Errorf("Got %v, wanted %v", ts, want)
 	}
@@ -135,14 +135,14 @@ func TestBaseMap_ConvertToNative_Struct(t *testing.T) {
 func TestBaseMap_ConvertToNative_StructPtr(t *testing.T) {
 	reg := NewRegistry()
 	mapValue := NewDynamicMap(reg, map[string]interface{}{
-		"message": "hello",
+		"m":       "hello",
 		"details": []string{"world", "universe"},
 	})
 	ts, err := mapValue.ConvertToNative(reflect.TypeOf(&testStruct{}))
 	if err != nil {
 		t.Error(err)
 	}
-	want := &testStruct{Message: "hello", Details: []string{"world", "universe"}}
+	want := &testStruct{M: "hello", Details: []string{"world", "universe"}}
 	if !reflect.DeepEqual(ts, want) {
 		t.Errorf("Got %v, wanted %v", ts, want)
 	}
@@ -151,9 +151,22 @@ func TestBaseMap_ConvertToNative_StructPtr(t *testing.T) {
 func TestBaseMap_ConvertToNative_Struct_InvalidFieldError(t *testing.T) {
 	reg := NewRegistry()
 	mapValue := NewDynamicMap(reg, map[string]interface{}{
-		"message": "hello",
+		"m":       "hello",
 		"details": []string{"world", "universe"},
 		"invalid": "invalid field",
+	})
+	ts, err := mapValue.ConvertToNative(reflect.TypeOf(&testStruct{}))
+	if err == nil {
+		t.Errorf("Got %v, wanted error", ts)
+	}
+}
+
+func TestBaseMap_ConvertToNative_Struct_EmptyFieldError(t *testing.T) {
+	reg := NewRegistry()
+	mapValue := NewDynamicMap(reg, map[string]interface{}{
+		"m":       "hello",
+		"details": []string{"world", "universe"},
+		"":        "empty field",
 	})
 	ts, err := mapValue.ConvertToNative(reflect.TypeOf(&testStruct{}))
 	if err == nil {

--- a/go.sum
+++ b/go.sum
@@ -15,12 +15,14 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/cel-spec v0.3.0 h1:pyNjzTVK5qHTDr48x/0HAhebeFYryZpBXV2r7pzKMX4=
 github.com/google/cel-spec v0.3.0/go.mod h1:MjQm800JAGhOZXI7vatnVpmIaFTR6L8FHcKk+piiKpI=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4 h1:c2HOrn5iMezYjSlGPncknSEr/8x5LELb/ilJbXi9DEA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961 h1:GmgasJE571dBGXS7E282h2rIZj+KvCLV8z5I6QXbKNI=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
+golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 h1:XQyxROzUlZH+WIQwySDgnISgOivlhjIEwaQaJEJrrN0=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -47,6 +49,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c h1:vamGzbGri8IKo20MQncCuljcQ5uAO6kaCeawQPVblAI=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
+golang.org/x/tools v0.0.0-20190311212946-11955173bddd h1:/e+gpKk9r3dJobndpTytxS2gOy6m5uvpg+ISQoEcusQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=


### PR DESCRIPTION
Improve the `ConvertToNative` support for list and map types.

* Add support for CEL string lists to type `[]interface{}` 
* Support the conversion of CEL maps with string keys to custom structs with exported field names.

Tests have also been added to illustrate some of the different conversion behaviors and limitations.