### PR TITLE
Add Library interface and top-level Compile method

### DIFF
--- a/cel/BUILD.bazel
+++ b/cel/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "cel.go",
         "env.go",
         "io.go",
+        "library.go",
         "options.go",
         "program.go",
     ],

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -198,7 +198,10 @@ func Test_CustomEnv(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		ast, _ := e.Compile("a.b.c")
+		ast, iss := e.Compile("a.b.c")
+		if iss != nil && iss.Err() != nil {
+			t.Fatal(iss.Err())
+		}
 		prg, _ := e.Program(ast)
 		out, _, _ := prg.Eval(map[string]interface{}{"a.b.c": true})
 		if out != types.True {

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -55,7 +55,7 @@ func Example() {
 		log.Fatalf("environment creation error: %s\n", err)
 	}
 
-	// Parse and check the expression.
+	// Compile the expression.
 	ast, iss := e.Compile("i.greet(you)")
 	if iss != nil && iss.Err() != nil {
 		log.Fatalln(iss.Err())
@@ -109,7 +109,7 @@ func Example_globalOverload() {
 		log.Fatalf("environment creation error: %s\n", err)
 	}
 
-	// Parse and check the expression.
+	// Compile the expression.
 	ast, iss := e.Compile(`shake_hands(i,you)`)
 	if iss != nil && iss.Err() != nil {
 		log.Fatalln(iss.Err())
@@ -159,7 +159,7 @@ func Test_ExampleWithBuiltins(t *testing.T) {
 		t.Fatalf("environment creation error: %s\n", err)
 	}
 
-	// Parse and type-check the expression.
+	// Compile the expression.
 	ast, iss := env.Compile(`"Hello " + you + "! I'm " + i + "."`)
 	if iss != nil && iss.Err() != nil {
 		t.Fatal(iss.Err())
@@ -182,7 +182,7 @@ func Test_ExampleWithBuiltins(t *testing.T) {
 
 	// Hello world! I'm CEL.
 	if out.Equal(types.String("Hello world! I'm CEL.")) != types.True {
-		t.Errorf(`Got '%v', wanted "Hello world! I'm CEL."`, out.Value())
+		t.Errorf(`got '%v', wanted "Hello world! I'm CEL."`, out.Value())
 	}
 }
 
@@ -193,7 +193,7 @@ func Test_CustomEnv(t *testing.T) {
 	t.Run("err", func(t *testing.T) {
 		_, iss := e.Compile("a.b.c == true")
 		if iss == nil || iss.Err() == nil {
-			t.Error("Got successful check, expected error for missing operator '_==_'")
+			t.Error("got successful compile, expected error for missing operator '_==_'")
 		}
 	})
 
@@ -205,7 +205,7 @@ func Test_CustomEnv(t *testing.T) {
 		prg, _ := e.Program(ast)
 		out, _, _ := prg.Eval(map[string]interface{}{"a.b.c": true})
 		if out != types.True {
-			t.Errorf("Got '%v', wanted 'true'", out.Value())
+			t.Errorf("got '%v', wanted 'true'", out.Value())
 		}
 	})
 }
@@ -227,19 +227,19 @@ func Test_HomogeneousAggregateLiterals(t *testing.T) {
 	t.Run("err_list", func(t *testing.T) {
 		_, iss := e.Compile("name in ['hello', 0]")
 		if iss == nil || iss.Err() == nil {
-			t.Error("Got successful check, expected error for mixed list entry types.")
+			t.Error("got successful compile, expected error for mixed list entry types.")
 		}
 	})
 	t.Run("err_map_key", func(t *testing.T) {
 		_, iss := e.Compile("name in {'hello':'world', 1:'!'}")
 		if iss == nil || iss.Err() == nil {
-			t.Error("Got successful check, expected error for mixed map key types.")
+			t.Error("got successful compile, expected error for mixed map key types.")
 		}
 	})
 	t.Run("err_map_val", func(t *testing.T) {
 		_, iss := e.Compile("name in {'hello':'world', 'goodbye':true}")
 		if iss == nil || iss.Err() == nil {
-			t.Error("Got successful check, expected error for mixed map value types.")
+			t.Error("got successful compile, expected error for mixed map value types.")
 		}
 	})
 	funcs := Functions(&functions.Overload{
@@ -254,29 +254,29 @@ func Test_HomogeneousAggregateLiterals(t *testing.T) {
 	t.Run("ok_list", func(t *testing.T) {
 		ast, iss := e.Compile("name in ['hello', 'world']")
 		if iss != nil && iss.Err() != nil {
-			t.Fatalf("Got issue: %v, expected successful check.", iss.Err())
+			t.Fatalf("got issue: %v, expected successful compile.", iss.Err())
 		}
 		prg, _ := e.Program(ast, funcs)
 		out, _, err := prg.Eval(map[string]interface{}{"name": "world"})
 		if err != nil {
-			t.Fatalf("Got err: %v, wanted result", err)
+			t.Fatalf("got err: %v, wanted result", err)
 		}
 		if out != types.True {
-			t.Errorf("Got '%v', wanted 'true'", out)
+			t.Errorf("got '%v', wanted 'true'", out)
 		}
 	})
 	t.Run("ok_map", func(t *testing.T) {
 		ast, iss := e.Compile("name in {'hello': false, 'world': true}")
 		if iss != nil && iss.Err() != nil {
-			t.Fatalf("Got issue: %v, expected successful check.", iss.Err())
+			t.Fatalf("got issue: %v, expected successful compile.", iss.Err())
 		}
 		prg, _ := e.Program(ast, funcs)
 		out, _, err := prg.Eval(map[string]interface{}{"name": "world"})
 		if err != nil {
-			t.Fatalf("Got err: %v, wanted result", err)
+			t.Fatalf("got err: %v, wanted result", err)
 		}
 		if out != types.True {
-			t.Errorf("Got '%v', wanted 'true'", out)
+			t.Errorf("got '%v', wanted 'true'", out)
 		}
 	})
 }
@@ -305,7 +305,7 @@ func Test_CustomTypes(t *testing.T) {
 					Expr{id: 3, ident_expr: Expr.Ident{ name: "b" }}]
 			}}`)
 	if !proto.Equal(ast.ResultType(), decls.Bool) {
-		t.Fatalf("Got %v, wanted type bool", ast.ResultType())
+		t.Fatalf("got %v, wanted type bool", ast.ResultType())
 	}
 	prg, _ := e.Program(ast)
 	vars := map[string]interface{}{"expr": &exprpb.Expr{
@@ -332,18 +332,18 @@ func Test_CustomTypes(t *testing.T) {
 	}}
 	out, _, _ := prg.Eval(vars)
 	if out != types.True {
-		t.Errorf("Got '%v', wanted 'true'", out.Value())
+		t.Errorf("got '%v', wanted 'true'", out.Value())
 	}
 }
 
 func Test_TypeIsolation(t *testing.T) {
 	b, err := ioutil.ReadFile("testdata/team.fds")
 	if err != nil {
-		t.Fatal("Can't read fds file: ", err)
+		t.Fatal("can't read fds file: ", err)
 	}
 	var fds descpb.FileDescriptorSet
 	if err = proto.Unmarshal(b, &fds); err != nil {
-		t.Fatal("Can't unmarshal descriptor data: ", err)
+		t.Fatal("can't unmarshal descriptor data: ", err)
 	}
 
 	e, err := NewEnv(
@@ -353,7 +353,7 @@ func Test_TypeIsolation(t *testing.T) {
 				decls.NewObjectType("cel.testdata.Team"),
 				nil)))
 	if err != nil {
-		t.Fatal("Can't create env: ", err)
+		t.Fatal("can't create env: ", err)
 	}
 
 	src := "myteam.members[0].name == 'Cyclops'"
@@ -370,7 +370,7 @@ func Test_TypeIsolation(t *testing.T) {
 				nil)))
 	_, iss = e2.Compile(src)
 	if iss == nil || iss.Err() == nil {
-		t.Errorf("Wanted check failure for unknown message.")
+		t.Errorf("wanted compile failure for unknown message.")
 	}
 }
 
@@ -425,7 +425,7 @@ func Test_GlobalVars(t *testing.T) {
 			"attrs": map[string]interface{}{}}
 		out, _, _ := prg.Eval(vars)
 		if out.Equal(types.String("third")) != types.True {
-			t.Errorf("Got '%v', expected 'third'.", out.Value())
+			t.Errorf("got '%v', expected 'third'.", out.Value())
 		}
 	})
 
@@ -434,7 +434,7 @@ func Test_GlobalVars(t *testing.T) {
 			"attrs": map[string]interface{}{"second": "yep"}}
 		out, _, _ := prg.Eval(vars)
 		if out.Equal(types.String("yep")) != types.True {
-			t.Errorf("Got '%v', expected 'yep'.", out.Value())
+			t.Errorf("got '%v', expected 'yep'.", out.Value())
 		}
 	})
 
@@ -444,7 +444,7 @@ func Test_GlobalVars(t *testing.T) {
 			"default": "fourth"}
 		out, _, _ := prg.Eval(vars)
 		if out.Equal(types.String("fourth")) != types.True {
-			t.Errorf("Got '%v', expected 'fourth'.", out.Value())
+			t.Errorf("got '%v', expected 'fourth'.", out.Value())
 		}
 	})
 }
@@ -497,7 +497,7 @@ func Test_CustomMacro(t *testing.T) {
 		t.Fatal(err)
 	}
 	if out.Equal(types.String("hello,cel,friend")) != types.True {
-		t.Errorf("Got %v, wanted 'hello,cel,friend'", out)
+		t.Errorf("got %v, wanted 'hello,cel,friend'", out)
 	}
 }
 
@@ -520,7 +520,7 @@ func Test_EvalOptions(t *testing.T) {
 		t.Fatalf("runtime error: %s\n", err)
 	}
 	if out != types.True {
-		t.Errorf("Got '%v', expected 'true'", out.Value())
+		t.Errorf("got '%v', expected 'true'", out.Value())
 	}
 
 	// Test to see whether 'v != false' was resolved to a value.
@@ -528,19 +528,19 @@ func Test_EvalOptions(t *testing.T) {
 	s := details.State()
 	lhsVal, found := s.Value(ast.Expr().GetCallExpr().GetArgs()[0].Id)
 	if !found {
-		t.Error("Got not found, wanted evaluation of left hand side expression.")
+		t.Error("got not found, wanted evaluation of left hand side expression.")
 		return
 	}
 	if lhsVal != types.True {
-		t.Errorf("Got '%v', expected 'true'", lhsVal)
+		t.Errorf("got '%v', expected 'true'", lhsVal)
 	}
 	rhsVal, found := s.Value(ast.Expr().GetCallExpr().GetArgs()[1].Id)
 	if !found {
-		t.Error("Got not found, wanted evaluation of right hand side expression.")
+		t.Error("got not found, wanted evaluation of right hand side expression.")
 		return
 	}
 	if rhsVal != types.True {
-		t.Errorf("Got '%v', expected 'true'", rhsVal)
+		t.Errorf("got '%v', expected 'true'", rhsVal)
 	}
 }
 
@@ -561,13 +561,13 @@ func Test_EvalRecover(t *testing.T) {
 	prgm, _ := e.Program(pAst, funcs)
 	_, _, err := prgm.Eval(map[string]interface{}{})
 	if err.Error() != "internal error: watch me recover" {
-		t.Errorf("Got '%v', wanted 'internal error: watch me recover'", err)
+		t.Errorf("got '%v', wanted 'internal error: watch me recover'", err)
 	}
 	// Test the factory-based evaluation.
 	prgm, _ = e.Program(pAst, funcs, EvalOptions(OptTrackState))
 	_, _, err = prgm.Eval(map[string]interface{}{})
 	if err.Error() != "internal error: watch me recover" {
-		t.Errorf("Got '%v', wanted 'internal error: watch me recover'", err)
+		t.Errorf("got '%v', wanted 'internal error: watch me recover'", err)
 	}
 }
 
@@ -585,7 +585,7 @@ func Test_ResidualAst(t *testing.T) {
 	)
 	out, det, err := prg.Eval(unkVars)
 	if !types.IsUnknown(out) {
-		t.Fatalf("Got %v, expected unknown", out)
+		t.Fatalf("got %v, expected unknown", out)
 	}
 	if err != nil {
 		t.Fatal(err)
@@ -599,7 +599,7 @@ func Test_ResidualAst(t *testing.T) {
 		t.Fatal(err)
 	}
 	if expr != "x < 10" {
-		t.Errorf("Got expr: %s, wanted x < 10", expr)
+		t.Errorf("got expr: %s, wanted x < 10", expr)
 	}
 }
 
@@ -633,7 +633,7 @@ func Test_ResidualAst_Complex(t *testing.T) {
 	)
 	out, det, err := prg.Eval(unkVars)
 	if !types.IsUnknown(out) {
-		t.Fatalf("Got %v, expected unknown", out)
+		t.Fatalf("got %v, expected unknown", out)
 	}
 	if err != nil {
 		t.Fatal(err)
@@ -647,7 +647,7 @@ func Test_ResidualAst_Complex(t *testing.T) {
 		t.Fatal(err)
 	}
 	if expr != `request.auth.claims.email == "wiley@acme.co"` {
-		t.Errorf("Got expr: %s, wanted request.auth.claims.email == \"wiley@acme.co\"", expr)
+		t.Errorf("got expr: %s, wanted request.auth.claims.email == \"wiley@acme.co\"", expr)
 	}
 }
 
@@ -694,7 +694,7 @@ func Test_EnvExtension(t *testing.T) {
 	)
 	e2, _ := e.Extend()
 	if e == e2 {
-		t.Error("Got object equality, wanted separate objects")
+		t.Error("got object equality, wanted separate objects")
 	}
 }
 
@@ -711,7 +711,7 @@ func Test_ParseAndCheckConcurrently(t *testing.T) {
 	parseAndCheck := func(expr string) {
 		_, iss := e.Compile(expr)
 		if iss != nil && iss.Err() != nil {
-			t.Fatalf("Failed to parse '%s': %v", expr, iss.Err())
+			t.Fatalf("failed to parse '%s': %v", expr, iss.Err())
 		}
 	}
 

--- a/cel/env.go
+++ b/cel/env.go
@@ -207,8 +207,18 @@ func (e *Env) CompileSource(src common.Source) (*Ast, *Issues) {
 
 // Extend the current environment with additional options to produce a new Env.
 func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
-	ext := &Env{}
-	*ext = *e
+	if e.chkErr != nil {
+		return nil, e.chkErr
+	}
+	ext := &Env{
+		declarations:                   e.declarations,
+		adapter:                        e.adapter,
+		enableDynamicAggregateLiterals: e.enableDynamicAggregateLiterals,
+		macros:                         e.macros,
+		pkg:                            e.pkg,
+		progOpts:                       e.progOpts,
+		provider:                       e.provider,
+	}
 	return ext.configure(opts)
 }
 

--- a/cel/env.go
+++ b/cel/env.go
@@ -16,6 +16,8 @@ package cel
 
 import (
 	"errors"
+	"log"
+	"sync"
 
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/checker/decls"
@@ -24,7 +26,6 @@ import (
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter"
-	"github.com/google/cel-go/interpreter/functions"
 	"github.com/google/cel-go/parser"
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
@@ -81,37 +82,50 @@ type Env struct {
 	declarations []*exprpb.Decl
 	macros       []parser.Macro
 	pkg          packages.Packager
-	provider     ref.TypeProvider
 	adapter      ref.TypeAdapter
-	chk          *checker.Env
+	provider     ref.TypeProvider
+	// program options tied to the environment.
+	progOpts []ProgramOption
 	// environment options, true by default.
-	enableBuiltins                 bool
 	enableDynamicAggregateLiterals bool
+
+	// Internal checker representation
+	chk  *checker.Env
+	once sync.Once
 }
 
-// NewEnv creates an Env instance suitable for parsing and checking expressions against a set of
-// user-defined constants, variables, and functions. Macros and the standard built-ins are enabled
-// by default.
+// NewEnv creates a program environment configured with the standard library of CEL functions and
+// macros. The Env value returned can parse and check any CEL program which builds upon the core
+// features documented in the CEL specification.
 //
-// See the EnvOptions for the options that can be used to configure the environment.
+// See the EnvOption helper functions for the options that can be used to configure the
+// environment.
 func NewEnv(opts ...EnvOption) (*Env, error) {
+	stdOpts := append([]EnvOption{StdLib()}, opts...)
+	return NewCustomEnv(stdOpts...)
+}
+
+// NewCustomEnv creates a custom program enviroment which is not automatically configured with the
+// standard library of functions and macros documented in the CEL spec.
+//
+// The purpose for using a custom environment might be for subsetting the standard library produced
+// by the cel.StdLib() function. Subsetting CEL is a core aspect of its design that allows users to
+// limit the compute and memory impact of a CEL program by controlling the functions and macros
+// that may appear in a given expression.
+//
+// See the EnvOption helper functions for the options that can be used to configure the
+// environment.
+func NewCustomEnv(opts ...EnvOption) (*Env, error) {
 	registry := types.NewRegistry()
 	return (&Env{
-		declarations:                   checker.StandardDeclarations(),
-		macros:                         parser.AllMacros,
+		declarations:                   []*exprpb.Decl{},
+		macros:                         []parser.Macro{},
 		pkg:                            packages.DefaultPackage,
-		provider:                       registry,
 		adapter:                        registry,
-		enableBuiltins:                 true,
+		provider:                       registry,
 		enableDynamicAggregateLiterals: true,
-	}).configure(opts...)
-}
-
-// Extend the current environment with additional options to produce a new Env.
-func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
-	ext := &Env{}
-	*ext = *e
-	return ext.configure(opts...)
+		progOpts:                       []ProgramOption{},
+	}).configure(opts)
 }
 
 // Check performs type-checking on the input Ast and yields a checked Ast and/or set of Issues.
@@ -124,6 +138,18 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 func (e *Env) Check(ast *Ast) (*Ast, *Issues) {
 	// Note, errors aren't currently possible on the Ast to ParsedExpr conversion.
 	pe, _ := AstToParsedExpr(ast)
+
+	// Construct the internal checker env, erroring if there is an issue adding the declarations.
+	e.once.Do(func() {
+		ce := checker.NewEnv(e.pkg, e.provider)
+		ce.EnableDynamicAggregateLiterals(e.enableDynamicAggregateLiterals)
+		err := ce.Add(e.declarations...)
+		if err != nil {
+			log.Panic(err)
+		}
+		e.chk = ce
+	})
+
 	res, errs := checker.Check(pe, ast.Source(), e.chk)
 	if len(errs.GetErrors()) > 0 {
 		return nil, &Issues{errs: errs}
@@ -136,6 +162,47 @@ func (e *Env) Check(ast *Ast) (*Ast, *Issues) {
 		info:    res.GetSourceInfo(),
 		refMap:  res.GetReferenceMap(),
 		typeMap: res.GetTypeMap()}, nil
+}
+
+// Compile combines the Parse and Check phases CEL program compilation to produce an Ast and
+// associated issues.
+//
+// If an error is encountered during parsing the Compile step will not continue with the Check
+// phase. If non-error issues are encountered during Parse, they may be combined with any issues
+// discovered during Check.
+//
+// Note, for parse-only uses of CEL use Parse.
+func (e *Env) Compile(txt string) (*Ast, *Issues) {
+	return e.CompileSource(common.NewTextSource(txt))
+}
+
+// CompileSource combines the Parse and Check phases CEL program compilation to produce an Ast and
+// associated issues.
+//
+// If an error is encountered during parsing the CompileSource step will not continue with the
+// Check phase. If non-error issues are encountered during Parse, they may be combined with any
+// issues discovered during Check.
+//
+// Note, for parse-only uses of CEL use Parse.
+func (e *Env) CompileSource(src common.Source) (*Ast, *Issues) {
+	ast, iss := e.ParseSource(src)
+	if iss != nil && iss.Err() != nil {
+		return nil, iss
+	}
+	checked, iss2 := e.Check(ast)
+	if iss != nil && iss2 != nil {
+		iss.Append(iss2)
+	} else if iss2 != nil {
+		iss = iss2
+	}
+	return checked, iss
+}
+
+// Extend the current environment with additional options to produce a new Env.
+func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
+	ext := &Env{}
+	*ext = *e
+	return ext.configure(opts)
 }
 
 // Parse parses the input expression value `txt` to a Ast and/or a set of Issues.
@@ -169,12 +236,14 @@ func (e *Env) ParseSource(src common.Source) (*Ast, *Issues) {
 
 // Program generates an evaluable instance of the Ast within the environment (Env).
 func (e *Env) Program(ast *Ast, opts ...ProgramOption) (Program, error) {
-	if e.enableBuiltins {
-		opts = append(
-			[]ProgramOption{Functions(functions.StandardOverloads()...)},
-			opts...)
+	optSet := e.progOpts
+	if len(opts) != 0 {
+		mergedOpts := []ProgramOption{}
+		mergedOpts = append(mergedOpts, e.progOpts...)
+		mergedOpts = append(mergedOpts, opts...)
+		optSet = mergedOpts
 	}
-	return newProgram(e, ast, opts...)
+	return newProgram(e, ast, optSet)
 }
 
 // TypeAdapter returns the `ref.TypeAdapter` configured for the environment.
@@ -250,7 +319,7 @@ func (e *Env) ResidualAst(a *Ast, details *EvalDetails) (*Ast, error) {
 }
 
 // configure applies a series of EnvOptions to the current environment.
-func (e *Env) configure(opts ...EnvOption) (*Env, error) {
+func (e *Env) configure(opts []EnvOption) (*Env, error) {
 	// Customized the environment using the provided EnvOption values. If an error is
 	// generated at any step this, will be returned as a nil Env with a non-nil error.
 	var err error
@@ -260,15 +329,6 @@ func (e *Env) configure(opts ...EnvOption) (*Env, error) {
 			return nil, err
 		}
 	}
-
-	// Construct the internal checker env, erroring if there is an issue adding the declarations.
-	ce := checker.NewEnv(e.pkg, e.provider)
-	ce.EnableDynamicAggregateLiterals(e.enableDynamicAggregateLiterals)
-	err = ce.Add(e.declarations...)
-	if err != nil {
-		return nil, err
-	}
-	e.chk = ce
 	return e, nil
 }
 

--- a/cel/library.go
+++ b/cel/library.go
@@ -1,0 +1,77 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cel
+
+import (
+	"github.com/google/cel-go/checker"
+	"github.com/google/cel-go/interpreter/functions"
+	"github.com/google/cel-go/parser"
+)
+
+// Library provides a collection of EnvOption and ProgramOption values used to confiugre a CEL
+// environment for a particular use case or with a related set of functionality.
+//
+// Note, the ProgramOption values provided by a library are expected to be static and not vary
+// between calls to Env.Program(). If there is a need for such dynamic configuration, prefer to
+// configure these options outside the Library and within the Env.Program() call directly.
+type Library interface {
+	// EnvOptions returns a collection of funcitional options for configuring the Parse / Check
+	// environment.
+	EnvOptions() []EnvOption
+
+	// ProgramOptions returns a collection of functional options which should be included in every
+	// Program generated from the Env.Program() call.
+	ProgramOptions() []ProgramOption
+}
+
+// Lib creates an EnvOption out of a Library, allowing libraries to be provided as functional args,
+// and to be linked to each other.
+func Lib(l Library) EnvOption {
+	return func(e *Env) (*Env, error) {
+		var err error
+		for _, opt := range l.EnvOptions() {
+			e, err = opt(e)
+			if err != nil {
+				return nil, err
+			}
+		}
+		e.progOpts = append(e.progOpts, l.ProgramOptions()...)
+		return e, nil
+	}
+}
+
+// StdLib returns an EnvOption for the standard library of CEL functions and macros.
+func StdLib() EnvOption {
+	return Lib(stdLibrary{})
+}
+
+// stdLibrary implements the Library interface and provides functional options for the core CEL
+// features documented in the specification.
+type stdLibrary struct{}
+
+// EnvOptions returns options for the standard CEL function declarations and macros.
+func (stdLibrary) EnvOptions() []EnvOption {
+	return []EnvOption{
+		Declarations(checker.StandardDeclarations()...),
+		Macros(parser.AllMacros...),
+	}
+}
+
+// ProgramOptions returns function implementations for the standard CEL functions.
+func (stdLibrary) ProgramOptions() []ProgramOption {
+	return []ProgramOption{
+		Functions(functions.StandardOverloads()...),
+	}
+}

--- a/cel/library.go
+++ b/cel/library.go
@@ -27,9 +27,9 @@ import (
 // between calls to Env.Program(). If there is a need for such dynamic configuration, prefer to
 // configure these options outside the Library and within the Env.Program() call directly.
 type Library interface {
-	// EnvOptions returns a collection of funcitional options for configuring the Parse / Check
+	// CompileOptions returns a collection of funcitional options for configuring the Parse / Check
 	// environment.
-	EnvOptions() []EnvOption
+	CompileOptions() []EnvOption
 
 	// ProgramOptions returns a collection of functional options which should be included in every
 	// Program generated from the Env.Program() call.
@@ -41,7 +41,7 @@ type Library interface {
 func Lib(l Library) EnvOption {
 	return func(e *Env) (*Env, error) {
 		var err error
-		for _, opt := range l.EnvOptions() {
+		for _, opt := range l.CompileOptions() {
 			e, err = opt(e)
 			if err != nil {
 				return nil, err
@@ -62,7 +62,7 @@ func StdLib() EnvOption {
 type stdLibrary struct{}
 
 // EnvOptions returns options for the standard CEL function declarations and macros.
-func (stdLibrary) EnvOptions() []EnvOption {
+func (stdLibrary) CompileOptions() []EnvOption {
 	return []EnvOption{
 		Declarations(checker.StandardDeclarations()...),
 		Macros(parser.AllMacros...),

--- a/cel/options.go
+++ b/cel/options.go
@@ -32,6 +32,20 @@ import (
 // EnvOption is a functional interface for configuring the environment.
 type EnvOption func(e *Env) (*Env, error)
 
+// ClearMacros options clears all parser macros.
+//
+// Clearing macros will ensure CEL expressions can only contain linear evaluation paths, as
+// comprehensions such as `all` and `exists` are enabled only via macros.
+//
+// Note: This option is a no-op when used with ClearBuiltIns, and must be used before Macros
+// if used together.
+func ClearMacros() EnvOption {
+	return func(e *Env) (*Env, error) {
+		e.macros = parser.NoMacros
+		return e, nil
+	}
+}
+
 // CustomTypeAdapter swaps the default ref.TypeAdapter implementation with a custom one.
 //
 // Note: This option must be specified before the Types and TypeDescs options when used together.

--- a/cel/options.go
+++ b/cel/options.go
@@ -32,32 +32,6 @@ import (
 // EnvOption is a functional interface for configuring the environment.
 type EnvOption func(e *Env) (*Env, error)
 
-// ClearBuiltIns option removes all standard types, operators, and macros from the environment.
-//
-// Note: This option must be specified before Declarations and/or Macros if used together.
-func ClearBuiltIns() EnvOption {
-	return func(e *Env) (*Env, error) {
-		e.declarations = []*exprpb.Decl{}
-		e.macros = parser.NoMacros
-		e.enableBuiltins = false
-		return e, nil
-	}
-}
-
-// ClearMacros options clears all parser macros.
-//
-// Clearing macros will ensure CEL expressions can only contain linear evaluation paths, as
-// comprehensions such as `all` and `exists` are enabled only via macros.
-//
-// Note: This option is a no-op when used with ClearBuiltIns, and must be used before Macros
-// if used together.
-func ClearMacros() EnvOption {
-	return func(e *Env) (*Env, error) {
-		e.macros = parser.NoMacros
-		return e, nil
-	}
-}
-
 // CustomTypeAdapter swaps the default ref.TypeAdapter implementation with a custom one.
 //
 // Note: This option must be specified before the Types and TypeDescs options when used together.

--- a/cel/program.go
+++ b/cel/program.go
@@ -112,7 +112,7 @@ type progGen struct {
 // ProgramOption values.
 //
 // If the program cannot be configured the prog will be nil, with a non-nil error response.
-func newProgram(e *Env, ast *Ast, opts ...ProgramOption) (Program, error) {
+func newProgram(e *Env, ast *Ast, opts []ProgramOption) (Program, error) {
 	// Build the dispatcher, interpreter, and default program value.
 	disp := interpreter.NewDispatcher()
 

--- a/examples/custom_global_function_test.go
+++ b/examples/custom_global_function_test.go
@@ -25,11 +25,7 @@ func ExampleCustomGlobalFunction() {
 		log.Fatalf("environment creation error: %v\n", err)
 	}
 	// Check iss for error in both Parse and Check.
-	p, iss := env.Parse(`shake_hands(i,you)`)
-	if iss != nil && iss.Err() != nil {
-		log.Fatalln(iss.Err())
-	}
-	c, iss := env.Check(p)
+	ast, iss := env.Compile(`shake_hands(i,you)`)
 	if iss != nil && iss.Err() != nil {
 		log.Fatalln(iss.Err())
 	}
@@ -39,7 +35,7 @@ func ExampleCustomGlobalFunction() {
 			return types.String(
 				fmt.Sprintf("%s and %s are shaking hands.\n", lhs, rhs))
 		}}
-	prg, err := env.Program(c, cel.Functions(shakeFunc))
+	prg, err := env.Program(ast, cel.Functions(shakeFunc))
 	if err != nil {
 		log.Fatalf("Program creation error: %v\n", err)
 	}

--- a/examples/custom_instance_function_test.go
+++ b/examples/custom_instance_function_test.go
@@ -42,7 +42,7 @@ func ExampleCustomInstanceFunction() {
 
 type customLib struct{}
 
-func (customLib) EnvOptions() []cel.EnvOption {
+func (customLib) CompileOptions() []cel.EnvOption {
 	return []cel.EnvOption{
 		cel.Declarations(
 			decls.NewIdent("i", decls.String, nil),

--- a/examples/simple_test.go
+++ b/examples/simple_test.go
@@ -15,15 +15,11 @@ func ExampleSimple() {
 		log.Fatalf("environment creation error: %v\n", err)
 	}
 	// Check iss for error in both Parse and Check.
-	p, iss := env.Parse(`"Hello world! I'm " + name + "."`)
+	ast, iss := env.Compile(`"Hello world! I'm " + name + "."`)
 	if iss != nil && iss.Err() != nil {
 		log.Fatalln(iss.Err())
 	}
-	c, iss := env.Check(p)
-	if iss != nil && iss.Err() != nil {
-		log.Fatalln(iss.Err())
-	}
-	prg, err := env.Program(c)
+	prg, err := env.Program(ast)
 
 	out, _, err := prg.Eval(map[string]interface{}{
 		"name": "CEL",

--- a/server/server.go
+++ b/server/server.go
@@ -73,15 +73,15 @@ func (s *ConformanceServer) Check(ctx context.Context, in *exprpb.CheckRequest) 
 		return nil, st.Err()
 	}
 	// Build the environment.
-	var checkOptions []cel.EnvOption
+	var checkOptions []cel.EnvOption = []cel.EnvOption{cel.StdLib()}
 	if in.NoStdEnv {
-		checkOptions = append(checkOptions, cel.ClearBuiltIns())
+		checkOptions = []cel.EnvOption{}
 	}
 	checkOptions = append(checkOptions, cel.Container(in.Container))
 	checkOptions = append(checkOptions, cel.Declarations(in.TypeEnv...))
 	checkOptions = append(checkOptions, cel.Types(&test2pb.TestAllTypes{}))
 	checkOptions = append(checkOptions, cel.Types(&test3pb.TestAllTypes{}))
-	env, _ := cel.NewEnv(checkOptions...)
+	env, _ := cel.NewCustomEnv(checkOptions...)
 
 	// Check the expression.
 	cast, iss := env.Check(cel.ParsedExprToAst(in.ParsedExpr))


### PR DESCRIPTION
There are a handful of usability issues which have been pointed out in #290 and #306 which
relate to how CEL programs are configured and specified. The idea of this change is to offer
a path forward where it is easier to specify a subset of the CEL standard environment _and_
easier to build new modules of functionality as `cel.Library` objects. 