### PR TITLE
Convert Ast, Env to concrete structs rather than top-level interfaces.

### DIFF
--- a/cel/env.go
+++ b/cel/env.go
@@ -34,67 +34,59 @@ type Source interface {
 	common.Source
 }
 
-// Ast interface representing the checked or unchecked expression, its source, and related metadata
-// such as source position information.
-type Ast interface {
-	// Expr returns the proto serializable instance of the parsed/checked expression.
-	Expr() *exprpb.Expr
+// Ast representing the checked or unchecked expression, its source, and related metadata such as
+// source position information.
+type Ast struct {
+	expr    *exprpb.Expr
+	info    *exprpb.SourceInfo
+	source  Source
+	refMap  map[int64]*exprpb.Reference
+	typeMap map[int64]*exprpb.Type
+}
 
-	// IsChecked returns whether the Ast value has been successfully type-checked.
-	IsChecked() bool
+// Expr returns the proto serializable instance of the parsed/checked expression.
+func (ast *Ast) Expr() *exprpb.Expr {
+	return ast.expr
+}
 
-	// ResultType returns the output type of the expression if the Ast has been type-checked,
-	// else returns decls.Dyn as the parse step cannot infer the type.
-	ResultType() *exprpb.Type
+// IsChecked returns whether the Ast value has been successfully type-checked.
+func (ast *Ast) IsChecked() bool {
+	return ast.refMap != nil && ast.typeMap != nil
+}
 
-	// Source returns a view of the input used to create the Ast. This source may be complete or
-	// constructed from the SourceInfo.
-	Source() Source
+// SourceInfo returns character offset and newling position information about expression elements.
+func (ast *Ast) SourceInfo() *exprpb.SourceInfo {
+	return ast.info
+}
 
-	// SourceInfo returns character offset and newling position information about expression
-	// elements.
-	SourceInfo() *exprpb.SourceInfo
+// ResultType returns the output type of the expression if the Ast has been type-checked, else
+// returns decls.Dyn as the parse step cannot infer the type.
+func (ast *Ast) ResultType() *exprpb.Type {
+	if !ast.IsChecked() {
+		return decls.Dyn
+	}
+	return ast.typeMap[ast.expr.Id]
+}
+
+// Source returns a view of the input used to create the Ast. This source may be complete or
+// constructed from the SourceInfo.
+func (ast *Ast) Source() Source {
+	return ast.source
 }
 
 // Env defines functions for parsing and type-checking expressions against a set of user-defined
 // constants, variables, and functions. The Env interface also defines a method for generating
 // evaluable programs from parsed and checked Asts.
-type Env interface {
-	// Extend the current environment with additional options to produce a new Env.
-	Extend(opts ...EnvOption) (Env, error)
-
-	// Check performs type-checking on the input Ast and yields a checked Ast and/or set of Issues.
-	//
-	// Checking has failed if the returned Issues value and its Issues.Err() value is non-nil.
-	// Issues should be inspected if they are non-nil, but may not represent a fatal error.
-	//
-	// It is possible to have both non-nil Ast and Issues values returned from this call: however,
-	// the mere presence of an Ast does not imply that it is valid for use.
-	Check(ast Ast) (Ast, *Issues)
-
-	// Parse parses the input expression value `txt` to a Ast and/or a set of Issues.
-	//
-	// This form of Parse creates a common.Source value for the input `txt` and forwards to the
-	// ParseSource method.
-	Parse(txt string) (Ast, *Issues)
-
-	// ParseSource parses the input source to an Ast and/or set of Issues.
-	//
-	// Parsing has failed if the returned Issues value and its Issues.Err() value is non-nil.
-	// Issues should be inspected if they are non-nil, but may not represent a fatal error.
-	//
-	// It is possible to have both non-nil Ast and Issues values returned from this call; however,
-	// the mere presence of an Ast does not imply that it is valid for use.
-	ParseSource(src common.Source) (Ast, *Issues)
-
-	// Program generates an evaluable instance of the Ast within the environment (Env).
-	Program(ast Ast, opts ...ProgramOption) (Program, error)
-
-	// TypeAdapter returns the `ref.TypeAdapter` configured for the environment.
-	TypeAdapter() ref.TypeAdapter
-
-	// TypeProvider returns the `ref.TypeProvider` configured for the environment.
-	TypeProvider() ref.TypeProvider
+type Env struct {
+	declarations []*exprpb.Decl
+	macros       []parser.Macro
+	pkg          packages.Packager
+	provider     ref.TypeProvider
+	adapter      ref.TypeAdapter
+	chk          *checker.Env
+	// environment options, true by default.
+	enableBuiltins                 bool
+	enableDynamicAggregateLiterals bool
 }
 
 // NewEnv creates an Env instance suitable for parsing and checking expressions against a set of
@@ -102,9 +94,9 @@ type Env interface {
 // by default.
 //
 // See the EnvOptions for the options that can be used to configure the environment.
-func NewEnv(opts ...EnvOption) (Env, error) {
+func NewEnv(opts ...EnvOption) (*Env, error) {
 	registry := types.NewRegistry()
-	return (&env{
+	return (&Env{
 		declarations:                   checker.StandardDeclarations(),
 		macros:                         parser.AllMacros,
 		pkg:                            packages.DefaultPackage,
@@ -116,14 +108,87 @@ func NewEnv(opts ...EnvOption) (Env, error) {
 }
 
 // Extend the current environment with additional options to produce a new Env.
-func (e *env) Extend(opts ...EnvOption) (Env, error) {
-	ext := &env{}
+func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
+	ext := &Env{}
 	*ext = *e
 	return ext.configure(opts...)
 }
 
+// Check performs type-checking on the input Ast and yields a checked Ast and/or set of Issues.
+//
+// Checking has failed if the returned Issues value and its Issues.Err() value is non-nil.
+// Issues should be inspected if they are non-nil, but may not represent a fatal error.
+//
+// It is possible to have both non-nil Ast and Issues values returned from this call: however,
+// the mere presence of an Ast does not imply that it is valid for use.
+func (e *Env) Check(ast *Ast) (*Ast, *Issues) {
+	// Note, errors aren't currently possible on the Ast to ParsedExpr conversion.
+	pe, _ := AstToParsedExpr(ast)
+	res, errs := checker.Check(pe, ast.Source(), e.chk)
+	if len(errs.GetErrors()) > 0 {
+		return nil, &Issues{errs: errs}
+	}
+	// Manually create the Ast to ensure that the Ast source information (which may be more
+	// detailed than the information provided by Check), is returned to the caller.
+	return &Ast{
+		source:  ast.Source(),
+		expr:    res.GetExpr(),
+		info:    res.GetSourceInfo(),
+		refMap:  res.GetReferenceMap(),
+		typeMap: res.GetTypeMap()}, nil
+}
+
+// Parse parses the input expression value `txt` to a Ast and/or a set of Issues.
+//
+// This form of Parse creates a common.Source value for the input `txt` and forwards to the
+// ParseSource method.
+func (e *Env) Parse(txt string) (*Ast, *Issues) {
+	src := common.NewTextSource(txt)
+	return e.ParseSource(src)
+}
+
+// ParseSource parses the input source to an Ast and/or set of Issues.
+//
+// Parsing has failed if the returned Issues value and its Issues.Err() value is non-nil.
+// Issues should be inspected if they are non-nil, but may not represent a fatal error.
+//
+// It is possible to have both non-nil Ast and Issues values returned from this call; however,
+// the mere presence of an Ast does not imply that it is valid for use.
+func (e *Env) ParseSource(src common.Source) (*Ast, *Issues) {
+	res, errs := parser.ParseWithMacros(src, e.macros)
+	if len(errs.GetErrors()) > 0 {
+		return nil, &Issues{errs: errs}
+	}
+	// Manually create the Ast to ensure that the text source information is propagated on
+	// subsequent calls to Check.
+	return &Ast{
+		source: Source(src),
+		expr:   res.GetExpr(),
+		info:   res.GetSourceInfo()}, nil
+}
+
+// Program generates an evaluable instance of the Ast within the environment (Env).
+func (e *Env) Program(ast *Ast, opts ...ProgramOption) (Program, error) {
+	if e.enableBuiltins {
+		opts = append(
+			[]ProgramOption{Functions(functions.StandardOverloads()...)},
+			opts...)
+	}
+	return newProgram(e, ast, opts...)
+}
+
+// TypeAdapter returns the `ref.TypeAdapter` configured for the environment.
+func (e *Env) TypeAdapter() ref.TypeAdapter {
+	return e.adapter
+}
+
+// TypeProvider returns the `ref.TypeProvider` configured for the environment.
+func (e *Env) TypeProvider() ref.TypeProvider {
+	return e.provider
+}
+
 // configure applies a series of EnvOptions to the current environment.
-func (e *env) configure(opts ...EnvOption) (Env, error) {
+func (e *Env) configure(opts ...EnvOption) (*Env, error) {
 	// Customized the environment using the provided EnvOption values. If an error is
 	// generated at any step this, will be returned as a nil Env with a non-nil error.
 	var err error
@@ -143,114 +208,6 @@ func (e *env) configure(opts ...EnvOption) (Env, error) {
 	}
 	e.chk = ce
 	return e, nil
-}
-
-// astValue is the internal implementation of the ast interface.
-type astValue struct {
-	expr    *exprpb.Expr
-	info    *exprpb.SourceInfo
-	source  Source
-	refMap  map[int64]*exprpb.Reference
-	typeMap map[int64]*exprpb.Type
-}
-
-// Expr implements the Ast interface method.
-func (ast *astValue) Expr() *exprpb.Expr {
-	return ast.expr
-}
-
-// IsChecked implements the Ast interface method.
-func (ast *astValue) IsChecked() bool {
-	return ast.refMap != nil && ast.typeMap != nil
-}
-
-// SourceInfo implements the Ast interface method.
-func (ast *astValue) SourceInfo() *exprpb.SourceInfo {
-	return ast.info
-}
-
-// ResultType implements the Ast interface method.
-func (ast *astValue) ResultType() *exprpb.Type {
-	if !ast.IsChecked() {
-		return decls.Dyn
-	}
-	return ast.typeMap[ast.expr.Id]
-}
-
-// Source implements the Ast interface method.
-func (ast *astValue) Source() Source {
-	return ast.source
-}
-
-// env is the internal implementation of the Env interface.
-type env struct {
-	declarations []*exprpb.Decl
-	macros       []parser.Macro
-	pkg          packages.Packager
-	provider     ref.TypeProvider
-	adapter      ref.TypeAdapter
-	chk          *checker.Env
-	// environment options, true by default.
-	enableBuiltins                 bool
-	enableDynamicAggregateLiterals bool
-}
-
-// Check implements the Env interface method.
-func (e *env) Check(ast Ast) (Ast, *Issues) {
-	// Note, errors aren't currently possible on the Ast to ParsedExpr conversion.
-	pe, _ := AstToParsedExpr(ast)
-	res, errs := checker.Check(pe, ast.Source(), e.chk)
-	if len(errs.GetErrors()) > 0 {
-		return nil, &Issues{errs: errs}
-	}
-	// Manually create the Ast to ensure that the Ast source information (which may be more
-	// detailed than the information provided by Check), is returned to the caller.
-	return &astValue{
-		source:  ast.Source(),
-		expr:    res.GetExpr(),
-		info:    res.GetSourceInfo(),
-		refMap:  res.GetReferenceMap(),
-		typeMap: res.GetTypeMap()}, nil
-}
-
-// Parse implements the Env interface method.
-func (e *env) Parse(txt string) (Ast, *Issues) {
-	src := common.NewTextSource(txt)
-	return e.ParseSource(src)
-}
-
-// ParseSource implements the Env interface method.
-func (e *env) ParseSource(src common.Source) (Ast, *Issues) {
-	res, errs := parser.ParseWithMacros(src, e.macros)
-	if len(errs.GetErrors()) > 0 {
-		return nil, &Issues{errs: errs}
-	}
-	// Manually create the Ast to ensure that the text source information is propagated on
-	// subsequent calls to Check.
-	return &astValue{
-		source: Source(src),
-		expr:   res.GetExpr(),
-		info:   res.GetSourceInfo()}, nil
-}
-
-// Program implements the Env interface method.
-func (e *env) Program(ast Ast, opts ...ProgramOption) (Program, error) {
-	if e.enableBuiltins {
-		opts = append(
-			[]ProgramOption{Functions(functions.StandardOverloads()...)},
-			opts...)
-	}
-	return newProgram(e, ast, opts...)
-}
-
-// TypeAdapter implements the Env interface method.
-func (e *env) TypeAdapter() ref.TypeAdapter {
-	return e.adapter
-}
-
-// TypeProvider implements the Env interface method.
-func (e *env) TypeProvider() ref.TypeProvider {
-	return e.provider
 }
 
 // Issues defines methods for inspecting the error details of parse and check calls.

--- a/cel/env.go
+++ b/cel/env.go
@@ -74,9 +74,8 @@ func (ast *Ast) Source() Source {
 	return ast.source
 }
 
-// Env defines functions for parsing and type-checking expressions against a set of user-defined
-// constants, variables, and functions. The Env interface also defines a method for generating
-// evaluable programs from parsed and checked Asts.
+// Env encapsulates the context necessary to perform parsing, type checking, or generation of
+// evaluable programs for different expressions.
 type Env struct {
 	declarations []*exprpb.Decl
 	macros       []parser.Macro
@@ -116,7 +115,7 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 
 // Check performs type-checking on the input Ast and yields a checked Ast and/or set of Issues.
 //
-// Checking has failed if the returned Issues value and its Issues.Err() value is non-nil.
+// Checking has failed if the returned Issues value and its Issues.Err() value are non-nil.
 // Issues should be inspected if they are non-nil, but may not represent a fatal error.
 //
 // It is possible to have both non-nil Ast and Issues values returned from this call: however,

--- a/cel/io.go
+++ b/cel/io.go
@@ -24,8 +24,8 @@ import (
 )
 
 // CheckedExprToAst converts a checked expression proto message to an Ast.
-func CheckedExprToAst(checkedExpr *exprpb.CheckedExpr) Ast {
-	return &astValue{
+func CheckedExprToAst(checkedExpr *exprpb.CheckedExpr) *Ast {
+	return &Ast{
 		expr:    checkedExpr.GetExpr(),
 		info:    checkedExpr.GetSourceInfo(),
 		source:  common.NewInfoSource(checkedExpr.GetSourceInfo()),
@@ -37,21 +37,21 @@ func CheckedExprToAst(checkedExpr *exprpb.CheckedExpr) Ast {
 // AstToCheckedExpr converts an Ast to an protobuf CheckedExpr value.
 //
 // If the Ast.IsChecked() returns false, this conversion method will return an error.
-func AstToCheckedExpr(a Ast) (*exprpb.CheckedExpr, error) {
+func AstToCheckedExpr(a *Ast) (*exprpb.CheckedExpr, error) {
 	if !a.IsChecked() {
 		return nil, fmt.Errorf("cannot convert unchecked ast")
 	}
 	return &exprpb.CheckedExpr{
 		Expr:         a.Expr(),
 		SourceInfo:   a.SourceInfo(),
-		ReferenceMap: a.(*astValue).refMap,
-		TypeMap:      a.(*astValue).typeMap,
+		ReferenceMap: a.refMap,
+		TypeMap:      a.typeMap,
 	}, nil
 }
 
 // ParsedExprToAst converts a parsed expression proto message to an Ast.
-func ParsedExprToAst(parsedExpr *exprpb.ParsedExpr) Ast {
-	return &astValue{
+func ParsedExprToAst(parsedExpr *exprpb.ParsedExpr) *Ast {
+	return &Ast{
 		expr:   parsedExpr.GetExpr(),
 		info:   parsedExpr.GetSourceInfo(),
 		source: common.NewInfoSource(parsedExpr.GetSourceInfo()),
@@ -59,7 +59,7 @@ func ParsedExprToAst(parsedExpr *exprpb.ParsedExpr) Ast {
 }
 
 // AstToParsedExpr converts an Ast to an protobuf ParsedExpr value.
-func AstToParsedExpr(a Ast) (*exprpb.ParsedExpr, error) {
+func AstToParsedExpr(a *Ast) (*exprpb.ParsedExpr, error) {
 	return &exprpb.ParsedExpr{
 		Expr:       a.Expr(),
 		SourceInfo: a.SourceInfo(),
@@ -70,7 +70,7 @@ func AstToParsedExpr(a Ast) (*exprpb.ParsedExpr, error) {
 //
 // Note, the conversion may not be an exact replica of the original expression, but will produce
 // a string that is semantically equivalent.
-func AstToString(a Ast) (string, error) {
+func AstToString(a *Ast) (string, error) {
 	expr := a.Expr()
 	info := a.SourceInfo()
 	return parser.Unparse(expr, info)

--- a/cel/options.go
+++ b/cel/options.go
@@ -30,13 +30,13 @@ import (
 )
 
 // EnvOption is a functional interface for configuring the environment.
-type EnvOption func(e *env) (*env, error)
+type EnvOption func(e *Env) (*Env, error)
 
 // ClearBuiltIns option removes all standard types, operators, and macros from the environment.
 //
 // Note: This option must be specified before Declarations and/or Macros if used together.
 func ClearBuiltIns() EnvOption {
-	return func(e *env) (*env, error) {
+	return func(e *Env) (*Env, error) {
 		e.declarations = []*exprpb.Decl{}
 		e.macros = parser.NoMacros
 		e.enableBuiltins = false
@@ -52,7 +52,7 @@ func ClearBuiltIns() EnvOption {
 // Note: This option is a no-op when used with ClearBuiltIns, and must be used before Macros
 // if used together.
 func ClearMacros() EnvOption {
-	return func(e *env) (*env, error) {
+	return func(e *Env) (*Env, error) {
 		e.macros = parser.NoMacros
 		return e, nil
 	}
@@ -62,7 +62,7 @@ func ClearMacros() EnvOption {
 //
 // Note: This option must be specified before the Types and TypeDescs options when used together.
 func CustomTypeAdapter(adapter ref.TypeAdapter) EnvOption {
-	return func(e *env) (*env, error) {
+	return func(e *Env) (*Env, error) {
 		e.adapter = adapter
 		return e, nil
 	}
@@ -72,7 +72,7 @@ func CustomTypeAdapter(adapter ref.TypeAdapter) EnvOption {
 //
 // Note: This option must be specified before the Types and TypeDescs options when used together.
 func CustomTypeProvider(provider ref.TypeProvider) EnvOption {
-	return func(e *env) (*env, error) {
+	return func(e *Env) (*Env, error) {
 		e.provider = provider
 		return e, nil
 	}
@@ -84,7 +84,7 @@ func CustomTypeProvider(provider ref.TypeProvider) EnvOption {
 func Declarations(decls ...*exprpb.Decl) EnvOption {
 	// TODO: provide an alternative means of specifying declarations that doesn't refer
 	// to the underlying proto implementations.
-	return func(e *env) (*env, error) {
+	return func(e *Env) (*Env, error) {
 		e.declarations = append(e.declarations, decls...)
 		return e, nil
 	}
@@ -97,7 +97,7 @@ func Declarations(decls ...*exprpb.Decl) EnvOption {
 // expression, as well as via conversion of well-known dynamic types, or with unchecked
 // expressions.
 func HomogeneousAggregateLiterals() EnvOption {
-	return func(e *env) (*env, error) {
+	return func(e *Env) (*Env, error) {
 		e.enableDynamicAggregateLiterals = false
 		return e, nil
 	}
@@ -107,7 +107,7 @@ func HomogeneousAggregateLiterals() EnvOption {
 //
 // Note: This option must be specified after ClearBuiltIns and/or ClearMacros if used together.
 func Macros(macros ...parser.Macro) EnvOption {
-	return func(e *env) (*env, error) {
+	return func(e *Env) (*Env, error) {
 		e.macros = append(e.macros, macros...)
 		return e, nil
 	}
@@ -119,7 +119,7 @@ func Macros(macros ...parser.Macro) EnvOption {
 // specifying a container of `google.type` would make it possible to write expressions such as
 // `Expr{expression: 'a < b'}` instead of having to write `google.type.Expr{...}`.
 func Container(pkg string) EnvOption {
-	return func(e *env) (*env, error) {
+	return func(e *Env) (*Env, error) {
 		e.pkg = packages.NewPackage(pkg)
 		return e, nil
 	}
@@ -136,7 +136,7 @@ func Container(pkg string) EnvOption {
 //
 // Note: This option must be specified after the CustomTypeProvider option when used together.
 func Types(addTypes ...interface{}) EnvOption {
-	return func(e *env) (*env, error) {
+	return func(e *Env) (*Env, error) {
 		reg, isReg := e.provider.(ref.TypeRegistry)
 		if !isReg {
 			return nil, fmt.Errorf("custom types not supported by provider: %T", e.provider)
@@ -172,7 +172,7 @@ func Types(addTypes ...interface{}) EnvOption {
 // via descriptor will not be able to instantiate messages, and so are
 // only useful for Check() operations.
 func TypeDescs(descs ...interface{}) EnvOption {
-	return func(e *env) (*env, error) {
+	return func(e *Env) (*Env, error) {
 		reg, isReg := e.provider.(ref.TypeRegistry)
 		if !isReg {
 			return nil, fmt.Errorf("custom types not supported by provider: %T", e.provider)

--- a/cel/program.go
+++ b/cel/program.go
@@ -40,14 +40,7 @@ type Program interface {
 	// An unsuccessful evaluation is typically the result of a series of incompatible `EnvOption`
 	// or `ProgramOption` values used in the creation of the evaluation environment or executable
 	// program.
-	Eval(vars interface{}) (ref.Val, EvalDetails, error)
-}
-
-// EvalDetails holds additional information observed during the Eval() call.
-type EvalDetails interface {
-	// State of the evaluation, non-nil if the OptTrackState or OptExhaustiveEval is specified
-	// within EvalOptions.
-	State() interpreter.EvalState
+	Eval(vars interface{}) (ref.Val, *EvalDetails, error)
 }
 
 // NoVars returns an empty Activation.
@@ -55,13 +48,14 @@ func NoVars() interpreter.Activation {
 	return interpreter.EmptyActivation()
 }
 
-// evalDetails is the internal implementation of the EvalDetails interface.
-type evalDetails struct {
+// EvalDetails holds additional information observed during the Eval() call.
+type EvalDetails struct {
 	state interpreter.EvalState
 }
 
-// State implements the Result interface method.
-func (ed *evalDetails) State() interpreter.EvalState {
+// State of the evaluation, non-nil if the OptTrackState or OptExhaustiveEval is specified
+// within EvalOptions.
+func (ed *EvalDetails) State() interpreter.EvalState {
 	return ed.state
 }
 
@@ -199,7 +193,7 @@ func initInterpretable(
 }
 
 // Eval implements the Program interface method.
-func (p *prog) Eval(input interface{}) (v ref.Val, det EvalDetails, err error) {
+func (p *prog) Eval(input interface{}) (v ref.Val, det *EvalDetails, err error) {
 	// Configure error recovery for unexpected panics during evaluation. Note, the use of named
 	// return values makes it possible to modify the error response during the recovery
 	// function.
@@ -227,12 +221,12 @@ func (p *prog) Eval(input interface{}) (v ref.Val, det EvalDetails, err error) {
 }
 
 // Eval implements the Program interface method.
-func (gen *progGen) Eval(input interface{}) (ref.Val, EvalDetails, error) {
+func (gen *progGen) Eval(input interface{}) (ref.Val, *EvalDetails, error) {
 	// The factory based Eval() differs from the standard evaluation model in that it generates a
 	// new EvalState instance for each call to ensure that unique evaluations yield unique stateful
 	// results.
 	state := interpreter.NewEvalState()
-	det := &evalDetails{state: state}
+	det := &EvalDetails{state: state}
 
 	// Generate a new instance of the interpretable using the factory configured during the call to
 	// newProgram(). It is incredibly unlikely that the factory call will generate an error given

--- a/cel/program.go
+++ b/cel/program.go
@@ -67,7 +67,7 @@ func (ed *evalDetails) State() interpreter.EvalState {
 
 // prog is the internal implementation of the Program interface.
 type prog struct {
-	*env
+	*Env
 	evalOpts      EvalOption
 	defaultVars   interpreter.Activation
 	dispatcher    interpreter.Dispatcher
@@ -88,7 +88,7 @@ type progGen struct {
 // ProgramOption values.
 //
 // If the program cannot be configured the prog will be nil, with a non-nil error response.
-func newProgram(e *env, ast Ast, opts ...ProgramOption) (Program, error) {
+func newProgram(e *Env, ast *Ast, opts ...ProgramOption) (Program, error) {
 	// Build the dispatcher, interpreter, and default program value.
 	disp := interpreter.NewDispatcher()
 
@@ -96,7 +96,7 @@ func newProgram(e *env, ast Ast, opts ...ProgramOption) (Program, error) {
 	// configured. The attribute factory may be overriden by using the CustomAttributeFactory.
 	attrFactory := interpreter.NewAttributeFactory(e.pkg, e.adapter, e.provider)
 	p := &prog{
-		env:         e,
+		Env:         e,
 		dispatcher:  disp,
 		attrFactory: attrFactory}
 
@@ -130,7 +130,7 @@ func newProgram(e *env, ast Ast, opts ...ProgramOption) (Program, error) {
 			clone := &prog{
 				evalOpts:    p.evalOpts,
 				defaultVars: p.defaultVars,
-				env:         e,
+				Env:         e,
 				dispatcher:  disp,
 				interpreter: interp}
 			return initInterpretable(clone, ast, decs)
@@ -145,7 +145,7 @@ func newProgram(e *env, ast Ast, opts ...ProgramOption) (Program, error) {
 			clone := &prog{
 				evalOpts:    p.evalOpts,
 				defaultVars: p.defaultVars,
-				env:         e,
+				Env:         e,
 				dispatcher:  disp,
 				interpreter: interp}
 			return initInterpretable(clone, ast, decs)
@@ -170,7 +170,7 @@ func initProgGen(factory progFactory) (Program, error) {
 // has been run through the type-checker.
 func initInterpretable(
 	p *prog,
-	ast Ast,
+	ast *Ast,
 	decorators []interpreter.InterpretableDecorator) (Program, error) {
 	var err error
 	// Unchecked programs do not contain type and reference information and may be


### PR DESCRIPTION
Replaces the top-level `Ast` and `Env` interfaces with structs. 

These values were never intended to be implemented by clients, but rather are
core object representations which CEL evaluation depends upon. 

Note: this is a breaking change since the signature of many methods has changed
from interface values for the `Ast` and `Env` to pointers: `*Ast`, `*Env`.

Closes #301 