### PR TITLE
Fix the doc comments referring to the extant ClearBuiltins() option

### DIFF
--- a/cel/options.go
+++ b/cel/options.go
@@ -65,9 +65,9 @@ func CustomTypeProvider(provider ref.TypeProvider) EnvOption {
 
 // Declarations option extends the declaration set configured in the environment.
 //
-// Note: Declarations will by default be appended to the pre-existing declaration set cnofigured
-// for the environment. The cel.NewEnv call builds on top of the standard CEL declarations. For
-// a purely custom set of declarations use cel.NewCustomEnv.
+// Note: Declarations will by default be appended to the pre-existing declaration set configured
+// for the environment. The NewEnv call builds on top of the standard CEL declarations. For a
+// purely custom set of declarations use NewCustomEnv.
 func Declarations(decls ...*exprpb.Decl) EnvOption {
 	// TODO: provide an alternative means of specifying declarations that doesn't refer
 	// to the underlying proto implementations.
@@ -92,7 +92,7 @@ func HomogeneousAggregateLiterals() EnvOption {
 
 // Macros option extends the macro set configured in the environment.
 //
-// Note: This option must be specified after ClearBuiltIns and/or ClearMacros if used together.
+// Note: This option must be specified after ClearMacros if used together.
 func Macros(macros ...parser.Macro) EnvOption {
 	return func(e *Env) (*Env, error) {
 		e.macros = append(e.macros, macros...)

--- a/cel/options.go
+++ b/cel/options.go
@@ -36,9 +36,6 @@ type EnvOption func(e *Env) (*Env, error)
 //
 // Clearing macros will ensure CEL expressions can only contain linear evaluation paths, as
 // comprehensions such as `all` and `exists` are enabled only via macros.
-//
-// Note: This option is a no-op when used with ClearBuiltIns, and must be used before Macros
-// if used together.
 func ClearMacros() EnvOption {
 	return func(e *Env) (*Env, error) {
 		e.macros = parser.NoMacros
@@ -68,7 +65,9 @@ func CustomTypeProvider(provider ref.TypeProvider) EnvOption {
 
 // Declarations option extends the declaration set configured in the environment.
 //
-// Note: This option must be specified after ClearBuiltIns if both are used together.
+// Note: Declarations will by default be appended to the pre-existing declaration set cnofigured
+// for the environment. The cel.NewEnv call builds on top of the standard CEL declarations. For
+// a purely custom set of declarations use cel.NewCustomEnv.
 func Declarations(decls ...*exprpb.Decl) EnvOption {
 	// TODO: provide an alternative means of specifying declarations that doesn't refer
 	// to the underlying proto implementations.


### PR DESCRIPTION
Doc comments have been updated, but no additional godoc level `Example` tests have been added yet because I'd like the example to be meaningful and most of the tests around custom environments are toy examples. 

When #290 is implemented, I can easily see the `NewCustomEnv` warranting its own example as it will be much easier to subset CEL. Comment added to the FR #290 to this effect.

Closes #344 