### PR TITLE
Create an extension library for working with strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea
+.vscode
 bazel-bin
 bazel-cel-go
 bazel-genfiles

--- a/checker/standard.go
+++ b/checker/standard.go
@@ -362,7 +362,7 @@ func StandardDeclarations() []*exprpb.Decl {
 			decls.NewInstanceOverload(overloads.EndsWithString,
 				[]*exprpb.Type{decls.String, decls.String}, decls.Bool)),
 		decls.NewFunction(overloads.Matches,
-			decls.NewInstanceOverload(overloads.MatchString,
+			decls.NewInstanceOverload(overloads.MatchesString,
 				[]*exprpb.Type{decls.String, decls.String}, decls.Bool)),
 		decls.NewFunction(overloads.StartsWith,
 			decls.NewInstanceOverload(overloads.StartsWithString,

--- a/common/overloads/overloads.go
+++ b/common/overloads/overloads.go
@@ -128,7 +128,7 @@ const (
 const (
 	ContainsString   = "contains_string"
 	EndsWithString   = "ends_with_string"
-	MatchString      = "matches_string"
+	MatchesString    = "matches_string"
 	StartsWithString = "starts_with_string"
 )
 

--- a/common/types/err.go
+++ b/common/types/err.go
@@ -37,6 +37,17 @@ func NewErr(format string, args ...interface{}) ref.Val {
 	return &Err{fmt.Errorf(format, args...)}
 }
 
+// NoSuchOverloadErr returns a new types.Err instance with a no such overload message.
+func NoSuchOverloadErr() ref.Val {
+	return NewErr("no such overload")
+}
+
+// MaybeNoSuchOverloadErr returns the error or unknown if the input ref.Val is one of these types,
+// else a new no such overload error.
+func MaybeNoSuchOverloadErr(val ref.Val) ref.Val {
+	return ValOrErr(val, "no such overload")
+}
+
 // ValOrErr either returns the existing error or create a new one.
 // TODO: Audit the use of this function and standardize the error messages and codes.
 func ValOrErr(val ref.Val, format string, args ...interface{}) ref.Val {

--- a/ext/BUILD.bazel
+++ b/ext/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(
+    licenses = ["notice"],  # Apache 2.0
+)
+
+go_library(
+    name = "go_strings_library",
+    srcs = [
+        "strings.go",
+    ],
+    importpath = "github.com/google/cel-go/ext",
+    deps = [
+        "//cel:go_default_library",
+        "//checker/decls:go_default_library",
+        "//common/types:go_default_library",
+        "//common/types/ref:go_default_library",
+        "//interpreter/functions:go_default_library",
+        "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = [
+        "strings_test.go",
+    ],
+    embed = [
+        ":go_strings_library",
+    ],
+    deps = [
+        "//cel:go_default_library",
+    ],
+)

--- a/ext/strings.go
+++ b/ext/strings.go
@@ -31,6 +31,7 @@ import (
 )
 
 // Strings returns a cel.EnvOption to configure extended functions for string manipulation.
+// As a general note, all indices are zero-based.
 //
 // CharAt
 //

--- a/ext/strings.go
+++ b/ext/strings.go
@@ -27,6 +27,12 @@ import (
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
+// Strings returns a cel.EnvOption to configure extended string functions.
+//
+//
+//
+//
+//
 func Strings() cel.EnvOption {
 	return cel.Lib(stringLib{})
 }

--- a/ext/strings.go
+++ b/ext/strings.go
@@ -249,7 +249,7 @@ func (stringLib) ProgramOptions() []cel.ProgramOption {
 					if len(values) == 4 {
 						return wrappedReplaceN(values...)
 					}
-					return types.NewErr("no such overload")
+					return types.NoSuchOverloadErr()
 				},
 			},
 			&functions.Overload{
@@ -371,7 +371,7 @@ func callInStrOutStr(fn func(string) string) functions.UnaryOp {
 	return func(val ref.Val) ref.Val {
 		vVal, ok := val.(types.String)
 		if !ok {
-			return types.ValOrErr(val, "no such overload")
+			return types.MaybeNoSuchOverloadErr(val)
 		}
 		return types.String(fn(string(vVal)))
 	}
@@ -381,11 +381,11 @@ func callInStrIntOutStr(fn func(string, int64) (string, error)) functions.Binary
 	return func(val, arg ref.Val) ref.Val {
 		vVal, ok := val.(types.String)
 		if !ok {
-			return types.ValOrErr(val, "no such overload")
+			return types.MaybeNoSuchOverloadErr(val)
 		}
 		argVal, ok := arg.(types.Int)
 		if !ok {
-			return types.ValOrErr(arg, "no such overload")
+			return types.MaybeNoSuchOverloadErr(arg)
 		}
 		out, err := fn(string(vVal), int64(argVal))
 		if err != nil {
@@ -399,11 +399,11 @@ func callInStrStrOutInt(fn func(string, string) (int64, error)) functions.Binary
 	return func(val, arg ref.Val) ref.Val {
 		vVal, ok := val.(types.String)
 		if !ok {
-			return types.ValOrErr(val, "no such overload")
+			return types.MaybeNoSuchOverloadErr(val)
 		}
 		argVal, ok := arg.(types.String)
 		if !ok {
-			return types.ValOrErr(arg, "no such overload")
+			return types.MaybeNoSuchOverloadErr(arg)
 		}
 		out, err := fn(string(vVal), string(argVal))
 		if err != nil {
@@ -417,11 +417,11 @@ func callInStrStrOutListStr(fn func(string, string) ([]string, error)) functions
 	return func(val, arg ref.Val) ref.Val {
 		vVal, ok := val.(types.String)
 		if !ok {
-			return types.ValOrErr(val, "no such overload")
+			return types.MaybeNoSuchOverloadErr(val)
 		}
 		argVal, ok := arg.(types.String)
 		if !ok {
-			return types.ValOrErr(arg, "no such overload")
+			return types.MaybeNoSuchOverloadErr(arg)
 		}
 		out, err := fn(string(vVal), string(argVal))
 		if err != nil {
@@ -434,19 +434,19 @@ func callInStrStrOutListStr(fn func(string, string) ([]string, error)) functions
 func callInStrIntIntOutStr(fn func(string, int64, int64) (string, error)) functions.FunctionOp {
 	return func(args ...ref.Val) ref.Val {
 		if len(args) != 3 {
-			return types.NewErr("no such overload")
+			return types.NoSuchOverloadErr()
 		}
 		vVal, ok := args[0].(types.String)
 		if !ok {
-			return types.ValOrErr(args[0], "no such overload")
+			return types.MaybeNoSuchOverloadErr(args[0])
 		}
 		arg1Val, ok := args[1].(types.Int)
 		if !ok {
-			return types.ValOrErr(args[1], "no such overload")
+			return types.MaybeNoSuchOverloadErr(args[1])
 		}
 		arg2Val, ok := args[2].(types.Int)
 		if !ok {
-			return types.ValOrErr(args[2], "no such overload")
+			return types.MaybeNoSuchOverloadErr(args[2])
 		}
 		out, err := fn(string(vVal), int64(arg1Val), int64(arg2Val))
 		if err != nil {
@@ -459,19 +459,19 @@ func callInStrIntIntOutStr(fn func(string, int64, int64) (string, error)) functi
 func callInStrStrStrOutStr(fn func(string, string, string) (string, error)) functions.FunctionOp {
 	return func(args ...ref.Val) ref.Val {
 		if len(args) != 3 {
-			return types.NewErr("no such overload")
+			return types.NoSuchOverloadErr()
 		}
 		vVal, ok := args[0].(types.String)
 		if !ok {
-			return types.ValOrErr(args[0], "no such overload")
+			return types.MaybeNoSuchOverloadErr(args[0])
 		}
 		arg1Val, ok := args[1].(types.String)
 		if !ok {
-			return types.ValOrErr(args[1], "no such overload")
+			return types.MaybeNoSuchOverloadErr(args[1])
 		}
 		arg2Val, ok := args[2].(types.String)
 		if !ok {
-			return types.ValOrErr(args[2], "no such overload")
+			return types.MaybeNoSuchOverloadErr(args[2])
 		}
 		out, err := fn(string(vVal), string(arg1Val), string(arg2Val))
 		if err != nil {
@@ -484,19 +484,19 @@ func callInStrStrStrOutStr(fn func(string, string, string) (string, error)) func
 func callInStrStrIntOutInt(fn func(string, string, int64) (int64, error)) functions.FunctionOp {
 	return func(args ...ref.Val) ref.Val {
 		if len(args) != 3 {
-			return types.NewErr("no such overload")
+			return types.NoSuchOverloadErr()
 		}
 		vVal, ok := args[0].(types.String)
 		if !ok {
-			return types.ValOrErr(args[0], "no such overload")
+			return types.MaybeNoSuchOverloadErr(args[0])
 		}
 		arg1Val, ok := args[1].(types.String)
 		if !ok {
-			return types.ValOrErr(args[1], "no such overload")
+			return types.MaybeNoSuchOverloadErr(args[1])
 		}
 		arg2Val, ok := args[2].(types.Int)
 		if !ok {
-			return types.ValOrErr(args[2], "no such overload")
+			return types.MaybeNoSuchOverloadErr(args[2])
 		}
 		out, err := fn(string(vVal), string(arg1Val), int64(arg2Val))
 		if err != nil {
@@ -509,19 +509,19 @@ func callInStrStrIntOutInt(fn func(string, string, int64) (int64, error)) functi
 func callInStrStrIntOutListStr(fn func(string, string, int64) ([]string, error)) functions.FunctionOp {
 	return func(args ...ref.Val) ref.Val {
 		if len(args) != 3 {
-			return types.NewErr("no such overload")
+			return types.NoSuchOverloadErr()
 		}
 		vVal, ok := args[0].(types.String)
 		if !ok {
-			return types.ValOrErr(args[0], "no such overload")
+			return types.MaybeNoSuchOverloadErr(args[0])
 		}
 		arg1Val, ok := args[1].(types.String)
 		if !ok {
-			return types.ValOrErr(args[1], "no such overload")
+			return types.MaybeNoSuchOverloadErr(args[1])
 		}
 		arg2Val, ok := args[2].(types.Int)
 		if !ok {
-			return types.ValOrErr(args[2], "no such overload")
+			return types.MaybeNoSuchOverloadErr(args[2])
 		}
 		out, err := fn(string(vVal), string(arg1Val), int64(arg2Val))
 		if err != nil {
@@ -534,23 +534,23 @@ func callInStrStrIntOutListStr(fn func(string, string, int64) ([]string, error))
 func callInStrStrStrIntOutStr(fn func(string, string, string, int64) (string, error)) functions.FunctionOp {
 	return func(args ...ref.Val) ref.Val {
 		if len(args) != 4 {
-			return types.NewErr("no such overload")
+			return types.NoSuchOverloadErr()
 		}
 		vVal, ok := args[0].(types.String)
 		if !ok {
-			return types.ValOrErr(args[0], "no such overload")
+			return types.MaybeNoSuchOverloadErr(args[0])
 		}
 		arg1Val, ok := args[1].(types.String)
 		if !ok {
-			return types.ValOrErr(args[1], "no such overload")
+			return types.MaybeNoSuchOverloadErr(args[1])
 		}
 		arg2Val, ok := args[2].(types.String)
 		if !ok {
-			return types.ValOrErr(args[2], "no such overload")
+			return types.MaybeNoSuchOverloadErr(args[2])
 		}
 		arg3Val, ok := args[3].(types.Int)
 		if !ok {
-			return types.ValOrErr(args[3], "no such overload")
+			return types.MaybeNoSuchOverloadErr(args[3])
 		}
 		out, err := fn(string(vVal), string(arg1Val), string(arg2Val), int64(arg3Val))
 		if err != nil {

--- a/ext/strings.go
+++ b/ext/strings.go
@@ -1,0 +1,570 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ext
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/interpreter/functions"
+
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+func Strings() cel.EnvOption {
+	return cel.Lib(stringLib{})
+}
+
+type stringLib struct{}
+
+func (stringLib) CompileOptions() []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Declarations(
+			decls.NewFunction("after",
+				decls.NewInstanceOverload("string_after_string",
+					[]*exprpb.Type{decls.String, decls.String},
+					decls.String),
+				decls.NewInstanceOverload("string_after_string_int",
+					[]*exprpb.Type{decls.String, decls.String, decls.Int},
+					decls.String)),
+			decls.NewFunction("before",
+				decls.NewInstanceOverload("string_before_string",
+					[]*exprpb.Type{decls.String, decls.String},
+					decls.String),
+				decls.NewInstanceOverload("string_before_string_int",
+					[]*exprpb.Type{decls.String, decls.String, decls.Int},
+					decls.String)),
+			decls.NewFunction("charAt",
+				decls.NewInstanceOverload("string_char_at_int",
+					[]*exprpb.Type{decls.String, decls.Int},
+					decls.String)),
+			decls.NewFunction("indexOf",
+				decls.NewInstanceOverload("string_index_of_string",
+					[]*exprpb.Type{decls.String, decls.String},
+					decls.Int),
+				decls.NewInstanceOverload("string_index_of_string_int",
+					[]*exprpb.Type{decls.String, decls.String, decls.Int},
+					decls.Int)),
+			decls.NewFunction("lower",
+				decls.NewInstanceOverload("string_lower",
+					[]*exprpb.Type{decls.String},
+					decls.String)),
+			decls.NewFunction("replace",
+				decls.NewInstanceOverload("string_replace_string_string",
+					[]*exprpb.Type{decls.String, decls.String, decls.String},
+					decls.String),
+				decls.NewInstanceOverload("string_replace_string_string_int",
+					[]*exprpb.Type{decls.String, decls.String, decls.String, decls.Int},
+					decls.String)),
+			decls.NewFunction("split",
+				decls.NewInstanceOverload("string_split_string",
+					[]*exprpb.Type{decls.String, decls.String},
+					decls.NewListType(decls.String)),
+				decls.NewInstanceOverload("string_split_string_int",
+					[]*exprpb.Type{decls.String, decls.String, decls.Int},
+					decls.NewListType(decls.String))),
+			decls.NewFunction("substring",
+				decls.NewInstanceOverload("string_substring_int",
+					[]*exprpb.Type{decls.String, decls.Int},
+					decls.String),
+				decls.NewInstanceOverload("string_substring_int_int",
+					[]*exprpb.Type{decls.String, decls.Int, decls.Int},
+					decls.String)),
+			decls.NewFunction("trim",
+				decls.NewInstanceOverload("string_trim",
+					[]*exprpb.Type{decls.String},
+					decls.String)),
+			decls.NewFunction("upper",
+				decls.NewInstanceOverload("string_upper",
+					[]*exprpb.Type{decls.String},
+					decls.String)),
+		),
+	}
+}
+
+func (stringLib) ProgramOptions() []cel.ProgramOption {
+	wrappedReplace := callInStrStrStrOutStr(replace)
+	wrappedReplaceN := callInStrStrStrIntOutStr(replaceN)
+	return []cel.ProgramOption{
+		cel.Functions(
+			&functions.Overload{
+				Operator: "after",
+				Binary:   callInStrStrOutStr(after),
+				Function: callInStrStrIntOutStr(afterOffset),
+			},
+			&functions.Overload{
+				Operator: "string_after_stirng",
+				Binary:   callInStrStrOutStr(after),
+			},
+			&functions.Overload{
+				Operator: "string_after_string_int",
+				Function: callInStrStrIntOutStr(afterOffset),
+			},
+			&functions.Overload{
+				Operator: "before",
+				Binary:   callInStrStrOutStr(before),
+				Function: callInStrStrIntOutStr(beforeOffset),
+			},
+			&functions.Overload{
+				Operator: "string_before_string",
+				Binary:   callInStrStrOutStr(before),
+			},
+			&functions.Overload{
+				Operator: "string_before_string_int",
+				Function: callInStrStrIntOutStr(beforeOffset),
+			},
+			&functions.Overload{
+				Operator: "charAt",
+				Binary:   callInStrIntOutStr(charAt),
+			},
+			&functions.Overload{
+				Operator: "string_chat_at_int",
+				Binary:   callInStrIntOutStr(charAt),
+			},
+			&functions.Overload{
+				Operator: "indexOf",
+				Binary:   callInStrStrOutInt(indexOf),
+				Function: callInStrStrIntOutInt(indexOfOffset),
+			},
+			&functions.Overload{
+				Operator: "string_index_of_string",
+				Binary:   callInStrStrOutInt(indexOf),
+			},
+			&functions.Overload{
+				Operator: "string_index_of_string_int",
+				Function: callInStrStrIntOutInt(indexOfOffset),
+			},
+			&functions.Overload{
+				Operator: "lower",
+				Unary:    callInStrOutStr(lower),
+			},
+			&functions.Overload{
+				Operator: "string_lower",
+				Unary:    callInStrOutStr(lower),
+			},
+			&functions.Overload{
+				Operator: "replace",
+				Function: func(values ...ref.Val) ref.Val {
+					if len(values) == 3 {
+						return wrappedReplace(values...)
+					}
+					if len(values) == 4 {
+						return wrappedReplaceN(values...)
+					}
+					return types.NewErr("no such overload")
+				},
+			},
+			&functions.Overload{
+				Operator: "string_replace_string_string",
+				Function: wrappedReplace,
+			},
+			&functions.Overload{
+				Operator: "string_replace_string_string_int",
+				Function: wrappedReplaceN,
+			},
+			&functions.Overload{
+				Operator: "split",
+				Binary:   callInStrStrOutListStr(split),
+				Function: callInStrStrIntOutListStr(splitN),
+			},
+			&functions.Overload{
+				Operator: "string_split_string",
+				Binary:   callInStrStrOutListStr(split),
+			},
+			&functions.Overload{
+				Operator: "string_split_string_int",
+				Function: callInStrStrIntOutListStr(splitN),
+			},
+			&functions.Overload{
+				Operator: "substring",
+				Binary:   callInStrIntOutStr(substr),
+				Function: callInStrIntIntOutStr(substrRange),
+			},
+			&functions.Overload{
+				Operator: "string_substring_int",
+				Binary:   callInStrIntOutStr(substr),
+			},
+			&functions.Overload{
+				Operator: "string_substring_int_int",
+				Function: callInStrIntIntOutStr(substrRange),
+			},
+			&functions.Overload{
+				Operator: "trim",
+				Unary:    callInStrOutStr(trim),
+			},
+			&functions.Overload{
+				Operator: "string_trim",
+				Unary:    callInStrOutStr(trim),
+			},
+			&functions.Overload{
+				Operator: "upper",
+				Unary:    callInStrOutStr(upper),
+			},
+			&functions.Overload{
+				Operator: "string_upper",
+				Unary:    callInStrOutStr(upper),
+			},
+		),
+	}
+}
+
+func after(str, sub string) (string, error) {
+	ind := strings.Index(str, sub)
+	if ind < 0 {
+		return "", nil
+	}
+	return str[ind+len(sub):], nil
+}
+
+func afterOffset(str, sub string, ind int64) (string, error) {
+	i := int(ind)
+	if i >= len(str) {
+		return "", fmt.Errorf("index out of range: %d", ind)
+	}
+	return after(str[i:], sub)
+}
+
+func before(str, sub string) (string, error) {
+	ind := strings.Index(str, sub)
+	if ind < 0 {
+		return str, nil
+	}
+	return str[:ind], nil
+}
+
+func beforeOffset(str, sub string, ind int64) (string, error) {
+	i := int(ind)
+	if i >= len(str) {
+		return "", fmt.Errorf("index out of range: %d", ind)
+	}
+	out, err := before(str[i:], sub)
+	if err != nil {
+		return "", err
+	}
+	return str[:i] + out, nil
+}
+
+func charAt(str string, ind int64) (string, error) {
+	i := int(ind)
+	if i >= len(str) {
+		return "", fmt.Errorf("index out of range: %d", ind)
+	}
+	return str[i : i+1], nil
+}
+
+func indexOf(str, substr string) (int64, error) {
+	return int64(strings.Index(str, substr)), nil
+}
+
+func indexOfOffset(str, substr string, offset int64) (int64, error) {
+	off := int(offset)
+	if off >= len(str) {
+		return -1, fmt.Errorf("index out of range: %d", off)
+	}
+	return offset + int64(strings.Index(str[offset:], substr)), nil
+}
+
+func lower(str string) (string, error) {
+	return strings.ToLower(str), nil
+}
+
+func replace(str, old, new string) (string, error) {
+	return strings.ReplaceAll(str, old, new), nil
+}
+
+func replaceN(str, old, new string, n int64) (string, error) {
+	return strings.Replace(str, old, new, int(n)), nil
+}
+
+func split(str, sep string) ([]string, error) {
+	return strings.Split(str, sep), nil
+}
+
+func splitN(str, sep string, n int64) ([]string, error) {
+	return strings.SplitN(str, sep, int(n)), nil
+}
+
+func substr(str string, start int64) (string, error) {
+	if int(start) >= len(str) {
+		return "", fmt.Errorf("index out of range: %d", start)
+	}
+	return str[int(start):], nil
+}
+
+func substrRange(str string, start, end int64) (string, error) {
+	l := len(str)
+	if start > end {
+		return "", fmt.Errorf("invalid substring range. start: %d, end: %d", start, end)
+	}
+	if int(start) >= l {
+		return "", fmt.Errorf("index out of range: %d", start)
+	}
+	if int(end) >= l {
+		return "", fmt.Errorf("index out of range: %d", end)
+	}
+	return str[int(start):int(end)], nil
+}
+
+func trim(str string) (string, error) {
+	return strings.TrimSpace(str), nil
+}
+
+func upper(str string) (string, error) {
+	return strings.ToUpper(str), nil
+}
+
+func callInStrOutStr(fn func(string) (string, error)) functions.UnaryOp {
+	return func(val ref.Val) ref.Val {
+		vVal, ok := val.(types.String)
+		if !ok {
+			return types.ValOrErr(val, "no such overload")
+		}
+		out, err := fn(string(vVal))
+		if err != nil {
+			return types.NewErr(err.Error())
+		}
+		return types.String(out)
+	}
+}
+
+func callInStrIntOutStr(fn func(string, int64) (string, error)) functions.BinaryOp {
+	return func(val, arg ref.Val) ref.Val {
+		vVal, ok := val.(types.String)
+		if !ok {
+			return types.ValOrErr(val, "no such overload")
+		}
+		argVal, ok := arg.(types.Int)
+		if !ok {
+			return types.ValOrErr(arg, "no such overload")
+		}
+		out, err := fn(string(vVal), int64(argVal))
+		if err != nil {
+			return types.NewErr(err.Error())
+		}
+		return types.String(out)
+	}
+}
+
+func callInStrStrOutInt(fn func(string, string) (int64, error)) functions.BinaryOp {
+	return func(val, arg ref.Val) ref.Val {
+		vVal, ok := val.(types.String)
+		if !ok {
+			return types.ValOrErr(val, "no such overload")
+		}
+		argVal, ok := arg.(types.String)
+		if !ok {
+			return types.ValOrErr(arg, "no such overload")
+		}
+		out, err := fn(string(vVal), string(argVal))
+		if err != nil {
+			return types.NewErr(err.Error())
+		}
+		return types.Int(out)
+	}
+}
+
+func callInStrStrOutStr(fn func(string, string) (string, error)) functions.BinaryOp {
+	return func(val, arg ref.Val) ref.Val {
+		vVal, ok := val.(types.String)
+		if !ok {
+			return types.ValOrErr(val, "no such overload")
+		}
+		argVal, ok := arg.(types.String)
+		if !ok {
+			return types.ValOrErr(arg, "no such overload")
+		}
+		out, err := fn(string(vVal), string(argVal))
+		if err != nil {
+			return types.NewErr(err.Error())
+		}
+		return types.String(out)
+	}
+}
+
+func callInStrStrOutListStr(fn func(string, string) ([]string, error)) functions.BinaryOp {
+	return func(val, arg ref.Val) ref.Val {
+		vVal, ok := val.(types.String)
+		if !ok {
+			return types.ValOrErr(val, "no such overload")
+		}
+		argVal, ok := arg.(types.String)
+		if !ok {
+			return types.ValOrErr(arg, "no such overload")
+		}
+		out, err := fn(string(vVal), string(argVal))
+		if err != nil {
+			return types.NewErr(err.Error())
+		}
+		return types.DefaultTypeAdapter.NativeToValue(out)
+	}
+}
+
+func callInStrIntIntOutStr(fn func(string, int64, int64) (string, error)) functions.FunctionOp {
+	return func(args ...ref.Val) ref.Val {
+		if len(args) != 3 {
+			return types.NewErr("no such overload")
+		}
+		vVal, ok := args[0].(types.String)
+		if !ok {
+			return types.ValOrErr(args[0], "no such overload")
+		}
+		arg1Val, ok := args[1].(types.Int)
+		if !ok {
+			return types.ValOrErr(args[1], "no such overload")
+		}
+		arg2Val, ok := args[2].(types.Int)
+		if !ok {
+			return types.ValOrErr(args[2], "no such overload")
+		}
+		out, err := fn(string(vVal), int64(arg1Val), int64(arg2Val))
+		if err != nil {
+			return types.NewErr(err.Error())
+		}
+		return types.String(out)
+	}
+}
+
+func callInStrStrIntOutStr(fn func(string, string, int64) (string, error)) functions.FunctionOp {
+	return func(args ...ref.Val) ref.Val {
+		if len(args) != 3 {
+			return types.NewErr("no such overload")
+		}
+		vVal, ok := args[0].(types.String)
+		if !ok {
+			return types.ValOrErr(args[0], "no such overload")
+		}
+		arg1Val, ok := args[1].(types.String)
+		if !ok {
+			return types.ValOrErr(args[1], "no such overload")
+		}
+		arg2Val, ok := args[2].(types.Int)
+		if !ok {
+			return types.ValOrErr(args[2], "no such overload")
+		}
+		out, err := fn(string(vVal), string(arg1Val), int64(arg2Val))
+		if err != nil {
+			return types.NewErr(err.Error())
+		}
+		return types.String(out)
+	}
+}
+
+func callInStrStrStrOutStr(fn func(string, string, string) (string, error)) functions.FunctionOp {
+	return func(args ...ref.Val) ref.Val {
+		if len(args) != 3 {
+			return types.NewErr("no such overload")
+		}
+		vVal, ok := args[0].(types.String)
+		if !ok {
+			return types.ValOrErr(args[0], "no such overload")
+		}
+		arg1Val, ok := args[1].(types.String)
+		if !ok {
+			return types.ValOrErr(args[1], "no such overload")
+		}
+		arg2Val, ok := args[2].(types.String)
+		if !ok {
+			return types.ValOrErr(args[2], "no such overload")
+		}
+		out, err := fn(string(vVal), string(arg1Val), string(arg2Val))
+		if err != nil {
+			return types.NewErr(err.Error())
+		}
+		return types.String(out)
+	}
+}
+
+func callInStrStrIntOutInt(fn func(string, string, int64) (int64, error)) functions.FunctionOp {
+	return func(args ...ref.Val) ref.Val {
+		if len(args) != 3 {
+			return types.NewErr("no such overload")
+		}
+		vVal, ok := args[0].(types.String)
+		if !ok {
+			return types.ValOrErr(args[0], "no such overload")
+		}
+		arg1Val, ok := args[1].(types.String)
+		if !ok {
+			return types.ValOrErr(args[1], "no such overload")
+		}
+		arg2Val, ok := args[2].(types.Int)
+		if !ok {
+			return types.ValOrErr(args[2], "no such overload")
+		}
+		out, err := fn(string(vVal), string(arg1Val), int64(arg2Val))
+		if err != nil {
+			return types.NewErr(err.Error())
+		}
+		return types.Int(out)
+	}
+}
+
+func callInStrStrIntOutListStr(fn func(string, string, int64) ([]string, error)) functions.FunctionOp {
+	return func(args ...ref.Val) ref.Val {
+		if len(args) != 3 {
+			return types.NewErr("no such overload")
+		}
+		vVal, ok := args[0].(types.String)
+		if !ok {
+			return types.ValOrErr(args[0], "no such overload")
+		}
+		arg1Val, ok := args[1].(types.String)
+		if !ok {
+			return types.ValOrErr(args[1], "no such overload")
+		}
+		arg2Val, ok := args[2].(types.Int)
+		if !ok {
+			return types.ValOrErr(args[2], "no such overload")
+		}
+		out, err := fn(string(vVal), string(arg1Val), int64(arg2Val))
+		if err != nil {
+			return types.NewErr(err.Error())
+		}
+		return types.DefaultTypeAdapter.NativeToValue(out)
+	}
+}
+
+func callInStrStrStrIntOutStr(fn func(string, string, string, int64) (string, error)) functions.FunctionOp {
+	return func(args ...ref.Val) ref.Val {
+		if len(args) != 4 {
+			return types.NewErr("no such overload")
+		}
+		vVal, ok := args[0].(types.String)
+		if !ok {
+			return types.ValOrErr(args[0], "no such overload")
+		}
+		arg1Val, ok := args[1].(types.String)
+		if !ok {
+			return types.ValOrErr(args[1], "no such overload")
+		}
+		arg2Val, ok := args[2].(types.String)
+		if !ok {
+			return types.ValOrErr(args[2], "no such overload")
+		}
+		arg3Val, ok := args[3].(types.Int)
+		if !ok {
+			return types.ValOrErr(args[3], "no such overload")
+		}
+		out, err := fn(string(vVal), string(arg1Val), string(arg2Val), int64(arg3Val))
+		if err != nil {
+			return types.NewErr(err.Error())
+		}
+		return types.String(out)
+	}
+}

--- a/ext/strings.go
+++ b/ext/strings.go
@@ -37,24 +37,24 @@ import (
 // Given the target string and a search string, return the substring that occurs after the search
 // string, or empty string if no match is found:
 //
-//		<string>.after(<string>) -> <string>
+//     <string>.after(<string>) -> <string>
 //
 // Examples:
 //
-//      'dragon'.after('taco')  // returns ''
-//      'tacocat'.after('taco') // returns 'cat'
+//     'dragon'.after('taco')  // returns ''
+//     'tacocat'.after('taco') // returns 'cat'
 //
 // Before
 //
 // Given the target string and a search string, return the substring that occurs before the search
 // string, or the target string if no match is found:
 //
-//		<string>.before(<string>) -> <string>
+//     <string>.before(<string>) -> <string>
 //
 // Examples:
 //
-// 		'dragon'.before('taco') // returns 'dragon'
-//		'tacocat'.before('cat') // returns 'taco'
+//     'dragon'.before('taco') // returns 'dragon'
+//     'tacocat'.before('cat') // returns 'taco'
 //
 // CharAt
 //
@@ -62,38 +62,38 @@ import (
 // length of the string, the function will produce an error. CharAt is an instance method with the
 // following signature:
 //
-//		<string>.charAt(<int>) -> <string>
+//     <string>.charAt(<int>) -> <string>
 //
 // Examples:
 //
-//		'hello'.charAt(4)  // return 'o'
-//      'hello'.charAt(-1) // error
-//      'hello'.charAt(5)  // error
+//     'hello'.charAt(4)  // return 'o'
+//     'hello'.charAt(-1) // error
+//     'hello'.charAt(5)  // error
 //
 // IndexOf
 //
 // Returns the integer index of the search string if found, or -1 if not found. Accepts an optional
 // index from which to start the search:
 //
-//		<string>.indexOf(<string>) -> <int>
-//		<string>.indexOf(<string>, <int>) -> <int>
+//     <string>.indexOf(<string>) -> <int>
+//     <string>.indexOf(<string>, <int>) -> <int>
 //
 // Examples:
 //
-//		'hello mellow'.indexOf('ello')     // returns 1
-//		'hello mellow'.indexOf('jello')    // returns -1
-//		'hello mellow'.indexOf('ello', 2)  // returns 7
-//		'hello mellow'.indexOf('ello', 20) // error
+//     'hello mellow'.indexOf('ello')     // returns 1
+//     'hello mellow'.indexOf('jello')    // returns -1
+//     'hello mellow'.indexOf('ello', 2)  // returns 7
+//     'hello mellow'.indexOf('ello', 20) // error
 //
 // Lower
 //
 // Return a new lowercase version of the target string:
 //
-//		<string>.lower() -> <string>
+//     <string>.lower() -> <string>
 //
 // Examples:
 //
-//		'User-Agent'.lower() // returns 'user-agent'
+//     'User-Agent'.lower() // returns 'user-agent'
 //
 // Replace
 //
@@ -101,31 +101,31 @@ import (
 // with a replacement string if present. Accepts an optional argument specifying a limit on the
 // number of substring replacements to be made:
 //
-//		<string>.replace(<string>, <string>) -> <string>
-//		<string>.replace(<string>, <string>, <int>) -> <string>
+//     <string>.replace(<string>, <string>) -> <string>
+//     <string>.replace(<string>, <string>, <int>) -> <string>
 //
 // Examples:
 //
-//		'hello hello'.replace('he', 'we')    // returns 'wello wello'
-//		'hello hello'.replace('he', 'we', 1) // returns 'wello hello'
-//		'hello hello'.replace('he', 'we', 0) // returns 'hello wello'
-//		'hello hello'.replace('he', 'we', -1) // returns 'wello wello'
+//     'hello hello'.replace('he', 'we')    // returns 'wello wello'
+//     'hello hello'.replace('he', 'we', 1) // returns 'wello hello'
+//     'hello hello'.replace('he', 'we', 0) // returns 'hello wello'
+//     'hello hello'.replace('he', 'we', -1) // returns 'wello wello'
 //
 // Split
 //
 // Produces a list of strings which were split from the input by the given seperator. Accepts an
 // optional argument specifying a limit on the number of substrings produced by the split:
 //
-// 		<string>.split(<string>) -> <list<string>>
-// 		<string>.split(<string>, <int>) -> <list<string>>
+//     <string>.split(<string>) -> <list<string>>
+//     <string>.split(<string>, <int>) -> <list<string>>
 //
 // Examples:
 //
-//		'hello hello hello'.split(' ')     // returns ['hello', 'hello', 'hello']
-//		'hello hello hello'.split(' ', 0)  // returns []
-//		'hello hello hello'.split(' ', 1)  // returns ['hello hello hello']
-//		'hello hello hello'.split(' ', 2)  // returns ['hello', 'hello hello']
-//		'hello hello hello'.split(' ', -1) // returns ['hello', 'hello', 'hello']
+//     'hello hello hello'.split(' ')     // returns ['hello', 'hello', 'hello']
+//     'hello hello hello'.split(' ', 0)  // returns []
+//     'hello hello hello'.split(' ', 1)  // returns ['hello hello hello']
+//     'hello hello hello'.split(' ', 2)  // returns ['hello', 'hello hello']
+//     'hello hello hello'.split(' ', -1) // returns ['hello', 'hello', 'hello']
 //
 // Substring
 //
@@ -133,15 +133,15 @@ import (
 // may omit the trailing range for a substring from a given character position until the end of
 // a string:
 //
-// 		<string>.substring(<int>) -> <string>
-//		<string>.substring(<int>, <int>) -> <string>
+//     <string>.substring(<int>) -> <string>
+//     <string>.substring(<int>, <int>) -> <string>
 //
 // Examples:
 //
-// 		'tacocat'.substring(4)    // returns 'cat'
-//		'tacocat'.substring(0, 4) // returns 'taco'
-//		'tacocat'.substring(-1)   // error
-//		'tacocat'.substring(2, 1) // error
+//     'tacocat'.substring(4)    // returns 'cat'
+//     'tacocat'.substring(0, 4) // returns 'taco'
+//     'tacocat'.substring(-1)   // error
+//     'tacocat'.substring(2, 1) // error
 //
 // Trim
 //
@@ -151,17 +151,17 @@ import (
 //
 // Examples:
 //
-//		'    trim    '.trim() // returns 'trim'
+//     '    trim    '.trim() // returns 'trim'
 //
 // Upper
 //
 // Returns a new uppercase version of the target string:
 //
-//		<string>.upper() -> <string>
+//     <string>.upper() -> <string>
 //
 // Examples:
 //
-//		'Constant'.upper() // returns 'CONSTANT'
+//     'Constant'.upper() // returns 'CONSTANT'
 func Strings() cel.EnvOption {
 	return cel.Lib(stringLib{})
 }

--- a/ext/strings.go
+++ b/ext/strings.go
@@ -48,30 +48,38 @@ import (
 // IndexOf
 //
 // Returns the integer index of the first occurrence of the search string. If the search string is
-// not found the function returns -1. The function also accepts an optional index from which to
-// begin the substring search:
+// not found the function returns -1.
+//
+// The function also accepts an optional index from which to begin the substring search. If the
+// substring is the empty string, the index where the search starts is returned (zero or custom).
 //
 //     <string>.indexOf(<string>) -> <int>
 //     <string>.indexOf(<string>, <int>) -> <int>
 //
 // Examples:
 //
+//     'hello mellow'.indexOf('')         // returns 0
 //     'hello mellow'.indexOf('ello')     // returns 1
 //     'hello mellow'.indexOf('jello')    // returns -1
+//     'hello mellow'.indexOf('', 2)      // returns 2
 //     'hello mellow'.indexOf('ello', 2)  // returns 7
 //     'hello mellow'.indexOf('ello', 20) // error
 //
 // LastIndexOf
 //
 // Returns the integer index of the last occurrence of the search string. If the search string is
-// not found the function returns -1. The function also accepts an optional index which represents
-// where to end the search.
+// not found the function returns -1.
+//
+// The function also accepts an optional index which represents where to begin the search in
+// through the string. If the substring is the empty string, the index where the search starts
+// is returned (string length or custom).
 //
 //     <string>.lastIndexOf(<string>) -> <int>
 //     <string>.lastIndexOf(<string>, <int>) -> <int>
 //
 // Examples:
 //
+//     'hello mellow'.lastIndexOf('')         // returns 12
 //     'hello mellow'.lastIndexOf('ello')     // returns 7
 //     'hello mellow'.lastIndexOf('jello')    // returns -1
 //     'hello mellow'.lastIndexOf('ello', 8)  // returns 2

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ext
 
 import (
@@ -8,82 +22,108 @@ import (
 )
 
 var stringTests = []struct {
-	expr string
-	err  string
+	expr      string
+	err       string
+	parseOnly bool
 }{
-	{
-		expr: `'hello'.after('l') == 'lo'`,
-	},
-	{
-		expr: `'hello'.after('l', 3) == 'o'`,
-	},
-	{
-		expr: `'hello'.after('none') == ''`,
-	},
+	// Success test cases.
+	{expr: `'hello'.after('l') == 'lo'`},
+	{expr: `'hello'.after('l', 3) == 'o'`},
+	{expr: `'hello'.after('none') == ''`},
+	{expr: `'tacocat'.before('c') == 'ta'`},
+	{expr: `'tacocat'.before('c', 3) == 'taco'`},
+	{expr: `'tacocat'.before('none') == 'tacocat'`},
+	{expr: `'tacocat'.charAt(3) == 'o'`},
+	{expr: `'tacocat'.indexOf('a') == 1`},
+	{expr: `'tacocat'.indexOf('a', 3) == 5`},
+	{expr: `'tacocat'.indexOf('none') == -1`},
+	{expr: `'MixedCase'.lower().after('mixed') == 'case'`},
+	{expr: `'MixedCase'.upper().after('MIXED') == 'CASE'`},
+	{expr: `"12 days 12 hours".replace("{0}", "2") == "12 days 12 hours"`},
+	{expr: `"{0} days {0} hours".replace("{0}", "2") == "2 days 2 hours"`},
+	{expr: `"{0} days {0} hours".replace("{0}", "2", 1).replace("{0}", "23") == "2 days 23 hours"`},
+	{expr: `"hello world".split(" ") == ["hello", "world"]`},
+	{expr: `"hello world events!".split(" ", 1) == ["hello world events!"]`},
+	{expr: `"hello world events!".split(" ", 2) == ["hello", "world events!"]`},
+	{expr: `"tacocat".substring(4) == "cat"`},
+	{expr: `"tacocat".substring(0, 4) == "taco"`},
+	{expr: `"tacocat".substring(4, 4) == ""`},
+	{expr: `"   trim   ".trim() == "trim"`},
+	// Error test cases.
 	{
 		expr: `'hello'.after('l', 30) == 'o'`,
 		err:  "index out of range: 30",
-	},
-	{
-		expr: `'tacocat'.before('c') == 'ta'`,
-	},
-	{
-		expr: `'tacocat'.before('c', 3) == 'taco'`,
-	},
-	{
-		expr: `'tacocat'.before('none') == 'tacocat'`,
 	},
 	{
 		expr: `'tacocat'.before('c', 30) == 'taco'`,
 		err:  "index out of range: 30",
 	},
 	{
-		expr: `'tacocat'.charAt(3) == 'o'`,
-	},
-	{
 		expr: `'tacocat'.charAt(30) == ''`,
 		err:  "index out of range: 30",
-	},
-	{
-		expr: `'tacocat'.indexOf('a') == 1`,
-	},
-	{
-		expr: `'tacocat'.indexOf('a', 3) == 5`,
-	},
-	{
-		expr: `'tacocat'.indexOf('none') == -1`,
 	},
 	{
 		expr: `'tacocat'.indexOf('a', 30) == -1`,
 		err:  "index out of range: 30",
 	},
 	{
-		expr: `'MixedCase'.lower().after('mixed') == 'case'`,
+		expr: `"tacocat".substring(40) == "cat"`,
+		err:  "index out of range: 40",
 	},
 	{
-		expr: `'MixedCase'.upper().after('MIXED') == 'CASE'`,
+		expr: `"tacocat".substring(-1) == "cat"`,
+		err:  "index out of range: -1",
 	},
 	{
-		expr: `"12 days 12 hours".replace("{0}", "2") == "12 days 12 hours"`,
+		expr: `"tacocat".substring(1, 50) == "cat"`,
+		err:  "index out of range: 50",
 	},
 	{
-		expr: `"{0} days {0} hours".replace("{0}", "2") == "2 days 2 hours"`,
+		expr: `"tacocat".substring(49, 50) == "cat"`,
+		err:  "index out of range: 49",
 	},
 	{
-		expr: `"{0} days {0} hours".replace("{0}", "2", 1).replace("{0}", "23") == "2 days 23 hours"`,
+		expr: `"tacocat".substring(4, 3) == ""`,
+		err:  "invalid substring range. start: 4, end: 3",
 	},
 	{
-		expr: `"hello world".split(" ") == ["hello", "world"]`,
+		expr:      `42.lower() == ""`,
+		err:       "no such overload",
+		parseOnly: true,
 	},
 	{
-		expr: `"hello world events!".split(" ", 1) == ["hello world events!"]`,
+		expr:      `42.charAt(2) == ""`,
+		err:       "no such overload",
+		parseOnly: true,
 	},
 	{
-		expr: `"hello world events!".split(" ", 2) == ["hello", "world events!"]`,
+		expr:      `'hello'.charAt(true) == ""`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `'hello'.substring(1, 2, 3) == ""`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `30.substring(true, 3) == ""`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `"tacocat".substring(true, 3) == ""`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `"tacocat".substring(0, false) == ""`,
+		err:       "no such overload",
+		parseOnly: true,
 	},
 }
 
-func TestStrings_Library(t *testing.T) {
+func TestStrings(t *testing.T) {
 	env, err := cel.NewEnv(Strings())
 	if err != nil {
 		t.Fatal(err)
@@ -91,26 +131,37 @@ func TestStrings_Library(t *testing.T) {
 	for i, tst := range stringTests {
 		tc := tst
 		t.Run(fmt.Sprintf("[%d]", i), func(tt *testing.T) {
-			ast, iss := env.Compile(tc.expr)
+			var asts []*cel.Ast
+			pAst, iss := env.Parse(tc.expr)
 			if iss.Err() != nil {
 				tt.Fatal(iss.Err())
 			}
-			exe, err := env.Program(ast)
-			if err != nil {
-				tt.Fatal(err)
+			asts = append(asts, pAst)
+			if !tc.parseOnly {
+				cAst, iss := env.Check(pAst)
+				if iss.Err() != nil {
+					tt.Fatal(iss.Err())
+				}
+				asts = append(asts, cAst)
 			}
-			out, _, err := exe.Eval(cel.NoVars())
-			if tc.err != "" {
-				if err == nil {
-					tt.Fatalf("got value %v, wanted error %s for expr: %s", out.Value(), tc.err, tc.expr)
+			for _, ast := range asts {
+				exe, err := env.Program(ast)
+				if err != nil {
+					tt.Fatal(err)
 				}
-				if tc.err != err.Error() {
-					tt.Errorf("got error %v, wanted error %s for expr: %s", err, tc.err, tc.expr)
+				out, _, err := exe.Eval(cel.NoVars())
+				if tc.err != "" {
+					if err == nil {
+						tt.Fatalf("got value %v, wanted error %s for expr: %s", out.Value(), tc.err, tc.expr)
+					}
+					if tc.err != err.Error() {
+						tt.Errorf("got error %v, wanted error %s for expr: %s", err, tc.err, tc.expr)
+					}
+				} else if err != nil {
+					tt.Fatal(err)
+				} else if out.Value() != true {
+					tt.Errorf("got %v, wanted true for expr: %s", out.Value(), tc.expr)
 				}
-			} else if err != nil {
-				tt.Fatal(err)
-			} else if out.Value() != true {
-				tt.Errorf("got %v, wanted true for expr: %s", out.Value(), tc.expr)
 			}
 		})
 	}

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -29,13 +29,27 @@ var stringTests = []struct {
 }{
 	// CharAt test.
 	{expr: `'tacocat'.charAt(3) == 'o'`},
-	// Indext of search string tests.
-	{expr: `'tacocat'.indexOf('a') == 1`},
-	{expr: `'tacocat'.indexOf('a', 3) == 5`},
+	{expr: `'tacocat'.charAt(7) == ''`},
+	{expr: `'©αT'.charAt(0) == '©' && '©αT'.charAt(1) == 'α' && '©αT'.charAt(2) == 'T'`},
+	// Index of search string tests.
+	{expr: `'tacocat'.indexOf('') == 0`},
+	{expr: `'tacocat'.indexOf('ac') == 1`},
 	{expr: `'tacocat'.indexOf('none') == -1`},
-	{expr: `'tacocat'.lastIndexOf('a') == 5`},
-	{expr: `'tacocat'.lastIndexOf('a', 3) == 1`},
+	{expr: `'tacocat'.indexOf('', 3) == 3`},
+	{expr: `'tacocat'.indexOf('a', 3) == 5`},
+	{expr: `'tacocat'.indexOf('at', 3) == 5`},
+	{expr: `'ta©o©αT'.indexOf('©') == 2`},
+	{expr: `'ta©o©αT'.indexOf('©', 3) == 4`},
+	{expr: `'ta©o©αT'.indexOf('©αT', 3) == 4`},
+	{expr: `'ta©o©αT'.indexOf('©α', 5) == -1`},
+	{expr: `'tacocat'.lastIndexOf('') == 7`},
+	{expr: `'tacocat'.lastIndexOf('at') == 5`},
 	{expr: `'tacocat'.lastIndexOf('none') == -1`},
+	{expr: `'tacocat'.lastIndexOf('', 3) == 3`},
+	{expr: `'tacocat'.lastIndexOf('a', 3) == 1`},
+	{expr: `'ta©o©αT'.lastIndexOf('©') == 4`},
+	{expr: `'ta©o©αT'.lastIndexOf('©', 3) == 2`},
+	{expr: `'ta©o©αT'.lastIndexOf('©α', 4) == 4`},
 	// Replace tests
 	{expr: `"12 days 12 hours".replace("{0}", "2") == "12 days 12 hours"`},
 	{expr: `"{0} days {0} hours".replace("{0}", "2") == "2 days 2 hours"`},
@@ -47,8 +61,11 @@ var stringTests = []struct {
 	{expr: `"hello world events!".split(" ", 2) == ["hello", "world events!"]`},
 	// Substring tests.
 	{expr: `"tacocat".substring(4) == "cat"`},
+	{expr: `"tacocat".substring(7) == ""`},
 	{expr: `"tacocat".substring(0, 4) == "taco"`},
 	{expr: `"tacocat".substring(4, 4) == ""`},
+	{expr: `'ta©o©αT'.substring(2, 6) == "©o©α"`},
+	{expr: `'ta©o©αT'.substring(7, 7) == ""`},
 	// Trim tests using the unicode standard for whitespace.
 	{expr: `" \f\n\r\t\vtext  ".trim() == "text"`},
 	{expr: `"\u0085\u00a0\u1680text".trim() == "text"`},
@@ -64,6 +81,14 @@ var stringTests = []struct {
 	},
 	{
 		expr: `'tacocat'.indexOf('a', 30) == -1`,
+		err:  "index out of range: 30",
+	},
+	{
+		expr: `'tacocat'.lastIndexOf('a', -1) == -1`,
+		err:  "index out of range: -1",
+	},
+	{
+		expr: `'tacocat'.lastIndexOf('a', 30) == -1`,
 		err:  "index out of range: 30",
 	},
 	{

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -21,33 +21,42 @@ import (
 	"github.com/google/cel-go/cel"
 )
 
+// TODO: move these tests to a conformance test.
 var stringTests = []struct {
 	expr      string
 	err       string
 	parseOnly bool
 }{
-	// Success test cases.
-	{expr: `'hello'.after('l') == 'lo'`},
-	{expr: `'hello'.after('none') == ''`},
-	{expr: `'tacocat'.before('c') == 'ta'`},
-	{expr: `'tacocat'.before('none') == 'tacocat'`},
+	// CharAt test.
 	{expr: `'tacocat'.charAt(3) == 'o'`},
+	// Indext of search string tests.
 	{expr: `'tacocat'.indexOf('a') == 1`},
 	{expr: `'tacocat'.indexOf('a', 3) == 5`},
 	{expr: `'tacocat'.indexOf('none') == -1`},
-	{expr: `'MixedCase'.lower().after('mixed') == 'case'`},
-	{expr: `'MixedCase'.upper().after('MIXED') == 'CASE'`},
+	{expr: `'tacocat'.lastIndexOf('a') == 5`},
+	{expr: `'tacocat'.lastIndexOf('a', 3) == 1`},
+	{expr: `'tacocat'.lastIndexOf('none') == -1`},
+	// Replace tests
 	{expr: `"12 days 12 hours".replace("{0}", "2") == "12 days 12 hours"`},
 	{expr: `"{0} days {0} hours".replace("{0}", "2") == "2 days 2 hours"`},
 	{expr: `"{0} days {0} hours".replace("{0}", "2", 1).replace("{0}", "23") == "2 days 23 hours"`},
+	// Split tests.
 	{expr: `"hello world".split(" ") == ["hello", "world"]`},
 	{expr: `"hello world events!".split(" ", 0) == []`},
 	{expr: `"hello world events!".split(" ", 1) == ["hello world events!"]`},
 	{expr: `"hello world events!".split(" ", 2) == ["hello", "world events!"]`},
+	// Substring tests.
 	{expr: `"tacocat".substring(4) == "cat"`},
 	{expr: `"tacocat".substring(0, 4) == "taco"`},
 	{expr: `"tacocat".substring(4, 4) == ""`},
-	{expr: `"   trim   ".trim() == "trim"`},
+	// Trim tests using the unicode standard for whitespace.
+	{expr: `" \f\n\r\t\vtext  ".trim() == "text"`},
+	{expr: `"\u0085\u00a0\u1680text".trim() == "text"`},
+	{expr: `"text\u2000\u2001\u2002\u2003\u2004\u2004\u2006\u2007\u2008\u2009".trim() == "text"`},
+	{expr: `"\u200atext\u2028\u2029\u202F\u205F\u3000".trim() == "text"`},
+	// Trim test with whitespace-like characters not included.
+	{expr: `"\u180etext\u200b\u200c\u200d\u2060\ufeff".trim()
+				== "\u180etext\u200b\u200c\u200d\u2060\ufeff"`},
 	// Error test cases based on checked expression usage.
 	{
 		expr: `'tacocat'.charAt(30) == ''`,
@@ -78,16 +87,6 @@ var stringTests = []struct {
 		err:  "invalid substring range. start: 4, end: 3",
 	},
 	// Valid parse-only expressions which should generate runtime errors.
-	{
-		expr:      `42.after("4") == "2"`,
-		err:       "no such overload",
-		parseOnly: true,
-	},
-	{
-		expr:      `"42".after(4) == "2"`,
-		err:       "no such overload",
-		parseOnly: true,
-	},
 	{
 		expr:      `42.charAt(2) == ""`,
 		err:       "no such overload",
@@ -125,11 +124,6 @@ var stringTests = []struct {
 	},
 	{
 		expr:      `'42'.indexOf('4', 0, 1) == 0`,
-		err:       "no such overload",
-		parseOnly: true,
-	},
-	{
-		expr:      `42.lower() == ""`,
 		err:       "no such overload",
 		parseOnly: true,
 	},

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -54,11 +54,12 @@ var stringTests = []struct {
 	{expr: `"12 days 12 hours".replace("{0}", "2") == "12 days 12 hours"`},
 	{expr: `"{0} days {0} hours".replace("{0}", "2") == "2 days 2 hours"`},
 	{expr: `"{0} days {0} hours".replace("{0}", "2", 1).replace("{0}", "23") == "2 days 23 hours"`},
+	{expr: `"1 ©αT taco".replace("αT", "o©α") == "1 ©o©α taco"`},
 	// Split tests.
 	{expr: `"hello world".split(" ") == ["hello", "world"]`},
 	{expr: `"hello world events!".split(" ", 0) == []`},
 	{expr: `"hello world events!".split(" ", 1) == ["hello world events!"]`},
-	{expr: `"hello world events!".split(" ", 2) == ["hello", "world events!"]`},
+	{expr: `"o©o©o©o".split("©", -1) == ["o", "o", "o", "o"]`},
 	// Substring tests.
 	{expr: `"tacocat".substring(4) == "cat"`},
 	{expr: `"tacocat".substring(7) == ""`},

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -49,7 +49,7 @@ var stringTests = []struct {
 	{expr: `"tacocat".substring(0, 4) == "taco"`},
 	{expr: `"tacocat".substring(4, 4) == ""`},
 	{expr: `"   trim   ".trim() == "trim"`},
-	// Error test cases.
+	// Error test cases based on checked expression usage.
 	{
 		expr: `'hello'.after('l', 30) == 'o'`,
 		err:  "index out of range: 30",
@@ -86,8 +86,34 @@ var stringTests = []struct {
 		expr: `"tacocat".substring(4, 3) == ""`,
 		err:  "invalid substring range. start: 4, end: 3",
 	},
+	// Valid parse-only expressions which should generate runtime errors.
 	{
-		expr:      `42.lower() == ""`,
+		expr:      `42.after("4") == "2"`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `"42".after(4) == "2"`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `42.after("4", 1) == ""`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `"42".after(4, 1) == ""`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `"42".after("4", "1") == ""`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `"42".after("4", 1, 1) == ""`,
 		err:       "no such overload",
 		parseOnly: true,
 	},
@@ -98,6 +124,116 @@ var stringTests = []struct {
 	},
 	{
 		expr:      `'hello'.charAt(true) == ""`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `24.indexOf('2') == 0`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `'hello'.indexOf(true) == 1`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `42.indexOf('4', 0) == 0`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `'42'.indexOf(4, 0) == 0`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `'42'.indexOf('4', '0') == 0`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `'42'.indexOf('4', 0, 1) == 0`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `42.lower() == ""`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `42.split("2") == ["4"]`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `42.replace(2, 1) == "41"`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `"42".replace(2, 1) == "41"`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `"42".replace("2", 1) == "41"`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `42.replace("2", "1", 1) == "41"`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `"42".replace(2, "1", 1) == "41"`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `"42".replace("2", 1, 1) == "41"`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `"42".replace("2", "1", "1") == "41"`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `"42".replace("2", "1", 1, false) == "41"`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `42.split("") == ["4", "2"]`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `"42".split(2) == ["4"]`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `42.split("2", "1") == ["4"]`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `"42".split(2, 1) == ["4"]`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `"42".split("2", "1") == ["4"]`,
+		err:       "no such overload",
+		parseOnly: true,
+	},
+	{
+		expr:      `"42".split("2", 1, 1) == ["4"]`,
 		err:       "no such overload",
 		parseOnly: true,
 	},

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -1,0 +1,117 @@
+package ext
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+)
+
+var stringTests = []struct {
+	expr string
+	err  string
+}{
+	{
+		expr: `'hello'.after('l') == 'lo'`,
+	},
+	{
+		expr: `'hello'.after('l', 3) == 'o'`,
+	},
+	{
+		expr: `'hello'.after('none') == ''`,
+	},
+	{
+		expr: `'hello'.after('l', 30) == 'o'`,
+		err:  "index out of range: 30",
+	},
+	{
+		expr: `'tacocat'.before('c') == 'ta'`,
+	},
+	{
+		expr: `'tacocat'.before('c', 3) == 'taco'`,
+	},
+	{
+		expr: `'tacocat'.before('none') == 'tacocat'`,
+	},
+	{
+		expr: `'tacocat'.before('c', 30) == 'taco'`,
+		err:  "index out of range: 30",
+	},
+	{
+		expr: `'tacocat'.charAt(3) == 'o'`,
+	},
+	{
+		expr: `'tacocat'.charAt(30) == ''`,
+		err:  "index out of range: 30",
+	},
+	{
+		expr: `'tacocat'.indexOf('a') == 1`,
+	},
+	{
+		expr: `'tacocat'.indexOf('a', 3) == 5`,
+	},
+	{
+		expr: `'tacocat'.indexOf('none') == -1`,
+	},
+	{
+		expr: `'tacocat'.indexOf('a', 30) == -1`,
+		err:  "index out of range: 30",
+	},
+	{
+		expr: `'MixedCase'.lower().after('mixed') == 'case'`,
+	},
+	{
+		expr: `'MixedCase'.upper().after('MIXED') == 'CASE'`,
+	},
+	{
+		expr: `"12 days 12 hours".replace("{0}", "2") == "12 days 12 hours"`,
+	},
+	{
+		expr: `"{0} days {0} hours".replace("{0}", "2") == "2 days 2 hours"`,
+	},
+	{
+		expr: `"{0} days {0} hours".replace("{0}", "2", 1).replace("{0}", "23") == "2 days 23 hours"`,
+	},
+	{
+		expr: `"hello world".split(" ") == ["hello", "world"]`,
+	},
+	{
+		expr: `"hello world events!".split(" ", 1) == ["hello world events!"]`,
+	},
+	{
+		expr: `"hello world events!".split(" ", 2) == ["hello", "world events!"]`,
+	},
+}
+
+func TestStrings_Library(t *testing.T) {
+	env, err := cel.NewEnv(Strings())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, tst := range stringTests {
+		tc := tst
+		t.Run(fmt.Sprintf("[%d]", i), func(tt *testing.T) {
+			ast, iss := env.Compile(tc.expr)
+			if iss.Err() != nil {
+				tt.Fatal(iss.Err())
+			}
+			exe, err := env.Program(ast)
+			if err != nil {
+				tt.Fatal(err)
+			}
+			out, _, err := exe.Eval(cel.NoVars())
+			if tc.err != "" {
+				if err == nil {
+					tt.Fatalf("got value %v, wanted error %s for expr: %s", out.Value(), tc.err, tc.expr)
+				}
+				if tc.err != err.Error() {
+					tt.Errorf("got error %v, wanted error %s for expr: %s", err, tc.err, tc.expr)
+				}
+			} else if err != nil {
+				tt.Fatal(err)
+			} else if out.Value() != true {
+				tt.Errorf("got %v, wanted true for expr: %s", out.Value(), tc.expr)
+			}
+		})
+	}
+}

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -28,10 +28,8 @@ var stringTests = []struct {
 }{
 	// Success test cases.
 	{expr: `'hello'.after('l') == 'lo'`},
-	{expr: `'hello'.after('l', 3) == 'o'`},
 	{expr: `'hello'.after('none') == ''`},
 	{expr: `'tacocat'.before('c') == 'ta'`},
-	{expr: `'tacocat'.before('c', 3) == 'taco'`},
 	{expr: `'tacocat'.before('none') == 'tacocat'`},
 	{expr: `'tacocat'.charAt(3) == 'o'`},
 	{expr: `'tacocat'.indexOf('a') == 1`},
@@ -43,6 +41,7 @@ var stringTests = []struct {
 	{expr: `"{0} days {0} hours".replace("{0}", "2") == "2 days 2 hours"`},
 	{expr: `"{0} days {0} hours".replace("{0}", "2", 1).replace("{0}", "23") == "2 days 23 hours"`},
 	{expr: `"hello world".split(" ") == ["hello", "world"]`},
+	{expr: `"hello world events!".split(" ", 0) == []`},
 	{expr: `"hello world events!".split(" ", 1) == ["hello world events!"]`},
 	{expr: `"hello world events!".split(" ", 2) == ["hello", "world events!"]`},
 	{expr: `"tacocat".substring(4) == "cat"`},
@@ -50,14 +49,6 @@ var stringTests = []struct {
 	{expr: `"tacocat".substring(4, 4) == ""`},
 	{expr: `"   trim   ".trim() == "trim"`},
 	// Error test cases based on checked expression usage.
-	{
-		expr: `'hello'.after('l', 30) == 'o'`,
-		err:  "index out of range: 30",
-	},
-	{
-		expr: `'tacocat'.before('c', 30) == 'taco'`,
-		err:  "index out of range: 30",
-	},
 	{
 		expr: `'tacocat'.charAt(30) == ''`,
 		err:  "index out of range: 30",
@@ -94,26 +85,6 @@ var stringTests = []struct {
 	},
 	{
 		expr:      `"42".after(4) == "2"`,
-		err:       "no such overload",
-		parseOnly: true,
-	},
-	{
-		expr:      `42.after("4", 1) == ""`,
-		err:       "no such overload",
-		parseOnly: true,
-	},
-	{
-		expr:      `"42".after(4, 1) == ""`,
-		err:       "no such overload",
-		parseOnly: true,
-	},
-	{
-		expr:      `"42".after("4", "1") == ""`,
-		err:       "no such overload",
-		parseOnly: true,
-	},
-	{
-		expr:      `"42".after("4", 1, 1) == ""`,
 		err:       "no such overload",
 		parseOnly: true,
 	},

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/antlr/antlr4 v0.0.0-20190819145818-b43a4c3a8015
 	github.com/golang/protobuf v1.3.2
 	github.com/google/cel-spec v0.3.0
-	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
+	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b // indirect
 	golang.org/x/text v0.3.2
 	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55

--- a/go.sum
+++ b/go.sum
@@ -62,5 +62,6 @@ google.golang.org/grpc v1.19.0 h1:cfg4PD8YEdSFnm7qLV4++93WcmhH2nIUhMjhdCvl3j8=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1 h1:Hz2g2wirWK7H0qIIhGIqRGTuMwTE8HEKFnDZZ7lm9NU=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
+google.golang.org/grpc v1.27.1 h1:zvIju4sqAGvwKspUQOhwnpcqSbzi7/H6QomNNjTL4sk=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099 h1:XJP7lxbSxWLOMNdBE4B/STaqVy6L73o0knwj2vIlxnw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
This code is based on FR #306 which requested support for built-in substrings. While substrings are not part of the core CEL spec, such functions are a common ask and the following is an implementation of such functions as extensions which can be layered onto the core CEL spec.

Closes #306  