### PR TITLE
Fix type of type checks and missing implementations

### DIFF
--- a/common/types/BUILD.bazel
+++ b/common/types/BUILD.bazel
@@ -68,6 +68,7 @@ go_test(
         "providers_test.go",
         "string_test.go",
         "timestamp_test.go",
+        "type_test.go",
         "uint_test.go",
     ],
     size = "small",

--- a/common/types/null.go
+++ b/common/types/null.go
@@ -73,11 +73,13 @@ func (n Null) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 
 // ConvertToType implements ref.Val.ConvertToType.
 func (n Null) ConvertToType(typeVal ref.Type) ref.Val {
-	if typeVal == StringType {
+	switch typeVal {
+	case StringType:
 		return String("null")
-	}
-	if typeVal == NullType {
+	case NullType:
 		return n
+	case TypeType:
+		return NullType
 	}
 	return NewErr("type conversion error from '%s' to '%s'", NullType, typeVal)
 }

--- a/common/types/null_test.go
+++ b/common/types/null_test.go
@@ -64,11 +64,14 @@ func TestNull_ConvertToNative(t *testing.T) {
 
 func TestNull_ConvertToType(t *testing.T) {
 	if !NullValue.ConvertToType(NullType).Equal(NullValue).(Bool) {
-		t.Error("Fail to get NullType of NullValue.")
+		t.Error("Failed to get NullType of NullValue.")
 	}
 
 	if !NullValue.ConvertToType(StringType).Equal(String("null")).(Bool) {
-		t.Error("Fail to get StringType of NullValue.")
+		t.Error("Failed to get StringType of NullValue.")
+	}
+	if !NullValue.ConvertToType(TypeType).Equal(NullType).(Bool) {
+		t.Error("Failed to convert NullValue to type.")
 	}
 }
 

--- a/common/types/type.go
+++ b/common/types/type.go
@@ -62,7 +62,7 @@ func (t *TypeValue) ConvertToNative(typeDesc reflect.Type) (interface{}, error) 
 func (t *TypeValue) ConvertToType(typeVal ref.Type) ref.Val {
 	switch typeVal {
 	case TypeType:
-		return t
+		return TypeType
 	case StringType:
 		return String(t.TypeName())
 	}

--- a/common/types/type_test.go
+++ b/common/types/type_test.go
@@ -1,0 +1,46 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "testing"
+
+func TestType_ConvertToType(t *testing.T) {
+	stdTypes := []*TypeValue{
+		BoolType,
+		BytesType,
+		DoubleType,
+		DurationType,
+		IntType,
+		ListType,
+		MapType,
+		NullType,
+		StringType,
+		TimestampType,
+		TypeType,
+		UintType,
+	}
+	for _, stdType := range stdTypes {
+		cnv := stdType.ConvertToType(TypeType)
+		if !cnv.Equal(TypeType).(Bool) {
+			t.Errorf("Got %v, wanted 'type'", cnv)
+		}
+	}
+}
+
+func TestType_Type(t *testing.T) {
+	if TypeType.Type() != TypeType {
+		t.Error("type of type is not type.")
+	}
+}


### PR DESCRIPTION
Ensure that the `type(<type>)` call returns `type` for all standard types.