### PR TITLE
Re-enable conformance tests for undefined vars.

### DIFF
--- a/conformance/BUILD.bazel
+++ b/conformance/BUILD.bazel
@@ -4,9 +4,7 @@ sh_test(
     args = [
         "$(location @com_google_cel_spec//tests/simple:simple_test)",
         "--server=$(location //server/main:cel_server)",
-        "--skip_test=basic/variables/self_eval_unbound_lookup",
         "--skip_test=comparisons/in_map_literal/key_in_mixed_key_type_map_error",
-        "--skip_test=conversions/type/dyn_no_denotation",
         "--skip_test=fields/qualified_identifier_resolution/map_key_float,map_key_null,map_value_repeat_key",
         "--skip_test=integer_math/int64_math/int64_overflow_positive,int64_overflow_negative,uint64_overflow_positive,uint64_overflow_negative",
         "$(location @com_google_cel_spec//tests/simple:testdata/plumbing.textproto)",


### PR DESCRIPTION
Passes after #284.