### PR TITLE
Copy validated declarations between checker.Env instances on extension

### DIFF
--- a/cel/BUILD.bazel
+++ b/cel/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "//test/proto3pb:go_default_library",
         "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
         "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",
+        "@org_golang_google_protobuf//proto:go_default_library",
         "@org_golang_google_protobuf//types/known/structpb:go_default_library",
     ],
 )

--- a/cel/BUILD.bazel
+++ b/cel/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
     srcs = [
         "cel_example_test.go",
         "cel_test.go",
+        "env_test.go",
         "io_test.go",
     ],
     data = [

--- a/cel/env.go
+++ b/cel/env.go
@@ -109,6 +109,10 @@ type Env struct {
 // See the EnvOption helper functions for the options that can be used to configure the
 // environment.
 func NewEnv(opts ...EnvOption) (*Env, error) {
+	// Extend the statically configured standard environment, disabling eager validation to ensure
+	// the cost of setup for the environment is still just as cheap as it is in v0.11.x and earlier
+	// releases. The user provided options can easily re-enable the eager validation as they are
+	// processed after this default option.
 	stdOpts := append([]EnvOption{EagerlyValidateDeclarations(false)}, opts...)
 	return stdEnv.Extend(stdOpts...)
 }

--- a/cel/env.go
+++ b/cel/env.go
@@ -243,6 +243,7 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 	chkOptsCopy := make([]checker.Option, len(e.chkOpts))
 	copy(chkOptsCopy, e.chkOpts)
 
+	// Copy the declarations if needed.
 	decsCopy := []*exprpb.Decl{}
 	if e.chk != nil {
 		// If the type-checker has already been instantiated, then the e.declarations have been
@@ -254,7 +255,8 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 		decsCopy = make([]*exprpb.Decl, len(e.declarations))
 		copy(decsCopy, e.declarations)
 	}
-	// Copy slices.
+
+	// Copy macros and program options
 	macsCopy := make([]parser.Macro, len(e.macros))
 	progOptsCopy := make([]ProgramOption, len(e.progOpts))
 	copy(macsCopy, e.macros)

--- a/cel/env_test.go
+++ b/cel/env_test.go
@@ -18,7 +18,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common"
+	"github.com/google/cel-go/common/operators"
+	"github.com/google/cel-go/common/types"
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 func TestIssuesNil(t *testing.T) {
@@ -77,5 +81,61 @@ ERROR: <input>:1:2: Syntax error: mismatched input '<EOF>' expecting {'[', '{', 
  | .^`
 	if iss.String() != wantIss {
 		t.Errorf("iss.String() returned %v, wanted %v", iss.String(), wantIss)
+	}
+}
+
+func BenchmarkNewEnv(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		env, err := NewEnv()
+		if err != nil {
+			b.Fatalf("NewEnv() failed: %v", err)
+		}
+		_, iss := env.Compile("123")
+		if iss.Err() != nil {
+			b.Fatalf("env.Compile(123) failed: %v", iss.Err())
+		}
+	}
+}
+
+func BenchmarkEnvExtend(b *testing.B) {
+	env, err := NewEnv(EagerlyValidateDeclarations(true))
+	if err != nil {
+		b.Fatalf("NewEnv() failed: %v", err)
+	}
+	for i := 0; i < b.N; i++ {
+		ext, err := env.Extend(
+			Declarations(
+				decls.NewVar("test_var", decls.String),
+				decls.NewFunction(
+					operators.In,
+					decls.NewOverload("string_in_string", []*exprpb.Type{
+						decls.String, decls.String,
+					}, decls.Bool)),
+			),
+		)
+		if err != nil {
+			b.Fatalf("env.Extend() failed: %v", err)
+		}
+		_, iss := ext.Compile("123")
+		if iss.Err() != nil {
+			b.Fatalf("env.Compile(123) failed: %v", iss.Err())
+		}
+	}
+}
+
+func BenchmarkEnvExtendNoDecls(b *testing.B) {
+	env, err := NewEnv(EagerlyValidateDeclarations(true))
+	if err != nil {
+		b.Fatalf("NewEnv() failed: %v", err)
+	}
+	for i := 0; i < b.N; i++ {
+		ext, err := env.Extend(CustomTypeProvider(types.NewEmptyRegistry()))
+		if err != nil {
+			b.Fatalf("env.Extend() failed: %v", err)
+		}
+		_, iss := ext.Compile("123")
+		if iss.Err() != nil {
+			b.Fatalf("env.Compile(123) failed: %v", iss.Err())
+		}
 	}
 }

--- a/cel/env_test.go
+++ b/cel/env_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/types"
+
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
@@ -84,7 +85,27 @@ ERROR: <input>:1:2: Syntax error: mismatched input '<EOF>' expecting {'[', '{', 
 	}
 }
 
+func BenchmarkNewCustomEnvLazy(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := NewCustomEnv(StdLib(), EagerlyValidateDeclarations(false))
+		if err != nil {
+			b.Fatalf("NewCustomEnv() failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkNewCustomEnvEager(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := NewCustomEnv(StdLib(), EagerlyValidateDeclarations(true))
+		if err != nil {
+			b.Fatalf("NewCustomEnv() failed: %v", err)
+		}
+	}
+}
+
 func BenchmarkNewEnv(b *testing.B) {
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		env, err := NewEnv()
 		if err != nil {
@@ -103,16 +124,7 @@ func BenchmarkEnvExtend(b *testing.B) {
 		b.Fatalf("NewEnv() failed: %v", err)
 	}
 	for i := 0; i < b.N; i++ {
-		ext, err := env.Extend(
-			Declarations(
-				decls.NewVar("test_var", decls.String),
-				decls.NewFunction(
-					operators.In,
-					decls.NewOverload("string_in_string", []*exprpb.Type{
-						decls.String, decls.String,
-					}, decls.Bool)),
-			),
-		)
+		ext, err := env.Extend(CustomTypeProvider(types.NewEmptyRegistry()))
 		if err != nil {
 			b.Fatalf("env.Extend() failed: %v", err)
 		}
@@ -123,13 +135,22 @@ func BenchmarkEnvExtend(b *testing.B) {
 	}
 }
 
-func BenchmarkEnvExtendNoDecls(b *testing.B) {
+func BenchmarkEnvExtendDecls(b *testing.B) {
 	env, err := NewEnv(EagerlyValidateDeclarations(true))
 	if err != nil {
 		b.Fatalf("NewEnv() failed: %v", err)
 	}
 	for i := 0; i < b.N; i++ {
-		ext, err := env.Extend(CustomTypeProvider(types.NewEmptyRegistry()))
+		ext, err := env.Extend(
+			Declarations(
+				decls.NewVar("test_var", decls.String),
+				decls.NewFunction(
+					operators.In,
+					decls.NewOverload("string_in_string", []*exprpb.Type{
+						decls.String, decls.String,
+					}, decls.Bool)),
+			),
+		)
 		if err != nil {
 			b.Fatalf("env.Extend() failed: %v", err)
 		}

--- a/cel/env_test.go
+++ b/cel/env_test.go
@@ -104,8 +104,16 @@ func BenchmarkNewCustomEnvEager(b *testing.B) {
 	}
 }
 
-func BenchmarkNewEnv(b *testing.B) {
-	b.ResetTimer()
+func BenchmarkNewEnvLazy(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := NewEnv()
+		if err != nil {
+			b.Fatalf("NewEnv() failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkNewEnvEager(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		env, err := NewEnv()
 		if err != nil {
@@ -118,7 +126,24 @@ func BenchmarkNewEnv(b *testing.B) {
 	}
 }
 
-func BenchmarkEnvExtend(b *testing.B) {
+func BenchmarkEnvExtendEager(b *testing.B) {
+	env, err := NewEnv()
+	if err != nil {
+		b.Fatalf("NewEnv() failed: %v", err)
+	}
+	for i := 0; i < b.N; i++ {
+		ext, err := env.Extend()
+		if err != nil {
+			b.Fatalf("env.Extend() failed: %v", err)
+		}
+		_, iss := ext.Compile("123")
+		if iss.Err() != nil {
+			b.Fatalf("env.Compile(123) failed: %v", iss.Err())
+		}
+	}
+}
+
+func BenchmarkEnvExtendEagerTypes(b *testing.B) {
 	env, err := NewEnv(EagerlyValidateDeclarations(true))
 	if err != nil {
 		b.Fatalf("NewEnv() failed: %v", err)
@@ -135,7 +160,7 @@ func BenchmarkEnvExtend(b *testing.B) {
 	}
 }
 
-func BenchmarkEnvExtendDecls(b *testing.B) {
+func BenchmarkEnvExtendEagerDecls(b *testing.B) {
 	env, err := NewEnv(EagerlyValidateDeclarations(true))
 	if err != nil {
 		b.Fatalf("NewEnv() failed: %v", err)

--- a/cel/options.go
+++ b/cel/options.go
@@ -107,6 +107,14 @@ func Declarations(decls ...*exprpb.Decl) EnvOption {
 	}
 }
 
+// EagerlyValidateDeclarations ensures that any collisions between configured declarations are caught
+// at the time of the `NewEnv` call.
+//
+// Eagerly validating declarations is also useful for bootstrapping a base `cel.Env` value.
+// Calls to base `Env.Extend()` will be significantly faster when declarations are eagerly validated
+// as declarations will be collision-checked at most once and only incrementally by way of `Extend`
+//
+// Disabled by default as not all environments are used for type-checking.
 func EagerlyValidateDeclarations(enabled bool) EnvOption {
 	return features(featureEagerlyValidateDeclarations, enabled)
 }

--- a/cel/options.go
+++ b/cel/options.go
@@ -53,6 +53,10 @@ const (
 
 	// Enable the use of cross-type numeric comparisons at the type-checker.
 	featureCrossTypeNumericComparisons
+
+	// Enable eager validation of declarations to ensure that Env values created
+	// with `Extend` inherit a validated list of declarations from the parent Env.
+	featureEagerlyValidateDeclarations
 )
 
 // EnvOption is a functional interface for configuring the environment.
@@ -101,6 +105,10 @@ func Declarations(decls ...*exprpb.Decl) EnvOption {
 		e.declarations = append(e.declarations, decls...)
 		return e, nil
 	}
+}
+
+func EagerlyValidateDeclarations(enabled bool) EnvOption {
+	return features(featureEagerlyValidateDeclarations, enabled)
 }
 
 // HomogeneousAggregateLiterals option ensures that list and map literal entry types must agree

--- a/checker/decls/scopes.go
+++ b/checker/decls/scopes.go
@@ -33,6 +33,18 @@ func NewScopes() *Scopes {
 	}
 }
 
+func (s *Scopes) Copy() *Scopes {
+	cpy := NewScopes()
+	if s == nil {
+		return cpy
+	}
+	if s.parent != nil {
+		cpy.parent = s.parent.Copy()
+	}
+	cpy.scopes = s.scopes.copy()
+	return cpy
+}
+
 // Push creates a new Scopes value which references the current Scope as its parent.
 func (s *Scopes) Push() *Scopes {
 	return &Scopes{
@@ -80,9 +92,9 @@ func (s *Scopes) FindIdentInScope(name string) *exprpb.Decl {
 	return nil
 }
 
-// AddFunction adds the function Decl to the current scope.
+// SetFunction adds the function Decl to the current scope.
 // Note: Any previous entry for a function in the current scope with the same name is overwritten.
-func (s *Scopes) AddFunction(fn *exprpb.Decl) {
+func (s *Scopes) SetFunction(fn *exprpb.Decl) {
 	s.scopes.functions[fn.Name] = fn
 }
 
@@ -105,6 +117,17 @@ func (s *Scopes) FindFunction(name string) *exprpb.Decl {
 type Group struct {
 	idents    map[string]*exprpb.Decl
 	functions map[string]*exprpb.Decl
+}
+
+func (g *Group) copy() *Group {
+	cpy := newGroup()
+	for n, id := range g.idents {
+		cpy.idents[n] = id
+	}
+	for n, fn := range g.functions {
+		cpy.functions[n] = fn
+	}
+	return cpy
 }
 
 func newGroup() *Group {

--- a/checker/decls/scopes.go
+++ b/checker/decls/scopes.go
@@ -33,6 +33,7 @@ func NewScopes() *Scopes {
 	}
 }
 
+// Copy creates a copy of the current Scopes values, including a copy of its parent if non-nil.
 func (s *Scopes) Copy() *Scopes {
 	cpy := NewScopes()
 	if s == nil {
@@ -119,8 +120,13 @@ type Group struct {
 	functions map[string]*exprpb.Decl
 }
 
+// copy creates a new Group instance with a shallow copy of the variables and functions.
+// If callers need to mutate the exprpb.Decl definitions for a Function, they should copy-on-write.
 func (g *Group) copy() *Group {
-	cpy := newGroup()
+	cpy := &Group{
+		idents:    make(map[string]*exprpb.Decl, len(g.idents)),
+		functions: make(map[string]*exprpb.Decl, len(g.functions)),
+	}
 	for n, id := range g.idents {
 		cpy.idents[n] = id
 	}
@@ -130,6 +136,7 @@ func (g *Group) copy() *Group {
 	return cpy
 }
 
+// newGroup creates a new Group with empty maps for identifiers and functions.
 func newGroup() *Group {
 	return &Group{
 		idents:    make(map[string]*exprpb.Decl),

--- a/checker/env.go
+++ b/checker/env.go
@@ -122,7 +122,7 @@ func (e *Env) Add(decls ...*exprpb.Decl) error {
 		case *exprpb.Decl_Ident:
 			errMsgs = append(errMsgs, e.addIdent(sanitizeIdent(decl)))
 		case *exprpb.Decl_Function:
-			errMsgs = append(errMsgs, e.addFunction(sanitizeFunction(decl))...)
+			errMsgs = append(errMsgs, e.setFunction(sanitizeFunction(decl))...)
 		}
 	}
 	return formatError(errMsgs)
@@ -209,10 +209,10 @@ func (e *Env) addOverload(f *exprpb.Decl, overload *exprpb.Decl_FunctionDecl_Ove
 	return errMsgs
 }
 
-// addFunction adds the function Decl to the Env.
+// setFunction adds the function Decl to the Env.
 // Adds a function decl if one doesn't already exist, then adds all overloads from the Decl.
 // If overload overlaps with an existing overload, adds to the errors  in the Env instead.
-func (e *Env) addFunction(decl *exprpb.Decl) []errorMsg {
+func (e *Env) setFunction(decl *exprpb.Decl) []errorMsg {
 	current := e.declarations.FindFunction(decl.Name)
 	if current == nil {
 		//Add the function declaration without overloads and check the overloads below.
@@ -325,9 +325,10 @@ func getObjectWellKnownType(t *exprpb.Type) *exprpb.Type {
 	return pb.CheckedWellKnowns[t.GetMessageType()]
 }
 
-// validatedDeclarations returns a copy of the internal validated variable and function declaration scope stack.
+// validatedDeclarations returns a reference to the validated variable and function declaration scope stack.
+// must be copied before use.
 func (e *Env) validatedDeclarations() *decls.Scopes {
-	return e.declarations.Copy()
+	return e.declarations
 }
 
 // enterScope creates a new Env instance with a new innermost declaration scope.

--- a/checker/env.go
+++ b/checker/env.go
@@ -241,11 +241,10 @@ func (e *Env) addIdent(decl *exprpb.Decl) errorMsg {
 	return ""
 }
 
+// isOverloadDisabled returns whether the overloadID is disabled in the current environment.
 func (e *Env) isOverloadDisabled(overloadID string) bool {
-	if _, found := e.filteredOverloadIDs[overloadID]; found {
-		return found
-	}
-	return false
+	_, found := e.filteredOverloadIDs[overloadID]
+	return found
 }
 
 // sanitizeFunction replaces well-known types referenced by message name with their equivalent

--- a/checker/env_test.go
+++ b/checker/env_test.go
@@ -89,6 +89,21 @@ func TestSanitizedInstanceOverload(t *testing.T) {
 	}
 }
 
+func BenchmarkNewStdEnv(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		env, err := NewEnv(containers.DefaultContainer, newTestRegistry(b))
+		if err != nil {
+			b.Fatalf("NewEnv() failed: %v", err)
+		}
+		decls := []*exprpb.Decl{}
+		decls = append(decls, StandardDeclarations()...)
+		err = env.Add(decls...)
+		if err != nil {
+			b.Fatalf("env.Add(StandardDeclarations()) failed: %v", err)
+		}
+	}
+}
+
 func newStdEnv(t *testing.T) *Env {
 	t.Helper()
 	env, err := NewEnv(containers.DefaultContainer, newTestRegistry(t))
@@ -102,7 +117,7 @@ func newStdEnv(t *testing.T) *Env {
 	return env
 }
 
-func newTestRegistry(t *testing.T) ref.TypeRegistry {
+func newTestRegistry(t testing.TB) ref.TypeRegistry {
 	t.Helper()
 	reg, err := types.NewRegistry()
 	if err != nil {

--- a/checker/env_test.go
+++ b/checker/env_test.go
@@ -19,11 +19,13 @@ import (
 	"testing"
 
 	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/containers"
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/overloads"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/parser"
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
@@ -89,6 +91,29 @@ func TestSanitizedInstanceOverload(t *testing.T) {
 	}
 }
 
+func TestCopyDeclarations(t *testing.T) {
+	src := common.NewTextSource(`1 + 2 != 3 - 4`)
+	parsedAst, errors := parser.Parse(src)
+	if len(errors.GetErrors()) > 0 {
+		t.Fatalf("Unexpected parse errors: %v", errors.ToDisplayString())
+	}
+
+	env := newStdEnv(t)
+	_, errors = Check(parsedAst, src, env)
+	if len(errors.GetErrors()) > 0 {
+		t.Fatalf("Check(parsedAst, src, env): %v", errors.ToDisplayString())
+	}
+
+	copy, err := NewEnv(containers.DefaultContainer, newTestRegistry(t), ValidatedDeclarations(env))
+	if err != nil {
+		t.Fatalf("NewEnv(container, registry, CopyDeclarations(env)) failed %v: ", err)
+	}
+	_, errors = Check(parsedAst, src, copy)
+	if len(errors.GetErrors()) > 0 {
+		t.Fatalf("Check(parsedAst, src, copy): %v", errors.ToDisplayString())
+	}
+}
+
 func BenchmarkNewStdEnv(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		env, err := NewEnv(containers.DefaultContainer, newTestRegistry(b))
@@ -101,6 +126,22 @@ func BenchmarkNewStdEnv(b *testing.B) {
 		if err != nil {
 			b.Fatalf("env.Add(StandardDeclarations()) failed: %v", err)
 		}
+	}
+}
+
+func BenchmarkCopyDeclarations(b *testing.B) {
+	env, err := NewEnv(containers.DefaultContainer, newTestRegistry(b))
+	if err != nil {
+		b.Fatalf("NewEnv() failed: %v", err)
+	}
+	decls := []*exprpb.Decl{}
+	decls = append(decls, StandardDeclarations()...)
+	err = env.Add(decls...)
+	if err != nil {
+		b.Fatalf("env.Add(StandardDeclarations()) failed: %v", err)
+	}
+	for i := 0; i < b.N; i++ {
+		env.validatedDeclarations().Copy()
 	}
 }
 

--- a/checker/errors.go
+++ b/checker/errors.go
@@ -29,10 +29,6 @@ func (e *typeErrors) undeclaredReference(l common.Location, container string, na
 	e.ReportError(l, "undeclared reference to '%s' (in container '%s')", name, container)
 }
 
-func (e *typeErrors) expressionDoesNotSelectField(l common.Location) {
-	e.ReportError(l, "expression does not select a field")
-}
-
 func (e *typeErrors) typeDoesNotSupportFieldSelection(l common.Location, t *exprpb.Type) {
 	e.ReportError(l, "type '%s' does not support field selection", t)
 }

--- a/checker/options.go
+++ b/checker/options.go
@@ -14,9 +14,12 @@
 
 package checker
 
+import "github.com/google/cel-go/checker/decls"
+
 type options struct {
 	crossTypeNumericComparisons  bool
 	homogeneousAggregateLiterals bool
+	validatedDeclarations        *decls.Scopes
 }
 
 // Option is a functional option for configuring the type-checker
@@ -36,6 +39,13 @@ func CrossTypeNumericComparisons(enabled bool) Option {
 func HomogeneousAggregateLiterals(enabled bool) Option {
 	return func(opts *options) error {
 		opts.homogeneousAggregateLiterals = enabled
+		return nil
+	}
+}
+
+func CopyDeclarations(env *Env) Option {
+	return func(opts *options) error {
+		opts.validatedDeclarations = env.validatedDeclarations().Copy()
 		return nil
 	}
 }

--- a/checker/options.go
+++ b/checker/options.go
@@ -43,9 +43,11 @@ func HomogeneousAggregateLiterals(enabled bool) Option {
 	}
 }
 
-func CopyDeclarations(env *Env) Option {
+// ValidatedDeclarations provides a references to validated declarations which will be copied
+// into new checker instances.
+func ValidatedDeclarations(env *Env) Option {
 	return func(opts *options) error {
-		opts.validatedDeclarations = env.validatedDeclarations().Copy()
+		opts.validatedDeclarations = env.validatedDeclarations()
 		return nil
 	}
 }

--- a/checker/types.go
+++ b/checker/types.go
@@ -239,7 +239,8 @@ func internalIsAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) bool {
 // - t2 does not occur within t1.
 func isValidTypeSubstitution(m *mapping, t1, t2 *exprpb.Type) (valid, hasSub bool) {
 	if t2Sub, found := m.find(t2); found {
-		if proto.Equal(t1, t2Sub) {
+		kind1, kind2 := kindOf(t1), kindOf(t2)
+		if kind1 == kind2 && proto.Equal(t1, t2Sub) {
 			return true, true
 		}
 		// If the types are compatible, pick the more general type and return true

--- a/checker/types.go
+++ b/checker/types.go
@@ -184,13 +184,13 @@ func internalIsAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) bool {
 	kind1, kind2 := kindOf(t1), kindOf(t2)
 	if kind2 == kindTypeParam {
 		// If t2 is a valid type substitution for t1, return true.
-		valid, hasSub := isValidTypeSubstitution(m, t1, t2)
+		valid, t2HasSub := isValidTypeSubstitution(m, t1, t2)
 		if valid {
 			return true
 		}
 		// If t2 is not a valid type sub for t1, and already has a known substitution return false
 		// since it is not possible for t1 to be a substitution for t2.
-		if !valid && hasSub {
+		if !valid && t2HasSub {
 			return false
 		}
 		// Otherwise, fall through to check whether t1 is a possible substitution for t2.

--- a/checker/types.go
+++ b/checker/types.go
@@ -232,8 +232,8 @@ func internalIsAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) bool {
 	}
 }
 
-// isValidTypeSubstitution returns whether t2 (or its type substituion) is a valid type
-// substituion for t1.
+// isValidTypeSubstitution returns whether t2 (or its type substitution) is a valid type
+// substitution for t1.
 //
 // The type t2 is a valid substitution for t1 if any of the following statements is true
 // - t2 has a type substitition (t2sub) equal to t1

--- a/common/types/pb/pb_test.go
+++ b/common/types/pb/pb_test.go
@@ -43,6 +43,12 @@ func TestDbCopy(t *testing.T) {
 	}
 }
 
+func BenchmarkDbCopy(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewDb().Copy()
+	}
+}
+
 func TestProtoReflectRoundTrip(t *testing.T) {
 	msg := &proto3pb.TestAllTypes{SingleBool: true}
 	fdMap := CollectFileDescriptorSet(msg)

--- a/common/types/provider_test.go
+++ b/common/types/provider_test.go
@@ -520,7 +520,7 @@ func BenchmarkNativeToValue(b *testing.B) {
 	}
 }
 
-func BenchmarkTypeProvider_NewValue(b *testing.B) {
+func BenchmarkTypeProviderNewValue(b *testing.B) {
 	reg, err := NewRegistry(&exprpb.ParsedExpr{})
 	if err != nil {
 		b.Fatalf("NewRegistry() failed: %v", err)
@@ -533,6 +533,16 @@ func BenchmarkTypeProvider_NewValue(b *testing.B) {
 				"LineOffsets": NewDynamicList(reg, []int64{0, 2}),
 				"Positions":   NewDynamicMap(reg, map[int64]int64{1: 2, 2: 4}),
 			})
+	}
+}
+
+func BenchmarkTypeProviderCopy(b *testing.B) {
+	reg, err := NewRegistry()
+	if err != nil {
+		b.Fatalf("NewRegistry() failed: %v", err)
+	}
+	for i := 0; i < b.N; i++ {
+		reg.Copy()
 	}
 }
 


### PR DESCRIPTION
This change introduces several small changes to improve environment extension and CEL bootstrapping.

### Type-substitution Utility

Introduce a common helper method for performing type substitution checks. The helper method scopes
the use of `proto.Equal` within `internalIsAssignable` to only the cases where recursive type substitutions
occur. All other branches progressively narrow the types under consideration and use simpler checks
appropriate for the protobuf type.

This change improves check-time performance roughly 40% per issue #346. 

#### `EagerlyValidateDeclarations` Option

When this option is enabled, a guaranteed to compile expression is parsed and type-checked ensuring that
the internal instance of the `checker.Env` is initialized and all declarations provided as options to the
`cel.NewEnv()` call are checked to ensure there are no overlapping / colliding function declarations. 

Using this option in combination with `Extend` also makes it possible to copy the already validated
declarations into the cloned `checker.Env` of the extended environment. The cloned declarations are
shallowly copied on `checker.Env` initialization. If a declaration provided to the derived environment
needs to be merged with a function type declared in an ancestor environment, the ancestor function
is copied prior to being modified to ensure changes are isolated to the derived environment.

#### NewEnv() Extends by Default

The `NewEnv()` call now extends a globally initialized copy of the CEL standard environment whose
declarations have been validated as part of an `init()` call. This means in the common case that when
only a few declarations or parameters are changed as part of the CEL standard environment, the internal
`checker.Env` setup cost is kept to a minimum.

#### Filtered Overloads

The support for `CrossNumericTypes` was filtering overloads on addition to the `checker.Env`. This
behavior has now been shifted to filtering on access of the overload set within the type-checker.
Without this change it was impossible to toggle `CrossNumericTypes` support between `Extend`
calls.

#### Performance

The performance impact of these changes is dramatic, dropping the cost of the simple case by >95%

```
benchmark                          old ns/op     new ns/op     delta
BenchmarkNewEnvLazy-8              14748         13535         -8.22%
BenchmarkNewEnvEager-8             2506297       61987         -97.53%
BenchmarkEnvExtendEager-8          2658853       62218         -97.66%
BenchmarkEnvExtendEagerTypes-8     2742668       65600         -97.61%
BenchmarkEnvExtendEagerDecls-8     2650621       102302        -96.14%

benchmark                          old allocs     new allocs     delta
BenchmarkNewEnvLazy-8              97             39             -59.79%
BenchmarkNewEnvEager-8             20283          209            -98.97%
BenchmarkEnvExtendEager-8          20300          204            -99.00%
BenchmarkEnvExtendEagerTypes-8     20205          221            -98.91%
BenchmarkEnvExtendEagerDecls-8     20409          474            -97.68%

benchmark                          old bytes     new bytes     delta
BenchmarkNewEnvLazy-8              10489         7634          -27.22%
BenchmarkNewEnvEager-8             578535        18031         -96.88%
BenchmarkEnvExtendEager-8          581087        17801         -96.94%
BenchmarkEnvExtendEagerTypes-8     576225        20088         -96.51%
BenchmarkEnvExtendEagerDecls-8     579028        27177         -95.31%
```
