### PR TITLE
Fix to the parser panic

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -123,7 +123,8 @@ func (p *parser) Visit(tree antlr.ParseTree) interface{} {
 		return p.VisitCreateStruct(tree.(*gen.CreateStructContext))
 	}
 
-	// The code only gets to this point if there is an error produced earlier.
+	// Report at least one error if the parser reaches an unknown parse element.
+	// Typically, this happens if the parser has already encountered a syntax error elsewhere.
 	if len(p.errors.GetErrors()) == 0 {
 		txt := "<<nil>>"
 		if tree != nil {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -17,6 +17,7 @@
 package parser
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
@@ -123,6 +124,13 @@ func (p *parser) Visit(tree antlr.ParseTree) interface{} {
 	}
 
 	// The code only gets to this point if there is an error produced earlier.
+	if len(p.errors.GetErrors()) == 0 {
+		txt := "<<nil>>"
+		if tree != nil {
+			txt = fmt.Sprintf("<<%T>>", tree)
+		}
+		return p.reportError(common.NoLocation, "unknown parse element encountered: %s", txt)
+	}
 	return p.helper.newExpr(common.NoLocation)
 
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -17,8 +17,6 @@
 package parser
 
 import (
-	"fmt"
-	"reflect"
 	"strconv"
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
@@ -124,11 +122,9 @@ func (p *parser) Visit(tree antlr.ParseTree) interface{} {
 		return p.VisitCreateStruct(tree.(*gen.CreateStructContext))
 	}
 
-	text := "<<nil>>"
-	if tree != nil {
-		text = tree.GetText()
-	}
-	panic(fmt.Sprintf("unknown parsetree type: '%+v': %+v [%s]", reflect.TypeOf(tree), tree, text))
+	// The code only gets to this point if there is an error produced earlier.
+	return p.helper.newExpr(common.NoLocation)
+
 }
 
 // Visit a parse tree produced by CELParser#start.

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1058,6 +1058,26 @@ ERROR: <input>:1:14: argument is not an identifier
 		| ind[a{b}]
 		| .......^`,
 	},
+	{
+		I: `--`,
+		E: `
+	   ERROR: <input>:1:3: Syntax error: no viable alternative at input '-'
+		| --
+		| ..^
+	   ERROR: <input>:1:3: Syntax error: mismatched input '<EOF>' expecting {'[', '{', '(', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}
+		| --
+		| ..^`,
+	},
+	{
+		I: `?`,
+		E: `
+	   ERROR: <input>:1:1: Syntax error: mismatched input '?' expecting {'[', '{', '(', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}
+		| ?
+		| ^
+	   ERROR: <input>:1:2: Syntax error: mismatched input '<EOF>' expecting {'[', '{', '(', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}
+		| ?
+		| .^`,
+	},
 }
 
 type testInfo struct {


### PR DESCRIPTION
Per the report in https://github.com/google/cel-go/issues/317, there was an extant `panic` in the parser which could be triggered if the parse input never produced a single valid expression node. The `panic` has been addressed, but the core issue of fuzzing remains open.