### PR TITLE
Updates the has() macro to be more consistent with the cel-spec.

### DIFF
--- a/checker/BUILD.bazel
+++ b/checker/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
         "//common/types:go_default_library",
         "//parser:go_default_library",
         "//test:go_default_library",
+        "//test/proto2pb:go_default_library",
         "//test/proto3pb:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_antlr//runtime/Go/antlr:go_default_library",

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -193,11 +193,6 @@ func (c *checker) checkSelect(e *exprpb.Expr) {
 			messageType.GetMessageType(),
 			sel.Field); found {
 			resultType = fieldType.Type
-			// In proto3, primitive field types can't support presence testing, so the has()
-			// style operation would be invalid in this instance.
-			if sel.TestOnly && !fieldType.SupportsPresence {
-				c.errors.fieldDoesNotSupportPresenceCheck(c.location(e), sel.Field)
-			}
 		}
 	case kindTypeParam:
 		// Set the operand type to DYN to prevent assignment to a potentionally incorrect type

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1486,6 +1486,26 @@ _&&_(_==_(list~type(list(dyn))^list,
 		  )~bool^logical_and`,
 		Type: decls.Bool,
 	},
+	{
+		I:         `TestAllTypes{}.repeated_nested_message`,
+		Container: "google.expr.proto2.test",
+		R:         `TestAllTypes{}~google.expr.proto2.test.TestAllTypes^google.expr.proto2.test.TestAllTypes.repeated_nested_message~list(google.expr.proto2.test.TestAllTypes.NestedMessage)`,
+		Type: decls.NewListType(
+			decls.NewObjectType(
+				"google.expr.proto2.test.TestAllTypes.NestedMessage",
+			),
+		),
+	},
+	{
+		I:         `TestAllTypes{}.repeated_nested_message`,
+		Container: "google.expr.proto3.test",
+		R:         `TestAllTypes{}~google.expr.proto3.test.TestAllTypes^google.expr.proto3.test.TestAllTypes.repeated_nested_message~list(google.expr.proto3.test.TestAllTypes.NestedMessage)`,
+		Type: decls.NewListType(
+			decls.NewObjectType(
+				"google.expr.proto3.test.TestAllTypes.NestedMessage",
+			),
+		),
+	},
 }
 
 var testEnvs = map[string]env{

--- a/common/types/object.go
+++ b/common/types/object.go
@@ -116,9 +116,6 @@ func (o *protoObj) IsSet(field ref.Val) ref.Val {
 	if !found {
 		return NewErr("no such field '%s'", field)
 	}
-	if !fd.SupportsPresence() {
-		return NewErr("field does not support presence testing.")
-	}
 	if fd.IsSet(o.refValue) {
 		return True
 	}

--- a/common/types/pb/type.go
+++ b/common/types/pb/type.go
@@ -348,7 +348,9 @@ func (fd *FieldDescription) GetFrom(target interface{}) (interface{}, error) {
 		// Additionally, proto3 oneofs require the use of the accessor to get the proper value.
 		fieldVal = fd.getter.Call([]reflect.Value{t})[0]
 	}
-	// If the field is a message and it's not set, return its proper default value.
+	// If the field is a non-repeated message, and it's not set, return its default value.
+	// Note, repeated fields should have default values of empty list or empty map, so the checks
+	// for whether to return a default proto message don't really apply.
 	if fd.IsMessage() && !fd.IsRepeated() && !isFieldSet(fieldVal) {
 		// Well known wrapper types default to null if not set.
 		if fd.IsWrapper() {

--- a/common/types/pb/type.go
+++ b/common/types/pb/type.go
@@ -348,9 +348,8 @@ func (fd *FieldDescription) GetFrom(target interface{}) (interface{}, error) {
 		// Additionally, proto3 oneofs require the use of the accessor to get the proper value.
 		fieldVal = fd.getter.Call([]reflect.Value{t})[0]
 	}
-
 	// If the field is a message and it's not set, return its proper default value.
-	if fd.IsMessage() && !isFieldSet(fieldVal) {
+	if fd.IsMessage() && !fd.IsRepeated() && !isFieldSet(fieldVal) {
 		// Well known wrapper types default to null if not set.
 		if fd.IsWrapper() {
 			return structpb.NullValue_NULL_VALUE, nil

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -96,10 +96,9 @@ func (p *protoTypeRegistry) FindFieldType(messageType string,
 		return nil, false
 	}
 	return &ref.FieldType{
-			Type:             field.CheckedType(),
-			SupportsPresence: field.SupportsPresence(),
-			IsSet:            field.IsSet,
-			GetFrom:          field.GetFrom},
+			Type:    field.CheckedType(),
+			IsSet:   field.IsSet,
+			GetFrom: field.GetFrom},
 		true
 }
 

--- a/common/types/ref/provider.go
+++ b/common/types/ref/provider.go
@@ -83,9 +83,6 @@ type TypeRegistry interface {
 // FieldType represents a field's type value and whether that field supports
 // presence detection.
 type FieldType struct {
-	// SupportsPresence indicates if the field having been set can be detected.
-	SupportsPresence bool
-
 	// Type of the field.
 	Type *exprpb.Type
 

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -60,8 +60,7 @@ func (test *evalTestOnly) Eval(ctx Activation) ref.Val {
 			if ok {
 				opVal = refVal.Value()
 			}
-			isSet := test.fieldType.IsSet(opVal)
-			if isSet {
+			if test.fieldType.IsSet(opVal) {
 				return types.True
 			}
 			return types.False

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -372,10 +372,34 @@ var (
 			expr: `has({'a':1}.a) && !has({}.a)`,
 		},
 		{
-			name:  "macro_has_pb3_msg_field",
+			name:  "macro_has_pb2_field",
+			types: []proto.Message{&proto2pb.TestAllTypes{}},
+			env: []*exprpb.Decl{
+				decls.NewIdent("pb2", decls.NewObjectType("google.expr.proto2.test.TestAllTypes"), nil),
+			},
+			in: map[string]interface{}{
+				"pb2": &proto2pb.TestAllTypes{
+					RepeatedBool: []bool{false},
+					MapInt64NestedType: map[int64]*proto2pb.NestedTestAllTypes{
+						1: &proto2pb.NestedTestAllTypes{},
+					},
+					MapStringString: map[string]string{},
+				},
+			},
+			expr: `!has(pb2.single_int64)
+			&& has(pb2.repeated_bool)
+			&& !has(pb2.repeated_int32)
+			&& has(pb2.map_int64_nested_type)
+			&& !has(pb2.map_string_string)`,
+		},
+		{
+			name:  "macro_has_pb3_field",
 			types: []proto.Message{&exprpb.ParsedExpr{}},
 			pkg:   "google.api.expr.v1alpha1",
 			expr: `has(v1alpha1.ParsedExpr{expr:Expr{id: 1}}.expr)
+				&& !has(ParsedExpr{expr:Expr{}}.expr.id)
+				&& has(SourceInfo{positions:{1:1}}.positions)
+				&& !has(SourceInfo{positions:{}}.positions)
 				&& !has(expr.v1alpha1.ParsedExpr{expr:Expr{id: 1}}.source_info)`,
 		},
 		{

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -782,6 +782,13 @@ var (
 			},
 			out: types.Int(10),
 		},
+		{
+			name:  "select_empty_repeated_nested",
+			expr:  `TestAllTypes{}.repeated_nested_message.size() == 0`,
+			types: []proto.Message{&proto3pb.TestAllTypes{}},
+			pkg:   "google.expr.proto3.test",
+			out:   types.True,
+		},
 	}
 )
 


### PR DESCRIPTION
The cel-spec specifies the following behavior for the `has()` macro:

```
This means means that has(e.f) ... produces false if f is declared but not set
(or, in proto3, has its default value). Moreover, has(e.f) where e is a map
returns false if f is not defined in the map.
```

In proto2 all non-repeated fields are represented by pointers which will be `nil` if not set. In proto3 all message fields are represented by pointers which will be `nil` if not set. The `has()` macro must also return false if the proto3 primitive field is equal to its zero value. 

In the process of making cel-go more consistent with cel-spec, it seems worth reexamining whether the proto3 test for default-ness should also be extended to repeated types (array, map) for both proto2 and proto3 where:

```
has(e.repeated_f) returns false if repeated_f contains zero elements. 
```

The code has been implemented to reflect this slight deviation from the cel-spec, and an issue for https://github.com/google/cel-spec/issues/113 to address the issue at the spec level.

Closes #329 