### PR TITLE
Fix shared state in Env extension

### DIFF
--- a/cel/BUILD.bazel
+++ b/cel/BUILD.bazel
@@ -52,6 +52,8 @@ go_test(
         "//common/types/ref:go_default_library",
         "//common/types/traits:go_default_library",
         "//interpreter/functions:go_default_library",
+        "//test/proto2pb:go_default_library",
+        "//test/proto3pb:go_default_library",
         "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
         "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",
     ],

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -705,9 +705,25 @@ func Test_EnvExtension(t *testing.T) {
 				decls.NewObjectType("google.api.expr.v1alpha1.Expr"), nil),
 		),
 	)
-	e2, _ := e.Extend()
+	e2, _ := e.Extend(
+		CustomTypeAdapter(types.DefaultTypeAdapter),
+		Types(&proto3pb.TestAllTypes{}),
+	)
 	if e == e2 {
 		t.Error("got object equality, wanted separate objects")
+	}
+	if e.TypeAdapter() == e2.TypeAdapter() {
+		t.Error("got the same type adapter, wanted isolated instances.")
+	}
+	if e.TypeProvider() == e2.TypeProvider() {
+		t.Error("got the same type provider, wanted isolated instances.")
+	}
+	e3, _ := e2.Extend()
+	if e2.TypeAdapter() != e3.TypeAdapter() {
+		t.Error("got different type adapters, wanted immutable adapter reference")
+	}
+	if e2.TypeProvider() == e3.TypeProvider() {
+		t.Error("got the same type provider, wanted isolated instances.")
 	}
 }
 

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -730,9 +730,14 @@ func Test_EnvExtensionIsolation(t *testing.T) {
 	if _, issues := env2.Compile("size(group) > 10"); issues.Err() != nil {
 		t.Fatal(issues.Err())
 	}
-	// I expect this to work but env1 now has "group" instead of "name"
+	if _, issues := env2.Compile("size(name) > 10"); issues.Err() == nil {
+		t.Fatal("env2 contains 'name', but should not")
+	}
 	if _, issues := env1.Compile("size(name) > 10"); issues.Err() != nil {
 		t.Fatal(issues.Err())
+	}
+	if _, issues := env1.Compile("size(group) > 10"); issues.Err() == nil {
+		t.Fatal("env1 contains 'group', but should not")
 	}
 }
 

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -709,6 +709,33 @@ func Test_EnvExtension(t *testing.T) {
 	}
 }
 
