### PR TITLE
Update test parallelism and remove append() calls with side-effects

### DIFF
--- a/checker/BUILD.bazel
+++ b/checker/BUILD.bazel
@@ -47,7 +47,7 @@ go_test(
         ":go_default_library",
     ],
     deps = [
-        "//common/types/ref:go_default_library",
+        "//common/types:go_default_library",
         "//parser:go_default_library",
         "//test:go_default_library",
         "//test/proto3pb:go_default_library",

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/cel-go/common/overloads"
 	"github.com/google/cel-go/common/packages"
 	"github.com/google/cel-go/common/types"
-	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/parser"
 	"github.com/google/cel-go/test"
 
@@ -1451,12 +1450,6 @@ _&&_(_==_(list~type(list(dyn))^list,
 	},
 }
 
-var reg = initTypeRegistry()
-
-func initTypeRegistry() ref.TypeRegistry {
-	return types.NewRegistry(&proto3pb.NestedTestAllTypes{}, &proto3pb.TestAllTypes{})
-}
-
 var testEnvs = map[string]env{
 	"default": {
 		functions: []*exprpb.Decl{
@@ -1522,11 +1515,12 @@ func TestCheck(t *testing.T) {
 			src := common.NewTextSource(tc.I)
 			expression, errors := parser.Parse(src)
 			if len(errors.GetErrors()) > 0 {
-				tt.Fatalf("Unexpected parse errors: %v",
-					errors.ToDisplayString())
-				return
+				tt.Fatalf("Unexpected parse errors: %v", errors.ToDisplayString())
 			}
 
+			reg := types.NewRegistry()
+			reg.RegisterMessage(&proto3pb.NestedTestAllTypes{})
+			reg.RegisterMessage(&proto3pb.TestAllTypes{})
 			pkg := packages.NewPackage(tc.Container)
 			env := NewStandardEnv(pkg, reg)
 			if tc.DisableStdEnv {

--- a/checker/types.go
+++ b/checker/types.go
@@ -497,10 +497,10 @@ func flattenFunctionTypes(f *exprpb.Type_FunctionType) []*exprpb.Type {
 	if len(argTypes) == 0 {
 		return []*exprpb.Type{f.GetResultType()}
 	}
-	merged := make([]*exprpb.Type, len(argTypes)+1, len(argTypes)+1)
+	flattend := make([]*exprpb.Type, len(argTypes)+1, len(argTypes)+1)
 	for i, at := range argTypes {
-		merged[i] = at
+		flattend[i] = at
 	}
-	merged[len(argTypes)] = f.GetResultType()
-	return merged
+	flattend[len(argTypes)] = f.GetResultType()
+	return flattend
 }

--- a/checker/types.go
+++ b/checker/types.go
@@ -284,8 +284,8 @@ func internalIsAssignableAbstractType(m *mapping,
 func internalIsAssignableFunction(m *mapping,
 	f1 *exprpb.Type_FunctionType,
 	f2 *exprpb.Type_FunctionType) bool {
-	f1ArgTypes := mergeFunctionTypes(f1)
-	f2ArgTypes := mergeFunctionTypes(f2)
+	f1ArgTypes := flattenFunctionTypes(f1)
+	f2ArgTypes := flattenFunctionTypes(f2)
 	if internalIsAssignableList(m, f1ArgTypes, f2ArgTypes) {
 		return true
 	}
@@ -424,7 +424,7 @@ func notReferencedIn(m *mapping, t *exprpb.Type, withinType *exprpb.Type) bool {
 		return true
 	case kindFunction:
 		fn := withinType.GetFunction()
-		types := mergeFunctionTypes(fn)
+		types := flattenFunctionTypes(fn)
 		for _, a := range types {
 			if !notReferencedIn(m, t, a) {
 				return false
@@ -490,7 +490,9 @@ func typeKey(t *exprpb.Type) string {
 	return FormatCheckedType(t)
 }
 
-func mergeFunctionTypes(f *exprpb.Type_FunctionType) []*exprpb.Type {
+// flattenFunctionTypes takes a function with arg types T1, T2, ..., TN and result type TR
+// and returns a slice containing {T1, T2, ..., TN, TR}.
+func flattenFunctionTypes(f *exprpb.Type_FunctionType) []*exprpb.Type {
 	argTypes := f.GetArgTypes()
 	if len(argTypes) == 0 {
 		return []*exprpb.Type{f.GetResultType()}

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -803,6 +803,8 @@ func TestInterpreter(t *testing.T) {
 			t.Fatalf("%s: %v", tc.name, err)
 		}
 		t.Run(tc.name, func(tt *testing.T) {
+			tt.Parallel()
+
 			var want ref.Val = types.True
 			if tc.out != nil {
 				want = tc.out.(ref.Val)
@@ -811,17 +813,14 @@ func TestInterpreter(t *testing.T) {
 			_, expectUnk := want.(types.Unknown)
 			if expectUnk {
 				if !reflect.DeepEqual(got, want) {
-					tt.Errorf("Got %v, wanted %v", got, want)
-					return
+					tt.Fatalf("Got %v, wanted %v", got, want)
 				}
 			} else if tc.err != "" {
 				if !types.IsError(got) || got.(*types.Err).String() != tc.err {
-					tt.Errorf("Got %v (%T), wanted error: %s", got, got, tc.err)
-					return
+					tt.Fatalf("Got %v (%T), wanted error: %s", got, got, tc.err)
 				}
 			} else if got.Equal(want) != types.True {
-				tt.Errorf("Got %v, wanted %v", got, want)
-				return
+				tt.Fatalf("Got %v, wanted %v", got, want)
 			}
 			state := NewEvalState()
 			opts := map[string]InterpretableDecorator{


### PR DESCRIPTION
This PR improves the list mutation guarantees and parallelism coverage for the checker and interpreter. 

This PR partially addresses #322. PR #323 should cover the remainder once submitted.