### PR TITLE
Follow substitutions through the 'occurs' check.

### DIFF
--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1387,6 +1387,13 @@ _&&_(_==_(list~type(list(dyn))^list,
 		)~list(dyn)^add_list`,
 		Type: decls.NewListType(decls.Dyn),
 	},
+	{
+		I: `[].map(x, [].map(y, x in y && y in x))`,
+		Error: `
+		ERROR: <input>:1:33: found no matching overload for '@in' applied to '(type_param:"_var2" , type_param:"_var0" )'
+		| [].map(x, [].map(y, x in y && y in x))
+		| ................................^`,
+	},
 }
 
 var reg = initTypeRegistry()


### PR DESCRIPTION
Fixes the 'occurs' cycle possible when following through type unification on type-param arguments.

Closes #294 