### PR TITLE
Support hexadecimal integer literals

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -19,6 +19,7 @@ package parser
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
@@ -455,10 +456,15 @@ func (p *parser) VisitMapInitializerList(ctx *gen.MapInitializerListContext) int
 // Visit a parse tree produced by CELParser#Int.
 func (p *parser) VisitInt(ctx *gen.IntContext) interface{} {
 	text := ctx.GetTok().GetText()
+	base := 10
+	if strings.HasPrefix(text, "0x") {
+		base = 16
+		text = text[2:]
+	}
 	if ctx.GetSign() != nil {
 		text = ctx.GetSign().GetText() + text
 	}
-	i, err := strconv.ParseInt(text, 10, 64)
+	i, err := strconv.ParseInt(text, base, 64)
 	if err != nil {
 		return p.reportError(ctx, "invalid int literal")
 	}
@@ -470,7 +476,12 @@ func (p *parser) VisitUint(ctx *gen.UintContext) interface{} {
 	text := ctx.GetTok().GetText()
 	// trim the 'u' designator included in the uint literal.
 	text = text[:len(text)-1]
-	i, err := strconv.ParseUint(text, 10, 64)
+	base := 10
+	if strings.HasPrefix(text, "0x") {
+		base = 16
+		text = text[2:]
+	}
+	i, err := strconv.ParseUint(text, base, 64)
 	if err != nil {
 		return p.reportError(ctx, "invalid uint literal")
 	}


### PR DESCRIPTION
Implements support for hexadecimal integer literals, as defined in the [language lexis](https://github.com/google/cel-spec/blob/master/doc/langdef.md#syntax). Tests are being added to [cel-spec](https://github.com/google/cel-spec/pull/136).