### PR TITLE
Fix for index attribute resolution with global function call result

### DIFF
--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -217,7 +217,7 @@ var (
 		},
 		{
 			name: "index",
-			expr: `m['key'][1] == 42u && m['null'] == null`,
+			expr: `m['key'][1] == 42u && m['null'] == null && m[string(0)] == 10`,
 			env: []*exprpb.Decl{
 				decls.NewIdent("m", decls.NewMapType(decls.String, decls.Dyn), nil),
 			},
@@ -225,6 +225,7 @@ var (
 				"m": map[string]interface{}{
 					"key":  []uint{21, 42},
 					"null": nil,
+					"0":    10,
 				},
 			},
 		},

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -501,7 +501,7 @@ func (p *planner) planCallIndex(expr *exprpb.Expr,
 	if isIndAttr {
 		return opAttr.AddQualifier(indAttr.Attr())
 	}
-	return nil, fmt.Errorf("unsupported index expression: %v", expr)
+	return opAttr.AddQualifier(p.attrFactory.RelativeAttribute(ind.ID(), ind))
 }
 
 // planCreateList generates a list construction Interpretable.


### PR DESCRIPTION
For index expressions where the argument to the index is a global function call, the expression plan fails with an error, e.g. 

fails: `map[string('key')]`
succeeds: `map['key']`

The solution is to make sure that a `RelativeAttribute` is created for the argument to the index operation when it is not already an `Attribute` or `Constant` value.