### PR TITLE
Add heuristic evaluation cost to expressions

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -876,3 +876,38 @@ func Test_CustomInterpreterDecorator(t *testing.T) {
 		t.Errorf("got %v as the last observed constant, wanted 1", lastConst)
 	}
 }
+
+func Test_Cost(t *testing.T) {
+	e, err := NewEnv()
+	if err != nil {
+		log.Fatalf("environment creation error: %s\n", err)
+	}
+	ast, iss := e.Compile(`"Hello, World!"`)
+	if iss.Err() != nil {
+		log.Fatalln(iss.Err())
+	}
+
+	wantedCost := []int64{0, 0}
+
+	// Test standard evaluation cost.
+	prg, err := e.Program(ast)
+	if err != nil {
+		log.Fatalf("program creation error: %s\n", err)
+	}
+	min, max := EstimateCost(prg)
+	if min != wantedCost[0] || max != wantedCost[1] {
+		log.Fatalf("Got cost interval [%v, %v], wanted %v",
+			min, max, wantedCost)
+	}
+
+	// Test the factory-based evaluation cost.
+	prg, err = e.Program(ast, EvalOptions(OptExhaustiveEval))
+	if err != nil {
+		t.Fatalf("program creation error: %s\n", err)
+	}
+	min, max = EstimateCost(prg)
+	if min != wantedCost[0] || max != wantedCost[1] {
+		log.Fatalf("Got cost interval [%v, %v], wanted %v",
+			min, max, wantedCost)
+	}
+}

--- a/interpreter/BUILD.bazel
+++ b/interpreter/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "activation.go",
         "attributes.go",
         "attribute_patterns.go",
+        "coster.go",
         "decorators.go",
         "dispatcher.go",
         "evalstate.go",

--- a/interpreter/attributes_test.go
+++ b/interpreter/attributes_test.go
@@ -56,6 +56,10 @@ func TestAttributes_AbsoluteAttr(t *testing.T) {
 	if out != types.String("success") {
 		t.Errorf("Got %v (%T), wanted success", out, out)
 	}
+	wantedMin, wantedMax := int64(1), int64(1)
+	if min, max := estimateCost(attr); min != wantedMin || max != wantedMax {
+		t.Errorf("Got cost interval [%v, %v], wanted [%v, %v]", min, max, wantedMin, wantedMax)
+	}
 }
 
 func TestAttributes_AbsoluteAttr_Type(t *testing.T) {
@@ -70,6 +74,10 @@ func TestAttributes_AbsoluteAttr_Type(t *testing.T) {
 	}
 	if out != types.IntType {
 		t.Errorf("Got %v, wanted success", out)
+	}
+	wantedMin, wantedMax := int64(1), int64(1)
+	if min, max := estimateCost(attr); min != wantedMin || max != wantedMax {
+		t.Errorf("Got cost interval [%v, %v], wanted [%v, %v]", min, max, wantedMin, wantedMax)
 	}
 }
 
@@ -104,6 +112,10 @@ func TestAttributes_RelativeAttr(t *testing.T) {
 	}
 	if out != types.Int(42) {
 		t.Errorf("Got %v (%T), wanted 42", out, out)
+	}
+	wantedMin, wantedMax := int64(1), int64(1)
+	if min, max := estimateCost(attr); min != wantedMin || max != wantedMax {
+		t.Errorf("Got cost interval [%v, %v], wanted [%v, %v]", min, max, wantedMin, wantedMax)
 	}
 }
 
@@ -146,6 +158,10 @@ func TestAttributes_RelativeAttr_OneOf(t *testing.T) {
 	}
 	if out != types.Int(42) {
 		t.Errorf("Got %v (%T), wanted 42", out, out)
+	}
+	wantedMin, wantedMax := int64(1), int64(1)
+	if min, max := estimateCost(attr); min != wantedMin || max != wantedMax {
+		t.Errorf("Got cost interval [%v, %v], wanted [%v, %v]", min, max, wantedMin, wantedMax)
 	}
 }
 
@@ -192,6 +208,10 @@ func TestAttributes_RelativeAttr_Conditional(t *testing.T) {
 	}
 	if out != types.Int(42) {
 		t.Errorf("Got %v (%T), wanted 42", out, out)
+	}
+	wantedMin, wantedMax := int64(1), int64(1)
+	if min, max := estimateCost(attr); min != wantedMin || max != wantedMax {
+		t.Errorf("Got cost interval [%v, %v], wanted [%v, %v]", min, max, wantedMin, wantedMax)
 	}
 }
 
@@ -260,6 +280,10 @@ func TestAttributes_RelativeAttr_Relative(t *testing.T) {
 	if out != types.Uint(2) {
 		t.Errorf("Got %v (%T), wanted 2", out, out)
 	}
+	wantedMin, wantedMax := int64(1), int64(1)
+	if min, max := estimateCost(attr); min != wantedMin || max != wantedMax {
+		t.Errorf("Got cost interval [%v, %v], wanted [%v, %v]", min, max, wantedMin, wantedMax)
+	}
 }
 
 func TestAttributes_OneofAttr(t *testing.T) {
@@ -285,6 +309,10 @@ func TestAttributes_OneofAttr(t *testing.T) {
 	}
 	if out != "found" {
 		t.Errorf("Got %v, wanted 'found'", out)
+	}
+	wantedMin, wantedMax := int64(1), int64(1)
+	if min, max := estimateCost(attr); min != wantedMin || max != wantedMax {
+		t.Errorf("Got cost interval [%v, %v], wanted [%v, %v]", min, max, wantedMin, wantedMax)
 	}
 }
 
