### PR TITLE
Add runtime support for timestamp from Unix epoch

### DIFF
--- a/common/types/int.go
+++ b/common/types/int.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"time"
 
 	"github.com/golang/protobuf/ptypes"
 
@@ -163,6 +164,13 @@ func (i Int) ConvertToType(typeVal ref.Type) ref.Val {
 		return Double(i)
 	case StringType:
 		return String(fmt.Sprintf("%d", int64(i)))
+	case TimestampType:
+		t := time.Unix(int64(i), 0)
+		ts, err := ptypes.TimestampProto(t)
+		if err != nil {
+			return NewErr(err.Error())
+		}
+		return Timestamp{Timestamp: ts}
 	case TypeType:
 		return IntType
 	}

--- a/common/types/int_test.go
+++ b/common/types/int_test.go
@@ -18,6 +18,7 @@ import (
 	"math"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
@@ -177,6 +178,12 @@ func TestInt_ConvertToType(t *testing.T) {
 	}
 	if !IsError(Int(-4).ConvertToType(DurationType)) {
 		t.Error("Got duration, expected error.")
+	}
+	tm := time.Unix(946684800, 0)
+	ts, _ := ptypes.TimestampProto(tm)
+	celts := Timestamp{Timestamp: ts}
+	if !Int(946684800).ConvertToType(TimestampType).Equal(celts).(Bool) {
+		t.Error("unsuccessful type conversion to timestamp")
 	}
 }
 

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -391,6 +391,30 @@ var (
 			},
 		},
 		{
+			name: "timestamp_eq_timestamp",
+			expr: `timestamp(0) == timestamp(0)`,
+		},
+		{
+			name: "timestamp_eq_timestamp",
+			expr: `timestamp(1) != timestamp(2)`,
+		},
+		{
+			name: "timestamp_lt_timestamp",
+			expr: `timestamp(0) < timestamp(1)`,
+		},
+		{
+			name: "timestamp_le_timestamp",
+			expr: `timestamp(2) <= timestamp(2)`,
+		},
+		{
+			name: "timestamp_gt_timestamp",
+			expr: `timestamp(1) > timestamp(0)`,
+		},
+		{
+			name: "timestamp_ge_timestamp",
+			expr: `timestamp(2) >= timestamp(2)`,
+		},
+		{
 			name: "string_to_timestamp",
 			expr: `timestamp('1986-04-26T01:23:40Z')`,
 			out:  &tpb.Timestamp{Seconds: 514862620},


### PR DESCRIPTION
Add runtime support for `timestamp(<epoch>)`. The function is apparently already declared in the `checker`, but was not implemented and not documented in the CEL spec. A separate ticket will be filed to fix the spec.

Closes #357 