### PR TITLE
The type map references when keyed by attribute may be incorrect.

### DIFF
--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -540,6 +540,25 @@ var (
 			},
 		},
 		{
+			name:  "nested_proto_field",
+			expr:  `pb3.single_nested_message.bb`,
+			types: []proto.Message{&proto3pb.TestAllTypes{}},
+			env: []*exprpb.Decl{
+				decls.NewVar("pb3",
+					decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+			},
+			in: map[string]interface{}{
+				"pb3": &proto3pb.TestAllTypes{
+					NestedType: &proto3pb.TestAllTypes_SingleNestedMessage{
+						SingleNestedMessage: &proto3pb.TestAllTypes_NestedMessage{
+							Bb: 1234,
+						},
+					},
+				},
+			},
+			out: types.Int(1234),
+		},
+		{
 			name: "or_true_1st",
 			expr: `ai == 20 || ar["foo"] == "bar"`,
 			env: []*exprpb.Decl{


### PR DESCRIPTION
Attribute ids refer to the first operand in the qualified field path; however, the type map and reference map ids refer to the last field in the qualified attribute field path. Ensure that the types and references are correctly determined by referring directly to the id as it comes from the `checked.proto` AST.

Closes #364 