### PR TITLE
Ensure protodesc.FileDescriptor references are sourced from the global proto registry

### DIFF
--- a/common/types/pb/BUILD.bazel
+++ b/common/types/pb/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
         "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
+        "@org_golang_google_protobuf//reflect/protoregistry:go_default_library",
         "@org_golang_google_protobuf//types/dynamicpb:go_default_library",
         "@org_golang_google_protobuf//types/known/anypb:go_default_library",
         "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
@@ -43,6 +44,7 @@ go_test(
         "//test/proto2pb:test_all_types_go_proto",
         "//test/proto3pb:test_all_types_go_proto",
         "@org_golang_google_protobuf//reflect/protodesc:go_default_library",
+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
         "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
     ],
 )

--- a/common/types/pb/pb_test.go
+++ b/common/types/pb/pb_test.go
@@ -20,7 +20,11 @@ import (
 	"reflect"
 	"testing"
 
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
 	proto3pb "github.com/google/cel-go/test/proto3pb"
+	descpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 func TestDbCopy(t *testing.T) {
@@ -38,5 +42,48 @@ func TestDbCopy(t *testing.T) {
 	clone2 := clone.Copy()
 	if !reflect.DeepEqual(clone, clone2) {
 		t.Error("db.Copy() did not result in eqivalent objects.")
+	}
+}
+
+func TestProtoReflectRoundTrip(t *testing.T) {
+	msg := &proto3pb.TestAllTypes{SingleBool: true}
+	fdMap := CollectFileDescriptorSet(msg)
+	files := []*descpb.FileDescriptorProto{}
+	for _, fd := range fdMap {
+		files = append(files, protodesc.ToFileDescriptorProto(fd))
+	}
+	// Round-tripping from a protoreflect.FileDescriptor to a FileDescriptorSet and back
+	// will result in completely independent copies of the protoreflect.FileDescriptor
+	// whose values are incompatible with each other.
+	//
+	// This test showcases what happens when the protoregistry.GlobalFiles values are
+	// used when a given protoreflect.FileDescriptor is linked into the binary.
+	fds := &descpb.FileDescriptorSet{File: files}
+	pbReg, err := protodesc.NewFiles(fds)
+	if err != nil {
+		t.Fatalf("protodesc.NewFiles() failed: %v", err)
+	}
+	pbdb := NewDb()
+	pbReg.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+		_, err := pbdb.RegisterDescriptor(fd)
+		if err != nil {
+			t.Fatalf("pbdb.RegisterDecriptor(%v) failed: %v", fd, err)
+		}
+		return true
+	})
+	msgType, found := pbdb.DescribeType("google.expr.proto3.test.TestAllTypes")
+	if !found {
+		t.Fatal("pbdb.DescribeType(google.expr.proto3.test.TestAllTypes) failed")
+	}
+	boolField, found := msgType.FieldByName("single_bool")
+	if !found {
+		t.Fatal("msgType.FieldByName(single_bool) failed")
+	}
+	val, err := boolField.GetFrom(msg)
+	if err != nil {
+		t.Errorf("boolField.GetFrom(msg) failed: %v", err)
+	}
+	if val != true {
+		t.Errorf("got TestAllTypes.single_bool %v, wanted true", val)
 	}
 }


### PR DESCRIPTION
Round-tripping from a `protoreflect.FileDescriptor` to a `FileDescriptorProto` and back results in a `protoreflect.FileDescriptor` value which is incompatible with the original. This is by design. Based on this choice, all `protoreflect.FileDescriptor` values must be checked to see if they are also defined in the `protoregistry.GlobalFiles` and if so, sourced from the global proto registry rather than taken as-is.