### PR TITLE
Simplify base64 functions.

### DIFF
--- a/ext/README.md
+++ b/ext/README.md
@@ -9,34 +9,27 @@ Encoding utilies for marshalling data into standardized representations.
 
 ### Base64.Decode
 
-Decodes base64-encoded text to a sequence of bytes. The text can be supplied
-as a string or utf8-encoded bytes.
+Decodes base64-encoded string to bytes.
 
-This function will return an error if the UTF-8 string input is not
+This function will return an error if the string input is not
 base64-encoded.
 
-    base64.decode(<bytes>)  -> <bytes>
     base64.decode(<string>) -> <bytes>
 
 Examples:
 
-    base64.decode(b'aGVsbG8=') // return b'hello'
     base64.decode('aGVsbG8=')  // return b'hello'
     base64.decode('aGVsbG8')   // error
 
 ### Base64.Encode
 
-Encodes binary data to base64-encoded text. The binary data can by bytes or
-a string, which will be utf8-encoded to binary before base64-encoding. The
-base64-encoded text is returned as utf8-encoded bytes.
+Encodes bytes to a base64-encoded string.
 
-    base64.encode(<bytes>)  -> <bytes>
-    base64.encode(<string>) -> <bytes>
+    base64.encode(<bytes>)  -> <string>
 
-Examples:
+Example:
 
-    base64.encode(b'hello') // return b'aGVsbG8='
-    base64.encode('hello')  // return b'aGVsbG8='
+    base64.encode(b'hello') // return 'aGVsbG8='
 
 ## Strings
 

--- a/ext/encoders_test.go
+++ b/ext/encoders_test.go
@@ -28,20 +28,18 @@ func TestEncoders(t *testing.T) {
 		parseOnly bool
 	}{
 		{expr: "base64.decode('aGVsbG8=') == b'hello'"},
-		{expr: "base64.decode(b'aGVsbG8=') == b'hello'"},
 		{
 			expr: "base64.decode('aGVsbG8') == b'error'",
 			err:  "illegal base64 data at input byte 4",
 		},
 		{
-			expr:      "base64.decode(123) == b'error'",
+			expr:      "base64.decode(b'aGVsbG8=') == b'hello'",
 			err:       "no such overload",
 			parseOnly: true,
 		},
-		{expr: "base64.encode('hello') == b'aGVsbG8='"},
-		{expr: "base64.encode(b'hello') == b'aGVsbG8='"},
+		{expr: "base64.encode(b'hello') == 'aGVsbG8='"},
 		{
-			expr:      "base64.encode(123) == b'error'",
+			expr:      "base64.encode('hello') == b'aGVsbG8='",
 			err:       "no such overload",
 			parseOnly: true,
 		},

--- a/ext/guards.go
+++ b/ext/guards.go
@@ -36,6 +36,20 @@ func callInBytesOutBytes(fn func([]byte) ([]byte, error)) functions.UnaryOp {
 	}
 }
 
+func callInBytesOutString(fn func([]byte) (string, error)) functions.UnaryOp {
+	return func(val ref.Val) ref.Val {
+		vVal, ok := val.(types.Bytes)
+		if !ok {
+			return types.MaybeNoSuchOverloadErr(val)
+		}
+		str, err := fn([]byte(vVal))
+		if err != nil {
+			return types.NewErr(err.Error())
+		}
+		return types.String(str)
+	}
+}
+
 func callInStrOutBytes(fn func(string) ([]byte, error)) functions.UnaryOp {
 	return func(val ref.Val) ref.Val {
 		vVal, ok := val.(types.String)


### PR DESCRIPTION
Removed variants can by expressed by composing with explicit string-byte conversions if needed.  Dependence on utf8 is left to conversion functions rather than internalized here.
