### PR TITLE
Re-enable timezone-based tests.

### DIFF
--- a/conformance/BUILD.bazel
+++ b/conformance/BUILD.bazel
@@ -50,8 +50,6 @@ sh_test(
         "$(location @com_google_cel_spec//tests/simple:simple_test)",
         "--server=$(location //server/main:cel_server)",
         "-test.v",
-        # Failing due to a GCB builder issue
-        "--skip_test=timestamps/timestamp_selectors_tz/getDate,getDayOfMonth_name_neg,getDayOfMonth_name_pos,getDayOfYear,getMinutes",
         "$(location @com_google_cel_spec//tests/simple:testdata/plumbing.textproto)",
         "$(location @com_google_cel_spec//tests/simple:testdata/basic.textproto)",
         "$(location @com_google_cel_spec//tests/simple:testdata/comparisons.textproto)",


### PR DESCRIPTION
The background build environment should now be fixed.