+func Test_EnvExtensionIsolation(t *testing.T) {
+	baseEnv, err := NewEnv(Declarations(
+		decls.NewIdent("age", decls.Int, nil),
+		decls.NewIdent("gender", decls.String, nil),
+		decls.NewIdent("country", decls.String, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	env1, err := baseEnv.Extend(Declarations(
+		decls.NewIdent("name", decls.String, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	env2, err := baseEnv.Extend(Declarations(
+		decls.NewIdent("group", decls.String, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, issues := env2.Compile("size(group) > 10"); issues.Err() != nil {
+		t.Fatal(issues.Err())
+	}
+	// I expect this to work but env1 now has "group" instead of "name"
+	if _, issues := env1.Compile("size(name) > 10"); issues.Err() != nil {
+		t.Fatal(issues.Err())
+	}
+}
+
 func Test_ParseAndCheckConcurrently(t *testing.T) {
 	e, _ := NewEnv(
 		Container("google.api.expr.v1alpha1"),

--- a/cel/env.go
+++ b/cel/env.go
@@ -209,13 +209,20 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 	if e.chkErr != nil {
 		return nil, e.chkErr
 	}
+	decsCopy := make([]*exprpb.Decl, len(e.declarations))
+	macsCopy := make([]parser.Macro, len(e.macros))
+	progOptsCopy := make([]ProgramOption, len(e.progOpts))
+	copy(decsCopy, e.declarations)
+	copy(macsCopy, e.macros)
+	copy(progOptsCopy, e.progOpts)
+
 	ext := &Env{
-		declarations:                   e.declarations,
+		declarations:                   decsCopy,
+		macros:                         macsCopy,
+		progOpts:                       progOptsCopy,
 		adapter:                        e.adapter,
 		enableDynamicAggregateLiterals: e.enableDynamicAggregateLiterals,
-		macros:                         e.macros,
 		pkg:                            e.pkg,
-		progOpts:                       e.progOpts,
 		provider:                       e.provider,
 	}
 	return ext.configure(opts)

--- a/cel/env.go
+++ b/cel/env.go
@@ -224,8 +224,8 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 	copy(progOptsCopy, e.progOpts)
 
 	// Copy the adapter / provider if they appear to be mutable.
-	var adapter ref.TypeAdapter
-	var provider ref.TypeProvider
+	adapter := e.adapter
+	provider := e.provider
 	adapterReg, isAdapterReg := e.adapter.(ref.TypeRegistry)
 	providerReg, isProviderReg := e.provider.(ref.TypeRegistry)
 	// In most cases the provider and adapter will be a ref.TypeRegistry;

--- a/common/types/pb/pb.go
+++ b/common/types/pb/pb.go
@@ -61,6 +61,15 @@ func NewDb() *Db {
 	return pbdb
 }
 
+// Copy creates a copy of the current database with its own internal descriptor mapping.
+func (pbdb *Db) Copy() *Db {
+	copy := NewDb()
+	for k, v := range pbdb.revFileDescriptorMap {
+		copy.revFileDescriptorMap[k] = v
+	}
+	return copy
+}
+
 // RegisterDescriptor produces a `FileDescription` from a `FileDescriptorProto` and registers the
 // message and enum types into the `pb.Db`.
 func (pbdb *Db) RegisterDescriptor(fileDesc *descpb.FileDescriptorProto) (*FileDescription, error) {

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -77,6 +77,19 @@ func NewEmptyRegistry() ref.TypeRegistry {
 	}
 }
 
+// Copy implements the ref.TypeRegistry interface method which copies the current state of the
+// registry into its own memory space.
+func (p *protoTypeRegistry) Copy() ref.TypeRegistry {
+	copy := &protoTypeRegistry{
+		revTypeMap: make(map[string]ref.Type),
+		pbdb:       p.pbdb.Copy(),
+	}
+	for k, v := range p.revTypeMap {
+		copy.revTypeMap[k] = v
+	}
+	return copy
+}
+
 func (p *protoTypeRegistry) EnumValue(enumName string) ref.Val {
 	enumVal, err := p.pbdb.DescribeEnum(enumName)
 	if err != nil {

--- a/common/types/ref/provider.go
+++ b/common/types/ref/provider.go
@@ -78,6 +78,9 @@ type TypeRegistry interface {
 	// If a type is provided more than once with an alternative definition, the
 	// call will result in an error.
 	RegisterType(types ...Type) error
+
+	// Copy the TypeRegistry and return a new registry whose mutable state is isolated.
+	Copy() TypeRegistry
 }
 
 // FieldType represents a field's type value and whether that field supports

--- a/test/proto2pb/BUILD.bazel
+++ b/test/proto2pb/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 package(
     default_visibility = [
+        "//cel:__subpackages__",
         "//checker:__subpackages__",
         "//common:__subpackages__",
         "//interpreter:__subpackages__",

--- a/test/proto3pb/BUILD.bazel
+++ b/test/proto3pb/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 package(
     default_visibility = [
+        "//cel:__subpackages__",
         "//checker:__subpackages__",
         "//common:__subpackages__",
         "//interpreter:__subpackages__",


### PR DESCRIPTION
Ensure that slices with the `Env` object are deep-copied during the `Env.Extend` call to ensure extensions are isolated from each other.

Closes #333 