### PR TITLE
Stable sort errors by location

### DIFF
--- a/common/errors.go
+++ b/common/errors.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"fmt"
+	"sort"
 )
 
 // Errors type which contains a list of errors observed during parsing.
@@ -57,6 +58,13 @@ func (e *Errors) Append(errs []Error) *Errors {
 // ToDisplayString returns the error set to a newline delimited string.
 func (e *Errors) ToDisplayString() string {
 	var result = ""
+	sort.SliceStable(e.errors, func(i, j int) bool {
+		ei := e.errors[i]
+		ej := e.errors[j]
+		eiOff, _ := e.source.LocationOffset(ei.Location)
+		ejOff, _ := e.source.LocationOffset(ej.Location)
+		return eiOff < ejOff
+	})
 	for i, err := range e.errors {
 		if i >= 1 {
 			result += "\n"

--- a/common/errors.go
+++ b/common/errors.go
@@ -59,11 +59,10 @@ func (e *Errors) Append(errs []Error) *Errors {
 func (e *Errors) ToDisplayString() string {
 	var result = ""
 	sort.SliceStable(e.errors, func(i, j int) bool {
-		ei := e.errors[i]
-		ej := e.errors[j]
-		eiOff, _ := e.source.LocationOffset(ei.Location)
-		ejOff, _ := e.source.LocationOffset(ej.Location)
-		return eiOff < ejOff
+		ei := e.errors[i].Location
+		ej := e.errors[j].Location
+		return ei.Line() < ej.Line() ||
+			(ei.Line() == ej.Line() && ei.Column() < ej.Column())
 	})
 	for i, err := range e.errors {
 		if i >= 1 {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -388,12 +388,12 @@ var testCases = []testInfo{
 	{
 		I: `*@a | b`,
 		E: `
-ERROR: <input>:1:2: Syntax error: token recognition error at: '@'
- | *@a | b
- | .^
 ERROR: <input>:1:1: Syntax error: extraneous input '*' expecting {'[', '{', '(', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}
  | *@a | b
  | ^
+ERROR: <input>:1:2: Syntax error: token recognition error at: '@'
+ | *@a | b
+ | .^
 ERROR: <input>:1:5: Syntax error: token recognition error at: '| '
  | *@a | b
  | ....^
@@ -1003,7 +1003,10 @@ ERROR: <input>:1:6: Syntax error: mismatched input '<EOF>' expecting {'[', '{', 
 	},
 	{
 		I: "[1, 2, 3].map(var, var * var)",
-		E: `ERROR: <input>:1:15: reserved identifier: var
+		E: `ERROR: <input>:1:14: argument is not an identifier
+ | [1, 2, 3].map(var, var * var)
+ | .............^
+ERROR: <input>:1:15: reserved identifier: var
  | [1, 2, 3].map(var, var * var)
  | ..............^
 ERROR: <input>:1:20: reserved identifier: var
@@ -1011,10 +1014,7 @@ ERROR: <input>:1:20: reserved identifier: var
  | ...................^
 ERROR: <input>:1:26: reserved identifier: var
  | [1, 2, 3].map(var, var * var)
- | .........................^
-ERROR: <input>:1:14: argument is not an identifier
- | [1, 2, 3].map(var, var * var)
- | .............^`,
+ | .........................^`,
 	},
 	{
 		I: "func{{a}}",


### PR DESCRIPTION
Errors are typically reported in order; however, there are some cases where errors may be reported out of the order where they appear within the input. Add stable sorting of errors by location offset to ensure they are reported in the order in which they appear in the text.