### PR TITLE
Fix use of type params as valid comprehension ranges.

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -434,7 +434,7 @@ func (c *checker) checkComprehension(e *exprpb.Expr) {
 	case kindMap:
 		// Ranges over the keys.
 		varType = rangeType.GetMapType().KeyType
-	case kindDyn, kindError:
+	case kindDyn, kindError, kindTypeParam:
 		varType = decls.Dyn
 	default:
 		c.errors.notAComprehensionRange(c.location(comp.IterRange), rangeType)

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -201,7 +201,7 @@ func (c *checker) checkSelect(e *exprpb.Expr) {
 		}
 	case kindTypeParam:
 		// Type params are expected to be the same type as the target.
-		resultType = targetType
+		resultType = c.newTypeVar()
 	default:
 		// Dynamic / error values are treated as DYN type. Errors are handled this way as well
 		// in order to allow forward progress on the check.
@@ -434,8 +434,10 @@ func (c *checker) checkComprehension(e *exprpb.Expr) {
 	case kindMap:
 		// Ranges over the keys.
 		varType = rangeType.GetMapType().KeyType
-	case kindDyn, kindError, kindTypeParam:
+	case kindDyn, kindError:
 		varType = decls.Dyn
+	case kindTypeParam:
+		varType = c.newTypeVar()
 	default:
 		c.errors.notAComprehensionRange(c.location(comp.IterRange), rangeType)
 		varType = decls.Error

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -455,7 +455,7 @@ _!=_(_-_(_+_(1~double, _*_(2~double, 3~double)~double^multiply_double)
 					1~double
 				)~bool^equals
 			)~bool^logical_and
-		  )~bool^logical_and`,
+		)~bool^logical_and`,
 		Env: env{
 			idents: []*exprpb.Decl{
 				decls.NewIdent("x", decls.NewObjectType("google.protobuf.Struct"), nil),

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -419,43 +419,43 @@ _!=_(_-_(_+_(1~double, _*_(2~double, 3~double)~double^multiply_double)
 		&& z == 1.0`,
 		R: `_&&_(
 			_&&_(
-				_==_(
+			  _==_(
+				_[_](
+				  _[_](
 					_[_](
-						_[_](
-							_[_](
-								x~map(string, dyn)^x,
-								"claims"~string
-							)~dyn^index_map,
-							"groups"~string
-						)~list(string)^index_map,
-						0~int
-					)~string^index_list.name~string,
-					"dummy"~string
-				)~bool^equals,
-				_==_(
-					_[_](
-						x~map(string, dyn)^x.claims~dyn,
-						"exp"~string
+					  x~map(string, dyn)^x,
+					  "claims"~string
 					)~dyn^index_map,
-					_[_](
-						y~list(dyn)^y,
-						1~int
-					)~dyn^index_list.time~dyn
-				)~bool^equals
+					"groups"~string
+				  )~list(dyn)^index_map,
+				  0~int
+				)~dyn^index_list.name~string,
+				"dummy"~string
+			  )~bool^equals,
+			  _==_(
+				_[_](
+				  x~map(string, dyn)^x.claims~dyn,
+				  "exp"~string
+				)~dyn^index_map,
+				_[_](
+				  y~list(dyn)^y,
+				  1~int
+				)~dyn^index_list.time~dyn
+			  )~bool^equals
 			)~bool^logical_and,
 			_&&_(
-				_==_(
-					x~map(string, dyn)^x.claims~dyn.structured~dyn,
-					{
-						"key"~string:z~dyn^z
-					}~map(string, dyn)
-				)~bool^equals,
-				_==_(
-					z~dyn^z,
-					1~double
-				)~bool^equals
+			  _==_(
+				x~map(string, dyn)^x.claims~dyn.structured~dyn,
+				{
+				  "key"~string:z~dyn^z
+				}~map(string, dyn)
+			  )~bool^equals,
+			  _==_(
+				z~dyn^z,
+				1~double
+			  )~bool^equals
 			)~bool^logical_and
-		)~bool^logical_and`,
+		  )~bool^logical_and`,
 		Env: env{
 			idents: []*exprpb.Decl{
 				decls.NewIdent("x", decls.NewObjectType("google.protobuf.Struct"), nil),
@@ -1398,8 +1398,8 @@ _&&_(_==_(list~type(list(dyn))^list,
 			x,
 			// Target
 			_[_](
-			  args~map(string, dyn)^args.user~dyn,
-			  "myextension"~string
+			args~map(string, dyn)^args.user~dyn,
+			"myextension"~string
 			)~dyn^index_map.customAttributes~dyn,
 			// Accumulator
 			__result__,
@@ -1409,17 +1409,17 @@ _&&_(_==_(list~type(list(dyn))^list,
 			true~bool,
 			// LoopStep
 			_?_:_(
-			  _==_(
-				x~dyn^x.name~dyn,
+			_==_(
+				x~dyn^x.name~string,
 				"hobbies"~string
-			  )~bool^equals,
-			  _+_(
+			)~bool^equals,
+			_+_(
 				__result__~list(dyn)^__result__,
 				[
-				  x~dyn^x
+				x~dyn^x
 				]~list(dyn)
-			  )~list(dyn)^add_list,
-			  __result__~list(dyn)^__result__
+			)~list(dyn)^add_list,
+			__result__~list(dyn)^__result__
 			)~list(dyn)^conditional,
 			// Result
 			__result__~list(dyn)^__result__)~list(dyn)`,

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -419,41 +419,41 @@ _!=_(_-_(_+_(1~double, _*_(2~double, 3~double)~double^multiply_double)
 		&& z == 1.0`,
 		R: `_&&_(
 			_&&_(
-			  _==_(
-				_[_](
-				  _[_](
+				_==_(
 					_[_](
-					  x~map(string, dyn)^x,
-					  "claims"~string
+						_[_](
+							_[_](
+								x~map(string, dyn)^x,
+								"claims"~string
+							)~dyn^index_map,
+							"groups"~string
+						)~list(dyn)^index_map,
+						0~int
+					)~dyn^index_list.name~string,
+					"dummy"~string
+				)~bool^equals,
+				_==_(
+					_[_](
+						x~map(string, dyn)^x.claims~dyn,
+						"exp"~string
 					)~dyn^index_map,
-					"groups"~string
-				  )~list(dyn)^index_map,
-				  0~int
-				)~dyn^index_list.name~string,
-				"dummy"~string
-			  )~bool^equals,
-			  _==_(
-				_[_](
-				  x~map(string, dyn)^x.claims~dyn,
-				  "exp"~string
-				)~dyn^index_map,
-				_[_](
-				  y~list(dyn)^y,
-				  1~int
-				)~dyn^index_list.time~dyn
-			  )~bool^equals
+					_[_](
+						y~list(dyn)^y,
+						1~int
+					)~dyn^index_list.time~dyn
+				)~bool^equals
 			)~bool^logical_and,
 			_&&_(
-			  _==_(
-				x~map(string, dyn)^x.claims~dyn.structured~dyn,
-				{
-				  "key"~string:z~dyn^z
-				}~map(string, dyn)
-			  )~bool^equals,
-			  _==_(
-				z~dyn^z,
-				1~double
-			  )~bool^equals
+				_==_(
+					x~map(string, dyn)^x.claims~dyn.structured~dyn,
+					{
+						"key"~string:z~dyn^z
+					}~map(string, dyn)
+				)~bool^equals,
+				_==_(
+					z~dyn^z,
+					1~double
+				)~bool^equals
 			)~bool^logical_and
 		  )~bool^logical_and`,
 		Env: env{

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1391,6 +1391,45 @@ _&&_(_==_(list~type(list(dyn))^list,
 		| [].map(x, [].map(y, x in y && y in x))
 		| ................................^`,
 	},
+	{
+		I: `args.user["myextension"].customAttributes.filter(x, x.name == "hobbies")`,
+		R: `__comprehension__(
+			// Variable
+			x,
+			// Target
+			_[_](
+			  args~map(string, dyn)^args.user~dyn,
+			  "myextension"~string
+			)~dyn^index_map.customAttributes~dyn,
+			// Accumulator
+			__result__,
+			// Init
+			[]~list(dyn),
+			// LoopCondition
+			true~bool,
+			// LoopStep
+			_?_:_(
+			  _==_(
+				x~dyn^x.name~dyn,
+				"hobbies"~string
+			  )~bool^equals,
+			  _+_(
+				__result__~list(dyn)^__result__,
+				[
+				  x~dyn^x
+				]~list(dyn)
+			  )~list(dyn)^add_list,
+			  __result__~list(dyn)^__result__
+			)~list(dyn)^conditional,
+			// Result
+			__result__~list(dyn)^__result__)~list(dyn)`,
+		Env: env{
+			idents: []*exprpb.Decl{
+				decls.NewIdent("args", decls.NewMapType(decls.String, decls.Dyn), nil),
+			},
+		},
+		Type: decls.NewListType(decls.Dyn),
+	},
 }
 
 var reg = initTypeRegistry()


### PR DESCRIPTION
If a call yields an unresolved type param as a result, and is then used as an input range to a comprehension, the type-param should be traced through the expression.

In most cases the type-param will result to `dyn` at the final type-unification check; however, it appears as though there was bug within the `checkSelect` for field selection which improperly designated a result type-param with the same type-param as the input and would yield intermediate errors in type resolution. This too has been fixed.

Closes #304 