@@ -320,6 +348,10 @@ func TestAttributes_ConditionalAttr_TrueBranch(t *testing.T) {
 	if out != int32(42) {
 		t.Errorf("Got %v (%T), wanted 42", out, out)
 	}
+	wantedMin, wantedMax := int64(1), int64(1)
+	if min, max := estimateCost(fv); min != wantedMin || max != wantedMax {
+		t.Errorf("Got cost interval [%v, %v], wanted [%v, %v]", min, max, wantedMin, wantedMax)
+	}
 }
 
 func TestAttributes_ConditionalAttr_FalseBranch(t *testing.T) {
@@ -354,6 +386,10 @@ func TestAttributes_ConditionalAttr_FalseBranch(t *testing.T) {
 	if out != uint(42) {
 		t.Errorf("Got %v (%T), wanted 42", out, out)
 	}
+	wantedMin, wantedMax := int64(1), int64(1)
+	if min, max := estimateCost(fv); min != wantedMin || max != wantedMax {
+		t.Errorf("Got cost interval [%v, %v], wanted [%v, %v]", min, max, wantedMin, wantedMax)
+	}
 }
 
 func TestAttributes_ConditionalAttr_ErrorUnknown(t *testing.T) {
@@ -368,6 +404,10 @@ func TestAttributes_ConditionalAttr_ErrorUnknown(t *testing.T) {
 	if err == nil {
 		t.Errorf("Got %v, wanted error", out)
 	}
+	wantedMin, wantedMax := int64(1), int64(1)
+	if min, max := estimateCost(fv); min != wantedMin || max != wantedMax {
+		t.Errorf("Got cost interval [%v, %v], wanted [%v, %v]", min, max, wantedMin, wantedMax)
+	}
 
 	// unk ? a : b
 	condUnk := attrs.ConditionalAttribute(1, NewConstValue(0, types.Unknown{1}), tv, fv)
@@ -378,6 +418,10 @@ func TestAttributes_ConditionalAttr_ErrorUnknown(t *testing.T) {
 	unk, ok := out.(types.Unknown)
 	if !ok || !types.IsUnknown(unk) {
 		t.Errorf("Got %v, wanted unknown", out)
+	}
+	wantedMin, wantedMax = int64(1), int64(1)
+	if min, max := estimateCost(fv); min != wantedMin || max != wantedMax {
+		t.Errorf("Got cost interval [%v, %v], wanted [%v, %v]", min, max, wantedMin, wantedMax)
 	}
 }
 
@@ -405,6 +449,10 @@ func TestResolver_CustomQualifier(t *testing.T) {
 	}
 	if out != int32(123) {
 		t.Errorf("Got %v, wanted 123", out)
+	}
+	wantedMin, wantedMax := int64(1), int64(1)
+	if min, max := estimateCost(attr); min != wantedMin || max != wantedMax {
+		t.Errorf("Got cost interval [%v, %v], wanted [%v, %v]", min, max, wantedMin, wantedMax)
 	}
 }
 
@@ -498,4 +546,9 @@ func (q *nestedMsgQualifier) ID() int64 {
 func (q *nestedMsgQualifier) Qualify(vars Activation, obj interface{}) (interface{}, error) {
 	pb := obj.(*proto3pb.TestAllTypes_NestedMessage)
 	return pb.GetBb(), nil
+}
+
+// Cost implements the Coster interface method. It returns zero for testing purposes.
+func (q *nestedMsgQualifier) Cost() (min, max int64) {
+	return 0, 0
 }

--- a/interpreter/coster.go
+++ b/interpreter/coster.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interpreter
+
+import "math"
+
+// Coster calculates the heuristic cost incurred during evaluation.
+type Coster interface {
+	Cost() (min, max int64)
+}
+
+// estimateCost returns the heuristic cost interval for the program.
+func estimateCost(i interface{}) (min, max int64) {
+	c, ok := i.(Coster)
+	if !ok {
+		return 0, math.MaxInt64
+	}
+	return c.Cost()
+}


### PR DESCRIPTION
The primary goal for the change is for CEL policy templates where a 
cost limit can be configured and enforced at compile time and runtime.

I am uncertain about some of the cost estimations, but feel it is easier
 to discuss with a PR.

Below are the points that might be worth discussing:

* The cost for all operators and functions is 1, which may be 
customizable.
* The resulting cost is an interval, mainly for expression that contains
 short-circuitable operations, such logical and/or, condition ternary.
* The cost for all existing qualifiers is 1. The interface added there
 is more for extensibility (e.g. a custom qualifier) but we can also
  remove it.
* The actual cost for some expressions (`fold` specifically) may rely
 on the input size, which is not available at compile time. Currently I
  just return the maximum possible range. Wdyt? (this is also the
 reason I am using `int64` as the cost as it is more obvious when the
  cost overflows).
