### PR TITLE
Refactor of the proto description logic for safety

### DIFF
--- a/common/types/pb/enum.go
+++ b/common/types/pb/enum.go
@@ -18,7 +18,8 @@ import (
 	descpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 )
 
-// NewEnumValueDescription produces a new named enum value description.
+// NewEnumValueDescription produces an enum value description with the fully qualified enum value
+// name and the enum value descriptor.
 func NewEnumValueDescription(name string,
 	desc *descpb.EnumValueDescriptorProto) *EnumValueDescription {
 	return &EnumValueDescription{
@@ -27,13 +28,13 @@ func NewEnumValueDescription(name string,
 	}
 }
 
-// EnumValueDescription maps a qualified enum name to its numeric value.
+// EnumValueDescription maps a fully-qualified enum value name to its numeric value.
 type EnumValueDescription struct {
 	enumValueName string
 	desc          *descpb.EnumValueDescriptorProto
 }
 
-// Name returns the human-readable identifier name for the enum value.
+// Name returns the fully-qualified identifier name for the enum value.
 func (ed *EnumValueDescription) Name() string {
 	return ed.enumValueName
 }

--- a/common/types/pb/enum.go
+++ b/common/types/pb/enum.go
@@ -18,19 +18,27 @@ import (
 	descpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 )
 
-// EnumDescription maps a qualified enum name to its numeric value.
-type EnumDescription struct {
-	enumName string
-	file     *FileDescription
-	desc     *descpb.EnumValueDescriptorProto
+// NewEnumValueDescription produces a new named enum value description.
+func NewEnumValueDescription(name string,
+	desc *descpb.EnumValueDescriptorProto) *EnumValueDescription {
+	return &EnumValueDescription{
+		enumValueName: name,
+		desc:          desc,
+	}
 }
 
-// Name of the enum.
-func (ed *EnumDescription) Name() string {
-	return ed.enumName
+// EnumValueDescription maps a qualified enum name to its numeric value.
+type EnumValueDescription struct {
+	enumValueName string
+	desc          *descpb.EnumValueDescriptorProto
 }
 
-// Value (numeric) of the enum.
-func (ed *EnumDescription) Value() int32 {
+// Name returns the human-readable identifier name for the enum value.
+func (ed *EnumValueDescription) Name() string {
+	return ed.enumValueName
+}
+
+// Value returns the (numeric) value of the enum.
+func (ed *EnumValueDescription) Value() int32 {
 	return ed.desc.GetNumber()
 }

--- a/common/types/pb/file.go
+++ b/common/types/pb/file.go
@@ -16,23 +16,38 @@ package pb
 
 import (
 	"fmt"
-	"sync/atomic"
 
 	descpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 )
 
-// FileDescription holds a map of all types and enums declared within a .proto
-// file.
+// NewFileDescription returns a FileDescription instance with a complete listing of all the message
+// types and enum values declared within any scope in the file.
+func NewFileDescription(fileDesc *descpb.FileDescriptorProto, pbdb *Db) *FileDescription {
+	isProto3 := fileDesc.GetSyntax() == "proto3"
+	metadata := collectFileMetadata(fileDesc)
+	enums := make(map[string]*EnumValueDescription)
+	for name, enumVal := range metadata.enumValues {
+		enums[name] = NewEnumValueDescription(name, enumVal)
+	}
+	types := make(map[string]*TypeDescription)
+	for name, msgType := range metadata.msgTypes {
+		types[name] = NewTypeDescription(name, msgType, isProto3, pbdb.DescribeType)
+	}
+	return &FileDescription{
+		types: types,
+		enums: enums,
+	}
+}
+
+// FileDescription holds a map of all types and enum values declared within a proto file.
 type FileDescription struct {
-	pbdb  *Db
-	desc  *descpb.FileDescriptorProto
 	types map[string]*TypeDescription
-	enums map[string]*EnumDescription
+	enums map[string]*EnumValueDescription
 }
 
 // GetEnumDescription returns an EnumDescription for a qualified enum value
 // name declared within the .proto file.
-func (fd *FileDescription) GetEnumDescription(enumName string) (*EnumDescription, error) {
+func (fd *FileDescription) GetEnumDescription(enumName string) (*EnumValueDescription, error) {
 	if ed, found := fd.enums[sanitizeProtoName(enumName)]; found {
 		return ed, nil
 	}
@@ -70,44 +85,71 @@ func (fd *FileDescription) GetTypeNames() []string {
 	return typeNames
 }
 
-// Package returns the file's qualified package name.
-func (fd *FileDescription) Package() string {
-	return fd.desc.GetPackage()
-}
-
-func (fd *FileDescription) indexEnums(pkg string, enumTypes []*descpb.EnumDescriptorProto) {
-	for _, enumType := range enumTypes {
-		for _, enumValue := range enumType.Value {
-			enumValueName := fmt.Sprintf(
-				"%s.%s.%s", pkg, enumType.GetName(), enumValue.GetName())
-			fd.enums[enumValueName] = &EnumDescription{
-				enumName: enumValueName,
-				file:     fd,
-				desc:     enumValue}
-			fd.pbdb.revFileDescriptorMap[enumValueName] = fd
-		}
-	}
-}
-
-func (fd *FileDescription) indexTypes(pkg string, msgTypes []*descpb.DescriptorProto) {
-	for _, msgType := range msgTypes {
-		msgName := fmt.Sprintf("%s.%s", pkg, msgType.GetName())
-		td := &TypeDescription{
-			typeName: msgName,
-			file:     fd,
-			desc:     msgType,
-			metadata: &atomic.Value{},
-		}
-		fd.types[msgName] = td
-		fd.indexTypes(msgName, msgType.NestedType)
-		fd.indexEnums(msgName, msgType.EnumType)
-		fd.pbdb.revFileDescriptorMap[msgName] = fd
-	}
-}
-
+// sanitizeProtoName strips the leading '.' from the proto message name.
 func sanitizeProtoName(name string) string {
 	if name != "" && name[0] == '.' {
 		return name[1:]
 	}
 	return name
+}
+
+// fileMetadata is a flattened view of  message types and enum values within a file descriptor.
+type fileMetadata struct {
+	msgTypes   map[string]*descpb.DescriptorProto
+	enumValues map[string]*descpb.EnumValueDescriptorProto
+}
+
+// collectFileMetadata traverses the proto file object graph to collect message types and enum
+// values and index them by their fully qualified names.
+func collectFileMetadata(fileDesc *descpb.FileDescriptorProto) *fileMetadata {
+	pkg := fileDesc.GetPackage()
+	msgTypes := collectMsgTypes(pkg, fileDesc.GetMessageType())
+	enumValues := collectEnumValues(pkg, fileDesc.GetEnumType())
+	for container, msgType := range msgTypes {
+		nestedEnums := msgType.GetEnumType()
+		if len(nestedEnums) == 0 {
+			continue
+		}
+		nestedEnumValues := collectEnumValues(container, nestedEnums)
+		for name, enumVal := range nestedEnumValues {
+			enumValues[name] = enumVal
+		}
+	}
+	return &fileMetadata{
+		msgTypes:   msgTypes,
+		enumValues: enumValues,
+	}
+}
+
+// collectMsgTypes recursively collects messages and nested messages into a map of fully
+// qualified message names to message descriptors.
+func collectMsgTypes(container string,
+	msgTypes []*descpb.DescriptorProto) map[string]*descpb.DescriptorProto {
+	msgTypeMap := make(map[string]*descpb.DescriptorProto)
+	for _, msgType := range msgTypes {
+		msgName := fmt.Sprintf("%s.%s", container, msgType.GetName())
+		msgTypeMap[msgName] = msgType
+		nestedTypes := msgType.GetNestedType()
+		if len(nestedTypes) == 0 {
+			continue
+		}
+		nestedTypeMap := collectMsgTypes(msgName, nestedTypes)
+		for k, v := range nestedTypeMap {
+			msgTypeMap[k] = v
+		}
+	}
+	return msgTypeMap
+}
+
+// collectEnumValues accumulates the enum values within an enum declaration.
+func collectEnumValues(container string,
+	enumTypes []*descpb.EnumDescriptorProto) map[string]*descpb.EnumValueDescriptorProto {
+	enumValueMap := make(map[string]*descpb.EnumValueDescriptorProto)
+	for _, enumType := range enumTypes {
+		for _, enumValue := range enumType.GetValue() {
+			name := fmt.Sprintf("%s.%s.%s", container, enumType.GetName(), enumValue.GetName())
+			enumValueMap[name] = enumValue
+		}
+	}
+	return enumValueMap
 }

--- a/common/types/pb/file_test.go
+++ b/common/types/pb/file_test.go
@@ -41,9 +41,6 @@ func TestFileDescription_GetTypes(t *testing.T) {
 		if td.Name() != typeName {
 			t.Error("Indexed type name not equal to descriptor type name", td, typeName)
 		}
-		if td.file != fd {
-			t.Error("Indexed type does not refer to current file", td)
-		}
 	}
 }
 

--- a/common/types/pb/type.go
+++ b/common/types/pb/type.go
@@ -26,8 +26,8 @@ import (
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
-// NewTypeDescription produces a TypeDescription value for the proto type name with a given
-// descriptor.
+// NewTypeDescription produces a TypeDescription value for the fully-qualified proto type name
+// with a given descriptor.
 //
 // The type description creation method also expects the type to be marked clearly as a proto2 or
 // proto3 type, and accepts a typeResolver reference for resolving field TypeDescription during

--- a/common/types/pb/type.go
+++ b/common/types/pb/type.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"sync/atomic"
+	"sync"
 
 	"github.com/golang/protobuf/proto"
 	descpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
@@ -26,14 +26,41 @@ import (
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
+// NewTypeDescription produces a TypeDescription value for the proto type name with a given
+// descriptor.
+//
+// The type description creation method also expects the type to be marked clearly as a proto2 or
+// proto3 type, and accepts a typeResolver reference for resolving field TypeDescription during
+// lazily initialization of the type which is done atomically.
+func NewTypeDescription(typeName string, desc *descpb.DescriptorProto,
+	isProto3 bool, resolveType typeResolver) *TypeDescription {
+	return &TypeDescription{
+		typeName:    typeName,
+		isProto3:    isProto3,
+		desc:        desc,
+		resolveType: resolveType,
+	}
+}
+
 // TypeDescription is a collection of type metadata relevant to expression
 // checking and evaluation.
 type TypeDescription struct {
 	typeName string
-	file     *FileDescription
+	isProto3 bool
 	desc     *descpb.DescriptorProto
-	metadata *atomic.Value
+
+	// resolveType is used to lookup field types during type initialization.
+	// The resolver may point to shared state; however, this state is guaranteed to be computed at
+	// most one time.
+	resolveType typeResolver
+	init        sync.Once
+	metadata    *typeMetadata
 }
+
+// typeResolver accepts a type name and returns a TypeDescription.
+// The typeResolver is used to resolve field types during lazily initialization of the type
+// description metadata.
+type typeResolver func(typeName string) (*TypeDescription, error)
 
 type typeMetadata struct {
 	fields          map[string]*FieldDescription // fields by name (proto)
@@ -80,14 +107,14 @@ func (td *TypeDescription) DefaultValue() proto.Message {
 	return val.(proto.Message)
 }
 
+// getMetadata computes the type field metadata used for determining field types and default
+// values. The call to makeMetadata within this method is guaranteed to be invoked exactly
+// once.
 func (td *TypeDescription) getMetadata() *typeMetadata {
-	meta, ok := td.metadata.Load().(*typeMetadata)
-	if ok {
-		return meta
-	}
-	meta = td.makeMetadata()
-	td.metadata.Store(meta)
-	return meta
+	td.init.Do(func() {
+		td.metadata = td.makeMetadata()
+	})
+	return td.metadata
 }
 
 func (td *TypeDescription) makeMetadata() *typeMetadata {
@@ -162,7 +189,6 @@ func (td *TypeDescription) newFieldDesc(
 	index int) *FieldDescription {
 	getterName := fmt.Sprintf("Get%s", prop.Name)
 	getter, _ := tdType.MethodByName(getterName)
-	isProto3 := td.file.desc.GetSyntax() == "proto3"
 	var field *reflect.StructField
 	if tdType.Kind() == reflect.Ptr {
 		tdType = tdType.Elem()
@@ -177,12 +203,12 @@ func (td *TypeDescription) newFieldDesc(
 		getter:    getter.Func,
 		field:     field,
 		prop:      prop,
-		isProto3:  isProto3,
+		isProto3:  td.isProto3,
 		isWrapper: isWrapperType(desc),
 	}
 	if desc.GetType() == descpb.FieldDescriptorProto_TYPE_MESSAGE {
 		typeName := sanitizeProtoName(desc.GetTypeName())
-		fieldType, _ := td.file.pbdb.DescribeType(typeName)
+		fieldType, _ := td.resolveType(typeName)
 		fieldDesc.td = fieldType
 		return fieldDesc
 	}
@@ -203,7 +229,7 @@ func (td *TypeDescription) newMapFieldDesc(desc *descpb.FieldDescriptorProto) *F
 	return &FieldDescription{
 		desc:     desc,
 		index:    int(desc.GetNumber()),
-		isProto3: td.file.desc.GetSyntax() == "proto3",
+		isProto3: td.isProto3,
 	}
 }
 


### PR DESCRIPTION
Improvements in the initialization of `pb.FileDescription` and associated `pb.TypeDescription` values.

Notably, the `atomic.Value` members in the `pb.TypeDescription` have been replaced with a `sync.Once` object as the mutations were thread-safe, but should really only have been happening exactly once. 

Additionally, the reverse qualified name to file descriptor lookup is being managed entirely within the `pb.Db` as opposed to spread between the `pb.FileDescription` and `pb.Db` files. The net effect should be safer, simpler code that is better documented and better behaved.

Closes #322 