### PR TITLE
Bug in type assignment check for maps with different value types.

### DIFF
--- a/checker/types.go
+++ b/checker/types.go
@@ -169,7 +169,7 @@ func isEqualOrLessSpecific(t1 *exprpb.Type, t2 *exprpb.Type) bool {
 		m1 := t1.GetMapType()
 		m2 := t2.GetMapType()
 		return isEqualOrLessSpecific(m1.KeyType, m2.KeyType) &&
-			isEqualOrLessSpecific(m1.KeyType, m2.KeyType)
+			isEqualOrLessSpecific(m1.ValueType, m2.ValueType)
 	case kindType:
 		return true
 	default:


### PR DESCRIPTION
Looks like a simple copy+paste error which resulted in skipping map value type specificity. 