### PR TITLE
Optimize type conversion functions. 

### DIFF
--- a/common/overloads/overloads.go
+++ b/common/overloads/overloads.go
@@ -280,6 +280,7 @@ func IsTypeConversionFunction(function string) bool {
 		TypeConvertBytes,
 		TypeConvertDouble,
 		TypeConvertDuration,
+		TypeConvertDyn,
 		TypeConvertInt,
 		TypeConvertString,
 		TypeConvertTimestamp,

--- a/common/overloads/overloads.go
+++ b/common/overloads/overloads.go
@@ -271,3 +271,22 @@ const (
 	HasNext  = "@hasNext"
 	Next     = "@next"
 )
+
+// IsTypeConversionFunction returns whether the input function is a standard library type
+// conversion function.
+func IsTypeConversionFunction(function string) bool {
+	switch function {
+	case TypeConvertBool,
+		TypeConvertBytes,
+		TypeConvertDouble,
+		TypeConvertDuration,
+		TypeConvertInt,
+		TypeConvertString,
+		TypeConvertTimestamp,
+		TypeConvertType,
+		TypeConvertUint:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
Unary type-conversion functions with literal arguments should be evaluated
eagerly when the `cel.EvalOptions(cel.OptOptimize)` flag is set. The conversion
will also ensure that if an error is encountered when evaluating these functions,
such as when constructing timestamps or durations from strings, the evaluation
will result in an error in the `env.Program` call.

This is not a perfect fix for #359, but it can be used to assist with correctness checks.