### PR TITLE
Feature/decorators add

### DIFF
--- a/cel/options.go
+++ b/cel/options.go
@@ -250,3 +250,15 @@ func EvalOptions(opts ...EvalOption) ProgramOption {
 		return p, nil
 	}
 }
+
+// Decorators sets the decorator options which may affect the evaluation or Result.
+func Decorators(opts ...interpreter.InterpretableDecorator) ProgramOption {
+	return func(p *prog) (*prog, error) {
+		var decorators []interpreter.InterpretableDecorator
+		for _, opt := range opts {
+			decorators = append(decorators, opt)
+		}
+		p.decorators = decorators
+		return p, nil
+	}
+}

--- a/cel/program.go
+++ b/cel/program.go
@@ -97,6 +97,7 @@ type prog struct {
 	dispatcher    interpreter.Dispatcher
 	interpreter   interpreter.Interpreter
 	interpretable interpreter.Interpretable
+	decorators    []interpreter.InterpretableDecorator
 	attrFactory   interpreter.AttributeFactory
 }
 
@@ -147,6 +148,12 @@ func newProgram(e *Env, ast *Ast, opts []ProgramOption) (Program, error) {
 	// Enable constant folding first.
 	if p.evalOpts&OptOptimize == OptOptimize {
 		decorators = append(decorators, interpreter.Optimize())
+	}
+	// Add decorators from options
+	if len(p.decorators) != 0 {
+		for _, decorator := range p.decorators {
+			decorators = append(decorators, decorator)
+		}
 	}
 	// Enable exhaustive eval over state tracking since it offers a superset of features.
 	if p.evalOpts&OptExhaustiveEval == OptExhaustiveEval {

--- a/interpreter/attributes_test.go
+++ b/interpreter/attributes_test.go
@@ -89,9 +89,9 @@ func TestAttributes_RelativeAttr(t *testing.T) {
 	// }
 	//
 	// The expression being evaluated is: <map-literal>.a[-1][b] -> 42
-	op := &evalConst{
-		id:  1,
-		val: reg.NativeToValue(data),
+	op := &EvalConst{
+		Id:  1,
+		Val: reg.NativeToValue(data),
 	}
 	attr := attrs.RelativeAttribute(1, op)
 	qualA, _ := attrs.NewQualifier(nil, 2, "a")
@@ -134,9 +134,9 @@ func TestAttributes_RelativeAttr_OneOf(t *testing.T) {
 	// - <map-literal>.a[-1][acme.b]
 	//
 	// The correct behavior should yield the value of the last alternative.
-	op := &evalConst{
-		id:  1,
-		val: reg.NativeToValue(data),
+	op := &EvalConst{
+		Id:  1,
+		Val: reg.NativeToValue(data),
 	}
 	attr := attrs.RelativeAttribute(1, op)
 	qualA, _ := attrs.NewQualifier(nil, 2, "a")
@@ -176,9 +176,9 @@ func TestAttributes_RelativeAttr_Conditional(t *testing.T) {
 	// <map-literal>.a[-1][(false ? b : c)[0]] -> 42
 	//
 	// Effectively the same as saying <map-literal>.a[-1][c[0]]
-	cond := &evalConst{
-		id:  2,
-		val: types.False,
+	cond := &EvalConst{
+		Id:  2,
+		Val: types.False,
 	}
 	condAttr := attrs.ConditionalAttribute(4, cond,
 		attrs.AbsoluteAttribute(5, "b"),
@@ -186,9 +186,9 @@ func TestAttributes_RelativeAttr_Conditional(t *testing.T) {
 	qual0, _ := attrs.NewQualifier(nil, 7, 0)
 	condAttr.AddQualifier(qual0)
 
-	obj := &evalConst{
-		id:  1,
-		val: reg.NativeToValue(data),
+	obj := &EvalConst{
+		Id:  1,
+		Val: reg.NativeToValue(data),
 	}
 	attr := attrs.RelativeAttribute(1, obj)
 	qualA, _ := attrs.NewQualifier(nil, 2, "a")
@@ -247,13 +247,13 @@ func TestAttributes_RelativeAttr_Relative(t *testing.T) {
 	//
 	// This is equivalent to:
 	//   <obj>.a[-1]["second"] -> 2u
-	obj := &evalConst{
-		id:  1,
-		val: reg.NativeToValue(data),
+	obj := &EvalConst{
+		Id:  1,
+		Val: reg.NativeToValue(data),
 	}
-	mp := &evalConst{
-		id: 1,
-		val: reg.NativeToValue(map[uint32]interface{}{
+	mp := &EvalConst{
+		Id: 1,
+		Val: reg.NativeToValue(map[uint32]interface{}{
 			1: "first",
 			2: "second",
 			3: "third",
@@ -324,7 +324,7 @@ func TestAttributes_ConditionalAttr_TrueBranch(t *testing.T) {
 	fv := attrs.MaybeAttribute(3, "b")
 	qualC, _ := attrs.NewQualifier(nil, 4, "c")
 	fv.AddQualifier(qualC)
-	cond := attrs.ConditionalAttribute(1, &evalConst{val: types.True}, tv, fv)
+	cond := attrs.ConditionalAttribute(1, &EvalConst{Val: types.True}, tv, fv)
 	qualNeg1, _ := attrs.NewQualifier(nil, 5, int64(-1))
 	qual1, _ := attrs.NewQualifier(nil, 6, int64(1))
 	cond.AddQualifier(qualNeg1)
@@ -358,7 +358,7 @@ func TestAttributes_ConditionalAttr_FalseBranch(t *testing.T) {
 	fv := attrs.MaybeAttribute(3, "b")
 	qualC, _ := attrs.NewQualifier(nil, 4, "c")
 	fv.AddQualifier(qualC)
-	cond := attrs.ConditionalAttribute(1, &evalConst{val: types.False}, tv, fv)
+	cond := attrs.ConditionalAttribute(1, &EvalConst{Val: types.False}, tv, fv)
 	qualNeg1, _ := attrs.NewQualifier(nil, 5, int64(-1))
 	qual1, _ := attrs.NewQualifier(nil, 6, int64(1))
 	cond.AddQualifier(qualNeg1)
@@ -379,14 +379,14 @@ func TestAttributes_ConditionalAttr_ErrorUnknown(t *testing.T) {
 	// err ? a : b
 	tv := attrs.AbsoluteAttribute(2, "a")
 	fv := attrs.MaybeAttribute(3, "b")
-	cond := attrs.ConditionalAttribute(1, &evalConst{val: types.NewErr("test error")}, tv, fv)
+	cond := attrs.ConditionalAttribute(1, &EvalConst{Val: types.NewErr("test error")}, tv, fv)
 	out, err := cond.Resolve(EmptyActivation())
 	if err == nil {
 		t.Errorf("Got %v, wanted error", out)
 	}
 
 	// unk ? a : b
-	condUnk := attrs.ConditionalAttribute(1, &evalConst{val: types.Unknown{1}}, tv, fv)
+	condUnk := attrs.ConditionalAttribute(1, &EvalConst{Val: types.Unknown{1}}, tv, fv)
 	out, err = condUnk.Resolve(EmptyActivation())
 	if err != nil {
 		t.Fatal(err)

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -81,23 +81,23 @@ func (test *evalTestOnly) Eval(ctx Activation) ref.Val {
 
 }
 
-type evalConst struct {
-	id  int64
-	val ref.Val
+type EvalConst struct {
+	Id  int64
+	Val ref.Val
 }
 
 // ID implements the Interpretable interface method.
-func (cons *evalConst) ID() int64 {
-	return cons.id
+func (cons *EvalConst) ID() int64 {
+	return cons.Id
 }
 
 // Eval implements the Interpretable interface method.
-func (cons *evalConst) Eval(ctx Activation) ref.Val {
-	return cons.val
+func (cons *EvalConst) Eval(ctx Activation) ref.Val {
+	return cons.Val
 }
 
-func (cons *evalConst) Value() ref.Val {
-	return cons.val
+func (cons *EvalConst) Value() ref.Val {
+	return cons.Val
 }
 
 type evalOr struct {
@@ -278,7 +278,7 @@ func (un *evalUnary) Eval(ctx Activation) ref.Val {
 	return types.NewErr("no such overload: %s", un.function)
 }
 
-type evalBinary struct {
+type EvalBinary struct {
 	id       int64
 	function string
 	overload string
@@ -289,12 +289,12 @@ type evalBinary struct {
 }
 
 // ID implements the Interpretable interface method.
-func (bin *evalBinary) ID() int64 {
+func (bin *EvalBinary) ID() int64 {
 	return bin.id
 }
 
 // Eval implements the Interpretable interface method.
-func (bin *evalBinary) Eval(ctx Activation) ref.Val {
+func (bin *EvalBinary) Eval(ctx Activation) ref.Val {
 	lVal := bin.lhs.Eval(ctx)
 	rVal := bin.rhs.Eval(ctx)
 	// Early return if any argument to the function is unknown or error.
@@ -315,6 +315,21 @@ func (bin *evalBinary) Eval(ctx Activation) ref.Val {
 		return lVal.(traits.Receiver).Receive(bin.function, bin.overload, []ref.Val{rVal})
 	}
 	return types.NewErr("no such overload: %s", bin.function)
+}
+
+// Function returns the Binary Interpretable function.
+func (bin *EvalBinary) Function() string {
+	return bin.function
+}
+
+// Lhs returns the Binary Interpretable lhs.
+func (bin *EvalBinary) Lhs() Interpretable {
+	return bin.lhs
+}
+
+// Rhs returns the Binary Interpretable rhs.
+func (bin *EvalBinary) Rhs() Interpretable {
+	return bin.rhs
 }
 
 type evalVarArgs struct {
@@ -518,23 +533,28 @@ func (e *evalSetMembership) Eval(ctx Activation) ref.Val {
 	return types.False
 }
 
-// evalWatch is an Interpretable implementation that wraps the execution of a given
+// EvalWatch is an Interpretable implementation that wraps the execution of a given
 // expression so that it may observe the computed value and send it to an observer.
-type evalWatch struct {
+type EvalWatch struct {
 	inst     Interpretable
 	observer evalObserver
 }
 
 // ID implements the Interpretable interface method.
-func (e *evalWatch) ID() int64 {
+func (e *EvalWatch) ID() int64 {
 	return e.inst.ID()
 }
 
 // Eval implements the Interpretable interface method.
-func (e *evalWatch) Eval(ctx Activation) ref.Val {
+func (e *EvalWatch) Eval(ctx Activation) ref.Val {
 	val := e.inst.Eval(ctx)
 	e.observer(e.inst.ID(), val)
 	return val
+}
+
+// Inst implements the EvalWatch Interpretable.
+func (e *EvalWatch) Inst() Interpretable {
+	return e.inst
 }
 
 // evalWatchAttr describes a watcher of an instAttr Interpretable.

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -490,32 +490,32 @@ var (
 		},
 		{
 			name: "select_key",
-			expr: `m.strMap['val'] == 'string'
-				&& m.floatMap['val'] == 1.5
-				&& m.doubleMap['val'] == -2.0
-				&& m.intMap['val'] == -3
-				&& m.int32Map['val'] == 4
-				&& m.int64Map['val'] == -5
-				&& m.uintMap['val'] == 6u
-				&& m.uint32Map['val'] == 7u
-				&& m.uint64Map['val'] == 8u
-				&& m.boolMap['val'] == true
-				&& m.boolMap['val'] != false`,
+			expr: `m.strMap['Val'] == 'string'
+				&& m.floatMap['Val'] == 1.5
+				&& m.doubleMap['Val'] == -2.0
+				&& m.intMap['Val'] == -3
+				&& m.int32Map['Val'] == 4
+				&& m.int64Map['Val'] == -5
+				&& m.uintMap['Val'] == 6u
+				&& m.uint32Map['Val'] == 7u
+				&& m.uint64Map['Val'] == 8u
+				&& m.boolMap['Val'] == true
+				&& m.boolMap['Val'] != false`,
 			env: []*exprpb.Decl{
 				decls.NewIdent("m", decls.NewMapType(decls.String, decls.Dyn), nil),
 			},
 			in: map[string]interface{}{
 				"m": map[string]interface{}{
-					"strMap":    map[string]string{"val": "string"},
-					"floatMap":  map[string]float32{"val": 1.5},
-					"doubleMap": map[string]float64{"val": -2.0},
-					"intMap":    map[string]int{"val": -3},
-					"int32Map":  map[string]int32{"val": 4},
-					"int64Map":  map[string]int64{"val": -5},
-					"uintMap":   map[string]uint{"val": 6},
-					"uint32Map": map[string]uint32{"val": 7},
-					"uint64Map": map[string]uint64{"val": 8},
-					"boolMap":   map[string]bool{"val": true},
+					"strMap":    map[string]string{"Val": "string"},
+					"floatMap":  map[string]float32{"Val": 1.5},
+					"doubleMap": map[string]float64{"Val": -2.0},
+					"intMap":    map[string]int{"Val": -3},
+					"int32Map":  map[string]int32{"Val": 4},
+					"int64Map":  map[string]int64{"Val": -5},
+					"uintMap":   map[string]uint{"Val": 6},
+					"uint32Map": map[string]uint32{"Val": 7},
+					"uint64Map": map[string]uint64{"Val": 8},
+					"boolMap":   map[string]bool{"Val": true},
 				},
 			},
 		},

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -160,9 +160,9 @@ func (p *planner) planCheckedIdent(id int64, identRef *exprpb.Reference) (Interp
 		if !found {
 			return nil, fmt.Errorf("reference to undefined type: %s", identRef.Name)
 		}
-		return &evalConst{
-			id:  id,
-			val: cVal,
+		return &EvalConst{
+			Id:  id,
+			Val: cVal,
 		}, nil
 	}
 
@@ -369,7 +369,7 @@ func (p *planner) planCallBinary(expr *exprpb.Expr,
 		fn = impl.Binary
 		trait = impl.OperandTrait
 	}
-	return &evalBinary{
+	return &EvalBinary{
 		id:       expr.Id,
 		function: function,
 		overload: overload,
@@ -628,9 +628,9 @@ func (p *planner) planConst(expr *exprpb.Expr) (Interpretable, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &evalConst{
-		id:  expr.Id,
-		val: val,
+	return &EvalConst{
+		Id:  expr.Id,
+		Val: val,
 	}, nil
 }
 


### PR DESCRIPTION
## Add Decorators as Program Option 
1. Add cel.Decorators function to accept decorators as a Program 
2. Make EvalConst, EvalBinary, EvalWatch public visible so that they can be used in the decorators.