### PR TITLE
Top-level support for partial state evaluation

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -650,9 +650,9 @@ func Test_ResidualAst_Complex(t *testing.T) {
 		AttributePattern("request.auth.claims").Field("email"),
 	)
 	ast, iss := e.Parse(
-		`resource.name.startsWith("bucket/my-bucket") &&
+		`resource.name.startsWith('bucket/my-bucket') &&
 		 bool(request.auth.claims.email_verified) == true &&
-		 request.auth.claims.email == "wiley@acme.co"`)
+		 request.auth.claims.email == 'wiley@acme.co'`)
 	if iss != nil && iss.Err() != nil {
 		t.Fatal(iss.Err())
 	}
@@ -678,8 +678,8 @@ func Test_ResidualAst_Complex(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if expr != `request.auth.claims.email == "wiley@acme.co"` {
-		t.Errorf("Got expr: %s, wanted x < 10", expr)
+	if expr != `request.auth.claims.email == 'wiley@acme.co'` {
+		t.Errorf("Got expr: %s, wanted request.auth.claims.email == 'wiley@acme.co'", expr)
 	}
 }
 

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -647,12 +647,12 @@ func Test_ResidualAst_Complex(t *testing.T) {
 				"email_verified": "true",
 			},
 		},
-		AttributePattern("request.auth.claims").Field("email"),
+		AttributePattern("request.auth.claims").QualString("email"),
 	)
 	ast, iss := e.Parse(
-		`resource.name.startsWith('bucket/my-bucket') &&
+		`resource.name.startsWith("bucket/my-bucket") &&
 		 bool(request.auth.claims.email_verified) == true &&
-		 request.auth.claims.email == 'wiley@acme.co'`)
+		 request.auth.claims.email == "wiley@acme.co"`)
 	if iss != nil && iss.Err() != nil {
 		t.Fatal(iss.Err())
 	}
