### PR TITLE
Re-add support for duration and timestamp proto values to CEL values.

### DIFF
--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -28,7 +28,9 @@ import (
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	anypb "google.golang.org/protobuf/types/known/anypb"
+	dpb "google.golang.org/protobuf/types/known/durationpb"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	tpb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type protoTypeRegistry struct {
@@ -302,8 +304,12 @@ func nativeToValue(a ref.TypeAdapter, value interface{}) (ref.Val, bool) {
 		return Double(v), true
 	case string:
 		return String(v), true
+	case *dpb.Duration:
+		return Duration{Duration: v.AsDuration()}, true
 	case time.Duration:
 		return Duration{Duration: v}, true
+	case *tpb.Timestamp:
+		return Timestamp{Time: v.AsTime()}, true
 	case time.Time:
 		return Timestamp{Time: v}, true
 	case *bool:

--- a/common/types/provider_test.go
+++ b/common/types/provider_test.go
@@ -30,7 +30,9 @@ import (
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	anypb "google.golang.org/protobuf/types/known/anypb"
+	dpb "google.golang.org/protobuf/types/known/durationpb"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	tpb "google.golang.org/protobuf/types/known/timestamppb"
 	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -395,6 +397,9 @@ func TestNativeToValue_Primitive(t *testing.T) {
 	expectNativeToValue(t, []byte("world"), Bytes("world"))
 	expectNativeToValue(t, time.Duration(500), Duration{Duration: time.Duration(500)})
 	expectNativeToValue(t, time.Unix(12345, 0), Timestamp{Time: time.Unix(12345, 0)})
+	expectNativeToValue(t, dpb.New(time.Duration(500)), Duration{Duration: time.Duration(500)})
+	expectNativeToValue(t, time.Unix(12345, 0), Timestamp{Time: time.Unix(12345, 0)})
+	expectNativeToValue(t, tpb.New(time.Unix(12345, 0)), Timestamp{Time: time.Unix(12345, 0)})
 	expectNativeToValue(t, []int32{1, 2, 3}, NewDynamicList(reg, []int32{1, 2, 3}))
 	expectNativeToValue(t, map[int32]int32{1: 1, 2: 1, 3: 1},
 		NewDynamicMap(reg, map[int32]int32{1: 1, 2: 1, 3: 1}))

--- a/common/types/provider_test.go
+++ b/common/types/provider_test.go
@@ -398,7 +398,6 @@ func TestNativeToValue_Primitive(t *testing.T) {
 	expectNativeToValue(t, time.Duration(500), Duration{Duration: time.Duration(500)})
 	expectNativeToValue(t, time.Unix(12345, 0), Timestamp{Time: time.Unix(12345, 0)})
 	expectNativeToValue(t, dpb.New(time.Duration(500)), Duration{Duration: time.Duration(500)})
-	expectNativeToValue(t, time.Unix(12345, 0), Timestamp{Time: time.Unix(12345, 0)})
 	expectNativeToValue(t, tpb.New(time.Unix(12345, 0)), Timestamp{Time: time.Unix(12345, 0)})
 	expectNativeToValue(t, []int32{1, 2, 3}, NewDynamicList(reg, []int32{1, 2, 3}))
 	expectNativeToValue(t, map[int32]int32{1: 1, 2: 1, 3: 1},


### PR DESCRIPTION
Prior to cel 0.7.0, it was possible (and expected) to use a `google.protobuf.Timestamp` and `google.protobuf.Duration` value as `Timestamp` and `Duration` value respectively. Support has been re-added to the `providers.go` for these value types within the `NativeToValue` function.