### PR TITLE
Fix oneof presence testing

### DIFF
--- a/common/types/pb/type.go
+++ b/common/types/pb/type.go
@@ -317,6 +317,17 @@ func (fd *FieldDescription) IsSet(target interface{}) bool {
 		t = reflect.Indirect(t)
 		return isFieldSet(t.FieldByIndex(fd.field.Index))
 	}
+	// Oneof fields must consider two pieces of information:
+	// - whether the oneof is set to any value at all
+	// - whether the field in the oneof is the same as the field under test.
+	//
+	// In go protobuf libraries, oneofs result in the creation of special oneof type messages
+	// which contain a reference to the actual field type. The creation of these special message
+	// types makes it possible to test for presence of primitive field values in proto3.
+	//
+	// The logic below performs a get on the oneof to obtain the field reference and then checks
+	// the type of the field reference against the known oneof type determined FieldDescription
+	// initialization.
 	if fd.IsOneof() {
 		t = reflect.Indirect(t)
 		oneof := t.Field(fd.Index())

--- a/common/types/pb/type.go
+++ b/common/types/pb/type.go
@@ -317,6 +317,17 @@ func (fd *FieldDescription) IsSet(target interface{}) bool {
 		t = reflect.Indirect(t)
 		return isFieldSet(t.FieldByIndex(fd.field.Index))
 	}
+	if fd.IsOneof() {
+		t = reflect.Indirect(t)
+		oneof := t.Field(fd.Index())
+		if !isFieldSet(oneof) {
+			return false
+		}
+		oneofVal := oneof.Interface()
+		oneofType := reflect.TypeOf(oneofVal)
+		return oneofType == fd.OneofType()
+	}
+
 	// When the field is nil or when the field is a oneof, call the accessor
 	// associated with this field name to determine whether the field value is
 	// the default.

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -389,6 +389,8 @@ var (
 			},
 			expr: `has(TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.BAR}.standalone_enum)
 			&& has(TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.FOO}.standalone_enum)
+			&& !has(TestAllTypes{single_nested_enum: TestAllTypes.NestedEnum.FOO}.single_nested_message)
+			&& has(TestAllTypes{single_nested_enum: TestAllTypes.NestedEnum.FOO}.single_nested_enum)
 			&& !has(TestAllTypes{}.standalone_enum)
 			&& !has(pb2.single_int64)
 			&& has(pb2.repeated_bool)
@@ -414,6 +416,10 @@ var (
 			},
 			expr: `has(TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.BAR}.standalone_enum)
 			&& !has(TestAllTypes{standalone_enum: TestAllTypes.NestedEnum.FOO}.standalone_enum)
+			&& !has(TestAllTypes{single_nested_enum: TestAllTypes.NestedEnum.FOO}.single_nested_message)
+			&& has(TestAllTypes{single_nested_enum: TestAllTypes.NestedEnum.FOO}.single_nested_enum)
+			&& !has(TestAllTypes{}.single_nested_message)
+			&& has(TestAllTypes{single_nested_message: TestAllTypes.NestedMessage{}}.single_nested_message)
 			&& !has(TestAllTypes{}.standalone_enum)
 			&& !has(pb3.single_int64)
 			&& has(pb3.repeated_bool)


### PR DESCRIPTION
Oneof presence testing should consider whether the `oneof` a) has any value set, b) whether the value belongs to the field described by the proto field. Under the covers a `oneof` results in the creation of shadow types in Go that represent whether any value in the `oneof` has been set, and if so, which one. These types are based on the oneof field name.  

Previously, the presence test considered whether the field was set or empty, but not whether it was present within a oneof.