@@ -678,8 +678,8 @@ func Test_ResidualAst_Complex(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if expr != `request.auth.claims.email == 'wiley@acme.co'` {
-		t.Errorf("Got expr: %s, wanted request.auth.claims.email == 'wiley@acme.co'", expr)
+	if expr != `request.auth.claims.email == "wiley@acme.co"` {
+		t.Errorf("Got expr: %s, wanted request.auth.claims.email == \"wiley@acme.co\"", expr)
 	}
 }
 

--- a/cel/env.go
+++ b/cel/env.go
@@ -215,12 +215,15 @@ func (e *Env) UnknownVars() interpreter.PartialActivation {
 // - Optimizing constant expression evaluations away.
 // - Indexing and pruning expressions based on known input arguments.
 // - Surfacing additional requirements that are needed in order to complete an evaluation.
-// - Sharing the evaluation of an expression across multiple processes
+// - Sharing the evaluation of an expression across multiple machines/nodes.
 //
 // For example, if an expression targets a 'resource' and 'request' attribute and the possible
 // values for the resource are known, a PartialActivation could mark the 'request' as an unknown
 // interpreter.AttributePattern and the resulting ResidualAst would be reduced to only the parts
 // of the expression that reference the 'request'.
+//
+// Note, the expression ids within the residual AST generated through this method have no
+// correlation to the expression ids of the original AST.
 //
 // See the PartialVars helper for how to construct a PartialActivation.
 func (e *Env) ResidualAst(a *Ast, details *EvalDetails) (*Ast, error) {

--- a/cel/env.go
+++ b/cel/env.go
@@ -226,6 +226,9 @@ func (e *Env) UnknownVars() interpreter.PartialActivation {
 // correlation to the expression ids of the original AST.
 //
 // See the PartialVars helper for how to construct a PartialActivation.
+//
+// TODO: Consider adding an option to generate a Program.Residual to avoid round-tripping to an
+// Ast format and then Program again.
 func (e *Env) ResidualAst(a *Ast, details *EvalDetails) (*Ast, error) {
 	pruned := interpreter.PruneAst(a.Expr(), details.State())
 	expr, err := AstToString(ParsedExprToAst(&exprpb.ParsedExpr{Expr: pruned}))

--- a/cel/env.go
+++ b/cel/env.go
@@ -189,6 +189,10 @@ func (e *Env) TypeProvider() ref.TypeProvider {
 
 // UnknownActivation returns an interpreter.PartialActivation which marks all variables
 // declared in the Env as unknown AttributePattern values.
+//
+// Note, the UnknownActivation() will behave the same as an interpreter.EmptyActivation()
+// unless the cel.CustomAttributeFactory option is set to a PartialAttributeFactory
+// implementation.
 func (e *Env) UnknownActivation() interpreter.PartialActivation {
 	var unknownPatterns []*interpreter.AttributePattern
 	for _, d := range e.declarations {

--- a/cel/env.go
+++ b/cel/env.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/cel-go/common/packages"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/interpreter"
 	"github.com/google/cel-go/interpreter/functions"
 	"github.com/google/cel-go/parser"
 
@@ -184,6 +185,23 @@ func (e *Env) TypeAdapter() ref.TypeAdapter {
 // TypeProvider returns the `ref.TypeProvider` configured for the environment.
 func (e *Env) TypeProvider() ref.TypeProvider {
 	return e.provider
+}
+
+// UnknownActivation returns an interpreter.PartialActivation which marks all variables
+// declared in the Env as unknown AttributePattern values.
+func (e *Env) UnknownActivation() interpreter.PartialActivation {
+	var unknownPatterns []*interpreter.AttributePattern
+	for _, d := range e.declarations {
+		switch d.GetDeclKind().(type) {
+		case *exprpb.Decl_Ident:
+			unknownPatterns = append(unknownPatterns,
+				interpreter.NewAttributePattern(d.GetName()))
+		}
+	}
+	part, _ := interpreter.NewPartialActivation(
+		interpreter.EmptyActivation(),
+		unknownPatterns...)
+	return part
 }
 
 // configure applies a series of EnvOptions to the current environment.

--- a/cel/env.go
+++ b/cel/env.go
@@ -187,13 +187,12 @@ func (e *Env) TypeProvider() ref.TypeProvider {
 	return e.provider
 }
 
-// UnknownActivation returns an interpreter.PartialActivation which marks all variables
+// UnknownVars returns an interpreter.PartialActivation which marks all variables
 // declared in the Env as unknown AttributePattern values.
 //
-// Note, the UnknownActivation() will behave the same as an interpreter.EmptyActivation()
-// unless the cel.CustomAttributeFactory option is set to a PartialAttributeFactory
-// implementation.
-func (e *Env) UnknownActivation() interpreter.PartialActivation {
+// Note, the UnknownVars will behave the same as an interpreter.EmptyActivation
+// unless the PartialAttributes option is provided as a ProgramOption.
+func (e *Env) UnknownVars() interpreter.PartialActivation {
 	var unknownPatterns []*interpreter.AttributePattern
 	for _, d := range e.declarations {
 		switch d.GetDeclKind().(type) {
@@ -202,10 +201,46 @@ func (e *Env) UnknownActivation() interpreter.PartialActivation {
 				interpreter.NewAttributePattern(d.GetName()))
 		}
 	}
-	part, _ := interpreter.NewPartialActivation(
+	part, _ := PartialVars(
 		interpreter.EmptyActivation(),
 		unknownPatterns...)
 	return part
+}
+
+// ResidualAst takes an Ast and its EvalDetails to produce a new Ast which only contains the
+// attribute references which are unknown.
+//
+// Residual expressions are beneficial in a few scenarios:
+//
+// - Optimizing constant expression evaluations away.
+// - Indexing and pruning expressions based on known input arguments.
+// - Surfacing additional requirements that are needed in order to complete an evaluation.
+// - Sharing the evaluation of an expression across multiple processes
+//
+// For example, if an expression targets a 'resource' and 'request' attribute and the possible
+// values for the resource are known, a PartialActivation could mark the 'request' as an unknown
+// interpreter.AttributePattern and the resulting ResidualAst would be reduced to only the parts
+// of the expression that reference the 'request'.
+//
+// See the PartialVars helper for how to construct a PartialActivation.
+func (e *Env) ResidualAst(a *Ast, details *EvalDetails) (*Ast, error) {
+	pruned := interpreter.PruneAst(a.Expr(), details.State())
+	expr, err := AstToString(ParsedExprToAst(&exprpb.ParsedExpr{Expr: pruned}))
+	if err != nil {
+		return nil, err
+	}
+	parsed, iss := e.Parse(expr)
+	if iss != nil && iss.Err() != nil {
+		return nil, iss.Err()
+	}
+	if !a.IsChecked() {
+		return parsed, nil
+	}
+	checked, iss := e.Check(parsed)
+	if iss != nil && iss.Err() != nil {
+		return nil, iss.Err()
+	}
+	return checked, nil
 }
 
 // configure applies a series of EnvOptions to the current environment.

--- a/cel/io.go
+++ b/cel/io.go
@@ -73,7 +73,7 @@ func AstToParsedExpr(a *Ast) (*exprpb.ParsedExpr, error) {
 // AstToString converts an Ast back to a string if possible.
 //
 // Note, the conversion may not be an exact replica of the original expression, but will produce
-// a string that is semantically equivalent.
+// a string that is semantically equivalent and whose textual representation is stable.
 func AstToString(a *Ast) (string, error) {
 	expr := a.Expr()
 	info := a.SourceInfo()

--- a/cel/io.go
+++ b/cel/io.go
@@ -51,10 +51,14 @@ func AstToCheckedExpr(a *Ast) (*exprpb.CheckedExpr, error) {
 
 // ParsedExprToAst converts a parsed expression proto message to an Ast.
 func ParsedExprToAst(parsedExpr *exprpb.ParsedExpr) *Ast {
+	si := parsedExpr.GetSourceInfo()
+	if si == nil {
+		si = &exprpb.SourceInfo{}
+	}
 	return &Ast{
 		expr:   parsedExpr.GetExpr(),
-		info:   parsedExpr.GetSourceInfo(),
-		source: common.NewInfoSource(parsedExpr.GetSourceInfo()),
+		info:   si,
+		source: common.NewInfoSource(si),
 	}
 }
 

--- a/cel/options.go
+++ b/cel/options.go
@@ -228,34 +228,6 @@ func Globals(vars interface{}) ProgramOption {
 	}
 }
 
-// CustomAttributeFactory adjusts the variable and field resolution behavior of the Program.
-//
-// An expression containing a field references and/or indexing expressions is considered an
-// Attribute. An Attribute is a variable or object reference with zero or more Qualifier that
-// values determine which piece of data is relevant to the computation. When an Attribute
-// expression is encountered, the runtime resolves the Attribute to a concrete value.
-//
-// An AttributeFactory may be generic or it may be deeply aware of the objects which can appear
-// within CEL expressions. By default a generic AttributeFactory is created if a custom one is not
-// set.
-func CustomAttributeFactory(attrs interpreter.AttributeFactory) ProgramOption {
-	return func(p *prog) (*prog, error) {
-		p.attrFactory = attrs
-		return p, nil
-	}
-}
-
-// PartialAttributes enables the evaluation of a PartialActivation which contains data that may be
-// known to be missing, either as top-level variables, or somewhere within a variables object
-// member graph.
-func PartialAttributes() ProgramOption {
-	return func(p *prog) (*prog, error) {
-		attrFac := interpreter.NewPartialAttributeFactory(p.Env.pkg, p.Env.adapter, p.Env.provider)
-		p.attrFactory = attrFac
-		return p, nil
-	}
-}
-
 // EvalOption indicates an evaluation option that may affect the evaluation behavior or information
 // in the output result.
 type EvalOption int
@@ -271,6 +243,14 @@ const (
 	// creation time. This flag is useful when the expression will be evaluated repeatedly against
 	// a series of different inputs.
 	OptOptimize EvalOption = 1 << iota
+
+	// OptPartialEval enables the evaluation of a partial state where the input data that may be
+	// known to be missing, either as top-level variables, or somewhere within a variable's object
+	// member graph.
+	//
+	// By itself, OptPartialEval does not change evaluation behavior unless the input to the
+	// Program Eval is an PartialVars.
+	OptPartialEval EvalOption = 1 << iota
 )
 
 // EvalOptions sets one or more evaluation options which may affect the evaluation or Result.

--- a/cel/options.go
+++ b/cel/options.go
@@ -245,6 +245,17 @@ func CustomAttributeFactory(attrs interpreter.AttributeFactory) ProgramOption {
 	}
 }
 
+// PartialAttributes enables the evaluation of a PartialActivation which contains data that may be
+// known to be missing, either as top-level variables, or somewhere within a variables object
+// member graph.
+func PartialAttributes() ProgramOption {
+	return func(p *prog) (*prog, error) {
+		attrFac := interpreter.NewPartialAttributeFactory(p.Env.pkg, p.Env.adapter, p.Env.provider)
+		p.attrFactory = attrFac
+		return p, nil
+	}
+}
+
 // EvalOption indicates an evaluation option that may affect the evaluation behavior or information
 // in the output result.
 type EvalOption int

--- a/cel/program.go
+++ b/cel/program.go
@@ -61,10 +61,16 @@ func PartialVars(vars interface{},
 // AttributePattern returns an AttributePattern that matches a top-level variable. The pattern is
 // mutable, and its methods support the specification of one or more qualifier patterns.
 //
+// For example, the AttributePattern(`a`).QualString(`b`) represents a variable access `a` with a
+// string field or index qualification `b`. This pattern will match Attributes `a`, and `a.b`,
+// but not `a.c`.
+//
 // When using a CEL expression within a container, e.g. a package or namespace, the variable name
 // in the pattern must match the qualified name produced during the variable namespace resolution.
-//
-// TODO: example pattern show a.b matching a, a.b, but not a.c.
+// For example, when variable `a` is declared within an expression whose container is `ns.app`, the
+// fully qualified variable name may be `ns.app.a`, `ns.a`, or `a` per the CEL namespace resolution
+// rules. Pick the qualified variable name that makes sense within the container as the
+// AttributePattern `varName` argument.
 //
 // See the interpreter.AttributePattern and interpreter.AttributeQualifierPattern for more info
 // about how to create and manipulate AttributePattern values.

--- a/cel/program.go
+++ b/cel/program.go
@@ -50,31 +50,24 @@ func NoVars() interpreter.Activation {
 
 // PartialVars returns a PartialActivation which contains variables and a set of AttributePattern
 // values that indicate variables or parts of variables whose value are not yet known.
+//
+// The `vars` value may either be an interpreter.Activation or any valid input to the
+// interpreter.NewActivation call.
 func PartialVars(vars interface{},
 	unknowns ...*interpreter.AttributePattern) (interpreter.PartialActivation, error) {
 	return interpreter.NewPartialActivation(vars, unknowns...)
 }
 
-// AttributePattern represents a top-level variable with an optional set of qualifier patterns.
+// AttributePattern returns an AttributePattern that matches a top-level variable. The pattern is
+// mutable, and its methods support the specification of one or more qualifier patterns.
 //
-// The variable name must always be a string, and may be a qualified name according to the CEL
-// namespacing conventions, e.g. 'ns.app.a'.
+// When using a CEL expression within a container, e.g. a package or namespace, the variable name
+// in the pattern must match the qualified name produced during the variable namespace resolution.
 //
-// The qualifier patterns for attribute matching must be one of the following:
+// TODO: example pattern show a.b matching a, a.b, but not a.c.
 //
-//   - valid map key type: string, int, uint, bool
-//   - wildcard (*)
-//
-// Examples:
-//
-//   1. ns.myvar["complex-value"]
-//   2. ns.myvar["complex-value"][0]
-//   3. ns.myvar["complex-value"].*.name
-//
-// The first example is simple: match an attribute where the variable is 'ns.myvar' with a
-// field access on 'complex-value'. The second example expands the match to indicate that only
-// a specific index `0` should match. And lastly, the third example matches any indexed access
-// that later selects the 'name' field.
+// See the interpreter.AttributePattern and interpreter.AttributeQualifierPattern for more info
+// about how to create and manipulate AttributePattern values.
 func AttributePattern(varName string) *interpreter.AttributePattern {
 	return interpreter.NewAttributePattern(varName)
 }

--- a/cel/program.go
+++ b/cel/program.go
@@ -69,7 +69,7 @@ func PartialVars(vars interface{},
 // in the pattern must match the qualified name produced during the variable namespace resolution.
 // For example, when variable `a` is declared within an expression whose container is `ns.app`, the
 // fully qualified variable name may be `ns.app.a`, `ns.a`, or `a` per the CEL namespace resolution
-// rules. Pick the qualified variable name that makes sense within the container as the
+// rules. Pick the fully qualified variable name that makes sense within the container as the
 // AttributePattern `varName` argument.
 //
 // See the interpreter.AttributePattern and interpreter.AttributeQualifierPattern for more info

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -429,7 +429,7 @@ _!=_(_-_(_+_(1~double, _*_(2~double, 3~double)~double^multiply_double)
 							"groups"~string
 						)~list(dyn)^index_map,
 						0~int
-					)~dyn^index_list.name~string,
+					)~dyn^index_list.name~dyn,
 					"dummy"~string
 				)~bool^equals,
 				_==_(
@@ -1410,7 +1410,7 @@ _&&_(_==_(list~type(list(dyn))^list,
 			// LoopStep
 			_?_:_(
 			_==_(
-				x~dyn^x.name~string,
+				x~dyn^x.name~dyn,
 				"hobbies"~string
 			)~bool^equals,
 			_+_(
@@ -1429,6 +1429,25 @@ _&&_(_==_(list~type(list(dyn))^list,
 			},
 		},
 		Type: decls.NewListType(decls.Dyn),
+	},
+	{
+		I: `a.b + 1 == a[0]`,
+		R: `_==_(
+			_+_(
+			  a~dyn^a.b~dyn,
+			  1~int
+			)~int^add_int64,
+			_[_](
+			  a~dyn^a,
+			  0~int
+			)~dyn^index_list|index_map
+		  )~bool^equals`,
+		Env: env{
+			idents: []*exprpb.Decl{
+				decls.NewIdent("a", decls.NewTypeParamType("T"), nil),
+			},
+		},
+		Type: decls.Bool,
 	},
 }
 

--- a/common/types/pb/checked.go
+++ b/common/types/pb/checked.go
@@ -24,19 +24,21 @@ import (
 var (
 	// CheckedPrimitives map from proto field descriptor type to expr.Type.
 	CheckedPrimitives = map[descpb.FieldDescriptorProto_Type]*exprpb.Type{
-		descpb.FieldDescriptorProto_TYPE_BOOL:    checkedBool,
-		descpb.FieldDescriptorProto_TYPE_BYTES:   checkedBytes,
-		descpb.FieldDescriptorProto_TYPE_DOUBLE:  checkedDouble,
-		descpb.FieldDescriptorProto_TYPE_FLOAT:   checkedDouble,
-		descpb.FieldDescriptorProto_TYPE_INT32:   checkedInt,
-		descpb.FieldDescriptorProto_TYPE_INT64:   checkedInt,
-		descpb.FieldDescriptorProto_TYPE_SINT32:  checkedInt,
-		descpb.FieldDescriptorProto_TYPE_SINT64:  checkedInt,
-		descpb.FieldDescriptorProto_TYPE_UINT32:  checkedUint,
-		descpb.FieldDescriptorProto_TYPE_UINT64:  checkedUint,
-		descpb.FieldDescriptorProto_TYPE_FIXED32: checkedUint,
-		descpb.FieldDescriptorProto_TYPE_FIXED64: checkedUint,
-		descpb.FieldDescriptorProto_TYPE_STRING:  checkedString}
+		descpb.FieldDescriptorProto_TYPE_BOOL:     checkedBool,
+		descpb.FieldDescriptorProto_TYPE_BYTES:    checkedBytes,
+		descpb.FieldDescriptorProto_TYPE_DOUBLE:   checkedDouble,
+		descpb.FieldDescriptorProto_TYPE_FLOAT:    checkedDouble,
+		descpb.FieldDescriptorProto_TYPE_INT32:    checkedInt,
+		descpb.FieldDescriptorProto_TYPE_INT64:    checkedInt,
+		descpb.FieldDescriptorProto_TYPE_SINT32:   checkedInt,
+		descpb.FieldDescriptorProto_TYPE_SINT64:   checkedInt,
+		descpb.FieldDescriptorProto_TYPE_UINT32:   checkedUint,
+		descpb.FieldDescriptorProto_TYPE_UINT64:   checkedUint,
+		descpb.FieldDescriptorProto_TYPE_FIXED32:  checkedUint,
+		descpb.FieldDescriptorProto_TYPE_FIXED64:  checkedUint,
+		descpb.FieldDescriptorProto_TYPE_SFIXED32: checkedInt,
+		descpb.FieldDescriptorProto_TYPE_SFIXED64: checkedInt,
+		descpb.FieldDescriptorProto_TYPE_STRING:   checkedString}
 
 	// CheckedWellKnowns map from qualified proto type name to expr.Type for
 	// well-known proto types.

--- a/interpreter/BUILD.bazel
+++ b/interpreter/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     srcs = [
         "activation.go",
         "attributes.go",
+        "attribute_patterns.go",
         "decorators.go",
         "dispatcher.go",
         "evalstate.go",

--- a/interpreter/BUILD.bazel
+++ b/interpreter/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
     srcs = [
         "activation_test.go",
         "attributes_test.go",
+        "attribute_patterns_test.go",
         "interpreter_test.go",
         "prune_test.go",
     ],

--- a/interpreter/activation.go
+++ b/interpreter/activation.go
@@ -137,7 +137,7 @@ func NewHierarchicalActivation(parent Activation, child Activation) Activation {
 func UnknownActivation() Activation {
 	// TODO: consider removing unknown activation if there is a way to specify fine-grained
 	// unknown attributes.
-	a, _ := PartialActivation(EmptyActivation())
+	a, _ := NewPartialActivation(EmptyActivation())
 	return a
 }
 
@@ -154,12 +154,17 @@ func UnknownActivation() Activation {
 //
 // Values which are not represented as ref.Val types on input may be adapted to a ref.Val using
 // the ref.TypeAdapter configured in the environment.
-func PartialActivation(bindings interface{}) (Activation, error) {
+func NewPartialActivation(bindings interface{}) (PartialActivation, error) {
 	a, err := NewActivation(bindings)
 	if err != nil {
 		return nil, err
 	}
 	return &partActivation{known: a}, nil
+}
+
+type PartialActivation interface {
+	Activation
+	UnknownAttributePatterns() []AttributePattern
 }
 
 type partActivation struct {
@@ -178,6 +183,10 @@ func (a *partActivation) ResolveName(name string) (interface{}, bool) {
 // Parent implements the Activation interface method.
 func (a *partActivation) Parent() Activation {
 	return a.known.Parent()
+}
+
+func (a *partActivation) UnknownAttributePatterns() []AttributePattern {
+	return []AttributePattern{}
 }
 
 // newVarActivation returns a new varActivation instance.

--- a/interpreter/activation.go
+++ b/interpreter/activation.go
@@ -47,7 +47,7 @@ func EmptyActivation() Activation {
 //
 // The input `bindings` may either be of type `Activation` or `map[string]interface{}`.
 //
-// Lazy bindings may be supplied in either of the following forms:
+// Lazy bindings may be supplied within the map-based input in either of the following forms:
 // - func() interface{}
 // - func() ref.Val
 //
@@ -134,20 +134,8 @@ func NewHierarchicalActivation(parent Activation, child Activation) Activation {
 // NewPartialActivation returns an Activation which contains a list of AttributePattern values
 // representing field and index operations that should result in a 'types.Unknown' result.
 //
-// The input `bindings` may either be of type `Activation` or `map[string]interface{}`. The
-// input `unknowns` are a set of AttributePattern values which represent unknown attribute paths
-// in the input `bindings`. The bindings in this case are partial data. Some data objects support
-// safe field traversal, so the patterns are useful in identifying when the value is safe or
-// simply incomplete.
-//
-// Lazy bindings may be supplied in either of the following forms:
-// - func() interface{}
-// - func() ref.Val
-//
-// The output of the lazy binding will overwrite the variable reference in the internal map.
-//
-// Values which are not represented as ref.Val types on input may be adapted to a ref.Val using
-// the ref.TypeAdapter configured in the environment.
+// The `vars` value may be any value type supported by the interpreter.NewActivation call,
+// but is typically either an existing Activation or map[string]interface{}.
 func NewPartialActivation(bindings interface{},
 	unknowns ...*AttributePattern) (PartialActivation, error) {
 	a, err := NewActivation(bindings)

--- a/interpreter/activation.go
+++ b/interpreter/activation.go
@@ -134,7 +134,7 @@ func NewHierarchicalActivation(parent Activation, child Activation) Activation {
 // NewPartialActivation returns an Activation which contains a list of AttributePattern values
 // representing field and index operations that should result in a 'types.Unknown' result.
 //
-// The `vars` value may be any value type supported by the interpreter.NewActivation call,
+// The `bindings` value may be any value type supported by the interpreter.NewActivation call,
 // but is typically either an existing Activation or map[string]interface{}.
 func NewPartialActivation(bindings interface{},
 	unknowns ...*AttributePattern) (PartialActivation, error) {

--- a/interpreter/attribute_patterns.go
+++ b/interpreter/attribute_patterns.go
@@ -26,9 +26,8 @@ import (
 //
 // When using a CEL expression within a container, e.g. a package or namespace, the variable name
 // in the pattern must match the qualified name produced during the variable namespace resolution.
-// Variable names provided on input to the AttributePattern are taken at face value. For example,
-// if variable `c` appears in an expression whose container is `a.b`, the variable name supplied
-// to the pattern must be `a.b.c`
+// For example, if variable `c` appears in an expression whose container is `a.b`, the variable
+// name supplied to the pattern must be `a.b.c`
 //
 // The qualifier patterns for attribute matching must be one of the following:
 //

--- a/interpreter/attribute_patterns.go
+++ b/interpreter/attribute_patterns.go
@@ -288,6 +288,9 @@ func (fac *partialAttributeFactory) matchesUnknownPatterns(
 			}
 			matchExprID = qual.ID()
 			qualPat := qualPats[i]
+			// Note, the AttributeQualifierPattern relies on the input Qualifier not being an
+			// Attribute, since there is no way to resolve the Attribute with the information
+			// provided to the Matches call.
 			if !qualPat.Matches(qual) {
 				isUnk = false
 				break

--- a/interpreter/attribute_patterns.go
+++ b/interpreter/attribute_patterns.go
@@ -1,0 +1,90 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interpreter
+
+type partialAttributeFactory struct {
+	AttributeFactory
+}
+
+func (fac *partialAttributeFactory) matchesUnknownAttributePatterns(
+	vars PartialActivation,
+	variable string,
+	qualifiers []Qualifier) (bool, error) {
+	patterns := vars.UnknownAttributePatterns()
+	candIndices := []int{}
+	for i, pat := range patterns {
+		if pat.Matches(variable) {
+			candIndices = append(candIndices, i)
+		}
+	}
+	// Determine whether to return early if there are no candidate unknown patterns.
+	if len(candIndices) == 0 {
+		return false, nil
+	}
+
+	// Determine whether to return early if there are no qualifiers.
+	if len(qualifiers) == 0 {
+		return true, nil
+	}
+	// Resolve the attribute qualifiers into a static set.
+	newQuals := make([]Qualifier, len(qualifiers), len(qualifiers))
+	for i, qual := range qualifiers {
+		attr, isAttr := qual.(Attribute)
+		if isAttr {
+			val, err := attr.Resolve(vars)
+			if err != nil {
+				return false, err
+			}
+			qual, err = fac.NewQualifier(nil, qual.ID(), val)
+			if err != nil {
+				return false, err
+			}
+		}
+		newQuals[i] = qual
+	}
+
+	// Determine whether any of the unknown patterns match.
+	for _, patIdx := range candIndices {
+		pat := patterns[patIdx]
+		isUnk := true
+		// lastIdx := 0
+		qualPats := pat.Qualifiers()
+		for i, qual := range newQuals {
+			//lastIdx = i
+			if i >= len(qualPats) {
+				break
+			}
+			qualPat := qualPats[i]
+			if !qualPat.Matches(qual) {
+				isUnk = false
+				break
+			}
+		}
+		if isUnk {
+			return true, nil
+			// return match type, attribute trail, and unknown pattern
+		}
+	}
+	return false, nil
+}
+
+type AttributePattern interface {
+	Matches(string) bool
+	Qualifiers() []AttributeQualifierPattern
+}
+
+type AttributeQualifierPattern interface {
+	Matches(Qualifier) bool
+}

--- a/interpreter/attribute_patterns.go
+++ b/interpreter/attribute_patterns.go
@@ -94,7 +94,8 @@ func (apat *AttributePattern) Wildcard() *AttributePattern {
 	return apat
 }
 
-// VariableMatches returns true if the variable matches the AttributePattern variable.
+// VariableMatches returns true if the fully qualified variable matches the AttributePattern
+// fully qualified variable name.
 func (apat *AttributePattern) VariableMatches(variable string) bool {
 	return apat.variable == variable
 }

--- a/interpreter/attribute_patterns.go
+++ b/interpreter/attribute_patterns.go
@@ -15,10 +15,166 @@
 package interpreter
 
 import (
+	"fmt"
+
 	"github.com/google/cel-go/common/packages"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 )
+
+// AttributePattern represents a top-level variable with an optional set of qualifier patterns.
+//
+// The variable name must always be a string, and may be a qualified name according to the CEL
+// namespacing conventions, e.g. 'ns.app.a'.
+//
+// The qualifier patterns for attribute matching must be one of the following:
+//
+//   - valid map key type: string, int, uint, bool
+//   - wildcard (*)
+//
+// Examples:
+//
+//   1. ns.myvar["complex-value"]
+//   2. ns.myvar["complex-value"][0]
+//   3. ns.myvar["complex-value"].*.name
+//
+// The first example is simple: match an attribute where the variable is 'ns.myvar' with a
+// field access on 'complex-value'. The second example expands the match to indicate that only
+// a specific index `0` should match. And lastly, the third example matches any indexed access
+// that later selects the 'name' field.
+type AttributePattern struct {
+	variable          string
+	qualifierPatterns []*AttributeQualifierPattern
+}
+
+// NewAttributePattern produces a new mutable AttributePattern based on a variable name.
+func NewAttributePattern(variable string) *AttributePattern {
+	return &AttributePattern{
+		variable:          variable,
+		qualifierPatterns: []*AttributeQualifierPattern{},
+	}
+}
+
+// Field adds a string qualifier pattern to the AttributePattern. The string may be a valid
+// identifier, or string map key including empty string.
+func (apat *AttributePattern) Field(pattern string) *AttributePattern {
+	apat.qualifierPatterns = append(apat.qualifierPatterns,
+		&AttributeQualifierPattern{value: pattern})
+	return apat
+}
+
+// Index adds an int qualifier pattern to the AttributePattern. The index may be either a map or
+// list index.
+func (apat *AttributePattern) Index(pattern int64) *AttributePattern {
+	apat.qualifierPatterns = append(apat.qualifierPatterns,
+		&AttributeQualifierPattern{value: pattern})
+	return apat
+}
+
+// IndexUint adds an uint qualifier pattern for a map index operation to the AttributePattern.
+func (apat *AttributePattern) IndexUint(pattern uint64) *AttributePattern {
+	apat.qualifierPatterns = append(apat.qualifierPatterns,
+		&AttributeQualifierPattern{value: pattern})
+	return apat
+}
+
+// IndexBool adds a bool qualifier pattern for a map index operation to the AttributePattern.
+func (apat *AttributePattern) IndexBool(pattern bool) *AttributePattern {
+	apat.qualifierPatterns = append(apat.qualifierPatterns,
+		&AttributeQualifierPattern{value: pattern})
+	return apat
+}
+
+// Wildcard adds a special sentinel qualifier pattern that indicates any value will yeild a
+// qualifier match.
+func (apat *AttributePattern) Wildcard() *AttributePattern {
+	apat.qualifierPatterns = append(apat.qualifierPatterns,
+		&AttributeQualifierPattern{wildcard: true})
+	return apat
+}
+
+// Matches returns true if the variable matches the AttributePattern variable.
+func (apat *AttributePattern) Matches(variable string) bool {
+	return apat.variable == variable
+}
+
+// QualifierPatterns returns the set of AttributeQualifierPattern values on the AttributePattern.
+func (apat *AttributePattern) QualifierPatterns() []*AttributeQualifierPattern {
+	return apat.qualifierPatterns
+}
+
+// AttributeQualifierPattern holds a wilcard or valued qualifier pattern.
+type AttributeQualifierPattern struct {
+	wildcard bool
+	value    interface{}
+}
+
+// Matches returns true if the qualifier pattern is a wildcard, or the Qualifier implements the
+// qualifierValueEquator interface and its IsValueEqualTo returns true for the qualifier pattern.
+func (qpat *AttributeQualifierPattern) Matches(q Qualifier) bool {
+	if qpat.wildcard {
+		return true
+	}
+	qve, ok := q.(qualifierValueEquator)
+	return ok && qve.QualifierValueEquals(qpat.value)
+}
+
+// qualifierValueEquator defines an interface for determining if an input value, of valid map key
+// type, is equal to the value held in the Qualifier. This interface is used by the
+// AttributeQualifierPattern to determine pattern matches for non-wildcard qualifier patterns.
+//
+// Note: Attribute values are also Qualifier values; however, Attriutes are resolved before
+// qualification happens. This is an implementation detail, but one relevant to why the Attribute
+// types do no surface in the list of implementations.
+type qualifierValueEquator interface {
+	// QualifierValueEquals returns true if the input value is equal to the value held in the
+	// Qualifier.
+	QualifierValueEquals(value interface{}) bool
+}
+
+// QualifierValueEquals implementation for boolean qualifiers.
+func (q *boolQualifier) QualifierValueEquals(value interface{}) bool {
+	bval, ok := value.(bool)
+	return ok && q.value == bval
+}
+
+// QualifierValueEquals implementation for field qualifiers.
+func (q *fieldQualifier) QualifierValueEquals(value interface{}) bool {
+	sval, ok := value.(string)
+	return ok && q.Name == sval
+}
+
+// QualifierValueEquals implementation for string qualifiers.
+func (q *stringQualifier) QualifierValueEquals(value interface{}) bool {
+	sval, ok := value.(string)
+	return ok && q.value == sval
+}
+
+// QualifierValueEquals implementation for int qualifiers.
+func (q *intQualifier) QualifierValueEquals(value interface{}) bool {
+	ival, ok := value.(int64)
+	return ok && q.value == ival
+}
+
+// QualifierValueEquals implementation for uint qualifiers.
+func (q *uintQualifier) QualifierValueEquals(value interface{}) bool {
+	uval, ok := value.(uint64)
+	return ok && q.value == uval
+}
+
+// NewPartialAttributeFactory returns an AttributeFactory implementation capable of performing
+// AttributePattern matches with PartialActivation inputs.
+func NewPartialAttributeFactory(pkg packages.Packager,
+	adapter ref.TypeAdapter,
+	provider ref.TypeProvider) AttributeFactory {
+	fac := NewAttributeFactory(pkg, adapter, provider)
+	return &partialAttributeFactory{
+		AttributeFactory: fac,
+		pkg:              pkg,
+		adapter:          adapter,
+		provider:         provider,
+	}
+}
 
 type partialAttributeFactory struct {
 	AttributeFactory
@@ -27,44 +183,17 @@ type partialAttributeFactory struct {
 	provider ref.TypeProvider
 }
 
-type attributeMatcher struct {
-	NamespacedAttribute
-	qualifiers []Qualifier
-	fac        *partialAttributeFactory
-}
-
-func (m *attributeMatcher) AddQualifier(qual Qualifier) (Attribute, error) {
-	_, err := m.NamespacedAttribute.AddQualifier(qual)
-	if err != nil {
-		return nil, err
-	}
-	m.qualifiers = append(m.qualifiers, qual)
-	return m, nil
-}
-
-func (m *attributeMatcher) TryResolve(vars Activation) (interface{}, bool, error) {
-	id := m.NamespacedAttribute.ID()
-	partial, isPartial := vars.(PartialActivation)
-	if isPartial {
-		isUnk, err := m.fac.matchesUnknownPatterns(
-			partial,
-			m.CandidateVariableNames(),
-			m.qualifiers)
-		if err != nil {
-			return nil, true, err
-		}
-		if isUnk {
-			return types.Unknown{id}, true, nil
-		}
-	}
-	return m.NamespacedAttribute.TryResolve(vars)
-}
-
+// AbsoluteAttribute implementation of the AttributeFactory interface which wraps the
+// NamespacedAttribute resolution in an internal attributeMatcher object to dynamically match
+// unknown patterns from PartialActivation inputs if given.
 func (fac *partialAttributeFactory) AbsoluteAttribute(id int64, names ...string) NamespacedAttribute {
 	attr := fac.AttributeFactory.AbsoluteAttribute(id, names...)
 	return &attributeMatcher{fac: fac, NamespacedAttribute: attr}
 }
 
+// MaybeAttribute implementation of the AttributeFactory interface which ensure that the set of
+// 'maybe' NamespacedAttribute values are produced using the PartialAttributeFactory rather than
+// the base AttributeFactory implementation.
 func (fac *partialAttributeFactory) MaybeAttribute(id int64, name string) Attribute {
 	return &maybeAttribute{
 		id: id,
@@ -73,10 +202,13 @@ func (fac *partialAttributeFactory) MaybeAttribute(id int64, name string) Attrib
 		},
 		adapter:  fac.adapter,
 		provider: fac.provider,
-		res:      fac,
+		fac:      fac,
 	}
 }
 
+// matchesUnknownPatterns returns true if the variable names and qualifiers for a given
+// Attribute value match any of the ActivationPattern objects in the set of unknown activation
+// patterns on the given PartialActivation.
 func (fac *partialAttributeFactory) matchesUnknownPatterns(
 	vars PartialActivation,
 	variableNames []string,
@@ -94,12 +226,13 @@ func (fac *partialAttributeFactory) matchesUnknownPatterns(
 	if len(candIndices) == 0 {
 		return false, nil
 	}
-
 	// Determine whether to return early if there are no qualifiers.
 	if len(qualifiers) == 0 {
 		return true, nil
 	}
-	// Resolve the attribute qualifiers into a static set.
+	// Resolve the attribute qualifiers into a static set. This prevents more dynamic
+	// Attribute resolutions than necessary when there are multiple unknown patterns
+	// that traverse the same Attribute-based qualifier field.
 	newQuals := make([]Qualifier, len(qualifiers), len(qualifiers))
 	for i, qual := range qualifiers {
 		attr, isAttr := qual.(Attribute)
@@ -115,7 +248,6 @@ func (fac *partialAttributeFactory) matchesUnknownPatterns(
 		}
 		newQuals[i] = qual
 	}
-
 	// Determine whether any of the unknown patterns match.
 	for patIdx := range candIndices {
 		pat := patterns[patIdx]
@@ -141,104 +273,73 @@ func (fac *partialAttributeFactory) matchesUnknownPatterns(
 	return false, nil
 }
 
-type AttributePattern struct {
-	variable          string
-	qualifierPatterns []*AttributeQualifierPattern
+type attributeMatcher struct {
+	NamespacedAttribute
+	qualifiers []Qualifier
+	fac        *partialAttributeFactory
 }
 
-func NewAttributePattern(variable string) *AttributePattern {
-	return &AttributePattern{
-		variable:          variable,
-		qualifierPatterns: []*AttributeQualifierPattern{},
+// AddQualifier implements the Attribute interface method which adds the Qualifier onto the
+// underlying NamespacedAttribute as well as tracks the Qualifier in internal storage. The
+// double accounting for the Qualifier values is to assist with AttributePattern matching in
+// the TryResolve call.
+func (m *attributeMatcher) AddQualifier(qual Qualifier) (Attribute, error) {
+	_, err := m.NamespacedAttribute.AddQualifier(qual)
+	if err != nil {
+		return nil, err
 	}
+	m.qualifiers = append(m.qualifiers, qual)
+	return m, nil
 }
 
-func (ap *AttributePattern) Any() *AttributePattern {
-	ap.qualifierPatterns = append(ap.qualifierPatterns,
-		&AttributeQualifierPattern{any: true})
-	return ap
-}
-
-func (ap *AttributePattern) Name(pattern string) *AttributePattern {
-	ap.qualifierPatterns = append(ap.qualifierPatterns,
-		&AttributeQualifierPattern{value: pattern})
-	return ap
-}
-
-func (ap *AttributePattern) Index(pattern int64) *AttributePattern {
-	ap.qualifierPatterns = append(ap.qualifierPatterns,
-		&AttributeQualifierPattern{value: pattern})
-	return ap
-}
-
-func (ap *AttributePattern) IndexUint(pattern uint64) *AttributePattern {
-	ap.qualifierPatterns = append(ap.qualifierPatterns,
-		&AttributeQualifierPattern{value: pattern})
-	return ap
-}
-
-func (ap *AttributePattern) True() *AttributePattern {
-	ap.qualifierPatterns = append(ap.qualifierPatterns,
-		&AttributeQualifierPattern{value: true})
-	return ap
-}
-
-func (ap *AttributePattern) False() *AttributePattern {
-	ap.qualifierPatterns = append(ap.qualifierPatterns,
-		&AttributeQualifierPattern{value: false})
-	return ap
-}
-
-func (ap *AttributePattern) Matches(variable string) bool {
-	return ap.variable == variable
-}
-
-func (ap *AttributePattern) QualifierPatterns() []*AttributeQualifierPattern {
-	return ap.qualifierPatterns
-}
-
-type AttributeQualifierPattern struct {
-	any   bool
-	value interface{}
-}
-
-func (qp *AttributeQualifierPattern) Matches(q Qualifier) bool {
-	if qp.any {
-		return true
+// Resolve is an implementation of the Attribute interface method which uses the
+// attributeMatcher TryResolve implementation rather than the embedded NamespacedAttribute
+// Resolve implementation.
+func (m *attributeMatcher) Resolve(vars Activation) (interface{}, error) {
+	obj, found, err := m.TryResolve(vars)
+	if err != nil {
+		return nil, err
 	}
-	cq, ok := q.(QualifierEquivalence)
-	if !ok {
-		panic("only constant valued qualifiers should appear here.")
-		return false
+	if found {
+		return obj, nil
 	}
-	return cq.IsEquivalentTo(qp.value)
+	return nil, fmt.Errorf("no such attribute: %v", m.NamespacedAttribute)
 }
 
-type QualifierEquivalence interface {
-	IsEquivalentTo(value interface{}) bool
+// TryResolve is an implementation of the NamespacedAttribute interface method which tests
+// for matching unknown attribute patterns and returns types.Unknown if present. Otherwise,
+// the standard Resolve logic applies.
+func (m *attributeMatcher) TryResolve(vars Activation) (interface{}, bool, error) {
+	id := m.NamespacedAttribute.ID()
+	partial, isPartial := vars.(PartialActivation)
+	if isPartial {
+		isUnk, err := m.fac.matchesUnknownPatterns(
+			partial,
+			m.CandidateVariableNames(),
+			m.qualifiers)
+		if err != nil {
+			return nil, true, err
+		}
+		if isUnk {
+			return types.Unknown{id}, true, nil
+		}
+	}
+	return m.NamespacedAttribute.TryResolve(vars)
 }
 
-func (q *boolQualifier) IsEquivalentTo(value interface{}) bool {
-	bval, ok := value.(bool)
-	return ok && q.value == bval
-}
-
-func (q *fieldQualifier) IsEquivalentTo(value interface{}) bool {
-	sval, ok := value.(string)
-	return ok && q.Name == sval
-}
-
-func (q *stringQualifier) IsEquivalentTo(value interface{}) bool {
-	sval, ok := value.(string)
-	return ok && q.value == sval
-}
-
-func (q *intQualifier) IsEquivalentTo(value interface{}) bool {
-	ival, ok := value.(int64)
-	return ok && q.value == ival
-}
-
-func (q *uintQualifier) IsEquivalentTo(value interface{}) bool {
-	uval, ok := value.(uint64)
-	return ok && q.value == uval
+// Qualify is an implementation of the Qualifier interface method.
+func (m *attributeMatcher) Qualify(vars Activation, obj interface{}) (interface{}, error) {
+	val, err := m.Resolve(vars)
+	if err != nil {
+		return nil, err
+	}
+	unk, isUnk := val.(types.Unknown)
+	if isUnk {
+		return fmtUnknown(unk, m.NamespacedAttribute), nil
+	}
+	qual, err := m.fac.NewQualifier(nil, m.ID(), val)
+	if err != nil {
+		return nil, err
+	}
+	return qual.Qualify(vars, obj)
 }

--- a/interpreter/attribute_patterns.go
+++ b/interpreter/attribute_patterns.go
@@ -14,19 +14,80 @@
 
 package interpreter
 
+import (
+	"github.com/google/cel-go/common/packages"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
 type partialAttributeFactory struct {
 	AttributeFactory
+	pkg      packages.Packager
+	adapter  ref.TypeAdapter
+	provider ref.TypeProvider
 }
 
-func (fac *partialAttributeFactory) matchesUnknownAttributePatterns(
+type attributeMatcher struct {
+	NamespacedAttribute
+	qualifiers []Qualifier
+	fac        *partialAttributeFactory
+}
+
+func (m *attributeMatcher) AddQualifier(qual Qualifier) (Attribute, error) {
+	_, err := m.NamespacedAttribute.AddQualifier(qual)
+	if err != nil {
+		return nil, err
+	}
+	m.qualifiers = append(m.qualifiers, qual)
+	return m, nil
+}
+
+func (m *attributeMatcher) TryResolve(vars Activation) (interface{}, bool, error) {
+	id := m.NamespacedAttribute.ID()
+	partial, isPartial := vars.(PartialActivation)
+	if isPartial {
+		isUnk, err := m.fac.matchesUnknownPatterns(
+			partial,
+			m.CandidateVariableNames(),
+			m.qualifiers)
+		if err != nil {
+			return nil, true, err
+		}
+		if isUnk {
+			return types.Unknown{id}, true, nil
+		}
+	}
+	return m.NamespacedAttribute.TryResolve(vars)
+}
+
+func (fac *partialAttributeFactory) AbsoluteAttribute(id int64, names ...string) NamespacedAttribute {
+	attr := fac.AttributeFactory.AbsoluteAttribute(id, names...)
+	return &attributeMatcher{fac: fac, NamespacedAttribute: attr}
+}
+
+func (fac *partialAttributeFactory) MaybeAttribute(id int64, name string) Attribute {
+	return &maybeAttribute{
+		id: id,
+		attrs: []NamespacedAttribute{
+			fac.AbsoluteAttribute(id, fac.pkg.ResolveCandidateNames(name)...),
+		},
+		adapter:  fac.adapter,
+		provider: fac.provider,
+		res:      fac,
+	}
+}
+
+func (fac *partialAttributeFactory) matchesUnknownPatterns(
 	vars PartialActivation,
-	variable string,
+	variableNames []string,
 	qualifiers []Qualifier) (bool, error) {
 	patterns := vars.UnknownAttributePatterns()
-	candIndices := []int{}
-	for i, pat := range patterns {
-		if pat.Matches(variable) {
-			candIndices = append(candIndices, i)
+	candIndices := map[int]struct{}{}
+	for _, variable := range variableNames {
+		for i, pat := range patterns {
+			if pat.Matches(variable) {
+				candIndices[i] = struct{}{}
+			}
 		}
 	}
 	// Determine whether to return early if there are no candidate unknown patterns.
@@ -56,11 +117,11 @@ func (fac *partialAttributeFactory) matchesUnknownAttributePatterns(
 	}
 
 	// Determine whether any of the unknown patterns match.
-	for _, patIdx := range candIndices {
+	for patIdx := range candIndices {
 		pat := patterns[patIdx]
 		isUnk := true
 		// lastIdx := 0
-		qualPats := pat.Qualifiers()
+		qualPats := pat.QualifierPatterns()
 		for i, qual := range newQuals {
 			//lastIdx = i
 			if i >= len(qualPats) {
@@ -80,11 +141,104 @@ func (fac *partialAttributeFactory) matchesUnknownAttributePatterns(
 	return false, nil
 }
 
-type AttributePattern interface {
-	Matches(string) bool
-	Qualifiers() []AttributeQualifierPattern
+type AttributePattern struct {
+	variable          string
+	qualifierPatterns []*AttributeQualifierPattern
 }
 
-type AttributeQualifierPattern interface {
-	Matches(Qualifier) bool
+func NewAttributePattern(variable string) *AttributePattern {
+	return &AttributePattern{
+		variable:          variable,
+		qualifierPatterns: []*AttributeQualifierPattern{},
+	}
+}
+
+func (ap *AttributePattern) Any() *AttributePattern {
+	ap.qualifierPatterns = append(ap.qualifierPatterns,
+		&AttributeQualifierPattern{any: true})
+	return ap
+}
+
+func (ap *AttributePattern) Name(pattern string) *AttributePattern {
+	ap.qualifierPatterns = append(ap.qualifierPatterns,
+		&AttributeQualifierPattern{value: pattern})
+	return ap
+}
+
+func (ap *AttributePattern) Index(pattern int64) *AttributePattern {
+	ap.qualifierPatterns = append(ap.qualifierPatterns,
+		&AttributeQualifierPattern{value: pattern})
+	return ap
+}
+
+func (ap *AttributePattern) IndexUint(pattern uint64) *AttributePattern {
+	ap.qualifierPatterns = append(ap.qualifierPatterns,
+		&AttributeQualifierPattern{value: pattern})
+	return ap
+}
+
+func (ap *AttributePattern) True() *AttributePattern {
+	ap.qualifierPatterns = append(ap.qualifierPatterns,
+		&AttributeQualifierPattern{value: true})
+	return ap
+}
+
+func (ap *AttributePattern) False() *AttributePattern {
+	ap.qualifierPatterns = append(ap.qualifierPatterns,
+		&AttributeQualifierPattern{value: false})
+	return ap
+}
+
+func (ap *AttributePattern) Matches(variable string) bool {
+	return ap.variable == variable
+}
+
+func (ap *AttributePattern) QualifierPatterns() []*AttributeQualifierPattern {
+	return ap.qualifierPatterns
+}
+
+type AttributeQualifierPattern struct {
+	any   bool
+	value interface{}
+}
+
+func (qp *AttributeQualifierPattern) Matches(q Qualifier) bool {
+	if qp.any {
+		return true
+	}
+	cq, ok := q.(QualifierEquivalence)
+	if !ok {
+		panic("only constant valued qualifiers should appear here.")
+		return false
+	}
+	return cq.IsEquivalentTo(qp.value)
+}
+
+type QualifierEquivalence interface {
+	IsEquivalentTo(value interface{}) bool
+}
+
+func (q *boolQualifier) IsEquivalentTo(value interface{}) bool {
+	bval, ok := value.(bool)
+	return ok && q.value == bval
+}
+
+func (q *fieldQualifier) IsEquivalentTo(value interface{}) bool {
+	sval, ok := value.(string)
+	return ok && q.Name == sval
+}
+
+func (q *stringQualifier) IsEquivalentTo(value interface{}) bool {
+	sval, ok := value.(string)
+	return ok && q.value == sval
+}
+
+func (q *intQualifier) IsEquivalentTo(value interface{}) bool {
+	ival, ok := value.(int64)
+	return ok && q.value == ival
+}
+
+func (q *uintQualifier) IsEquivalentTo(value interface{}) bool {
+	uval, ok := value.(uint64)
+	return ok && q.value == uval
 }

--- a/interpreter/attribute_patterns_test.go
+++ b/interpreter/attribute_patterns_test.go
@@ -310,7 +310,7 @@ func genAttr(fac AttributeFactory, a attr) Attribute {
 	id := int64(1)
 	var attr Attribute
 	if a.unchecked {
-		attr = fac.uncheckedAttribute(1, a.name)
+		attr = fac.MaybeAttribute(1, a.name)
 	} else {
 		attr = fac.AbsoluteAttribute(1, a.name)
 	}

--- a/interpreter/attribute_patterns_test.go
+++ b/interpreter/attribute_patterns_test.go
@@ -15,8 +15,88 @@
 package interpreter
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/google/cel-go/common/packages"
+	"github.com/google/cel-go/common/types"
 )
 
-func TestXxx(t *testing.T) {
+type attr struct {
+	maybe bool
+	name  string
+	quals []interface{}
+}
+
+type patternTest struct {
+	pattern *AttributePattern
+	pkg     string
+	matches []attr
+	misses  []attr
+}
+
+var patternTests = map[string]patternTest{
+	"var": {
+		pattern: NewAttributePattern("var"),
+		matches: []attr{
+			{name: "var"},
+			{name: "var", quals: []interface{}{"field"}},
+		},
+		misses: []attr{
+			{name: "ns.var"},
+		},
+	},
+	"ns.var": {
+		pattern: NewAttributePattern("ns.app.var"),
+		pkg:     "ns.app",
+		matches: []attr{
+			{name: "ns.app.var"},
+			{name: "ns.app.var", quals: []interface{}{int64(0)}},
+			{name: "ns", quals: []interface{}{"app", "var"}, maybe: true},
+		},
+		misses: []attr{
+			{name: "ns.var"},
+			{name: "ns", quals: []interface{}{"var"}, maybe: true},
+		},
+	},
+}
+
+func TestAttributePattern(t *testing.T) {
+	reg := types.NewRegistry()
+	for nm, tc := range patternTests {
+		tst := tc
+		t.Run(nm, func(tt *testing.T) {
+			pkg := packages.DefaultPackage
+			if tst.pkg != "" {
+				pkg = packages.NewPackage(tst.pkg)
+			}
+			fac := NewPartialAttributeFactory(pkg, reg, reg)
+			for i, match := range tst.matches {
+				m := match
+				tt.Run(fmt.Sprintf("[%d]", i), func(ttt *testing.T) {
+					id := int64(1)
+					var attr Attribute
+					if m.maybe {
+						attr = fac.MaybeAttribute(1, m.name)
+					} else {
+						attr = fac.AbsoluteAttribute(1, m.name)
+					}
+					for _, q := range m.quals {
+						qual, _ := fac.NewQualifier(nil, id, q)
+						attr.AddQualifier(qual)
+						id++
+					}
+					partVars, _ := NewPartialActivation(EmptyActivation(), tst.pattern)
+					val, err := attr.Resolve(partVars)
+					if err != nil {
+						t.Fatalf("Got error: %s, wanted unknown", err)
+					}
+					_, isUnk := val.(types.Unknown)
+					if !isUnk {
+						t.Fatalf("Got value %v, wanted unknown", val)
+					}
+				})
+			}
+		})
+	}
 }

--- a/interpreter/attribute_patterns_test.go
+++ b/interpreter/attribute_patterns_test.go
@@ -1,0 +1,22 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interpreter
+
+import (
+	"testing"
+)
+
+func TestXxx(t *testing.T) {
+}

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -30,7 +30,14 @@ import (
 type AttributeFactory interface {
 	// AbsoluteAttribute creates an attribute that refers to a top-level variable name.
 	//
-	// Only type-checked expressions generate absolute attributes.
+	// Checked expressions generate absolute attribute with a single name.
+	// Parse-only expressions may have more than one possible absolute identifier when the
+	// expression is created within a container, e.g. package or namespace.
+	//
+	// When there is more than one name supplied to the AbsoluteAttribute call, the names
+	// must be in CEL's namespace resolution order. The name arguments provided here are
+	// returned in the same order as they were provided by the NamespacedAttribute
+	// CandidateVariableNames method.
 	AbsoluteAttribute(id int64, names ...string) NamespacedAttribute
 
 	// ConditionalAttribute creates an attribute with two Attribute branches, where the Attribute

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -280,7 +280,7 @@ func (a *absoluteAttribute) Qualify(vars Activation, obj interface{}) (interface
 	}
 	unk, isUnk := val.(types.Unknown)
 	if isUnk {
-		return fmtUnknown(unk, a), nil
+		return unk, nil
 	}
 	qual, err := a.fac.NewQualifier(nil, a.id, val)
 	if err != nil {
@@ -330,7 +330,7 @@ func (a *conditionalAttribute) Resolve(vars Activation) (interface{}, error) {
 		return a.falsy.Resolve(vars)
 	}
 	if types.IsUnknown(val) {
-		return fmtUnknown(val, a), nil
+		return val, nil
 	}
 	return nil, types.ValOrErr(val, "no such overload").Value().(error)
 }
@@ -343,7 +343,7 @@ func (a *conditionalAttribute) Qualify(vars Activation, obj interface{}) (interf
 	}
 	unk, isUnk := val.(types.Unknown)
 	if isUnk {
-		return fmtUnknown(unk, a), nil
+		return unk, nil
 	}
 	qual, err := a.fac.NewQualifier(nil, a.id, val)
 	if err != nil {
@@ -438,7 +438,7 @@ func (a *maybeAttribute) Qualify(vars Activation, obj interface{}) (interface{},
 	}
 	unk, isUnk := val.(types.Unknown)
 	if isUnk {
-		return fmtUnknown(unk, a), nil
+		return unk, nil
 	}
 	qual, err := a.fac.NewQualifier(nil, a.id, val)
 	if err != nil {
@@ -474,7 +474,7 @@ func (a *relativeAttribute) Resolve(vars Activation) (interface{}, error) {
 		return nil, v.Value().(error)
 	}
 	if types.IsUnknown(v) {
-		return fmtUnknown(v, a), nil
+		return v, nil
 	}
 	// Next, qualify it. Qualification handles unkonwns as well, so there's no need to recheck.
 	var err error
@@ -496,7 +496,7 @@ func (a *relativeAttribute) Qualify(vars Activation, obj interface{}) (interface
 	}
 	unk, isUnk := val.(types.Unknown)
 	if isUnk {
-		return fmtUnknown(unk, a), nil
+		return unk, nil
 	}
 	qual, err := a.fac.NewQualifier(nil, a.id, val)
 	if err != nil {
@@ -599,7 +599,7 @@ func (q *stringQualifier) Qualify(vars Activation, obj interface{}) (interface{}
 			return nil, err
 		}
 		if types.IsUnknown(elem) {
-			return fmtUnknown(elem, q), nil
+			return elem, nil
 		}
 		return elem, nil
 	}
@@ -704,7 +704,7 @@ func (q *intQualifier) Qualify(vars Activation, obj interface{}) (interface{}, e
 			return nil, err
 		}
 		if types.IsUnknown(elem) {
-			return fmtUnknown(elem, q), nil
+			return elem, nil
 		}
 		return elem, nil
 	}
@@ -756,7 +756,7 @@ func (q *uintQualifier) Qualify(vars Activation, obj interface{}) (interface{}, 
 			return nil, err
 		}
 		if types.IsUnknown(elem) {
-			return fmtUnknown(elem, q), nil
+			return elem, nil
 		}
 		return elem, nil
 	}
@@ -797,7 +797,7 @@ func (q *boolQualifier) Qualify(vars Activation, obj interface{}) (interface{}, 
 			return nil, err
 		}
 		if types.IsUnknown(elem) {
-			return fmtUnknown(elem, q), nil
+			return elem, nil
 		}
 		return elem, nil
 	}
@@ -828,16 +828,6 @@ func (q *fieldQualifier) Qualify(vars Activation, obj interface{}) (interface{},
 		obj = rv.Value()
 	}
 	return q.FieldType.GetFrom(obj)
-}
-
-// fmtUnknown ensure that unknown values are annotated with the qualifier id where they are
-// detected if an id is not already set.
-func fmtUnknown(elem ref.Val, qual Qualifier) ref.Val {
-	unk := elem.(types.Unknown)
-	if len(unk) == 0 {
-		return types.Unknown{qual.ID()}
-	}
-	return unk
 }
 
 // refResolve attempts to convert the value to a CEL value and then uses reflection methods

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -1025,7 +1025,7 @@ func TestInterpreter_MissingIdentInSelect(t *testing.T) {
 				"d": "hello",
 			},
 		},
-		NewAttributePattern("a.b").Field("c"))
+		NewAttributePattern("a.b").QualString("c"))
 	result := i.Eval(vars)
 	if !types.IsUnknown(result) {
 		t.Errorf("Got %v, wanted unknown", result)

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -1019,7 +1019,7 @@ func TestInterpreter_MissingIdentInSelect(t *testing.T) {
 	attrs := NewAttributeFactory(pkg, reg, reg)
 	interp := NewStandardInterpreter(pkg, reg, reg, attrs)
 	i, _ := interp.NewInterpretable(checked)
-	vars := UnknownActivation()
+	vars := EmptyActivation()
 	result := i.Eval(vars)
 	if !types.IsUnknown(result) {
 		t.Errorf("Got %v, wanted unknown", result)

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -1016,17 +1016,22 @@ func TestInterpreter_MissingIdentInSelect(t *testing.T) {
 		t.Fatalf(errors.ToDisplayString())
 	}
 
-	attrs := NewAttributeFactory(pkg, reg, reg)
+	attrs := NewPartialAttributeFactory(pkg, reg, reg)
 	interp := NewStandardInterpreter(pkg, reg, reg, attrs)
 	i, _ := interp.NewInterpretable(checked)
-	vars := EmptyActivation()
+	vars, _ := NewPartialActivation(
+		map[string]interface{}{
+			"a.b": map[string]interface{}{
+				"d": "hello",
+			},
+		},
+		NewAttributePattern("a.b").Field("c"))
 	result := i.Eval(vars)
 	if !types.IsUnknown(result) {
 		t.Errorf("Got %v, wanted unknown", result)
 	}
 
-	vars = EmptyActivation()
-	result = i.Eval(vars)
+	result = i.Eval(EmptyActivation())
 	if !types.IsError(result) {
 		t.Errorf("Got %v, wanted error", result)
 	}

--- a/interpreter/prune_test.go
+++ b/interpreter/prune_test.go
@@ -127,13 +127,7 @@ func TestPrune(t *testing.T) {
 		pExpr := &exprpb.ParsedExpr{Expr: tst.E}
 		state := NewEvalState()
 		reg := types.NewRegistry()
-		attrs := NewAttributeFactory(packages.DefaultPackage, reg, reg)
-		attrs = &partialAttributeFactory{
-			AttributeFactory: attrs,
-			pkg:              packages.DefaultPackage,
-			adapter:          reg,
-			provider:         reg,
-		}
+		attrs := NewPartialAttributeFactory(packages.DefaultPackage, reg, reg)
 		interp := NewStandardInterpreter(packages.DefaultPackage, reg, reg, attrs)
 		interpretable, _ := interp.NewUncheckedInterpretable(
 			pExpr.Expr,

--- a/interpreter/prune_test.go
+++ b/interpreter/prune_test.go
@@ -27,18 +27,21 @@ import (
 )
 
 type testInfo struct {
+	A Activation
 	E *exprpb.Expr
 	P string
 }
 
 var testCases = []testInfo{
 	{
+		A: unknownActivation(),
 		E: test.ExprCall(2, operators.LogicalAnd,
 			test.ExprLiteral(1, true),
 			test.ExprLiteral(3, false)),
 		P: `false`,
 	},
 	{
+		A: unknownActivation("x"),
 		E: test.ExprCall(4, operators.LogicalAnd,
 			test.ExprCall(2, operators.LogicalOr,
 				test.ExprLiteral(1, true),
@@ -47,6 +50,7 @@ var testCases = []testInfo{
 		P: `x`,
 	},
 	{
+		A: unknownActivation("x"),
 		E: test.ExprCall(4, operators.LogicalAnd,
 			test.ExprCall(2, operators.LogicalOr,
 				test.ExprLiteral(1, false),
@@ -55,6 +59,7 @@ var testCases = []testInfo{
 		P: `false`,
 	},
 	{
+		A: unknownActivation("a"),
 		E: test.ExprCall(2, operators.LogicalAnd,
 			test.ExprIdent(1, "a"),
 			test.ExprComprehension(3,
@@ -83,6 +88,7 @@ var testCases = []testInfo{
 		P: `a`,
 	},
 	{
+		A: unknownActivation(),
 		E: test.ExprMap(8,
 			test.ExprEntry(2,
 				test.ExprLiteral(1, "hello"),
@@ -101,6 +107,7 @@ var testCases = []testInfo{
 		P: `true`,
 	},
 	{
+		A: unknownActivation("b", "c"),
 		E: test.ExprCall(8, operators.Conditional,
 			test.ExprLiteral(1, true),
 			test.ExprCall(3,
@@ -121,15 +128,30 @@ func TestPrune(t *testing.T) {
 		state := NewEvalState()
 		reg := types.NewRegistry()
 		attrs := NewAttributeFactory(packages.DefaultPackage, reg, reg)
+		attrs = &partialAttributeFactory{
+			AttributeFactory: attrs,
+			pkg:              packages.DefaultPackage,
+			adapter:          reg,
+			provider:         reg,
+		}
 		interp := NewStandardInterpreter(packages.DefaultPackage, reg, reg, attrs)
 		interpretable, _ := interp.NewUncheckedInterpretable(
 			pExpr.Expr,
 			ExhaustiveEval(state))
-		interpretable.Eval(UnknownActivation())
+		interpretable.Eval(tst.A)
 		newExpr := PruneAst(pExpr.Expr, state)
 		actual := debug.ToDebugString(newExpr)
 		if !test.Compare(actual, tst.P) {
 			t.Errorf("prune[%d], diff: %s", i, test.DiffMessage("structure", actual, tst.P))
 		}
 	}
+}
+
+func unknownActivation(vars ...string) PartialActivation {
+	pats := make([]*AttributePattern, len(vars), len(vars))
+	for i, v := range vars {
+		pats[i] = NewAttributePattern(v)
+	}
+	a, _ := NewPartialActivation(map[string]interface{}{}, pats...)
+	return a
 }


### PR DESCRIPTION
This PR introduces top-level support for evaluating partial state and computing residual CEL expressions. 

The following partial attribute evaluation features have been exposed in the `cel` package:

* `OptPartialEval` - Enable partial attribute evaluation for a specific program.
* `PartialVars` - Provide variables, and mark variables or data within a variable's object
     member graph as unknown
* `AttributePattern` - Helper method to create a new attribute pattern which can be used
    to match unknown state for an object or some part of an object.
*  `ResidualAst` - Compute a new parsed / checked `Ast` from an original `Ast` and the
   `EvalDetails` captured from a previous evaluation.

Attribute patterns start with a variable can have an optional set of qualifier patterns which
can be any valid map key type (`string`, `int64`, `uint64`, `bool`) or wildcard. The attribute
pattern behaves similarly to a [`protobuf.FieldMask`](https://godoc.org/google.golang.org/genproto/protobuf/field_mask), but with support for array element
indexing.

Note, computing a residual does not yet work for comprehension macros and depends on the addition of source info for macro replacements (#292).  

Closes #299 