### PR TITLE
Fix issue with error and unknown propagation on complex type resolution.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.4 h1:87PNWwrRvUSnqS4dlcBU/ftvOIBep4sYuBLlh6rX2wk=
 github.com/google/cel-spec v0.3.0 h1:Dc+D/KBBmCJG5LJen9EBAzxkPsSnw2reo2LhMY1NLdI=
 github.com/google/cel-spec v0.3.0/go.mod h1:MjQm800JAGhOZXI7vatnVpmIaFTR6L8FHcKk+piiKpI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=

--- a/interpreter/BUILD.bazel
+++ b/interpreter/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
         "//test/proto2pb:go_default_library",
         "//test/proto3pb:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library",
         "@io_bazel_rules_go//proto/wkt:duration_go_proto",
         "@io_bazel_rules_go//proto/wkt:struct_go_proto",
         "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -860,5 +860,11 @@ func refResolve(adapter ref.TypeAdapter, idx ref.Val, obj interface{}) (ref.Val,
 		}
 		return elem, nil
 	}
+	if types.IsUnknown(celVal) {
+		return celVal, nil
+	}
+	if types.IsError(celVal) {
+		return nil, celVal.Value().(error)
+	}
 	return nil, errors.New("no such overload")
 }

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -863,6 +863,9 @@ func refResolve(adapter ref.TypeAdapter, idx ref.Val, obj interface{}) (ref.Val,
 	if types.IsUnknown(celVal) {
 		return celVal, nil
 	}
+	// TODO: If the types.Err value contains more than just an error message at some point in the
+	// future, then it would be reasonable to return error values as ref.Val types rather than
+	// simple go error types.
 	if types.IsError(celVal) {
 		return nil, celVal.Value().(error)
 	}

--- a/interpreter/attributes_test.go
+++ b/interpreter/attributes_test.go
@@ -17,6 +17,8 @@ package interpreter
 import (
 	"testing"
 
+	"github.com/golang/protobuf/ptypes"
+
 	"github.com/google/cel-go/common/packages"
 	"github.com/google/cel-go/common/types"
 
@@ -421,6 +423,49 @@ func TestResolver_CustomQualifier(t *testing.T) {
 	}
 	if out != int32(123) {
 		t.Errorf("Got %v, wanted 123", out)
+	}
+}
+
+func TestAttributes_MissingMsg(t *testing.T) {
+	reg := types.NewRegistry()
+	attrs := NewAttributeFactory(packages.DefaultPackage, reg, reg)
+	any, _ := ptypes.MarshalAny(&proto3pb.TestAllTypes{})
+	vars, _ := NewActivation(map[string]interface{}{
+		"missing_msg": any,
+	})
+
+	// missing_msg.field
+	attr := attrs.AbsoluteAttribute(1, "missing_msg")
+	field, _ := attrs.NewQualifier(nil, 2, "field")
+	attr.AddQualifier(field)
+	out, err := attr.Resolve(vars)
+	if err == nil {
+		t.Fatalf("got %v, wanted error", out)
+	}
+	if err.Error() != "unknown type: 'google.expr.proto3.test.TestAllTypes'" {
+		t.Fatalf("got %v, wanted unknown type: 'google.expr.proto3.test.TestAllTypes'", err)
+	}
+}
+
+func TestAttributes_MissingMsg__UnknownField(t *testing.T) {
+	reg := types.NewRegistry()
+	attrs := NewPartialAttributeFactory(packages.DefaultPackage, reg, reg)
+	any, _ := ptypes.MarshalAny(&proto3pb.TestAllTypes{})
+	vars, _ := NewPartialActivation(map[string]interface{}{
+		"missing_msg": any,
+	}, NewAttributePattern("missing_msg").QualString("field"))
+
+	// missing_msg.field
+	attr := attrs.AbsoluteAttribute(1, "missing_msg")
+	field, _ := attrs.NewQualifier(nil, 2, "field")
+	attr.AddQualifier(field)
+	out, err := attr.Resolve(vars)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, isUnk := out.(types.Unknown)
+	if !isUnk {
+		t.Errorf("got %v, wanted unknown value", out)
 	}
 }
 

--- a/interpreter/attributes_test.go
+++ b/interpreter/attributes_test.go
@@ -447,7 +447,7 @@ func TestAttributes_MissingMsg(t *testing.T) {
 	}
 }
 
-func TestAttributes_MissingMsg__UnknownField(t *testing.T) {
+func TestAttributes_MissingMsg_UnknownField(t *testing.T) {
 	reg := types.NewRegistry()
 	attrs := NewPartialAttributeFactory(packages.DefaultPackage, reg, reg)
 	any, _ := ptypes.MarshalAny(&proto3pb.TestAllTypes{})


### PR DESCRIPTION
The majority of the tests for attribute resolution deal with primitive types or declared message types. When the message has not been configured in the environment, an error was being swallowed during attribute resolution for the missing complex type, surfacing `no such overload` instead of the more appropriate error message.