### PR TITLE
Fixed unparsing to behave more like a formatting command.

### DIFF
--- a/cel/io.go
+++ b/cel/io.go
@@ -72,5 +72,6 @@ func AstToParsedExpr(a Ast) (*exprpb.ParsedExpr, error) {
 // a string that is semantically equivalent.
 func AstToString(a Ast) (string, error) {
 	expr := a.Expr()
-	return parser.Unparse(expr)
+	info := a.SourceInfo()
+	return parser.Unparse(expr, info)
 }

--- a/cel/io.go
+++ b/cel/io.go
@@ -72,6 +72,5 @@ func AstToParsedExpr(a Ast) (*exprpb.ParsedExpr, error) {
 // a string that is semantically equivalent.
 func AstToString(a Ast) (string, error) {
 	expr := a.Expr()
-	info := a.SourceInfo()
-	return parser.Unparse(expr, info)
+	return parser.Unparse(expr)
 }

--- a/parser/unparser.go
+++ b/parser/unparser.go
@@ -36,7 +36,7 @@ import (
 // - Spacing around punctuation marks may be lost.
 // - Parentheses will only be applied when they affect operator precedence.
 func Unparse(expr *exprpb.Expr, info *exprpb.SourceInfo) (string, error) {
-	un := &unparser{}
+	un := &unparser{info: info}
 	err := un.visit(expr)
 	if err != nil {
 		return "", err
@@ -48,6 +48,8 @@ func Unparse(expr *exprpb.Expr, info *exprpb.SourceInfo) (string, error) {
 type unparser struct {
 	str    strings.Builder
 	offset int32
+	// TODO: use the source info to rescontruct macros into function calls.
+	info *exprpb.SourceInfo
 }
 
 func (un *unparser) visit(expr *exprpb.Expr) error {

--- a/parser/unparser.go
+++ b/parser/unparser.go
@@ -35,34 +35,17 @@ import (
 // - Floating point values are converted to the small number of digits needed to represent the value.
 // - Spacing around punctuation marks may be lost.
 // - Parentheses will only be applied when they affect operator precedence.
-func Unparse(expr *exprpb.Expr, info *exprpb.SourceInfo) (string, error) {
-	un := &unparser{info: info}
+func Unparse(expr *exprpb.Expr) (string, error) {
+	un := &unparser{}
 	err := un.visit(expr)
 	if err != nil {
 		return "", err
 	}
-	// Test whether newlines need to be applied.
-	breaks := info.GetLineOffsets()
-	if len(breaks) <= 1 {
-		return un.str.String(), nil
-	}
-	// Apply the newlines.
-	txt := []rune(un.str.String())
-	sz := int32(len(txt))
-	for _, br := range breaks {
-		for ; br-1 < sz; br++ {
-			if txt[br-1] == rune(' ') {
-				txt[br-1] = rune('\n')
-				break
-			}
-		}
-	}
-	return string(txt), nil
+	return un.str.String(), nil
 }
 
 // unparser visits an expression to reconstruct a human-readable string from an AST.
 type unparser struct {
-	info   *exprpb.SourceInfo
 	str    strings.Builder
 	offset int32
 }
@@ -147,7 +130,6 @@ func (un *unparser) visitCallBinary(expr *exprpb.Expr) error {
 		return fmt.Errorf("cannot unmangle operator: %s", fun)
 	}
 	un.str.WriteString(" ")
-	un.pad(expr.GetId())
 	un.str.WriteString(unmangled)
 	un.str.WriteString(" ")
 	return un.visitMaybeNested(rhs, rhsParen)
@@ -163,8 +145,7 @@ func (un *unparser) visitCallConditional(expr *exprpb.Expr) error {
 	if err != nil {
 		return err
 	}
-	un.pad(expr.GetId())
-	un.str.WriteString("? ")
+	un.str.WriteString(" ? ")
 	// add parens if operand is a conditional itself.
 	nested = isSamePrecedence(operators.Conditional, args[1]) ||
 		isComplexOperator(args[1])
@@ -193,7 +174,6 @@ func (un *unparser) visitCallFunc(expr *exprpb.Expr) error {
 		un.str.WriteString(".")
 	}
 	un.str.WriteString(fun)
-	un.pad(expr.GetId())
 	un.str.WriteString("(")
 	for i, arg := range args {
 		err := un.visit(arg)
@@ -201,7 +181,7 @@ func (un *unparser) visitCallFunc(expr *exprpb.Expr) error {
 			return err
 		}
 		if i < len(args)-1 {
-			un.str.WriteString(",")
+			un.str.WriteString(", ")
 		}
 	}
 	un.str.WriteString(")")
@@ -216,7 +196,6 @@ func (un *unparser) visitCallIndex(expr *exprpb.Expr) error {
 	if err != nil {
 		return err
 	}
-	un.pad(expr.GetId())
 	un.str.WriteString("[")
 	err = un.visit(args[1])
 	if err != nil {
@@ -227,7 +206,6 @@ func (un *unparser) visitCallIndex(expr *exprpb.Expr) error {
 }
 
 func (un *unparser) visitCallUnary(expr *exprpb.Expr) error {
-	un.pad(expr.GetId())
 	c := expr.GetCallExpr()
 	fun := c.GetFunction()
 	args := c.GetArgs()
@@ -247,7 +225,6 @@ func (un *unparser) visitComprehension(expr *exprpb.Expr) error {
 }
 
 func (un *unparser) visitConst(expr *exprpb.Expr) error {
-	un.pad(expr.GetId())
 	c := expr.GetConstExpr()
 	switch c.ConstantKind.(type) {
 	case *exprpb.Constant_BoolValue:
@@ -282,7 +259,6 @@ func (un *unparser) visitConst(expr *exprpb.Expr) error {
 }
 
 func (un *unparser) visitIdent(expr *exprpb.Expr) error {
-	un.pad(expr.GetId())
 	un.str.WriteString(expr.GetIdentExpr().GetName())
 	return nil
 }
@@ -290,7 +266,6 @@ func (un *unparser) visitIdent(expr *exprpb.Expr) error {
 func (un *unparser) visitList(expr *exprpb.Expr) error {
 	l := expr.GetListExpr()
 	elems := l.GetElements()
-	un.pad(expr.GetId())
 	un.str.WriteString("[")
 	for i, elem := range elems {
 		err := un.visit(elem)
@@ -298,7 +273,7 @@ func (un *unparser) visitList(expr *exprpb.Expr) error {
 			return err
 		}
 		if i < len(elems)-1 {
-			un.str.WriteString(",")
+			un.str.WriteString(", ")
 		}
 	}
 	un.str.WriteString("]")
@@ -316,7 +291,6 @@ func (un *unparser) visitSelect(expr *exprpb.Expr) error {
 	if err != nil {
 		return err
 	}
-	un.pad(expr.GetId())
 	un.str.WriteString(".")
 	un.str.WriteString(sel.GetField())
 	if sel.GetTestOnly() {
@@ -339,12 +313,10 @@ func (un *unparser) visitStructMsg(expr *exprpb.Expr) error {
 	m := expr.GetStructExpr()
 	entries := m.GetEntries()
 	un.str.WriteString(m.GetMessageName())
-	un.pad(expr.GetId())
 	un.str.WriteString("{")
 	for i, entry := range entries {
 		f := entry.GetFieldKey()
 		un.str.WriteString(f)
-		un.pad(entry.GetId())
 		un.str.WriteString(": ")
 		v := entry.GetValue()
 		err := un.visit(v)
@@ -362,7 +334,6 @@ func (un *unparser) visitStructMsg(expr *exprpb.Expr) error {
 func (un *unparser) visitStructMap(expr *exprpb.Expr) error {
 	m := expr.GetStructExpr()
 	entries := m.GetEntries()
-	un.pad(expr.GetId())
 	un.str.WriteString("{")
 	for i, entry := range entries {
 		k := entry.GetMapKey()
@@ -370,7 +341,6 @@ func (un *unparser) visitStructMap(expr *exprpb.Expr) error {
 		if err != nil {
 			return err
 		}
-		un.pad(entry.GetId())
 		un.str.WriteString(": ")
 		v := entry.GetValue()
 		err = un.visit(v)
@@ -397,21 +367,6 @@ func (un *unparser) visitMaybeNested(expr *exprpb.Expr, nested bool) error {
 		un.str.WriteString(")")
 	}
 	return nil
-}
-
-// pos returns the source character offset of the expression id.
-func (un *unparser) pos(id int64) int32 {
-	return un.info.GetPositions()[id]
-}
-
-// pad potentially adds spaces from the current string builder position to the original position
-// of the input expression id.
-func (un *unparser) pad(id int64) {
-	last := int32(un.str.Len())
-	next := un.pos(id)
-	for ; last < next; last++ {
-		un.str.WriteString(" ")
-	}
 }
 
 // isLeftRecursive indicates whether the parser resolves the call in a left-recursive manner as
@@ -449,7 +404,7 @@ func isLowerPrecedence(op string, expr *exprpb.Expr) bool {
 // Indicates whether the expr is a complex operator, i.e., a call expression
 // with 2 or more arguments.
 func isComplexOperator(expr *exprpb.Expr) bool {
-	if expr.GetCallExpr() != nil || len(expr.GetCallExpr().GetArgs()) >= 2 {
+	if expr.GetCallExpr() != nil && len(expr.GetCallExpr().GetArgs()) >= 2 {
 		return true
 	}
 	return false

--- a/parser/unparser.go
+++ b/parser/unparser.go
@@ -35,7 +35,7 @@ import (
 // - Floating point values are converted to the small number of digits needed to represent the value.
 // - Spacing around punctuation marks may be lost.
 // - Parentheses will only be applied when they affect operator precedence.
-func Unparse(expr *exprpb.Expr) (string, error) {
+func Unparse(expr *exprpb.Expr, info *exprpb.SourceInfo) (string, error) {
 	un := &unparser{}
 	err := un.visit(expr)
 	if err != nil {

--- a/parser/unparser_test.go
+++ b/parser/unparser_test.go
@@ -96,7 +96,7 @@ func TestUnparse_Identical(t *testing.T) {
 			if len(iss.GetErrors()) > 0 {
 				tt.Fatal(iss.ToDisplayString())
 			}
-			out, err := Unparse(p.GetExpr())
+			out, err := Unparse(p.GetExpr(), p.GetSourceInfo())
 			if err != nil {
 				tt.Error(err)
 			}
@@ -131,7 +131,7 @@ func TestUnparse_Equivalent(t *testing.T) {
 			if len(iss.GetErrors()) > 0 {
 				tt.Fatal(iss.ToDisplayString())
 			}
-			out, err := Unparse(p.GetExpr())
+			out, err := Unparse(p.GetExpr(), p.GetSourceInfo())
 			if err != nil {
 				tt.Error(err)
 			}

--- a/parser/unparser_test.go
+++ b/parser/unparser_test.go
@@ -42,6 +42,8 @@ func TestUnparse_Identical(t *testing.T) {
 		"calc_distr_paren":    `(1 + 2) * 3`,
 		"calc_distr_noparen":  `1 + 2 * 3`,
 		"cond_tern_simple":    `(x > 5) ? (x - 5) : 0`,
+		"cond_tern_neg_expr":  `-((x > 5) ? (x - 5) : 0)`,
+		"cond_tern_neg_term":  `-x ? (x - 5) : 0`,
 		"func_global":         `size(a ? (b ? c : d) : e)`,
 		"func_member":         `a.hello("world")`,
 		"func_no_arg":         `zero()`,
@@ -94,7 +96,7 @@ func TestUnparse_Identical(t *testing.T) {
 			if len(iss.GetErrors()) > 0 {
 				tt.Fatal(iss.ToDisplayString())
 			}
-			out, err := Unparse(p.GetExpr(), p.GetSourceInfo())
+			out, err := Unparse(p.GetExpr())
 			if err != nil {
 				tt.Error(err)
 			}
@@ -114,14 +116,13 @@ func TestUnparse_Identical(t *testing.T) {
 
 func TestUnparse_Equivalent(t *testing.T) {
 	tests := map[string][]string{
-		"call_add":   {`a+b-c`, `a + b - c`},
-		"call_cond":  {`a ? b          : c`, `a ? b :          c`},
-		"call_index": {`a[  1  ]["b"]`, `a[  1]  ["b"]`},
-		"call_or_and": {`(false && !true) || false`,
-			` false && !true  || false`},
-		"call_not_not":    {`!!true`, `  true`},
+		"call_add":        {`a+b-c`, `a + b - c`},
+		"call_cond":       {`a ? b          : c`, `a ? b : c`},
+		"call_index":      {`a[  1  ]["b"]`, `a[1]["b"]`},
+		"call_or_and":     {`(false && !true) || false`, `false && !true || false`},
+		"call_not_not":    {`!!true`, `true`},
 		"lit_quote_bytes": {`b'aaa"bbb'`, `b"\141\141\141\042\142\142\142"`},
-		"select":          {`a . b . c`, `a .b  .c`},
+		"select":          {`a . b . c`, `a.b.c`},
 	}
 
 	for name, in := range tests {
@@ -130,7 +131,7 @@ func TestUnparse_Equivalent(t *testing.T) {
 			if len(iss.GetErrors()) > 0 {
 				tt.Fatal(iss.ToDisplayString())
 			}
-			out, err := Unparse(p.GetExpr(), p.GetSourceInfo())
+			out, err := Unparse(p.GetExpr())
 			if err != nil {
 				tt.Error(err)
 			}


### PR DESCRIPTION
The previous incarnation of the `parser.Unparse` command attempted to consider the 
original source positions of the expressions being unparsed. This usually wound up creating
a less than ideal experience. Instead, all CEL expressions are now formatted onto a single line
with proper spacing and formatting that matches best practices.

Additional refinement might be to consider introducing line breaks on logical `&&`, `||` at
some point in the future, but holding off on doing this until it's strongly desired.

Closes #282 