### PR TITLE
Improve the edge case handling within the parse tree visitor.

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -323,11 +323,7 @@ func (p *parser) VisitIFieldInitializerList(ctx gen.IFieldInitializerListContext
 	cols := ctx.GetCols()
 	vals := ctx.GetValues()
 	for i, f := range ctx.GetFields() {
-		if i >= len(cols) {
-			// This is the result of a syntax error detected elsewhere.
-			return []*exprpb.Expr_CreateStruct_Entry{}
-		}
-		if i >= len(vals) {
+		if i >= len(cols) || i >= len(vals) {
 			// This is the result of a syntax error detected elsewhere.
 			return []*exprpb.Expr_CreateStruct_Entry{}
 		}
@@ -420,11 +416,7 @@ func (p *parser) VisitMapInitializerList(ctx *gen.MapInitializerListContext) int
 	vals := ctx.GetValues()
 	for i, col := range ctx.GetCols() {
 		colID := p.helper.id(col)
-		if i >= len(keys) {
-			// This is the result of a syntax error detected elsewhere.
-			return []*exprpb.Expr_CreateStruct_Entry{}
-		}
-		if i >= len(vals) {
+		if i >= len(keys) || i >= len(vals) {
 			// This is the result of a syntax error detected elsewhere.
 			return []*exprpb.Expr_CreateStruct_Entry{}
 		}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1019,6 +1019,48 @@ ERROR: <input>:1:14: argument is not an identifier
  | [1, 2, 3].map(var, var * var)
  | .............^`,
 	},
+	{
+		I: "func{{a}}",
+		E: `ERROR: <input>:1:6: Syntax error: extraneous input '{' expecting {'}', IDENTIFIER}
+		| func{{a}}
+		| .....^
+	   ERROR: <input>:1:8: Syntax error: mismatched input '}' expecting ':'
+		| func{{a}}
+		| .......^
+	   ERROR: <input>:1:9: Syntax error: extraneous input '}' expecting <EOF>
+		| func{{a}}
+		| ........^`,
+	},
+	{
+		I: "msg{:a}",
+		E: `ERROR: <input>:1:5: Syntax error: extraneous input ':' expecting {'}', IDENTIFIER}
+		| msg{:a}
+		| ....^
+	   ERROR: <input>:1:7: Syntax error: mismatched input '}' expecting ':'
+		| msg{:a}
+		| ......^`,
+	},
+	{
+		I: "{a}",
+		E: `ERROR: <input>:1:3: Syntax error: mismatched input '}' expecting ':'
+		| {a}
+		| ..^`,
+	},
+	{
+		I: "{:a}",
+		E: `ERROR: <input>:1:2: Syntax error: extraneous input ':' expecting {'[', '{', '}', '(', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}
+		| {:a}
+		| .^
+	   ERROR: <input>:1:4: Syntax error: mismatched input '}' expecting ':'
+		| {:a}
+		| ...^`,
+	},
+	{
+		I: "ind[a{b}]",
+		E: `ERROR: <input>:1:8: Syntax error: mismatched input '}' expecting ':'
+		| ind[a{b}]
+		| .......^`,
+	},
 }
 
 type testInfo struct {


### PR DESCRIPTION
Ensure that the syntax errors are handled gracefully within the parse tree visitor to avoid panics.

Closes #283