### PR TITLE
Issues simplification for Parse / Check / Compile 

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -57,8 +57,8 @@ func Example() {
 
 	// Compile the expression.
 	ast, iss := e.Compile("i.greet(you)")
-	if iss != nil && iss.Err() != nil {
-		log.Fatalln(iss.Err())
+	if err := iss.Err(); err != nil {
+		log.Fatalln(err)
 	}
 
 	// Create the program.
@@ -111,8 +111,8 @@ func Example_globalOverload() {
 
 	// Compile the expression.
 	ast, iss := e.Compile(`shake_hands(i,you)`)
-	if iss != nil && iss.Err() != nil {
-		log.Fatalln(iss.Err())
+	if err := iss.Err(); err != nil {
+		log.Fatalln(err)
 	}
 
 	// Create the program.
@@ -161,7 +161,7 @@ func Test_ExampleWithBuiltins(t *testing.T) {
 
 	// Compile the expression.
 	ast, iss := env.Compile(`"Hello " + you + "! I'm " + i + "."`)
-	if iss != nil && iss.Err() != nil {
+	if iss.Err() != nil {
 		t.Fatal(iss.Err())
 	}
 
@@ -186,20 +186,31 @@ func Test_ExampleWithBuiltins(t *testing.T) {
 	}
 }
 
+func Test_CustomEnvError(t *testing.T) {
+	e, err := NewCustomEnv(StdLib(), StdLib())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, iss := e.Compile("a.b.c == true")
+	if iss.Err() == nil {
+		t.Error("got successful compile, expected error for duplicate function declarations.")
+	}
+}
+
 func Test_CustomEnv(t *testing.T) {
 	e, _ := NewCustomEnv(
 		Declarations(decls.NewIdent("a.b.c", decls.Bool, nil)))
 
 	t.Run("err", func(t *testing.T) {
 		_, iss := e.Compile("a.b.c == true")
-		if iss == nil || iss.Err() == nil {
+		if iss.Err() == nil {
 			t.Error("got successful compile, expected error for missing operator '_==_'")
 		}
 	})
 
 	t.Run("ok", func(t *testing.T) {
 		ast, iss := e.Compile("a.b.c")
-		if iss != nil && iss.Err() != nil {
+		if iss.Err() != nil {
 			t.Fatal(iss.Err())
 		}
 		prg, _ := e.Program(ast)
@@ -253,7 +264,7 @@ func Test_HomogeneousAggregateLiterals(t *testing.T) {
 	})
 	t.Run("ok_list", func(t *testing.T) {
 		ast, iss := e.Compile("name in ['hello', 'world']")
-		if iss != nil && iss.Err() != nil {
+		if iss.Err() != nil {
 			t.Fatalf("got issue: %v, expected successful compile.", iss.Err())
 		}
 		prg, _ := e.Program(ast, funcs)
@@ -267,7 +278,7 @@ func Test_HomogeneousAggregateLiterals(t *testing.T) {
 	})
 	t.Run("ok_map", func(t *testing.T) {
 		ast, iss := e.Compile("name in {'hello': false, 'world': true}")
-		if iss != nil && iss.Err() != nil {
+		if iss.Err() != nil {
 			t.Fatalf("got issue: %v, expected successful compile.", iss.Err())
 		}
 		prg, _ := e.Program(ast, funcs)
@@ -358,7 +369,7 @@ func Test_TypeIsolation(t *testing.T) {
 
 	src := "myteam.members[0].name == 'Cyclops'"
 	_, iss := e.Compile(src)
-	if iss != nil && iss.Err() != nil {
+	if iss.Err() != nil {
 		t.Error(iss.Err())
 	}
 
@@ -485,7 +496,7 @@ func Test_CustomMacro(t *testing.T) {
 		Macros(joinMacro),
 	)
 	ast, iss := e.Compile(`['hello', 'cel', 'friend'].join(',')`)
-	if iss != nil && iss.Err() != nil {
+	if iss.Err() != nil {
 		t.Fatal(iss.Err())
 	}
 	prg, err := e.Program(ast, EvalOptions(OptExhaustiveEval))
@@ -625,7 +636,7 @@ func Test_ResidualAst_Complex(t *testing.T) {
 		`resource.name.startsWith("bucket/my-bucket") &&
 		 bool(request.auth.claims.email_verified) == true &&
 		 request.auth.claims.email == "wiley@acme.co"`)
-	if iss != nil && iss.Err() != nil {
+	if iss.Err() != nil {
 		t.Fatal(iss.Err())
 	}
 	prg, _ := e.Program(ast,
@@ -710,7 +721,7 @@ func Test_ParseAndCheckConcurrently(t *testing.T) {
 
 	parseAndCheck := func(expr string) {
 		_, iss := e.Compile(expr)
-		if iss != nil && iss.Err() != nil {
+		if iss.Err() != nil {
 			t.Fatalf("failed to parse '%s': %v", expr, iss.Err())
 		}
 	}

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -57,8 +57,8 @@ func Example() {
 
 	// Compile the expression.
 	ast, iss := e.Compile("i.greet(you)")
-	if err := iss.Err(); err != nil {
-		log.Fatalln(err)
+	if iss.Err() != nil {
+		log.Fatalln(iss.Err())
 	}
 
 	// Create the program.
@@ -111,8 +111,8 @@ func Example_globalOverload() {
 
 	// Compile the expression.
 	ast, iss := e.Compile(`shake_hands(i,you)`)
-	if err := iss.Err(); err != nil {
-		log.Fatalln(err)
+	if iss.Err() != nil {
+		log.Fatalln(iss.Err())
 	}
 
 	// Create the program.

--- a/cel/env.go
+++ b/cel/env.go
@@ -150,7 +150,7 @@ func (e *Env) Check(ast *Ast) (*Ast, *Issues) {
 			e.chk = ce
 		}
 	})
-	// The once call will ensure that this value is set or
+	// The once call will ensure that this value is set or nil for all invocations.
 	if e.chkErr != nil {
 		errs := common.NewErrors(ast.Source())
 		errs.ReportError(common.NoLocation, e.chkErr.Error())
@@ -207,8 +207,8 @@ func (e *Env) CompileSource(src common.Source) (*Ast, *Issues) {
 
 // Extend the current environment with additional options to produce a new Env.
 func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
-	if e.chkErr != nil {		ext := &Env{}
-		return nil, e.chkErr		*ext = *e
+	if e.chkErr != nil {
+		return nil, e.chkErr
 	}
 	ext := &Env{
 		declarations:                   e.declarations,

--- a/cel/env.go
+++ b/cel/env.go
@@ -207,8 +207,18 @@ func (e *Env) CompileSource(src common.Source) (*Ast, *Issues) {
 
 // Extend the current environment with additional options to produce a new Env.
 func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
-	ext := &Env{}
-	*ext = *e
+	if e.chkErr != nil {		ext := &Env{}
+		return nil, e.chkErr		*ext = *e
+	}
+	ext := &Env{
+		declarations:                   e.declarations,
+		adapter:                        e.adapter,
+		enableDynamicAggregateLiterals: e.enableDynamicAggregateLiterals,
+		macros:                         e.macros,
+		pkg:                            e.pkg,
+		progOpts:                       e.progOpts,
+		provider:                       e.provider,
+	}
 	return ext.configure(opts)
 }
 

--- a/common/errors.go
+++ b/common/errors.go
@@ -45,9 +45,13 @@ func (e *Errors) GetErrors() []Error {
 	return e.errors[:]
 }
 
-// Append takes an Errors object as input and appends its errors to the current Errors object.
-func (e *Errors) Append(errs []Error) {
-	e.errors = append(e.errors, errs...)
+// Append takes an Errors object as input creates a new Errors object with the current and input
+// errors.
+func (e *Errors) Append(errs []Error) *Errors {
+	return &Errors{
+		errors: append(e.errors, errs...),
+		source: e.source,
+	}
 }
 
 // ToDisplayString returns the error set to a newline delimited string.

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,8 +14,11 @@ import (
     d := cel.Declarations(decls.NewIdent("name", decls.String, nil))
     env, err := cel.NewEnv(d)
 
-    // Check iss for error in both Parse and Check.
     ast, iss := env.Compile(`"Hello world! I'm " + name + "."`)
+    // Check iss for compilation errors.
+	if iss.Err() != nil {
+		log.Fatalln(iss.Err())
+	}
     prg, err := env.Program(ast)
     out, _, err := prg.Eval(map[string]interface{}{
         "name":   "CEL",

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,9 +16,9 @@ import (
 
     ast, iss := env.Compile(`"Hello world! I'm " + name + "."`)
     // Check iss for compilation errors.
-	if iss.Err() != nil {
-		log.Fatalln(iss.Err())
-	}
+    if iss.Err() != nil {
+        log.Fatalln(iss.Err())
+    }
     prg, err := env.Program(ast)
     out, _, err := prg.Eval(map[string]interface{}{
         "name":   "CEL",

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,20 +7,17 @@ name.
 
 ```go
 import (
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
+    "github.com/google/cel-go/cel"
+    "github.com/google/cel-go/checker/decls"
 )
 
-	d := cel.Declarations(decls.NewIdent("name", decls.String, nil))
-	env, err := cel.NewEnv(d)
+    d := cel.Declarations(decls.NewIdent("name", decls.String, nil))
+    env, err := cel.NewEnv(d)
 
     // Check iss for error in both Parse and Check.
-	p, iss := env.Parse(`"Hello world! I'm " + name + "."`)
-	c, iss := env.Check(p)
-
-	prg, err := env.Program(c)
-
-	out, _, err := prg.Eval(map[string]interface{}{
+    ast, iss := env.Compile(`"Hello world! I'm " + name + "."`)
+    prg, err := env.Program(ast)
+    out, _, err := prg.Eval(map[string]interface{}{
         "name":   "CEL",
     })
     fmt.Println(out)
@@ -47,12 +44,12 @@ parameters of function.
 
 ```go
     decls.NewIdent("i", decls.String, nil),
-	decls.NewIdent("you", decls.String, nil),
-	decls.NewFunction("greet",
-		decls.NewInstanceOverload("string_greet_string",
-			[]*exprpb.Type{decls.String, decls.String},
-			decls.String))
-	... // Create env and parse and check.
+    decls.NewIdent("you", decls.String, nil),
+    decls.NewFunction("greet",
+        decls.NewInstanceOverload("string_greet_string",
+            []*exprpb.Type{decls.String, decls.String},
+            decls.String))
+    ... // Create env and compile
 ```
 
 Let's implement `greet` function and pass it to `program`. We will be using
@@ -61,19 +58,19 @@ function parameter).
 
 ```go
     greetFunc := &functions.Overload{
-		Operator: "string_greet_string",
-		Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
-			return types.String(
-				fmt.Sprintf("Hello %s! Nice to meet you, I'm %s.\n", rhs, lhs))
+        Operator: "string_greet_string",
+        Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
+            return types.String(
+                fmt.Sprintf("Hello %s! Nice to meet you, I'm %s.\n", rhs, lhs))
             }}
     prg, err := env.Program(c, cel.Functions(greetFunc))
 
     out, _, err := prg.Eval(map[string]interface{}{
-		"i": "CEL",
-		"you": "world",
-	})
-	fmt.Println(out)
-	// Output:Hello world! Nice to meet you, I'm CEL.
+        "i": "CEL",
+        "you": "world",
+    })
+    fmt.Println(out)
+    // Output:Hello world! Nice to meet you, I'm CEL.
 ```
 [Source code](custom_instance_function_test.go)
 
@@ -91,27 +88,27 @@ In order to declare global function we need to use `NewOverload`:
 
 ```go
     decls.NewIdent("i", decls.String, nil),
-	decls.NewIdent("you", decls.String, nil),
-	decls.NewFunction("shake_hands",
-		decls.NewOverload("shake_hands_string_string",
-			[]*exprpb.Type{decls.String, decls.String},
-			decls.String))
-    ... // Create env and parse and check.
+    decls.NewIdent("you", decls.String, nil),
+    decls.NewFunction("shake_hands",
+        decls.NewOverload("shake_hands_string_string",
+            []*exprpb.Type{decls.String, decls.String},
+            decls.String))
+    ... // Create env and compile.
 
     shakeFunc := &functions.Overload{
-		Operator: "shake_hands_string_string",
-		Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
-			return types.String(
-				fmt.Sprintf("%s and %s are shaking hands.\n", lhs, rhs))
+        Operator: "shake_hands_string_string",
+        Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
+            return types.String(
+                fmt.Sprintf("%s and %s are shaking hands.\n", lhs, rhs))
             }}
     prg, err := env.Program(c, cel.Functions(shakeFunc))
 
     out, _, err := prg.Eval(map[string]interface{}{
-		"i": "CEL",
-		"you": "world",
-	})
-	fmt.Println(out)
-	// Output:CEL and world are shaking hands.
+        "i": "CEL",
+        "you": "world",
+    })
+    fmt.Println(out)
+    // Output:CEL and world are shaking hands.
 ```
 
 [Source code](custom_global_function_test.go)

--- a/examples/custom_global_function_test.go
+++ b/examples/custom_global_function_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package examples
 
 import (
@@ -26,7 +40,7 @@ func ExampleCustomGlobalFunction() {
 	}
 	// Check iss for error in both Parse and Check.
 	ast, iss := env.Compile(`shake_hands(i,you)`)
-	if iss != nil && iss.Err() != nil {
+	if iss.Err() != nil {
 		log.Fatalln(iss.Err())
 	}
 	shakeFunc := &functions.Overload{

--- a/examples/custom_instance_function_test.go
+++ b/examples/custom_instance_function_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package examples
 
 import (
@@ -20,7 +34,7 @@ func ExampleCustomInstanceFunction() {
 	}
 	// Check iss for error in both Parse and Check.
 	ast, iss := env.Compile(`i.greet(you)`)
-	if iss != nil && iss.Err() != nil {
+	if iss.Err() != nil {
 		log.Fatalln(iss.Err())
 	}
 	prg, err := env.Program(ast)

--- a/examples/simple_test.go
+++ b/examples/simple_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package examples
 
 import (
@@ -14,13 +28,12 @@ func ExampleSimple() {
 	if err != nil {
 		log.Fatalf("environment creation error: %v\n", err)
 	}
-	// Check iss for error in both Parse and Check.
 	ast, iss := env.Compile(`"Hello world! I'm " + name + "."`)
-	if iss != nil && iss.Err() != nil {
+	// Check iss for compilation errors.
+	if iss.Err() != nil {
 		log.Fatalln(iss.Err())
 	}
 	prg, err := env.Program(ast)
-
 	out, _, err := prg.Eval(map[string]interface{}{
 		"name": "CEL",
 	})


### PR DESCRIPTION
This change ensures the `*Issues` response is always non-nil from the Parse / Check / Compile
calls. 

Examples have been updated to match, along with appropriate copyright notices attached.