### PR TITLE
[Checker] Convert certain Type Param uses to DYN

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -533,10 +533,6 @@ func (c *checker) setType(e *exprpb.Expr, t *exprpb.Type) {
 	c.types[e.Id] = t
 }
 
-func (c *checker) setDynType(e *exprpb.Expr) {
-	c.types[e.Id] = decls.Dyn
-}
-
 func (c *checker) getType(e *exprpb.Expr) *exprpb.Type {
 	return c.types[e.Id]
 }

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -203,7 +203,7 @@ func (c *checker) checkSelect(e *exprpb.Expr) {
 		// Attempting to pick a type for the field might result in an impossible type
 		// assigment and overload selection for both the operand and the item being selected.
 		// Assign both to DYN to be safe.
-		c.mappings.add(targetType, decls.Dyn)
+		c.isAssignable(targetType, decls.Dyn)
 		resultType = decls.Dyn
 	default:
 		// Dynamic / error values are treated as DYN type. Errors are handled this way as well

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -429,7 +429,7 @@ _!=_(_-_(_+_(1~double, _*_(2~double, 3~double)~double^multiply_double)
 							"groups"~string
 						)~list(dyn)^index_map,
 						0~int
-					)~dyn^index_list.name~string,
+					)~dyn^index_list.name~dyn,
 					"dummy"~string
 				)~bool^equals,
 				_==_(
@@ -1410,7 +1410,7 @@ _&&_(_==_(list~type(list(dyn))^list,
 			// LoopStep
 			_?_:_(
 			_==_(
-				x~dyn^x.name~string,
+				x~dyn^x.name~dyn,
 				"hobbies"~string
 			)~bool^equals,
 			_+_(
@@ -1429,6 +1429,25 @@ _&&_(_==_(list~type(list(dyn))^list,
 			},
 		},
 		Type: decls.NewListType(decls.Dyn),
+	},
+	{
+		I: `a.b + 1 == a[0]`,
+		R: `_==_(
+			_+_(
+			  a~dyn^a.b~dyn,
+			  1~int
+			)~int^add_int64,
+			_[_](
+			  a~dyn^a,
+			  0~int
+			)~dyn^index_list|index_map
+		  )~bool^equals`,
+		Env: env{
+			idents: []*exprpb.Decl{
+				decls.NewIdent("a", decls.NewTypeParamType("T"), nil),
+			},
+		},
+		Type: decls.Bool,
 	},
 }
 


### PR DESCRIPTION
After further investigation, it appears as though it is possible to resolve type params to the incorrect type by using the technique taken in #305 

A new test case has been added to verify that `decls.Dyn` is the proper result in the case
where a free type-param appears in field selections, list and map index operations, and comprehension ranges.

This should properly fix the issue identified in #304 