### PR TITLE
Improve type resolution when there are multiple overloads

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -296,7 +296,6 @@ func (c *checker) resolveOverload(
 			for _, typePar := range overload.TypeParams {
 				substitutions.add(decls.NewTypeParamType(typePar), c.newTypeVar())
 			}
-
 			overloadType = substitute(substitutions, overloadType, false)
 		}
 
@@ -314,12 +313,14 @@ func (c *checker) resolveOverload(
 				false)
 			if resultType == nil {
 				resultType = fnResultType
-			} else if !isDyn(resultType) {
-				if !proto.Equal(fnResultType, resultType) {
-					resultType = decls.Dyn
-				}
+			} else if !isDyn(resultType) &&
+				!isTypeParam(resultType) &&
+				!isTypeParam(fnResultType) &&
+				c.isAssignable(fnResultType, resultType) {
+				resultType = mostGeneral(fnResultType, resultType)
+			} else {
+				resultType = decls.Dyn
 			}
-
 		}
 	}
 

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -313,12 +313,7 @@ func (c *checker) resolveOverload(
 				false)
 			if resultType == nil {
 				resultType = fnResultType
-			} else if !isDyn(resultType) &&
-				!isTypeParam(resultType) &&
-				!isTypeParam(fnResultType) &&
-				c.isAssignable(fnResultType, resultType) {
-				resultType = mostGeneral(fnResultType, resultType)
-			} else {
+			} else if !isDyn(resultType) && !proto.Equal(fnResultType, resultType) {
 				resultType = decls.Dyn
 			}
 		}

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -308,14 +308,16 @@ func (c *checker) resolveOverload(
 				checkedRef.OverloadId = append(checkedRef.OverloadId, overload.OverloadId)
 			}
 
+			// First matching overload, determines result type.
+			fnResultType := substitute(c.mappings,
+				overloadType.GetFunction().ResultType,
+				false)
 			if resultType == nil {
-				// First matching overload, determines result type.
-				resultType = substitute(c.mappings,
-					overloadType.GetFunction().ResultType,
-					false)
-			} else {
-				// More than one matching overload, narrow result type to DYN.
-				resultType = decls.Dyn
+				resultType = fnResultType
+			} else if !isDyn(resultType) {
+				if !proto.Equal(fnResultType, resultType) {
+					resultType = decls.Dyn
+				}
 			}
 
 		}

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1208,6 +1208,21 @@ _&&_(_==_(list~type(list(dyn))^list,
 	},
 
 	{
+		I: `1 in dyn([1, 2, 3])`,
+		R: `@in(
+			1~int,
+			dyn(
+			  [
+				1~int,
+				2~int,
+				3~int
+			  ]~list(int)
+			)~dyn^to_dyn
+		  )~bool^in_list|in_map`,
+		Type: decls.Bool,
+	},
+
+	{
 		I: `type(null) == null_type`,
 		R: `_==_(
     		  type(

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1079,7 +1079,7 @@ ERROR: <input>:1:5: undeclared reference to 'x' (in container '')
 				_>=_(
 					x~any^x,
 					x~any^x
-				)~dyn^greater_equals_bool|greater_equals_int64|greater_equals_uint64|greater_equals_double|greater_equals_string|greater_equals_bytes|greater_equals_timestamp|greater_equals_duration
+				)~bool^greater_equals_bool|greater_equals_int64|greater_equals_uint64|greater_equals_double|greater_equals_string|greater_equals_bytes|greater_equals_timestamp|greater_equals_duration
 			)~bool^logical_or
 		)~bool^logical_or
 		`,

--- a/checker/types.go
+++ b/checker/types.go
@@ -91,6 +91,11 @@ func FormatCheckedType(t *exprpb.Type) string {
 	return t.String()
 }
 
+// isTypeParam returns whether the type value is a TYPE_PARAM type.
+func isTypeParam(t *exprpb.Type) bool {
+	return kindOf(t) == kindTypeParam
+}
+
 // isDyn returns true if the input t is either type DYN or a well-known ANY message.
 func isDyn(t *exprpb.Type) bool {
 	// Note: object type values that are well-known and map to a DYN value in practice

--- a/checker/types.go
+++ b/checker/types.go
@@ -91,11 +91,6 @@ func FormatCheckedType(t *exprpb.Type) string {
 	return t.String()
 }
 
-// isTypeParam returns whether the type value is a TYPE_PARAM type.
-func isTypeParam(t *exprpb.Type) bool {
-	return kindOf(t) == kindTypeParam
-}
-
 // isDyn returns true if the input t is either type DYN or a well-known ANY message.
 func isDyn(t *exprpb.Type) bool {
 	// Note: object type values that are well-known and map to a DYN value in practice


### PR DESCRIPTION
When there is more than one overload that matches a call signature, the current behavior is to mark the function return as `dyn`; however, when all overloads share the same result type, the type inference can be much stronger.

For example, the `in` operator always returns a boolean even though it can accept either `map`, `list`, or `dyn` arguments:

before: `1 in dyn([1, 2, 3])` -> type(dyn)
after: `1 in dyn([1, 2, 3])` -> type(bool)

This issue was surfaced by @francislavoie of the [Caddy](https://github.com/caddyserver) team.

