### PR TITLE
Change unparsed byte literal representations to octal-encoded values

### DIFF
--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -259,6 +259,11 @@ var (
 			},
 		},
 		{
+			name: "literal_bytes_string",
+			expr: `string(b'aaa"bbb')`,
+			out:  `aaa"bbb`,
+		},
+		{
 			name:  "literal_pb3_msg",
 			pkg:   "google.api.expr",
 			types: []proto.Message{&exprpb.Expr{}},

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -264,6 +264,11 @@ var (
 			out:  `aaa"bbb`,
 		},
 		{
+			name: "literal_bytes_string2",
+			expr: `string(b"""Kim\t""")`,
+			out: `Kim	`,
+		},
+		{
 			name:  "literal_pb3_msg",
 			pkg:   "google.api.expr",
 			types: []proto.Message{&exprpb.Expr{}},

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -259,6 +259,18 @@ var (
 			},
 		},
 		{
+			name: "literal_equiv_string_bytes",
+			expr: `string(bytes("\303\277")) == '''\303\277'''`,
+		},
+		{
+			name: "literal_not_equiv_string_bytes",
+			expr: `string(b"\303\277") != '''\303\277'''`,
+		},
+		{
+			name: "literal_equiv_bytes_string",
+			expr: `string(b"\303\277") == 'ÿ'`,
+		},
+		{
 			name: "literal_bytes_string",
 			expr: `string(b'aaa"bbb')`,
 			out:  `aaa"bbb`,

--- a/parser/unescape_test.go
+++ b/parser/unescape_test.go
@@ -175,6 +175,17 @@ func TestUnescapeBytesOctalMax(t *testing.T) {
 	}
 }
 
+func TestUnescapeBytesQuoting(t *testing.T) {
+	bs, err := unescape(`'''"Kim\t"'''`, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "\x22\x4b\x69\x6d\x09\x22"
+	if bs != want {
+		t.Errorf("Got '%v', wanted '%v'", bs, want)
+	}
+}
+
 func TestUnescapeBytesHex(t *testing.T) {
 	bs, err := unescape(`"\xc3\xbf"`, true)
 	if err != nil {

--- a/parser/unparser.go
+++ b/parser/unparser.go
@@ -256,7 +256,7 @@ func (un *unparser) visitConst(expr *exprpb.Expr) error {
 		// bytes constants are surrounded with b"<bytes>"
 		b := c.GetBytesValue()
 		un.str.WriteString(`b"`)
-		un.str.WriteString(hexBytes(b))
+		un.str.WriteString(bytesToOctets(b))
 		un.str.WriteString(`"`)
 	case *exprpb.Constant_DoubleValue:
 		// represent the float using the minimum required digits
@@ -474,11 +474,12 @@ func isBinaryOrTernaryOperator(expr *exprpb.Expr) bool {
 	return isBinaryOp || isSamePrecedence(operators.Conditional, expr)
 }
 
-// hexBytes returns the byte values as a two character hex encoded prefixed with \x.
-func hexBytes(byteVal []byte) string {
+// bytesToOctets converts byte sequences to a string using a three digit octal encoded value
+// per byte.
+func bytesToOctets(byteVal []byte) string {
 	var b strings.Builder
 	for _, c := range byteVal {
-		fmt.Fprintf(&b, "\\x%02x", c)
+		fmt.Fprintf(&b, "\\%03o", c)
 	}
 	return b.String()
 }

--- a/parser/unparser.go
+++ b/parser/unparser.go
@@ -31,7 +31,7 @@ import (
 // formatting may be lost in translation, notably:
 //
 // - All quoted literals are doubled quoted.
-// - Byte literals are represented as utf8-string rather than byte, octal, or unicode escapes.
+// - Byte literals are represented as octal escapes (same as Google SQL).
 // - Floating point values are converted to the small number of digits needed to represent the value.
 // - Spacing around punctuation marks may be lost.
 // - Parentheses will only be applied when they affect operator precedence.

--- a/parser/unparser.go
+++ b/parser/unparser.go
@@ -256,7 +256,7 @@ func (un *unparser) visitConst(expr *exprpb.Expr) error {
 		// bytes constants are surrounded with b"<bytes>"
 		b := c.GetBytesValue()
 		un.str.WriteString(`b"`)
-		un.str.Write(b)
+		un.str.WriteString(hexBytes(b))
 		un.str.WriteString(`"`)
 	case *exprpb.Constant_DoubleValue:
 		// represent the float using the minimum required digits
@@ -472,4 +472,13 @@ func isBinaryOrTernaryOperator(expr *exprpb.Expr) bool {
 	}
 	_, isBinaryOp := operators.FindReverseBinaryOperator(expr.GetCallExpr().GetFunction())
 	return isBinaryOp || isSamePrecedence(operators.Conditional, expr)
+}
+
+// hexBytes returns the byte values as a two character hex encoded prefixed with \x.
+func hexBytes(byteVal []byte) string {
+	var b strings.Builder
+	for _, c := range byteVal {
+		fmt.Fprintf(&b, "\\x%02x", c)
+	}
+	return b.String()
 }

--- a/parser/unparser_test.go
+++ b/parser/unparser_test.go
@@ -53,7 +53,7 @@ func TestUnparse_Identical(t *testing.T) {
 		"list_empty":          `[]`,
 		"list_one":            `[1]`,
 		"list_many":           `["hello, world", "goodbye, world", "sure, why not?"]`,
-		"lit_bytes":           `b"\xc3\x83\xc2\xbf"`,
+		"lit_bytes":           `b"\303\203\302\277"`,
 		"lit_double":          `-42.101`,
 		"lit_false":           `false`,
 		"lit_int":             `-405069`,
@@ -64,7 +64,7 @@ func TestUnparse_Identical(t *testing.T) {
 		"ident":               `my_ident`,
 		"macro_has":           `has(hello.world)`,
 		"map_empty":           `{}`,
-		"map_lit_key":         `{"a": a.b.c, b"\x62": bytes(a.b.c)}`,
+		"map_lit_key":         `{"a": a.b.c, b"\142": bytes(a.b.c)}`,
 		"map_expr_key":        `{a: a, b: a.b, c: a.b.c, a ? b : c: false, a || b: true}`,
 		"msg_empty":           `v1alpha1.Expr{}`,
 		"msg_fields":          `v1alpha1.Expr{id: 1, call_expr: v1alpha1.Call_Expr{function: "name"}}`,
@@ -120,7 +120,7 @@ func TestUnparse_Equivalent(t *testing.T) {
 		"call_or_and": {`(false && !true) || false`,
 			` false && !true  || false`},
 		"call_not_not":    {`!!true`, `  true`},
-		"lit_quote_bytes": {`b'aaa"bbb'`, `b"\x61\x61\x61\x22\x62\x62\x62"`},
+		"lit_quote_bytes": {`b'aaa"bbb'`, `b"\141\141\141\042\142\142\142"`},
 		"select":          {`a . b . c`, `a .b  .c`},
 	}
 

--- a/parser/unparser_test.go
+++ b/parser/unparser_test.go
@@ -53,7 +53,7 @@ func TestUnparse_Identical(t *testing.T) {
 		"list_empty":          `[]`,
 		"list_one":            `[1]`,
 		"list_many":           `["hello, world", "goodbye, world", "sure, why not?"]`,
-		"lit_bytes":           `b"Ã¿"`,
+		"lit_bytes":           `b"\xc3\x83\xc2\xbf"`,
 		"lit_double":          `-42.101`,
 		"lit_false":           `false`,
 		"lit_int":             `-405069`,
@@ -64,7 +64,7 @@ func TestUnparse_Identical(t *testing.T) {
 		"ident":               `my_ident`,
 		"macro_has":           `has(hello.world)`,
 		"map_empty":           `{}`,
-		"map_lit_key":         `{"a": a.b.c, b"b": bytes(a.b.c)}`,
+		"map_lit_key":         `{"a": a.b.c, b"\x62": bytes(a.b.c)}`,
 		"map_expr_key":        `{a: a, b: a.b, c: a.b.c, a ? b : c: false, a || b: true}`,
 		"msg_empty":           `v1alpha1.Expr{}`,
 		"msg_fields":          `v1alpha1.Expr{id: 1, call_expr: v1alpha1.Call_Expr{function: "name"}}`,
@@ -119,8 +119,9 @@ func TestUnparse_Equivalent(t *testing.T) {
 		"call_index": {`a[  1  ]["b"]`, `a[  1]  ["b"]`},
 		"call_or_and": {`(false && !true) || false`,
 			` false && !true  || false`},
-		"call_not_not": {`!!true`, `  true`},
-		"select":       {`a . b . c`, `a .b  .c`},
+		"call_not_not":    {`!!true`, `  true`},
+		"lit_quote_bytes": {`b'aaa"bbb'`, `b"\x61\x61\x61\x22\x62\x62\x62"`},
+		"select":          {`a . b . c`, `a .b  .c`},
 	}
 
 	for name, in := range tests {


### PR DESCRIPTION
Presently byte literal values are represented as plain strings within the `parser.Unparse` call,
but this is problematic when printing quote (`'`, `"`) characters within byte literal sequences.

The change in formatting is aligned with Google SQL, which prints byte literal values as octal
sequences as well. Additionally, the change to a octal based encoding resolves issues with
quote handling.

Closes #281 