### PR TITLE
Expose interfaces to assist with creating CEL evaluation decorators

### DIFF
--- a/cel/options.go
+++ b/cel/options.go
@@ -189,6 +189,16 @@ func TypeDescs(descs ...interface{}) EnvOption {
 // ProgramOption is a functional interface for configuring evaluation bindings and behaviors.
 type ProgramOption func(p *prog) (*prog, error)
 
+// CustomDecorator appends an InterpreterDecorator to the program.
+//
+// InterpretableDecorators can be used to inspect, alter, or replace the Program plan.
+func CustomDecorator(dec interpreter.InterpretableDecorator) ProgramOption {
+	return func(p *prog) (*prog, error) {
+		p.decorators = append(p.decorators, dec)
+		return p, nil
+	}
+}
+
 // Functions adds function overloads that extend or override the set of CEL built-ins.
 func Functions(funcs ...*functions.Overload) ProgramOption {
 	return func(p *prog) (*prog, error) {

--- a/cel/program.go
+++ b/cel/program.go
@@ -93,6 +93,7 @@ func (ed *EvalDetails) State() interpreter.EvalState {
 type prog struct {
 	*Env
 	evalOpts      EvalOption
+	decorators    []interpreter.InterpretableDecorator
 	defaultVars   interpreter.Activation
 	dispatcher    interpreter.Dispatcher
 	interpreter   interpreter.Interpreter
@@ -118,7 +119,11 @@ func newProgram(e *Env, ast *Ast, opts []ProgramOption) (Program, error) {
 
 	// Ensure the default attribute factory is set after the adapter and provider are
 	// configured.
-	p := &prog{Env: e, dispatcher: disp}
+	p := &prog{
+		Env:        e,
+		decorators: []interpreter.InterpretableDecorator{},
+		dispatcher: disp,
+	}
 
 	// Configure the program via the ProgramOption values.
 	var err error
@@ -143,7 +148,9 @@ func newProgram(e *Env, ast *Ast, opts []ProgramOption) (Program, error) {
 	p.interpreter = interp
 
 	// Translate the EvalOption flags into InterpretableDecorator instances.
-	decorators := []interpreter.InterpretableDecorator{}
+	decorators := make([]interpreter.InterpretableDecorator, len(p.decorators))
+	copy(decorators, p.decorators)
+
 	// Enable constant folding first.
 	if p.evalOpts&OptOptimize == OptOptimize {
 		decorators = append(decorators, interpreter.Optimize())

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -75,6 +75,16 @@ type Qualifier interface {
 	Qualify(vars Activation, obj interface{}) (interface{}, error)
 }
 
+// ConstantQualifier interface embeds the Qualifier interface and provides an option to inspect the
+// qualifier's constant value.
+//
+// Non-constant qualifiers are of Attribute type.
+type ConstantQualifier interface {
+	Qualifier
+
+	Value() ref.Val
+}
+
 // Attribute values are a variable or value with an optional set of qualifiers, such as field, key,
 // or index accesses.
 type Attribute interface {
@@ -97,9 +107,8 @@ type NamespacedAttribute interface {
 	// the CEL namespace resolution order.
 	CandidateVariableNames() []string
 
-	// HasQualifiers indicates whether the attribute has any qualifiers. An attribute without
-	// qualifiers is just a variable.
-	HasQualifiers() bool
+	// Qualifiers returns the list of qualifiers associated with the Attribute.s
+	Qualifiers() []Qualifier
 
 	// TryResolve attempts to return the value of the attribute given the current Activation.
 	// If an error is encountered during attribute resolution, it will be returned immediately.
@@ -218,25 +227,37 @@ func (a *absoluteAttribute) ID() int64 {
 	return a.id
 }
 
-// String implements the Stringer interface method.
-func (a *absoluteAttribute) String() string {
-	return fmt.Sprintf("id: %v , names: %v", a.id, a.namespaceNames)
-}
-
 // AddQualifier implements the Attribute interface method.
 func (a *absoluteAttribute) AddQualifier(qual Qualifier) (Attribute, error) {
 	a.qualifiers = append(a.qualifiers, qual)
 	return a, nil
 }
 
-// HasQualifiers implements the NamespaceAttribute interface method.
-func (a *absoluteAttribute) HasQualifiers() bool {
-	return len(a.qualifiers) != 0
-}
-
 // CandidateVariableNames implements the NamespaceAttribute interface method.
 func (a *absoluteAttribute) CandidateVariableNames() []string {
 	return a.namespaceNames
+}
+
+// Qualifiers returns the list of Qualifier instances associated with the namespaced attribute.
+func (a *absoluteAttribute) Qualifiers() []Qualifier {
+	return a.qualifiers
+}
+
+// Qualify is an implementation of the Qualifier interface method.
+func (a *absoluteAttribute) Qualify(vars Activation, obj interface{}) (interface{}, error) {
+	val, err := a.Resolve(vars)
+	if err != nil {
+		return nil, err
+	}
+	unk, isUnk := val.(types.Unknown)
+	if isUnk {
+		return unk, nil
+	}
+	qual, err := a.fac.NewQualifier(nil, a.id, val)
+	if err != nil {
+		return nil, err
+	}
+	return qual.Qualify(vars, obj)
 }
 
 // Resolve returns the resolved Attribute value given the Activation, or error if the Attribute
@@ -250,6 +271,11 @@ func (a *absoluteAttribute) Resolve(vars Activation) (interface{}, error) {
 		return obj, nil
 	}
 	return nil, fmt.Errorf("no such attribute: %v", a)
+}
+
+// String implements the Stringer interface method.
+func (a *absoluteAttribute) String() string {
+	return fmt.Sprintf("id: %v, names: %v", a.id, a.namespaceNames)
 }
 
 // TryResolve iterates through the namespaced variable names until one is found within the
@@ -284,23 +310,6 @@ func (a *absoluteAttribute) TryResolve(vars Activation) (interface{}, bool, erro
 	return nil, false, nil
 }
 
-// Qualify is an implementation of the Qualifier interface method.
-func (a *absoluteAttribute) Qualify(vars Activation, obj interface{}) (interface{}, error) {
-	val, err := a.Resolve(vars)
-	if err != nil {
-		return nil, err
-	}
-	unk, isUnk := val.(types.Unknown)
-	if isUnk {
-		return unk, nil
-	}
-	qual, err := a.fac.NewQualifier(nil, a.id, val)
-	if err != nil {
-		return nil, err
-	}
-	return qual.Qualify(vars, obj)
-}
-
 type conditionalAttribute struct {
 	id      int64
 	expr    Interpretable
@@ -315,11 +324,6 @@ func (a *conditionalAttribute) ID() int64 {
 	return a.id
 }
 
-// String is an implementation of the Stringer interface method.
-func (a *conditionalAttribute) String() string {
-	return fmt.Sprintf("id: %v , truthy attribute: %v, falsy attribute: %v", a.id, a.truthy, a.falsy)
-}
-
 // AddQualifier appends the same qualifier to both sides of the conditional, in effect managing
 // the qualification of alternate attributes.
 func (a *conditionalAttribute) AddQualifier(qual Qualifier) (Attribute, error) {
@@ -332,6 +336,23 @@ func (a *conditionalAttribute) AddQualifier(qual Qualifier) (Attribute, error) {
 		return nil, err
 	}
 	return a, nil
+}
+
+// Qualify is an implementation of the Qualifier interface method.
+func (a *conditionalAttribute) Qualify(vars Activation, obj interface{}) (interface{}, error) {
+	val, err := a.Resolve(vars)
+	if err != nil {
+		return nil, err
+	}
+	unk, isUnk := val.(types.Unknown)
+	if isUnk {
+		return unk, nil
+	}
+	qual, err := a.fac.NewQualifier(nil, a.id, val)
+	if err != nil {
+		return nil, err
+	}
+	return qual.Qualify(vars, obj)
 }
 
 // Resolve evaluates the condition, and then resolves the truthy or falsy branch accordingly.
@@ -352,21 +373,9 @@ func (a *conditionalAttribute) Resolve(vars Activation) (interface{}, error) {
 	return nil, types.ValOrErr(val, "no such overload").Value().(error)
 }
 
-// Qualify is an implementation of the Qualifier interface method.
-func (a *conditionalAttribute) Qualify(vars Activation, obj interface{}) (interface{}, error) {
-	val, err := a.Resolve(vars)
-	if err != nil {
-		return nil, err
-	}
-	unk, isUnk := val.(types.Unknown)
-	if isUnk {
-		return unk, nil
-	}
-	qual, err := a.fac.NewQualifier(nil, a.id, val)
-	if err != nil {
-		return nil, err
-	}
-	return qual.Qualify(vars, obj)
+// String is an implementation of the Stringer interface method.
+func (a *conditionalAttribute) String() string {
+	return fmt.Sprintf("id: %v, truthy attribute: %v, falsy attribute: %v", a.id, a.truthy, a.falsy)
 }
 
 type maybeAttribute struct {
@@ -380,11 +389,6 @@ type maybeAttribute struct {
 // ID is an implementation of the Attribute interface method.
 func (a *maybeAttribute) ID() int64 {
 	return a.id
-}
-
-// String is an implementation of the Stringer interface method.
-func (a *maybeAttribute) String() string {
-	return fmt.Sprintf("id: %v , attributes: %v", a.id, a.attrs)
 }
 
 // AddQualifier adds a qualifier to each possible attribute variant, and also creates
@@ -416,7 +420,7 @@ func (a *maybeAttribute) AddQualifier(qual Qualifier) (Attribute, error) {
 	var augmentedNames []string
 	// First add the qualifier to all existing attributes in the oneof.
 	for _, attr := range a.attrs {
-		if isStr && !attr.HasQualifiers() {
+		if isStr && len(attr.Qualifiers()) == 0 {
 			candidateVars := attr.CandidateVariableNames()
 			augmentedNames = make([]string,
 				len(candidateVars),
@@ -432,6 +436,23 @@ func (a *maybeAttribute) AddQualifier(qual Qualifier) (Attribute, error) {
 		a.fac.AbsoluteAttribute(qual.ID(), augmentedNames...),
 	}, a.attrs...)
 	return a, nil
+}
+
+// Qualify is an implementation of the Qualifier interface method.
+func (a *maybeAttribute) Qualify(vars Activation, obj interface{}) (interface{}, error) {
+	val, err := a.Resolve(vars)
+	if err != nil {
+		return nil, err
+	}
+	unk, isUnk := val.(types.Unknown)
+	if isUnk {
+		return unk, nil
+	}
+	qual, err := a.fac.NewQualifier(nil, a.id, val)
+	if err != nil {
+		return nil, err
+	}
+	return qual.Qualify(vars, obj)
 }
 
 // Resolve follows the variable resolution rules to determine whether the attribute is a variable
@@ -452,21 +473,9 @@ func (a *maybeAttribute) Resolve(vars Activation) (interface{}, error) {
 	return nil, fmt.Errorf("no such attribute: %v", a)
 }
 
-// Qualify is an implementation of the Qualifier interface method.
-func (a *maybeAttribute) Qualify(vars Activation, obj interface{}) (interface{}, error) {
-	val, err := a.Resolve(vars)
-	if err != nil {
-		return nil, err
-	}
-	unk, isUnk := val.(types.Unknown)
-	if isUnk {
-		return unk, nil
-	}
-	qual, err := a.fac.NewQualifier(nil, a.id, val)
-	if err != nil {
-		return nil, err
-	}
-	return qual.Qualify(vars, obj)
+// String is an implementation of the Stringer interface method.
+func (a *maybeAttribute) String() string {
+	return fmt.Sprintf("id: %v, attributes: %v", a.id, a.attrs)
 }
 
 type relativeAttribute struct {
@@ -482,15 +491,27 @@ func (a *relativeAttribute) ID() int64 {
 	return a.id
 }
 
-// String is an implementation of the Stringer interface method.
-func (a *relativeAttribute) String() string {
-	return fmt.Sprintf("id: %v , operand: %v", a.id, a.operand)
-}
-
 // AddQualifier implements the Attribute interface method.
 func (a *relativeAttribute) AddQualifier(qual Qualifier) (Attribute, error) {
 	a.qualifiers = append(a.qualifiers, qual)
 	return a, nil
+}
+
+// Qualify is an implementation of the Qualifier interface method.
+func (a *relativeAttribute) Qualify(vars Activation, obj interface{}) (interface{}, error) {
+	val, err := a.Resolve(vars)
+	if err != nil {
+		return nil, err
+	}
+	unk, isUnk := val.(types.Unknown)
+	if isUnk {
+		return unk, nil
+	}
+	qual, err := a.fac.NewQualifier(nil, a.id, val)
+	if err != nil {
+		return nil, err
+	}
+	return qual.Qualify(vars, obj)
 }
 
 // Resolve expression value and qualifier relative to the expression result.
@@ -515,21 +536,9 @@ func (a *relativeAttribute) Resolve(vars Activation) (interface{}, error) {
 	return obj, nil
 }
 
-// Qualify is an implementation of the Qualifier interface method.
-func (a *relativeAttribute) Qualify(vars Activation, obj interface{}) (interface{}, error) {
-	val, err := a.Resolve(vars)
-	if err != nil {
-		return nil, err
-	}
-	unk, isUnk := val.(types.Unknown)
-	if isUnk {
-		return unk, nil
-	}
-	qual, err := a.fac.NewQualifier(nil, a.id, val)
-	if err != nil {
-		return nil, err
-	}
-	return qual.Qualify(vars, obj)
+// String is an implementation of the Stringer interface method.
+func (a *relativeAttribute) String() string {
+	return fmt.Sprintf("id: %v, operand: %v", a.id, a.operand)
 }
 
 func newQualifier(adapter ref.TypeAdapter, id int64, v interface{}) (Qualifier, error) {
@@ -634,6 +643,11 @@ func (q *stringQualifier) Qualify(vars Activation, obj interface{}) (interface{}
 		return nil, fmt.Errorf("no such key: %v", s)
 	}
 	return obj, nil
+}
+
+// Value implements the ConstantQualifier interface
+func (q *stringQualifier) Value() ref.Val {
+	return q.celValue
 }
 
 type intQualifier struct {
@@ -744,6 +758,11 @@ func (q *intQualifier) Qualify(vars Activation, obj interface{}) (interface{}, e
 	return obj, nil
 }
 
+// Value implements the ConstantQualifier interface
+func (q *intQualifier) Value() ref.Val {
+	return q.celValue
+}
+
 type uintQualifier struct {
 	id       int64
 	value    uint64
@@ -793,6 +812,11 @@ func (q *uintQualifier) Qualify(vars Activation, obj interface{}) (interface{}, 
 	return obj, nil
 }
 
+// Value implements the ConstantQualifier interface
+func (q *uintQualifier) Value() ref.Val {
+	return q.celValue
+}
+
 type boolQualifier struct {
 	id       int64
 	value    bool
@@ -834,6 +858,11 @@ func (q *boolQualifier) Qualify(vars Activation, obj interface{}) (interface{}, 
 	return obj, nil
 }
 
+// Value implements the ConstantQualifier interface
+func (q *boolQualifier) Value() ref.Val {
+	return q.celValue
+}
+
 // fieldQualifier indicates that the qualification is a well-defined field with a known
 // field type. When the field type is known this can be used to improve the speed and
 // efficiency of field resolution.
@@ -855,6 +884,11 @@ func (q *fieldQualifier) Qualify(vars Activation, obj interface{}) (interface{},
 		obj = rv.Value()
 	}
 	return q.FieldType.GetFrom(obj)
+}
+
+// Value implements the ConstantQualifier interface
+func (q *fieldQualifier) Value() ref.Val {
+	return types.String(q.Name)
 }
 
 // refResolve attempts to convert the value to a CEL value and then uses reflection methods

--- a/interpreter/attributes_test.go
+++ b/interpreter/attributes_test.go
@@ -91,10 +91,7 @@ func TestAttributes_RelativeAttr(t *testing.T) {
 	// }
 	//
 	// The expression being evaluated is: <map-literal>.a[-1][b] -> 42
-	op := &evalConst{
-		id:  1,
-		val: reg.NativeToValue(data),
-	}
+	op := NewConstValue(1, reg.NativeToValue(data))
 	attr := attrs.RelativeAttribute(1, op)
 	qualA, _ := attrs.NewQualifier(nil, 2, "a")
 	qualNeg1, _ := attrs.NewQualifier(nil, 3, int64(-1))
@@ -136,10 +133,7 @@ func TestAttributes_RelativeAttr_OneOf(t *testing.T) {
 	// - <map-literal>.a[-1][acme.b]
 	//
 	// The correct behavior should yield the value of the last alternative.
-	op := &evalConst{
-		id:  1,
-		val: reg.NativeToValue(data),
-	}
+	op := NewConstValue(1, reg.NativeToValue(data))
 	attr := attrs.RelativeAttribute(1, op)
 	qualA, _ := attrs.NewQualifier(nil, 2, "a")
 	qualNeg1, _ := attrs.NewQualifier(nil, 3, int64(-1))
@@ -178,20 +172,14 @@ func TestAttributes_RelativeAttr_Conditional(t *testing.T) {
 	// <map-literal>.a[-1][(false ? b : c)[0]] -> 42
 	//
 	// Effectively the same as saying <map-literal>.a[-1][c[0]]
-	cond := &evalConst{
-		id:  2,
-		val: types.False,
-	}
+	cond := NewConstValue(2, types.False)
 	condAttr := attrs.ConditionalAttribute(4, cond,
 		attrs.AbsoluteAttribute(5, "b"),
 		attrs.AbsoluteAttribute(6, "c"))
 	qual0, _ := attrs.NewQualifier(nil, 7, 0)
 	condAttr.AddQualifier(qual0)
 
-	obj := &evalConst{
-		id:  1,
-		val: reg.NativeToValue(data),
-	}
+	obj := NewConstValue(1, reg.NativeToValue(data))
 	attr := attrs.RelativeAttribute(1, obj)
 	qualA, _ := attrs.NewQualifier(nil, 2, "a")
 	qualNeg1, _ := attrs.NewQualifier(nil, 3, int64(-1))
@@ -249,18 +237,12 @@ func TestAttributes_RelativeAttr_Relative(t *testing.T) {
 	//
 	// This is equivalent to:
 	//   <obj>.a[-1]["second"] -> 2u
-	obj := &evalConst{
-		id:  1,
-		val: reg.NativeToValue(data),
-	}
-	mp := &evalConst{
-		id: 1,
-		val: reg.NativeToValue(map[uint32]interface{}{
-			1: "first",
-			2: "second",
-			3: "third",
-		}),
-	}
+	obj := NewConstValue(1, reg.NativeToValue(data))
+	mp := NewConstValue(1, reg.NativeToValue(map[uint32]interface{}{
+		1: "first",
+		2: "second",
+		3: "third",
+	}))
 	relAttr := attrs.RelativeAttribute(4, mp)
 	qualB, _ := attrs.NewQualifier(nil, 5, attrs.AbsoluteAttribute(5, "b"))
 	relAttr.AddQualifier(qualB)
@@ -326,7 +308,7 @@ func TestAttributes_ConditionalAttr_TrueBranch(t *testing.T) {
 	fv := attrs.MaybeAttribute(3, "b")
 	qualC, _ := attrs.NewQualifier(nil, 4, "c")
 	fv.AddQualifier(qualC)
-	cond := attrs.ConditionalAttribute(1, &evalConst{val: types.True}, tv, fv)
+	cond := attrs.ConditionalAttribute(1, NewConstValue(0, types.True), tv, fv)
 	qualNeg1, _ := attrs.NewQualifier(nil, 5, int64(-1))
 	qual1, _ := attrs.NewQualifier(nil, 6, int64(1))
 	cond.AddQualifier(qualNeg1)
@@ -360,7 +342,7 @@ func TestAttributes_ConditionalAttr_FalseBranch(t *testing.T) {
 	fv := attrs.MaybeAttribute(3, "b")
 	qualC, _ := attrs.NewQualifier(nil, 4, "c")
 	fv.AddQualifier(qualC)
-	cond := attrs.ConditionalAttribute(1, &evalConst{val: types.False}, tv, fv)
+	cond := attrs.ConditionalAttribute(1, NewConstValue(0, types.False), tv, fv)
 	qualNeg1, _ := attrs.NewQualifier(nil, 5, int64(-1))
 	qual1, _ := attrs.NewQualifier(nil, 6, int64(1))
 	cond.AddQualifier(qualNeg1)
@@ -381,14 +363,14 @@ func TestAttributes_ConditionalAttr_ErrorUnknown(t *testing.T) {
 	// err ? a : b
 	tv := attrs.AbsoluteAttribute(2, "a")
 	fv := attrs.MaybeAttribute(3, "b")
-	cond := attrs.ConditionalAttribute(1, &evalConst{val: types.NewErr("test error")}, tv, fv)
+	cond := attrs.ConditionalAttribute(1, NewConstValue(0, types.NewErr("test error")), tv, fv)
 	out, err := cond.Resolve(EmptyActivation())
 	if err == nil {
 		t.Errorf("Got %v, wanted error", out)
 	}
 
 	// unk ? a : b
-	condUnk := attrs.ConditionalAttribute(1, &evalConst{val: types.Unknown{1}}, tv, fv)
+	condUnk := attrs.ConditionalAttribute(1, NewConstValue(0, types.Unknown{1}), tv, fv)
 	out, err = condUnk.Resolve(EmptyActivation())
 	if err != nil {
 		t.Fatal(err)

--- a/interpreter/decorators.go
+++ b/interpreter/decorators.go
@@ -35,20 +35,20 @@ func decObserveEval(observer evalObserver) InterpretableDecorator {
 		case *evalWatch, *evalWatchAttr, *evalWatchConst:
 			// these instruction are already watching, return straight-away.
 			return i, nil
-		case instAttr:
+		case InterpretableAttribute:
 			return &evalWatchAttr{
-				instAttr: inst,
-				observer: observer,
+				InterpretableAttribute: inst,
+				observer:               observer,
 			}, nil
-		case instConst:
+		case InterpretableConst:
 			return &evalWatchConst{
-				instConst: inst,
-				observer:  observer,
+				InterpretableConst: inst,
+				observer:           observer,
 			}, nil
 		default:
 			return &evalWatch{
-				inst:     i,
-				observer: observer,
+				Interpretable: i,
+				observer:      observer,
 			}, nil
 		}
 	}
@@ -81,7 +81,7 @@ func decDisableShortcircuits() InterpretableDecorator {
 				step:      expr.step,
 				result:    expr.result,
 			}, nil
-		case instAttr:
+		case InterpretableAttribute:
 			cond, isCond := expr.Attr().(*conditionalAttribute)
 			if isCond {
 				return &evalExhaustiveConditional{
@@ -101,15 +101,14 @@ func decDisableShortcircuits() InterpretableDecorator {
 // - convert 'in' operations to set membership tests if possible.
 func decOptimize() InterpretableDecorator {
 	return func(i Interpretable) (Interpretable, error) {
-		switch i.(type) {
+		switch inst := i.(type) {
 		case *evalList:
-			return maybeBuildListLiteral(i, i.(*evalList))
+			return maybeBuildListLiteral(i, inst)
 		case *evalMap:
-			return maybeBuildMapLiteral(i, i.(*evalMap))
-		case *evalBinary:
-			call := i.(*evalBinary)
-			if call.overload == overloads.InList {
-				return maybeOptimizeSetMembership(i, call)
+			return maybeBuildMapLiteral(i, inst)
+		case InterpretableCall:
+			if inst.OverloadID() == overloads.InList {
+				return maybeOptimizeSetMembership(i, inst)
 			}
 		}
 		return i, nil
@@ -118,53 +117,45 @@ func decOptimize() InterpretableDecorator {
 
 func maybeBuildListLiteral(i Interpretable, l *evalList) (Interpretable, error) {
 	for _, elem := range l.elems {
-		_, isConst := elem.(*evalConst)
+		_, isConst := elem.(InterpretableConst)
 		if !isConst {
 			return i, nil
 		}
 	}
-	val := l.Eval(EmptyActivation())
-	return &evalConst{
-		id:  l.id,
-		val: val,
-	}, nil
+	return NewConstValue(l.ID(), l.Eval(EmptyActivation())), nil
 }
 
 func maybeBuildMapLiteral(i Interpretable, mp *evalMap) (Interpretable, error) {
 	for idx, key := range mp.keys {
-		_, isConst := key.(*evalConst)
+		_, isConst := key.(InterpretableConst)
 		if !isConst {
 			return i, nil
 		}
-		_, isConst = mp.vals[idx].(*evalConst)
+		_, isConst = mp.vals[idx].(InterpretableConst)
 		if !isConst {
 			return i, nil
 		}
 	}
-	val := mp.Eval(EmptyActivation())
-	return &evalConst{
-		id:  mp.id,
-		val: val,
-	}, nil
+	return NewConstValue(mp.ID(), mp.Eval(EmptyActivation())), nil
 }
 
 // maybeOptimizeSetMembership may convert an 'in' operation against a list to map key membership
 // test if the following conditions are true:
 // - the list is a constant with homogeneous element types.
 // - the elements are all of primitive type.
-func maybeOptimizeSetMembership(i Interpretable, inlist *evalBinary) (Interpretable, error) {
-	l, isConst := inlist.rhs.(*evalConst)
+func maybeOptimizeSetMembership(i Interpretable, inlist InterpretableCall) (Interpretable, error) {
+	args := inlist.Args()
+	lhs := args[0]
+	rhs := args[1]
+	l, isConst := rhs.(InterpretableConst)
 	if !isConst {
 		return i, nil
 	}
 	// When the incoming binary call is flagged with as the InList overload, the value will
 	// always be convertible to a `traits.Lister` type.
-	list := l.val.(traits.Lister)
+	list := l.Value().(traits.Lister)
 	if list.Size() == types.IntZero {
-		return &evalConst{
-			id:  inlist.id,
-			val: types.False,
-		}, nil
+		return NewConstValue(inlist.ID(), types.False), nil
 	}
 	it := list.Iterator()
 	var typ ref.Type
@@ -184,7 +175,7 @@ func maybeOptimizeSetMembership(i Interpretable, inlist *evalBinary) (Interpreta
 	}
 	return &evalSetMembership{
 		inst:        inlist,
-		arg:         inlist.lhs,
+		arg:         lhs,
 		argTypeName: typ.TypeName(),
 		valueSet:    valueSet,
 	}, nil

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -53,8 +53,11 @@ type InterpretableAttribute interface {
 	Adapter() ref.TypeAdapter
 
 	// AddQualifier proxies the Attribute.AddQualifier method.
-	// Note, this method will mutate the current attribute state. If the desire is to clone the
-	// Attribute, then alte
+	//
+	// Note, this method may mutate the current attribute state. If the desire is to clone the
+	// Attribute, the Attribute should first be copied before adding the qualifier. Attributes
+	// are not copyable by default, so this is a capable that would need to be added to the
+	// AttributeFactory or specifically to the underlying Attribute implementation.
 	AddQualifier(Qualifier) (InterpretableAttribute, error)
 }
 


### PR DESCRIPTION
If the `cel.EvalOptions(cel.OptOptimize)` option is provided to the `env.Program(ast, opts)` call, CEL applies a series of `InterpretableDecorator` functional objects as part of the program plan stage which in some cases will replace or rewrite CEL expressions to perform more optimally. 

CEL also uses the same technique to support state tracking and exhaustive evaluation. This is a generally useful technique, but unless the user had access to the internal implementation details of CEL, it was impossible to use outside of CEL. The following interface changes make it possible for a limited set of custom decorators to be created where any decorator may inspect any `Attribute` or `InterpretableConst` or `InterpretableCall` at program plan phase and observe, alter, or replace the evaluation node to support a specific use case.

Closes #363