### PR TITLE
Support trailing commas in CreateMessage and CreateStruct expressions

### DIFF
--- a/parser/gen/CEL.g4
+++ b/parser/gen/CEL.g4
@@ -54,14 +54,14 @@ member
     : primary                                                       # PrimaryExpr
     | member op='.' id=IDENTIFIER (open='(' args=exprList? ')')?    # SelectOrCall
     | member op='[' index=expr ']'                                  # Index
-    | member op='{' entries=fieldInitializerList? '}'               # CreateMessage
+    | member op='{' entries=fieldInitializerList? ','? '}'          # CreateMessage
     ;
 
 primary
     : leadingDot='.'? id=IDENTIFIER (op='(' args=exprList? ')')?    # IdentOrGlobalCall
     | '(' e=expr ')'                                                # Nested
     | op='[' elems=exprList? ','? ']'                               # CreateList
-    | op='{' entries=mapInitializerList? '}'                        # CreateStruct
+    | op='{' entries=mapInitializerList? ','? '}'                   # CreateStruct
     | literal                                                       # ConstantLiteral
     ;
 

--- a/parser/gen/CEL.tokens
+++ b/parser/gen/CEL.tokens
@@ -1,6 +1,6 @@
-T__0=1
-EQUALS=2
-NOT_EQUALS=3
+EQUALS=1
+NOT_EQUALS=2
+IN=3
 LESS=4
 LESS_EQUALS=5
 GREATER_EQUALS=6
@@ -34,9 +34,9 @@ NUM_UINT=33
 STRING=34
 BYTES=35
 IDENTIFIER=36
-'in'=1
-'=='=2
-'!='=3
+'=='=1
+'!='=2
+'in'=3
 '<'=4
 '<='=5
 '>='=6

--- a/parser/gen/CELLexer.tokens
+++ b/parser/gen/CELLexer.tokens
@@ -1,6 +1,6 @@
-T__0=1
-EQUALS=2
-NOT_EQUALS=3
+EQUALS=1
+NOT_EQUALS=2
+IN=3
 LESS=4
 LESS_EQUALS=5
 GREATER_EQUALS=6
@@ -34,9 +34,9 @@ NUM_UINT=33
 STRING=34
 BYTES=35
 IDENTIFIER=36
-'in'=1
-'=='=2
-'!='=3
+'=='=1
+'!='=2
+'in'=3
 '<'=4
 '<='=5
 '>='=6

--- a/parser/gen/cel_base_listener.go
+++ b/parser/gen/cel_base_listener.go
@@ -1,4 +1,4 @@
-// Generated from /Users/tswadell/lace/go/src/github.com/google/cel-go/bin/../parser/gen/CEL.g4 by ANTLR 4.7.
+// Generated from /Users/tswadell/go/src/github.com/google/cel-go/bin/../parser/gen/CEL.g4 by ANTLR 4.7.
 
 package gen // CEL
 import "github.com/antlr/antlr4/runtime/Go/antlr"

--- a/parser/gen/cel_base_visitor.go
+++ b/parser/gen/cel_base_visitor.go
@@ -1,4 +1,4 @@
-// Generated from /Users/tswadell/lace/go/src/github.com/google/cel-go/bin/../parser/gen/CEL.g4 by ANTLR 4.7.
+// Generated from /Users/tswadell/go/src/github.com/google/cel-go/bin/../parser/gen/CEL.g4 by ANTLR 4.7.
 
 package gen // CEL
 import "github.com/antlr/antlr4/runtime/Go/antlr"

--- a/parser/gen/cel_lexer.go
+++ b/parser/gen/cel_lexer.go
@@ -1,4 +1,4 @@
-// Generated from /Users/tswadell/lace/go/src/github.com/google/cel-go/bin/../parser/gen/CEL.g4 by ANTLR 4.7.
+// Generated from /Users/tswadell/go/src/github.com/google/cel-go/bin/../parser/gen/CEL.g4 by ANTLR 4.7.
 
 package gen
 
@@ -94,9 +94,9 @@ var serializedLexerAtn = []uint16{
 	3, 2, 2, 2, 73, 195, 3, 2, 2, 2, 75, 198, 3, 2, 2, 2, 77, 203, 3, 2, 2,
 	2, 79, 226, 3, 2, 2, 2, 81, 229, 3, 2, 2, 2, 83, 235, 3, 2, 2, 2, 85, 276,
 	3, 2, 2, 2, 87, 291, 3, 2, 2, 2, 89, 310, 3, 2, 2, 2, 91, 408, 3, 2, 2,
-	2, 93, 410, 3, 2, 2, 2, 95, 415, 3, 2, 2, 2, 97, 98, 7, 107, 2, 2, 98,
-	99, 7, 112, 2, 2, 99, 4, 3, 2, 2, 2, 100, 101, 7, 63, 2, 2, 101, 102, 7,
-	63, 2, 2, 102, 6, 3, 2, 2, 2, 103, 104, 7, 35, 2, 2, 104, 105, 7, 63, 2,
+	2, 93, 410, 3, 2, 2, 2, 95, 415, 3, 2, 2, 2, 97, 98, 7, 63, 2, 2, 98, 99,
+	7, 63, 2, 2, 99, 4, 3, 2, 2, 2, 100, 101, 7, 35, 2, 2, 101, 102, 7, 63,
+	2, 2, 102, 6, 3, 2, 2, 2, 103, 104, 7, 107, 2, 2, 104, 105, 7, 112, 2,
 	2, 105, 8, 3, 2, 2, 2, 106, 107, 7, 62, 2, 2, 107, 10, 3, 2, 2, 2, 108,
 	109, 7, 62, 2, 2, 109, 110, 7, 63, 2, 2, 110, 12, 3, 2, 2, 2, 111, 112,
 	7, 64, 2, 2, 112, 113, 7, 63, 2, 2, 113, 14, 3, 2, 2, 2, 114, 115, 7, 64,
@@ -224,13 +224,13 @@ var lexerModeNames = []string{
 }
 
 var lexerLiteralNames = []string{
-	"", "'in'", "'=='", "'!='", "'<'", "'<='", "'>='", "'>'", "'&&'", "'||'",
+	"", "'=='", "'!='", "'in'", "'<'", "'<='", "'>='", "'>'", "'&&'", "'||'",
 	"'['", "']'", "'{'", "'}'", "'('", "')'", "'.'", "','", "'-'", "'!'", "'?'",
 	"':'", "'+'", "'*'", "'/'", "'%'", "'true'", "'false'", "'null'",
 }
 
 var lexerSymbolicNames = []string{
-	"", "", "EQUALS", "NOT_EQUALS", "LESS", "LESS_EQUALS", "GREATER_EQUALS",
+	"", "EQUALS", "NOT_EQUALS", "IN", "LESS", "LESS_EQUALS", "GREATER_EQUALS",
 	"GREATER", "LOGICAL_AND", "LOGICAL_OR", "LBRACKET", "RPRACKET", "LBRACE",
 	"RBRACE", "LPAREN", "RPAREN", "DOT", "COMMA", "MINUS", "EXCLAM", "QUESTIONMARK",
 	"COLON", "PLUS", "STAR", "SLASH", "PERCENT", "TRUE", "FALSE", "NULL", "WHITESPACE",
@@ -238,7 +238,7 @@ var lexerSymbolicNames = []string{
 }
 
 var lexerRuleNames = []string{
-	"T__0", "EQUALS", "NOT_EQUALS", "LESS", "LESS_EQUALS", "GREATER_EQUALS",
+	"EQUALS", "NOT_EQUALS", "IN", "LESS", "LESS_EQUALS", "GREATER_EQUALS",
 	"GREATER", "LOGICAL_AND", "LOGICAL_OR", "LBRACKET", "RPRACKET", "LBRACE",
 	"RBRACE", "LPAREN", "RPAREN", "DOT", "COMMA", "MINUS", "EXCLAM", "QUESTIONMARK",
 	"COLON", "PLUS", "STAR", "SLASH", "PERCENT", "TRUE", "FALSE", "NULL", "BACKSLASH",
@@ -280,9 +280,9 @@ func NewCELLexer(input antlr.CharStream) *CELLexer {
 
 // CELLexer tokens.
 const (
-	CELLexerT__0           = 1
-	CELLexerEQUALS         = 2
-	CELLexerNOT_EQUALS     = 3
+	CELLexerEQUALS         = 1
+	CELLexerNOT_EQUALS     = 2
+	CELLexerIN             = 3
 	CELLexerLESS           = 4
 	CELLexerLESS_EQUALS    = 5
 	CELLexerGREATER_EQUALS = 6

--- a/parser/gen/cel_listener.go
+++ b/parser/gen/cel_listener.go
@@ -1,4 +1,4 @@
-// Generated from /Users/tswadell/lace/go/src/github.com/google/cel-go/bin/../parser/gen/CEL.g4 by ANTLR 4.7.
+// Generated from /Users/tswadell/go/src/github.com/google/cel-go/bin/../parser/gen/CEL.g4 by ANTLR 4.7.
 
 package gen // CEL
 import "github.com/antlr/antlr4/runtime/Go/antlr"

--- a/parser/gen/cel_parser.go
+++ b/parser/gen/cel_parser.go
@@ -1,4 +1,4 @@
-// Generated from /Users/tswadell/lace/go/src/github.com/google/cel-go/bin/../parser/gen/CEL.g4 by ANTLR 4.7.
+// Generated from /Users/tswadell/go/src/github.com/google/cel-go/bin/../parser/gen/CEL.g4 by ANTLR 4.7.
 
 package gen // CEL
 import (
@@ -15,7 +15,7 @@ var _ = reflect.Copy
 var _ = strconv.Itoa
 
 var parserATN = []uint16{
-	3, 24715, 42794, 33075, 47597, 16764, 15335, 30598, 22884, 3, 38, 205,
+	3, 24715, 42794, 33075, 47597, 16764, 15335, 30598, 22884, 3, 38, 211,
 	4, 2, 9, 2, 4, 3, 9, 3, 4, 4, 9, 4, 4, 5, 9, 5, 4, 6, 9, 6, 4, 7, 9, 7,
 	4, 8, 9, 8, 4, 9, 9, 9, 4, 10, 9, 10, 4, 11, 9, 11, 4, 12, 9, 12, 4, 13,
 	9, 13, 4, 14, 9, 14, 3, 2, 3, 2, 3, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
@@ -27,96 +27,99 @@ var parserATN = []uint16{
 	3, 8, 3, 8, 6, 8, 89, 10, 8, 13, 8, 14, 8, 90, 3, 8, 5, 8, 94, 10, 8, 3,
 	9, 3, 9, 3, 9, 3, 9, 3, 9, 3, 9, 3, 9, 3, 9, 5, 9, 104, 10, 9, 3, 9, 5,
 	9, 107, 10, 9, 3, 9, 3, 9, 3, 9, 3, 9, 3, 9, 3, 9, 3, 9, 3, 9, 5, 9, 117,
-	10, 9, 3, 9, 7, 9, 120, 10, 9, 12, 9, 14, 9, 123, 11, 9, 3, 10, 5, 10,
-	126, 10, 10, 3, 10, 3, 10, 3, 10, 5, 10, 131, 10, 10, 3, 10, 5, 10, 134,
-	10, 10, 3, 10, 3, 10, 3, 10, 3, 10, 3, 10, 3, 10, 5, 10, 142, 10, 10, 3,
-	10, 5, 10, 145, 10, 10, 3, 10, 3, 10, 3, 10, 5, 10, 150, 10, 10, 3, 10,
-	3, 10, 5, 10, 154, 10, 10, 3, 11, 3, 11, 3, 11, 7, 11, 159, 10, 11, 12,
-	11, 14, 11, 162, 11, 11, 3, 12, 3, 12, 3, 12, 3, 12, 3, 12, 3, 12, 3, 12,
-	7, 12, 171, 10, 12, 12, 12, 14, 12, 174, 11, 12, 3, 13, 3, 13, 3, 13, 3,
-	13, 3, 13, 3, 13, 3, 13, 3, 13, 7, 13, 184, 10, 13, 12, 13, 14, 13, 187,
-	11, 13, 3, 14, 5, 14, 190, 10, 14, 3, 14, 3, 14, 3, 14, 5, 14, 195, 10,
-	14, 3, 14, 3, 14, 3, 14, 3, 14, 3, 14, 3, 14, 5, 14, 203, 10, 14, 3, 14,
-	2, 5, 10, 12, 16, 15, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 2,
-	5, 3, 2, 3, 9, 3, 2, 25, 27, 4, 2, 20, 20, 24, 24, 2, 229, 2, 28, 3, 2,
-	2, 2, 4, 31, 3, 2, 2, 2, 6, 39, 3, 2, 2, 2, 8, 47, 3, 2, 2, 2, 10, 55,
-	3, 2, 2, 2, 12, 66, 3, 2, 2, 2, 14, 93, 3, 2, 2, 2, 16, 95, 3, 2, 2, 2,
-	18, 153, 3, 2, 2, 2, 20, 155, 3, 2, 2, 2, 22, 163, 3, 2, 2, 2, 24, 175,
-	3, 2, 2, 2, 26, 202, 3, 2, 2, 2, 28, 29, 5, 4, 3, 2, 29, 30, 7, 2, 2, 3,
-	30, 3, 3, 2, 2, 2, 31, 37, 5, 6, 4, 2, 32, 33, 7, 22, 2, 2, 33, 34, 5,
-	6, 4, 2, 34, 35, 7, 23, 2, 2, 35, 36, 5, 4, 3, 2, 36, 38, 3, 2, 2, 2, 37,
-	32, 3, 2, 2, 2, 37, 38, 3, 2, 2, 2, 38, 5, 3, 2, 2, 2, 39, 44, 5, 8, 5,
-	2, 40, 41, 7, 11, 2, 2, 41, 43, 5, 8, 5, 2, 42, 40, 3, 2, 2, 2, 43, 46,
-	3, 2, 2, 2, 44, 42, 3, 2, 2, 2, 44, 45, 3, 2, 2, 2, 45, 7, 3, 2, 2, 2,
-	46, 44, 3, 2, 2, 2, 47, 52, 5, 10, 6, 2, 48, 49, 7, 10, 2, 2, 49, 51, 5,
-	10, 6, 2, 50, 48, 3, 2, 2, 2, 51, 54, 3, 2, 2, 2, 52, 50, 3, 2, 2, 2, 52,
-	53, 3, 2, 2, 2, 53, 9, 3, 2, 2, 2, 54, 52, 3, 2, 2, 2, 55, 56, 8, 6, 1,
-	2, 56, 57, 5, 12, 7, 2, 57, 63, 3, 2, 2, 2, 58, 59, 12, 3, 2, 2, 59, 60,
-	9, 2, 2, 2, 60, 62, 5, 10, 6, 4, 61, 58, 3, 2, 2, 2, 62, 65, 3, 2, 2, 2,
-	63, 61, 3, 2, 2, 2, 63, 64, 3, 2, 2, 2, 64, 11, 3, 2, 2, 2, 65, 63, 3,
-	2, 2, 2, 66, 67, 8, 7, 1, 2, 67, 68, 5, 14, 8, 2, 68, 77, 3, 2, 2, 2, 69,
-	70, 12, 4, 2, 2, 70, 71, 9, 3, 2, 2, 71, 76, 5, 12, 7, 5, 72, 73, 12, 3,
-	2, 2, 73, 74, 9, 4, 2, 2, 74, 76, 5, 12, 7, 4, 75, 69, 3, 2, 2, 2, 75,
-	72, 3, 2, 2, 2, 76, 79, 3, 2, 2, 2, 77, 75, 3, 2, 2, 2, 77, 78, 3, 2, 2,
-	2, 78, 13, 3, 2, 2, 2, 79, 77, 3, 2, 2, 2, 80, 94, 5, 16, 9, 2, 81, 83,
-	7, 21, 2, 2, 82, 81, 3, 2, 2, 2, 83, 84, 3, 2, 2, 2, 84, 82, 3, 2, 2, 2,
-	84, 85, 3, 2, 2, 2, 85, 86, 3, 2, 2, 2, 86, 94, 5, 16, 9, 2, 87, 89, 7,
-	20, 2, 2, 88, 87, 3, 2, 2, 2, 89, 90, 3, 2, 2, 2, 90, 88, 3, 2, 2, 2, 90,
-	91, 3, 2, 2, 2, 91, 92, 3, 2, 2, 2, 92, 94, 5, 16, 9, 2, 93, 80, 3, 2,
-	2, 2, 93, 82, 3, 2, 2, 2, 93, 88, 3, 2, 2, 2, 94, 15, 3, 2, 2, 2, 95, 96,
-	8, 9, 1, 2, 96, 97, 5, 18, 10, 2, 97, 121, 3, 2, 2, 2, 98, 99, 12, 5, 2,
-	2, 99, 100, 7, 18, 2, 2, 100, 106, 7, 38, 2, 2, 101, 103, 7, 16, 2, 2,
-	102, 104, 5, 20, 11, 2, 103, 102, 3, 2, 2, 2, 103, 104, 3, 2, 2, 2, 104,
-	105, 3, 2, 2, 2, 105, 107, 7, 17, 2, 2, 106, 101, 3, 2, 2, 2, 106, 107,
-	3, 2, 2, 2, 107, 120, 3, 2, 2, 2, 108, 109, 12, 4, 2, 2, 109, 110, 7, 12,
-	2, 2, 110, 111, 5, 4, 3, 2, 111, 112, 7, 13, 2, 2, 112, 120, 3, 2, 2, 2,
-	113, 114, 12, 3, 2, 2, 114, 116, 7, 14, 2, 2, 115, 117, 5, 22, 12, 2, 116,
-	115, 3, 2, 2, 2, 116, 117, 3, 2, 2, 2, 117, 118, 3, 2, 2, 2, 118, 120,
-	7, 15, 2, 2, 119, 98, 3, 2, 2, 2, 119, 108, 3, 2, 2, 2, 119, 113, 3, 2,
-	2, 2, 120, 123, 3, 2, 2, 2, 121, 119, 3, 2, 2, 2, 121, 122, 3, 2, 2, 2,
-	122, 17, 3, 2, 2, 2, 123, 121, 3, 2, 2, 2, 124, 126, 7, 18, 2, 2, 125,
-	124, 3, 2, 2, 2, 125, 126, 3, 2, 2, 2, 126, 127, 3, 2, 2, 2, 127, 133,
-	7, 38, 2, 2, 128, 130, 7, 16, 2, 2, 129, 131, 5, 20, 11, 2, 130, 129, 3,
-	2, 2, 2, 130, 131, 3, 2, 2, 2, 131, 132, 3, 2, 2, 2, 132, 134, 7, 17, 2,
-	2, 133, 128, 3, 2, 2, 2, 133, 134, 3, 2, 2, 2, 134, 154, 3, 2, 2, 2, 135,
-	136, 7, 16, 2, 2, 136, 137, 5, 4, 3, 2, 137, 138, 7, 17, 2, 2, 138, 154,
-	3, 2, 2, 2, 139, 141, 7, 12, 2, 2, 140, 142, 5, 20, 11, 2, 141, 140, 3,
-	2, 2, 2, 141, 142, 3, 2, 2, 2, 142, 144, 3, 2, 2, 2, 143, 145, 7, 19, 2,
-	2, 144, 143, 3, 2, 2, 2, 144, 145, 3, 2, 2, 2, 145, 146, 3, 2, 2, 2, 146,
-	154, 7, 13, 2, 2, 147, 149, 7, 14, 2, 2, 148, 150, 5, 24, 13, 2, 149, 148,
-	3, 2, 2, 2, 149, 150, 3, 2, 2, 2, 150, 151, 3, 2, 2, 2, 151, 154, 7, 15,
-	2, 2, 152, 154, 5, 26, 14, 2, 153, 125, 3, 2, 2, 2, 153, 135, 3, 2, 2,
-	2, 153, 139, 3, 2, 2, 2, 153, 147, 3, 2, 2, 2, 153, 152, 3, 2, 2, 2, 154,
-	19, 3, 2, 2, 2, 155, 160, 5, 4, 3, 2, 156, 157, 7, 19, 2, 2, 157, 159,
-	5, 4, 3, 2, 158, 156, 3, 2, 2, 2, 159, 162, 3, 2, 2, 2, 160, 158, 3, 2,
-	2, 2, 160, 161, 3, 2, 2, 2, 161, 21, 3, 2, 2, 2, 162, 160, 3, 2, 2, 2,
-	163, 164, 7, 38, 2, 2, 164, 165, 7, 23, 2, 2, 165, 172, 5, 4, 3, 2, 166,
-	167, 7, 19, 2, 2, 167, 168, 7, 38, 2, 2, 168, 169, 7, 23, 2, 2, 169, 171,
-	5, 4, 3, 2, 170, 166, 3, 2, 2, 2, 171, 174, 3, 2, 2, 2, 172, 170, 3, 2,
-	2, 2, 172, 173, 3, 2, 2, 2, 173, 23, 3, 2, 2, 2, 174, 172, 3, 2, 2, 2,
-	175, 176, 5, 4, 3, 2, 176, 177, 7, 23, 2, 2, 177, 185, 5, 4, 3, 2, 178,
-	179, 7, 19, 2, 2, 179, 180, 5, 4, 3, 2, 180, 181, 7, 23, 2, 2, 181, 182,
-	5, 4, 3, 2, 182, 184, 3, 2, 2, 2, 183, 178, 3, 2, 2, 2, 184, 187, 3, 2,
-	2, 2, 185, 183, 3, 2, 2, 2, 185, 186, 3, 2, 2, 2, 186, 25, 3, 2, 2, 2,
-	187, 185, 3, 2, 2, 2, 188, 190, 7, 20, 2, 2, 189, 188, 3, 2, 2, 2, 189,
-	190, 3, 2, 2, 2, 190, 191, 3, 2, 2, 2, 191, 203, 7, 34, 2, 2, 192, 203,
-	7, 35, 2, 2, 193, 195, 7, 20, 2, 2, 194, 193, 3, 2, 2, 2, 194, 195, 3,
-	2, 2, 2, 195, 196, 3, 2, 2, 2, 196, 203, 7, 33, 2, 2, 197, 203, 7, 36,
-	2, 2, 198, 203, 7, 37, 2, 2, 199, 203, 7, 28, 2, 2, 200, 203, 7, 29, 2,
-	2, 201, 203, 7, 30, 2, 2, 202, 189, 3, 2, 2, 2, 202, 192, 3, 2, 2, 2, 202,
-	194, 3, 2, 2, 2, 202, 197, 3, 2, 2, 2, 202, 198, 3, 2, 2, 2, 202, 199,
-	3, 2, 2, 2, 202, 200, 3, 2, 2, 2, 202, 201, 3, 2, 2, 2, 203, 27, 3, 2,
-	2, 2, 29, 37, 44, 52, 63, 75, 77, 84, 90, 93, 103, 106, 116, 119, 121,
-	125, 130, 133, 141, 144, 149, 153, 160, 172, 185, 189, 194, 202,
+	10, 9, 3, 9, 5, 9, 120, 10, 9, 3, 9, 7, 9, 123, 10, 9, 12, 9, 14, 9, 126,
+	11, 9, 3, 10, 5, 10, 129, 10, 10, 3, 10, 3, 10, 3, 10, 5, 10, 134, 10,
+	10, 3, 10, 5, 10, 137, 10, 10, 3, 10, 3, 10, 3, 10, 3, 10, 3, 10, 3, 10,
+	5, 10, 145, 10, 10, 3, 10, 5, 10, 148, 10, 10, 3, 10, 3, 10, 3, 10, 5,
+	10, 153, 10, 10, 3, 10, 5, 10, 156, 10, 10, 3, 10, 3, 10, 5, 10, 160, 10,
+	10, 3, 11, 3, 11, 3, 11, 7, 11, 165, 10, 11, 12, 11, 14, 11, 168, 11, 11,
+	3, 12, 3, 12, 3, 12, 3, 12, 3, 12, 3, 12, 3, 12, 7, 12, 177, 10, 12, 12,
+	12, 14, 12, 180, 11, 12, 3, 13, 3, 13, 3, 13, 3, 13, 3, 13, 3, 13, 3, 13,
+	3, 13, 7, 13, 190, 10, 13, 12, 13, 14, 13, 193, 11, 13, 3, 14, 5, 14, 196,
+	10, 14, 3, 14, 3, 14, 3, 14, 5, 14, 201, 10, 14, 3, 14, 3, 14, 3, 14, 3,
+	14, 3, 14, 3, 14, 5, 14, 209, 10, 14, 3, 14, 2, 5, 10, 12, 16, 15, 2, 4,
+	6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 2, 5, 3, 2, 3, 9, 3, 2, 25, 27,
+	4, 2, 20, 20, 24, 24, 2, 237, 2, 28, 3, 2, 2, 2, 4, 31, 3, 2, 2, 2, 6,
+	39, 3, 2, 2, 2, 8, 47, 3, 2, 2, 2, 10, 55, 3, 2, 2, 2, 12, 66, 3, 2, 2,
+	2, 14, 93, 3, 2, 2, 2, 16, 95, 3, 2, 2, 2, 18, 159, 3, 2, 2, 2, 20, 161,
+	3, 2, 2, 2, 22, 169, 3, 2, 2, 2, 24, 181, 3, 2, 2, 2, 26, 208, 3, 2, 2,
+	2, 28, 29, 5, 4, 3, 2, 29, 30, 7, 2, 2, 3, 30, 3, 3, 2, 2, 2, 31, 37, 5,
+	6, 4, 2, 32, 33, 7, 22, 2, 2, 33, 34, 5, 6, 4, 2, 34, 35, 7, 23, 2, 2,
+	35, 36, 5, 4, 3, 2, 36, 38, 3, 2, 2, 2, 37, 32, 3, 2, 2, 2, 37, 38, 3,
+	2, 2, 2, 38, 5, 3, 2, 2, 2, 39, 44, 5, 8, 5, 2, 40, 41, 7, 11, 2, 2, 41,
+	43, 5, 8, 5, 2, 42, 40, 3, 2, 2, 2, 43, 46, 3, 2, 2, 2, 44, 42, 3, 2, 2,
+	2, 44, 45, 3, 2, 2, 2, 45, 7, 3, 2, 2, 2, 46, 44, 3, 2, 2, 2, 47, 52, 5,
+	10, 6, 2, 48, 49, 7, 10, 2, 2, 49, 51, 5, 10, 6, 2, 50, 48, 3, 2, 2, 2,
+	51, 54, 3, 2, 2, 2, 52, 50, 3, 2, 2, 2, 52, 53, 3, 2, 2, 2, 53, 9, 3, 2,
+	2, 2, 54, 52, 3, 2, 2, 2, 55, 56, 8, 6, 1, 2, 56, 57, 5, 12, 7, 2, 57,
+	63, 3, 2, 2, 2, 58, 59, 12, 3, 2, 2, 59, 60, 9, 2, 2, 2, 60, 62, 5, 10,
+	6, 4, 61, 58, 3, 2, 2, 2, 62, 65, 3, 2, 2, 2, 63, 61, 3, 2, 2, 2, 63, 64,
+	3, 2, 2, 2, 64, 11, 3, 2, 2, 2, 65, 63, 3, 2, 2, 2, 66, 67, 8, 7, 1, 2,
+	67, 68, 5, 14, 8, 2, 68, 77, 3, 2, 2, 2, 69, 70, 12, 4, 2, 2, 70, 71, 9,
+	3, 2, 2, 71, 76, 5, 12, 7, 5, 72, 73, 12, 3, 2, 2, 73, 74, 9, 4, 2, 2,
+	74, 76, 5, 12, 7, 4, 75, 69, 3, 2, 2, 2, 75, 72, 3, 2, 2, 2, 76, 79, 3,
+	2, 2, 2, 77, 75, 3, 2, 2, 2, 77, 78, 3, 2, 2, 2, 78, 13, 3, 2, 2, 2, 79,
+	77, 3, 2, 2, 2, 80, 94, 5, 16, 9, 2, 81, 83, 7, 21, 2, 2, 82, 81, 3, 2,
+	2, 2, 83, 84, 3, 2, 2, 2, 84, 82, 3, 2, 2, 2, 84, 85, 3, 2, 2, 2, 85, 86,
+	3, 2, 2, 2, 86, 94, 5, 16, 9, 2, 87, 89, 7, 20, 2, 2, 88, 87, 3, 2, 2,
+	2, 89, 90, 3, 2, 2, 2, 90, 88, 3, 2, 2, 2, 90, 91, 3, 2, 2, 2, 91, 92,
+	3, 2, 2, 2, 92, 94, 5, 16, 9, 2, 93, 80, 3, 2, 2, 2, 93, 82, 3, 2, 2, 2,
+	93, 88, 3, 2, 2, 2, 94, 15, 3, 2, 2, 2, 95, 96, 8, 9, 1, 2, 96, 97, 5,
+	18, 10, 2, 97, 124, 3, 2, 2, 2, 98, 99, 12, 5, 2, 2, 99, 100, 7, 18, 2,
+	2, 100, 106, 7, 38, 2, 2, 101, 103, 7, 16, 2, 2, 102, 104, 5, 20, 11, 2,
+	103, 102, 3, 2, 2, 2, 103, 104, 3, 2, 2, 2, 104, 105, 3, 2, 2, 2, 105,
+	107, 7, 17, 2, 2, 106, 101, 3, 2, 2, 2, 106, 107, 3, 2, 2, 2, 107, 123,
+	3, 2, 2, 2, 108, 109, 12, 4, 2, 2, 109, 110, 7, 12, 2, 2, 110, 111, 5,
+	4, 3, 2, 111, 112, 7, 13, 2, 2, 112, 123, 3, 2, 2, 2, 113, 114, 12, 3,
+	2, 2, 114, 116, 7, 14, 2, 2, 115, 117, 5, 22, 12, 2, 116, 115, 3, 2, 2,
+	2, 116, 117, 3, 2, 2, 2, 117, 119, 3, 2, 2, 2, 118, 120, 7, 19, 2, 2, 119,
+	118, 3, 2, 2, 2, 119, 120, 3, 2, 2, 2, 120, 121, 3, 2, 2, 2, 121, 123,
+	7, 15, 2, 2, 122, 98, 3, 2, 2, 2, 122, 108, 3, 2, 2, 2, 122, 113, 3, 2,
+	2, 2, 123, 126, 3, 2, 2, 2, 124, 122, 3, 2, 2, 2, 124, 125, 3, 2, 2, 2,
+	125, 17, 3, 2, 2, 2, 126, 124, 3, 2, 2, 2, 127, 129, 7, 18, 2, 2, 128,
+	127, 3, 2, 2, 2, 128, 129, 3, 2, 2, 2, 129, 130, 3, 2, 2, 2, 130, 136,
+	7, 38, 2, 2, 131, 133, 7, 16, 2, 2, 132, 134, 5, 20, 11, 2, 133, 132, 3,
+	2, 2, 2, 133, 134, 3, 2, 2, 2, 134, 135, 3, 2, 2, 2, 135, 137, 7, 17, 2,
+	2, 136, 131, 3, 2, 2, 2, 136, 137, 3, 2, 2, 2, 137, 160, 3, 2, 2, 2, 138,
+	139, 7, 16, 2, 2, 139, 140, 5, 4, 3, 2, 140, 141, 7, 17, 2, 2, 141, 160,
+	3, 2, 2, 2, 142, 144, 7, 12, 2, 2, 143, 145, 5, 20, 11, 2, 144, 143, 3,
+	2, 2, 2, 144, 145, 3, 2, 2, 2, 145, 147, 3, 2, 2, 2, 146, 148, 7, 19, 2,
+	2, 147, 146, 3, 2, 2, 2, 147, 148, 3, 2, 2, 2, 148, 149, 3, 2, 2, 2, 149,
+	160, 7, 13, 2, 2, 150, 152, 7, 14, 2, 2, 151, 153, 5, 24, 13, 2, 152, 151,
+	3, 2, 2, 2, 152, 153, 3, 2, 2, 2, 153, 155, 3, 2, 2, 2, 154, 156, 7, 19,
+	2, 2, 155, 154, 3, 2, 2, 2, 155, 156, 3, 2, 2, 2, 156, 157, 3, 2, 2, 2,
+	157, 160, 7, 15, 2, 2, 158, 160, 5, 26, 14, 2, 159, 128, 3, 2, 2, 2, 159,
+	138, 3, 2, 2, 2, 159, 142, 3, 2, 2, 2, 159, 150, 3, 2, 2, 2, 159, 158,
+	3, 2, 2, 2, 160, 19, 3, 2, 2, 2, 161, 166, 5, 4, 3, 2, 162, 163, 7, 19,
+	2, 2, 163, 165, 5, 4, 3, 2, 164, 162, 3, 2, 2, 2, 165, 168, 3, 2, 2, 2,
+	166, 164, 3, 2, 2, 2, 166, 167, 3, 2, 2, 2, 167, 21, 3, 2, 2, 2, 168, 166,
+	3, 2, 2, 2, 169, 170, 7, 38, 2, 2, 170, 171, 7, 23, 2, 2, 171, 178, 5,
+	4, 3, 2, 172, 173, 7, 19, 2, 2, 173, 174, 7, 38, 2, 2, 174, 175, 7, 23,
+	2, 2, 175, 177, 5, 4, 3, 2, 176, 172, 3, 2, 2, 2, 177, 180, 3, 2, 2, 2,
+	178, 176, 3, 2, 2, 2, 178, 179, 3, 2, 2, 2, 179, 23, 3, 2, 2, 2, 180, 178,
+	3, 2, 2, 2, 181, 182, 5, 4, 3, 2, 182, 183, 7, 23, 2, 2, 183, 191, 5, 4,
+	3, 2, 184, 185, 7, 19, 2, 2, 185, 186, 5, 4, 3, 2, 186, 187, 7, 23, 2,
+	2, 187, 188, 5, 4, 3, 2, 188, 190, 3, 2, 2, 2, 189, 184, 3, 2, 2, 2, 190,
+	193, 3, 2, 2, 2, 191, 189, 3, 2, 2, 2, 191, 192, 3, 2, 2, 2, 192, 25, 3,
+	2, 2, 2, 193, 191, 3, 2, 2, 2, 194, 196, 7, 20, 2, 2, 195, 194, 3, 2, 2,
+	2, 195, 196, 3, 2, 2, 2, 196, 197, 3, 2, 2, 2, 197, 209, 7, 34, 2, 2, 198,
+	209, 7, 35, 2, 2, 199, 201, 7, 20, 2, 2, 200, 199, 3, 2, 2, 2, 200, 201,
+	3, 2, 2, 2, 201, 202, 3, 2, 2, 2, 202, 209, 7, 33, 2, 2, 203, 209, 7, 36,
+	2, 2, 204, 209, 7, 37, 2, 2, 205, 209, 7, 28, 2, 2, 206, 209, 7, 29, 2,
+	2, 207, 209, 7, 30, 2, 2, 208, 195, 3, 2, 2, 2, 208, 198, 3, 2, 2, 2, 208,
+	200, 3, 2, 2, 2, 208, 203, 3, 2, 2, 2, 208, 204, 3, 2, 2, 2, 208, 205,
+	3, 2, 2, 2, 208, 206, 3, 2, 2, 2, 208, 207, 3, 2, 2, 2, 209, 27, 3, 2,
+	2, 2, 31, 37, 44, 52, 63, 75, 77, 84, 90, 93, 103, 106, 116, 119, 122,
+	124, 128, 133, 136, 144, 147, 152, 155, 159, 166, 178, 191, 195, 200, 208,
 }
 
 var literalNames = []string{
-	"", "'in'", "'=='", "'!='", "'<'", "'<='", "'>='", "'>'", "'&&'", "'||'",
+	"", "'=='", "'!='", "'in'", "'<'", "'<='", "'>='", "'>'", "'&&'", "'||'",
 	"'['", "']'", "'{'", "'}'", "'('", "')'", "'.'", "','", "'-'", "'!'", "'?'",
 	"':'", "'+'", "'*'", "'/'", "'%'", "'true'", "'false'", "'null'",
 }
 var symbolicNames = []string{
-	"", "", "EQUALS", "NOT_EQUALS", "LESS", "LESS_EQUALS", "GREATER_EQUALS",
+	"", "EQUALS", "NOT_EQUALS", "IN", "LESS", "LESS_EQUALS", "GREATER_EQUALS",
 	"GREATER", "LOGICAL_AND", "LOGICAL_OR", "LBRACKET", "RPRACKET", "LBRACE",
 	"RBRACE", "LPAREN", "RPAREN", "DOT", "COMMA", "MINUS", "EXCLAM", "QUESTIONMARK",
 	"COLON", "PLUS", "STAR", "SLASH", "PERCENT", "TRUE", "FALSE", "NULL", "WHITESPACE",
@@ -141,6 +144,7 @@ func NewCELParser(input antlr.TokenStream) *CELParser {
 	for index, ds := range deserializedATN.DecisionToState {
 		decisionToDFA[index] = antlr.NewDFA(ds, index)
 	}
+
 	this.BaseParser = antlr.NewBaseParser(input)
 
 	this.Interpreter = antlr.NewParserATNSimulator(this, deserializedATN, decisionToDFA, antlr.NewPredictionContextCache())
@@ -155,9 +159,9 @@ func NewCELParser(input antlr.TokenStream) *CELParser {
 // CELParser tokens.
 const (
 	CELParserEOF            = antlr.TokenEOF
-	CELParserT__0           = 1
-	CELParserEQUALS         = 2
-	CELParserNOT_EQUALS     = 3
+	CELParserEQUALS         = 1
+	CELParserNOT_EQUALS     = 2
+	CELParserIN             = 3
 	CELParserLESS           = 4
 	CELParserLESS_EQUALS    = 5
 	CELParserGREATER_EQUALS = 6
@@ -1135,7 +1139,7 @@ func (p *CELParser) relation(_p int) (localctx IRelationContext) {
 
 			_la = p.GetTokenStream().LA(1)
 
-			if !(((_la)&-(0x1f+1)) == 0 && ((1<<uint(_la))&((1<<CELParserT__0)|(1<<CELParserEQUALS)|(1<<CELParserNOT_EQUALS)|(1<<CELParserLESS)|(1<<CELParserLESS_EQUALS)|(1<<CELParserGREATER_EQUALS)|(1<<CELParserGREATER))) != 0) {
+			if !(((_la)&-(0x1f+1)) == 0 && ((1<<uint(_la))&((1<<CELParserEQUALS)|(1<<CELParserNOT_EQUALS)|(1<<CELParserIN)|(1<<CELParserLESS)|(1<<CELParserLESS_EQUALS)|(1<<CELParserGREATER_EQUALS)|(1<<CELParserGREATER))) != 0) {
 				var _ri = p.GetErrorHandler().RecoverInline(p)
 
 				localctx.(*RelationContext).op = _ri
@@ -2073,9 +2077,9 @@ func (p *CELParser) member(_p int) (localctx IMemberContext) {
 	}
 
 	p.GetParserRuleContext().SetStop(p.GetTokenStream().LT(-1))
-	p.SetState(119)
+	p.SetState(122)
 	p.GetErrorHandler().Sync(p)
-	_alt = p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 13, p.GetParserRuleContext())
+	_alt = p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 14, p.GetParserRuleContext())
 
 	for _alt != 2 && _alt != antlr.ATNInvalidAltNumber {
 		if _alt == 1 {
@@ -2083,9 +2087,9 @@ func (p *CELParser) member(_p int) (localctx IMemberContext) {
 				p.TriggerExitRuleEvent()
 			}
 			_prevctx = localctx
-			p.SetState(117)
+			p.SetState(120)
 			p.GetErrorHandler().Sync(p)
-			switch p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 12, p.GetParserRuleContext()) {
+			switch p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 13, p.GetParserRuleContext()) {
 			case 1:
 				localctx = NewSelectOrCallContext(p, NewMemberContext(p, _parentctx, _parentState))
 				p.PushNewRecursionContext(localctx, _startState, CELParserRULE_member)
@@ -2196,17 +2200,28 @@ func (p *CELParser) member(_p int) (localctx IMemberContext) {
 					}
 
 				}
+				p.SetState(117)
+				p.GetErrorHandler().Sync(p)
+				_la = p.GetTokenStream().LA(1)
+
+				if _la == CELParserCOMMA {
+					{
+						p.SetState(116)
+						p.Match(CELParserCOMMA)
+					}
+
+				}
 				{
-					p.SetState(116)
+					p.SetState(119)
 					p.Match(CELParserRBRACE)
 				}
 
 			}
 
 		}
-		p.SetState(121)
+		p.SetState(124)
 		p.GetErrorHandler().Sync(p)
-		_alt = p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 13, p.GetParserRuleContext())
+		_alt = p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 14, p.GetParserRuleContext())
 	}
 
 	return localctx
@@ -2582,20 +2597,20 @@ func (p *CELParser) Primary() (localctx IPrimaryContext) {
 		}
 	}()
 
-	p.SetState(151)
+	p.SetState(157)
 	p.GetErrorHandler().Sync(p)
 
 	switch p.GetTokenStream().LA(1) {
 	case CELParserDOT, CELParserIDENTIFIER:
 		localctx = NewIdentOrGlobalCallContext(p, localctx)
 		p.EnterOuterAlt(localctx, 1)
-		p.SetState(123)
+		p.SetState(126)
 		p.GetErrorHandler().Sync(p)
 		_la = p.GetTokenStream().LA(1)
 
 		if _la == CELParserDOT {
 			{
-				p.SetState(122)
+				p.SetState(125)
 
 				var _m = p.Match(CELParserDOT)
 
@@ -2604,30 +2619,30 @@ func (p *CELParser) Primary() (localctx IPrimaryContext) {
 
 		}
 		{
-			p.SetState(125)
+			p.SetState(128)
 
 			var _m = p.Match(CELParserIDENTIFIER)
 
 			localctx.(*IdentOrGlobalCallContext).id = _m
 		}
-		p.SetState(131)
+		p.SetState(134)
 		p.GetErrorHandler().Sync(p)
 
-		if p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 16, p.GetParserRuleContext()) == 1 {
+		if p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 17, p.GetParserRuleContext()) == 1 {
 			{
-				p.SetState(126)
+				p.SetState(129)
 
 				var _m = p.Match(CELParserLPAREN)
 
 				localctx.(*IdentOrGlobalCallContext).op = _m
 			}
-			p.SetState(128)
+			p.SetState(131)
 			p.GetErrorHandler().Sync(p)
 			_la = p.GetTokenStream().LA(1)
 
 			if ((_la-10)&-(0x1f+1)) == 0 && ((1<<uint((_la-10)))&((1<<(CELParserLBRACKET-10))|(1<<(CELParserLBRACE-10))|(1<<(CELParserLPAREN-10))|(1<<(CELParserDOT-10))|(1<<(CELParserMINUS-10))|(1<<(CELParserEXCLAM-10))|(1<<(CELParserTRUE-10))|(1<<(CELParserFALSE-10))|(1<<(CELParserNULL-10))|(1<<(CELParserNUM_FLOAT-10))|(1<<(CELParserNUM_INT-10))|(1<<(CELParserNUM_UINT-10))|(1<<(CELParserSTRING-10))|(1<<(CELParserBYTES-10))|(1<<(CELParserIDENTIFIER-10)))) != 0 {
 				{
-					p.SetState(127)
+					p.SetState(130)
 
 					var _x = p.ExprList()
 
@@ -2636,7 +2651,7 @@ func (p *CELParser) Primary() (localctx IPrimaryContext) {
 
 			}
 			{
-				p.SetState(130)
+				p.SetState(133)
 				p.Match(CELParserRPAREN)
 			}
 
@@ -2646,18 +2661,18 @@ func (p *CELParser) Primary() (localctx IPrimaryContext) {
 		localctx = NewNestedContext(p, localctx)
 		p.EnterOuterAlt(localctx, 2)
 		{
-			p.SetState(133)
+			p.SetState(136)
 			p.Match(CELParserLPAREN)
 		}
 		{
-			p.SetState(134)
+			p.SetState(137)
 
 			var _x = p.Expr()
 
 			localctx.(*NestedContext).e = _x
 		}
 		{
-			p.SetState(135)
+			p.SetState(138)
 			p.Match(CELParserRPAREN)
 		}
 
@@ -2665,19 +2680,19 @@ func (p *CELParser) Primary() (localctx IPrimaryContext) {
 		localctx = NewCreateListContext(p, localctx)
 		p.EnterOuterAlt(localctx, 3)
 		{
-			p.SetState(137)
+			p.SetState(140)
 
 			var _m = p.Match(CELParserLBRACKET)
 
 			localctx.(*CreateListContext).op = _m
 		}
-		p.SetState(139)
+		p.SetState(142)
 		p.GetErrorHandler().Sync(p)
 		_la = p.GetTokenStream().LA(1)
 
 		if ((_la-10)&-(0x1f+1)) == 0 && ((1<<uint((_la-10)))&((1<<(CELParserLBRACKET-10))|(1<<(CELParserLBRACE-10))|(1<<(CELParserLPAREN-10))|(1<<(CELParserDOT-10))|(1<<(CELParserMINUS-10))|(1<<(CELParserEXCLAM-10))|(1<<(CELParserTRUE-10))|(1<<(CELParserFALSE-10))|(1<<(CELParserNULL-10))|(1<<(CELParserNUM_FLOAT-10))|(1<<(CELParserNUM_INT-10))|(1<<(CELParserNUM_UINT-10))|(1<<(CELParserSTRING-10))|(1<<(CELParserBYTES-10))|(1<<(CELParserIDENTIFIER-10)))) != 0 {
 			{
-				p.SetState(138)
+				p.SetState(141)
 
 				var _x = p.ExprList()
 
@@ -2685,19 +2700,19 @@ func (p *CELParser) Primary() (localctx IPrimaryContext) {
 			}
 
 		}
-		p.SetState(142)
+		p.SetState(145)
 		p.GetErrorHandler().Sync(p)
 		_la = p.GetTokenStream().LA(1)
 
 		if _la == CELParserCOMMA {
 			{
-				p.SetState(141)
+				p.SetState(144)
 				p.Match(CELParserCOMMA)
 			}
 
 		}
 		{
-			p.SetState(144)
+			p.SetState(147)
 			p.Match(CELParserRPRACKET)
 		}
 
@@ -2705,19 +2720,19 @@ func (p *CELParser) Primary() (localctx IPrimaryContext) {
 		localctx = NewCreateStructContext(p, localctx)
 		p.EnterOuterAlt(localctx, 4)
 		{
-			p.SetState(145)
+			p.SetState(148)
 
 			var _m = p.Match(CELParserLBRACE)
 
 			localctx.(*CreateStructContext).op = _m
 		}
-		p.SetState(147)
+		p.SetState(150)
 		p.GetErrorHandler().Sync(p)
 		_la = p.GetTokenStream().LA(1)
 
 		if ((_la-10)&-(0x1f+1)) == 0 && ((1<<uint((_la-10)))&((1<<(CELParserLBRACKET-10))|(1<<(CELParserLBRACE-10))|(1<<(CELParserLPAREN-10))|(1<<(CELParserDOT-10))|(1<<(CELParserMINUS-10))|(1<<(CELParserEXCLAM-10))|(1<<(CELParserTRUE-10))|(1<<(CELParserFALSE-10))|(1<<(CELParserNULL-10))|(1<<(CELParserNUM_FLOAT-10))|(1<<(CELParserNUM_INT-10))|(1<<(CELParserNUM_UINT-10))|(1<<(CELParserSTRING-10))|(1<<(CELParserBYTES-10))|(1<<(CELParserIDENTIFIER-10)))) != 0 {
 			{
-				p.SetState(146)
+				p.SetState(149)
 
 				var _x = p.MapInitializerList()
 
@@ -2725,8 +2740,19 @@ func (p *CELParser) Primary() (localctx IPrimaryContext) {
 			}
 
 		}
+		p.SetState(153)
+		p.GetErrorHandler().Sync(p)
+		_la = p.GetTokenStream().LA(1)
+
+		if _la == CELParserCOMMA {
+			{
+				p.SetState(152)
+				p.Match(CELParserCOMMA)
+			}
+
+		}
 		{
-			p.SetState(149)
+			p.SetState(155)
 			p.Match(CELParserRBRACE)
 		}
 
@@ -2734,7 +2760,7 @@ func (p *CELParser) Primary() (localctx IPrimaryContext) {
 		localctx = NewConstantLiteralContext(p, localctx)
 		p.EnterOuterAlt(localctx, 5)
 		{
-			p.SetState(150)
+			p.SetState(156)
 			p.Literal()
 		}
 
@@ -2882,25 +2908,25 @@ func (p *CELParser) ExprList() (localctx IExprListContext) {
 
 	p.EnterOuterAlt(localctx, 1)
 	{
-		p.SetState(153)
+		p.SetState(159)
 
 		var _x = p.Expr()
 
 		localctx.(*ExprListContext)._expr = _x
 	}
 	localctx.(*ExprListContext).e = append(localctx.(*ExprListContext).e, localctx.(*ExprListContext)._expr)
-	p.SetState(158)
+	p.SetState(164)
 	p.GetErrorHandler().Sync(p)
-	_alt = p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 21, p.GetParserRuleContext())
+	_alt = p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 23, p.GetParserRuleContext())
 
 	for _alt != 2 && _alt != antlr.ATNInvalidAltNumber {
 		if _alt == 1 {
 			{
-				p.SetState(154)
+				p.SetState(160)
 				p.Match(CELParserCOMMA)
 			}
 			{
-				p.SetState(155)
+				p.SetState(161)
 
 				var _x = p.Expr()
 
@@ -2909,9 +2935,9 @@ func (p *CELParser) ExprList() (localctx IExprListContext) {
 			localctx.(*ExprListContext).e = append(localctx.(*ExprListContext).e, localctx.(*ExprListContext)._expr)
 
 		}
-		p.SetState(160)
+		p.SetState(166)
 		p.GetErrorHandler().Sync(p)
-		_alt = p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 21, p.GetParserRuleContext())
+		_alt = p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 23, p.GetParserRuleContext())
 	}
 
 	return localctx
@@ -3085,7 +3111,6 @@ func (s *FieldInitializerListContext) Accept(visitor antlr.ParseTreeVisitor) int
 func (p *CELParser) FieldInitializerList() (localctx IFieldInitializerListContext) {
 	localctx = NewFieldInitializerListContext(p, p.GetParserRuleContext(), p.GetState())
 	p.EnterRule(localctx, 20, CELParserRULE_fieldInitializerList)
-	var _la int
 
 	defer func() {
 		p.ExitRule()
@@ -3103,9 +3128,11 @@ func (p *CELParser) FieldInitializerList() (localctx IFieldInitializerListContex
 		}
 	}()
 
+	var _alt int
+
 	p.EnterOuterAlt(localctx, 1)
 	{
-		p.SetState(161)
+		p.SetState(167)
 
 		var _m = p.Match(CELParserIDENTIFIER)
 
@@ -3113,7 +3140,7 @@ func (p *CELParser) FieldInitializerList() (localctx IFieldInitializerListContex
 	}
 	localctx.(*FieldInitializerListContext).fields = append(localctx.(*FieldInitializerListContext).fields, localctx.(*FieldInitializerListContext)._IDENTIFIER)
 	{
-		p.SetState(162)
+		p.SetState(168)
 
 		var _m = p.Match(CELParserCOLON)
 
@@ -3121,50 +3148,52 @@ func (p *CELParser) FieldInitializerList() (localctx IFieldInitializerListContex
 	}
 	localctx.(*FieldInitializerListContext).cols = append(localctx.(*FieldInitializerListContext).cols, localctx.(*FieldInitializerListContext).s21)
 	{
-		p.SetState(163)
+		p.SetState(169)
 
 		var _x = p.Expr()
 
 		localctx.(*FieldInitializerListContext)._expr = _x
 	}
 	localctx.(*FieldInitializerListContext).values = append(localctx.(*FieldInitializerListContext).values, localctx.(*FieldInitializerListContext)._expr)
-	p.SetState(170)
+	p.SetState(176)
 	p.GetErrorHandler().Sync(p)
-	_la = p.GetTokenStream().LA(1)
+	_alt = p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 24, p.GetParserRuleContext())
 
-	for _la == CELParserCOMMA {
-		{
-			p.SetState(164)
-			p.Match(CELParserCOMMA)
+	for _alt != 2 && _alt != antlr.ATNInvalidAltNumber {
+		if _alt == 1 {
+			{
+				p.SetState(170)
+				p.Match(CELParserCOMMA)
+			}
+			{
+				p.SetState(171)
+
+				var _m = p.Match(CELParserIDENTIFIER)
+
+				localctx.(*FieldInitializerListContext)._IDENTIFIER = _m
+			}
+			localctx.(*FieldInitializerListContext).fields = append(localctx.(*FieldInitializerListContext).fields, localctx.(*FieldInitializerListContext)._IDENTIFIER)
+			{
+				p.SetState(172)
+
+				var _m = p.Match(CELParserCOLON)
+
+				localctx.(*FieldInitializerListContext).s21 = _m
+			}
+			localctx.(*FieldInitializerListContext).cols = append(localctx.(*FieldInitializerListContext).cols, localctx.(*FieldInitializerListContext).s21)
+			{
+				p.SetState(173)
+
+				var _x = p.Expr()
+
+				localctx.(*FieldInitializerListContext)._expr = _x
+			}
+			localctx.(*FieldInitializerListContext).values = append(localctx.(*FieldInitializerListContext).values, localctx.(*FieldInitializerListContext)._expr)
+
 		}
-		{
-			p.SetState(165)
-
-			var _m = p.Match(CELParserIDENTIFIER)
-
-			localctx.(*FieldInitializerListContext)._IDENTIFIER = _m
-		}
-		localctx.(*FieldInitializerListContext).fields = append(localctx.(*FieldInitializerListContext).fields, localctx.(*FieldInitializerListContext)._IDENTIFIER)
-		{
-			p.SetState(166)
-
-			var _m = p.Match(CELParserCOLON)
-
-			localctx.(*FieldInitializerListContext).s21 = _m
-		}
-		localctx.(*FieldInitializerListContext).cols = append(localctx.(*FieldInitializerListContext).cols, localctx.(*FieldInitializerListContext).s21)
-		{
-			p.SetState(167)
-
-			var _x = p.Expr()
-
-			localctx.(*FieldInitializerListContext)._expr = _x
-		}
-		localctx.(*FieldInitializerListContext).values = append(localctx.(*FieldInitializerListContext).values, localctx.(*FieldInitializerListContext)._expr)
-
-		p.SetState(172)
+		p.SetState(178)
 		p.GetErrorHandler().Sync(p)
-		_la = p.GetTokenStream().LA(1)
+		_alt = p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 24, p.GetParserRuleContext())
 	}
 
 	return localctx
@@ -3319,7 +3348,6 @@ func (s *MapInitializerListContext) Accept(visitor antlr.ParseTreeVisitor) inter
 func (p *CELParser) MapInitializerList() (localctx IMapInitializerListContext) {
 	localctx = NewMapInitializerListContext(p, p.GetParserRuleContext(), p.GetState())
 	p.EnterRule(localctx, 22, CELParserRULE_mapInitializerList)
-	var _la int
 
 	defer func() {
 		p.ExitRule()
@@ -3337,9 +3365,11 @@ func (p *CELParser) MapInitializerList() (localctx IMapInitializerListContext) {
 		}
 	}()
 
+	var _alt int
+
 	p.EnterOuterAlt(localctx, 1)
 	{
-		p.SetState(173)
+		p.SetState(179)
 
 		var _x = p.Expr()
 
@@ -3347,7 +3377,7 @@ func (p *CELParser) MapInitializerList() (localctx IMapInitializerListContext) {
 	}
 	localctx.(*MapInitializerListContext).keys = append(localctx.(*MapInitializerListContext).keys, localctx.(*MapInitializerListContext)._expr)
 	{
-		p.SetState(174)
+		p.SetState(180)
 
 		var _m = p.Match(CELParserCOLON)
 
@@ -3355,50 +3385,52 @@ func (p *CELParser) MapInitializerList() (localctx IMapInitializerListContext) {
 	}
 	localctx.(*MapInitializerListContext).cols = append(localctx.(*MapInitializerListContext).cols, localctx.(*MapInitializerListContext).s21)
 	{
-		p.SetState(175)
+		p.SetState(181)
 
 		var _x = p.Expr()
 
 		localctx.(*MapInitializerListContext)._expr = _x
 	}
 	localctx.(*MapInitializerListContext).values = append(localctx.(*MapInitializerListContext).values, localctx.(*MapInitializerListContext)._expr)
-	p.SetState(183)
+	p.SetState(189)
 	p.GetErrorHandler().Sync(p)
-	_la = p.GetTokenStream().LA(1)
+	_alt = p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 25, p.GetParserRuleContext())
 
-	for _la == CELParserCOMMA {
-		{
-			p.SetState(176)
-			p.Match(CELParserCOMMA)
+	for _alt != 2 && _alt != antlr.ATNInvalidAltNumber {
+		if _alt == 1 {
+			{
+				p.SetState(182)
+				p.Match(CELParserCOMMA)
+			}
+			{
+				p.SetState(183)
+
+				var _x = p.Expr()
+
+				localctx.(*MapInitializerListContext)._expr = _x
+			}
+			localctx.(*MapInitializerListContext).keys = append(localctx.(*MapInitializerListContext).keys, localctx.(*MapInitializerListContext)._expr)
+			{
+				p.SetState(184)
+
+				var _m = p.Match(CELParserCOLON)
+
+				localctx.(*MapInitializerListContext).s21 = _m
+			}
+			localctx.(*MapInitializerListContext).cols = append(localctx.(*MapInitializerListContext).cols, localctx.(*MapInitializerListContext).s21)
+			{
+				p.SetState(185)
+
+				var _x = p.Expr()
+
+				localctx.(*MapInitializerListContext)._expr = _x
+			}
+			localctx.(*MapInitializerListContext).values = append(localctx.(*MapInitializerListContext).values, localctx.(*MapInitializerListContext)._expr)
+
 		}
-		{
-			p.SetState(177)
-
-			var _x = p.Expr()
-
-			localctx.(*MapInitializerListContext)._expr = _x
-		}
-		localctx.(*MapInitializerListContext).keys = append(localctx.(*MapInitializerListContext).keys, localctx.(*MapInitializerListContext)._expr)
-		{
-			p.SetState(178)
-
-			var _m = p.Match(CELParserCOLON)
-
-			localctx.(*MapInitializerListContext).s21 = _m
-		}
-		localctx.(*MapInitializerListContext).cols = append(localctx.(*MapInitializerListContext).cols, localctx.(*MapInitializerListContext).s21)
-		{
-			p.SetState(179)
-
-			var _x = p.Expr()
-
-			localctx.(*MapInitializerListContext)._expr = _x
-		}
-		localctx.(*MapInitializerListContext).values = append(localctx.(*MapInitializerListContext).values, localctx.(*MapInitializerListContext)._expr)
-
-		p.SetState(185)
+		p.SetState(191)
 		p.GetErrorHandler().Sync(p)
-		_la = p.GetTokenStream().LA(1)
+		_alt = p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 25, p.GetParserRuleContext())
 	}
 
 	return localctx
@@ -3873,19 +3905,19 @@ func (p *CELParser) Literal() (localctx ILiteralContext) {
 		}
 	}()
 
-	p.SetState(200)
+	p.SetState(206)
 	p.GetErrorHandler().Sync(p)
-	switch p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 26, p.GetParserRuleContext()) {
+	switch p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), 28, p.GetParserRuleContext()) {
 	case 1:
 		localctx = NewIntContext(p, localctx)
 		p.EnterOuterAlt(localctx, 1)
-		p.SetState(187)
+		p.SetState(193)
 		p.GetErrorHandler().Sync(p)
 		_la = p.GetTokenStream().LA(1)
 
 		if _la == CELParserMINUS {
 			{
-				p.SetState(186)
+				p.SetState(192)
 
 				var _m = p.Match(CELParserMINUS)
 
@@ -3894,7 +3926,7 @@ func (p *CELParser) Literal() (localctx ILiteralContext) {
 
 		}
 		{
-			p.SetState(189)
+			p.SetState(195)
 
 			var _m = p.Match(CELParserNUM_INT)
 
@@ -3905,7 +3937,7 @@ func (p *CELParser) Literal() (localctx ILiteralContext) {
 		localctx = NewUintContext(p, localctx)
 		p.EnterOuterAlt(localctx, 2)
 		{
-			p.SetState(190)
+			p.SetState(196)
 
 			var _m = p.Match(CELParserNUM_UINT)
 
@@ -3915,13 +3947,13 @@ func (p *CELParser) Literal() (localctx ILiteralContext) {
 	case 3:
 		localctx = NewDoubleContext(p, localctx)
 		p.EnterOuterAlt(localctx, 3)
-		p.SetState(192)
+		p.SetState(198)
 		p.GetErrorHandler().Sync(p)
 		_la = p.GetTokenStream().LA(1)
 
 		if _la == CELParserMINUS {
 			{
-				p.SetState(191)
+				p.SetState(197)
 
 				var _m = p.Match(CELParserMINUS)
 
@@ -3930,7 +3962,7 @@ func (p *CELParser) Literal() (localctx ILiteralContext) {
 
 		}
 		{
-			p.SetState(194)
+			p.SetState(200)
 
 			var _m = p.Match(CELParserNUM_FLOAT)
 
@@ -3941,7 +3973,7 @@ func (p *CELParser) Literal() (localctx ILiteralContext) {
 		localctx = NewStringContext(p, localctx)
 		p.EnterOuterAlt(localctx, 4)
 		{
-			p.SetState(195)
+			p.SetState(201)
 
 			var _m = p.Match(CELParserSTRING)
 
@@ -3952,7 +3984,7 @@ func (p *CELParser) Literal() (localctx ILiteralContext) {
 		localctx = NewBytesContext(p, localctx)
 		p.EnterOuterAlt(localctx, 5)
 		{
-			p.SetState(196)
+			p.SetState(202)
 
 			var _m = p.Match(CELParserBYTES)
 
@@ -3963,7 +3995,7 @@ func (p *CELParser) Literal() (localctx ILiteralContext) {
 		localctx = NewBoolTrueContext(p, localctx)
 		p.EnterOuterAlt(localctx, 6)
 		{
-			p.SetState(197)
+			p.SetState(203)
 
 			var _m = p.Match(CELParserTRUE)
 
@@ -3974,7 +4006,7 @@ func (p *CELParser) Literal() (localctx ILiteralContext) {
 		localctx = NewBoolFalseContext(p, localctx)
 		p.EnterOuterAlt(localctx, 7)
 		{
-			p.SetState(198)
+			p.SetState(204)
 
 			var _m = p.Match(CELParserFALSE)
 
@@ -3985,7 +4017,7 @@ func (p *CELParser) Literal() (localctx ILiteralContext) {
 		localctx = NewNullContext(p, localctx)
 		p.EnterOuterAlt(localctx, 8)
 		{
-			p.SetState(199)
+			p.SetState(205)
 
 			var _m = p.Match(CELParserNULL)
 

--- a/parser/gen/cel_visitor.go
+++ b/parser/gen/cel_visitor.go
@@ -1,4 +1,4 @@
-// Generated from /Users/tswadell/lace/go/src/github.com/google/cel-go/bin/../parser/gen/CEL.g4 by ANTLR 4.7.
+// Generated from /Users/tswadell/go/src/github.com/google/cel-go/bin/../parser/gen/CEL.g4 by ANTLR 4.7.
 
 package gen // CEL
 import "github.com/antlr/antlr4/runtime/Go/antlr"

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -597,7 +597,22 @@ ERROR: <input>:1:5: Syntax error: extraneous input 'b' expecting <EOF>
 		]^#1:*expr.Expr_ListExpr#`,
 	},
 	{
+		I: `[3, 4, 5,]`,
+		P: `[
+			3^#2:*expr.Constant_Int64Value#,
+			4^#3:*expr.Constant_Int64Value#,
+			5^#4:*expr.Constant_Int64Value#
+		]^#1:*expr.Expr_ListExpr#`,
+	},
+	{
 		I: `{foo: 5, bar: "xyz"}`,
+		P: `{
+			foo^#3:*expr.Expr_IdentExpr#:5^#4:*expr.Constant_Int64Value#^#2:*expr.Expr_CreateStruct_Entry#,
+			bar^#6:*expr.Expr_IdentExpr#:"xyz"^#7:*expr.Constant_StringValue#^#5:*expr.Expr_CreateStruct_Entry#
+		}^#1:*expr.Expr_StructExpr#`,
+	},
+	{
+		I: `{foo: 5, bar: "xyz", }`,
 		P: `{
 			foo^#3:*expr.Expr_IdentExpr#:5^#4:*expr.Constant_Int64Value#^#2:*expr.Expr_CreateStruct_Entry#,
 			bar^#6:*expr.Expr_IdentExpr#:"xyz"^#7:*expr.Constant_StringValue#^#5:*expr.Expr_CreateStruct_Entry#
@@ -631,7 +646,7 @@ ERROR: <input>:1:5: Syntax error: extraneous input 'b' expecting <EOF>
 	},
 	{
 		I: `{`,
-		E: `ERROR: <input>:1:2: Syntax error: mismatched input '<EOF>' expecting {'[', '{', '}', '(', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}
+		E: `ERROR: <input>:1:2: Syntax error: mismatched input '<EOF>' expecting {'[', '{', '}', '(', '.', ',', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}
 		 | {
 		 | .^`,
 	},
@@ -1018,7 +1033,7 @@ ERROR: <input>:1:26: reserved identifier: var
 	},
 	{
 		I: "func{{a}}",
-		E: `ERROR: <input>:1:6: Syntax error: extraneous input '{' expecting {'}', IDENTIFIER}
+		E: `ERROR: <input>:1:6: Syntax error: extraneous input '{' expecting {'}', ',', IDENTIFIER}
 		| func{{a}}
 		| .....^
 	   ERROR: <input>:1:8: Syntax error: mismatched input '}' expecting ':'
@@ -1030,7 +1045,7 @@ ERROR: <input>:1:26: reserved identifier: var
 	},
 	{
 		I: "msg{:a}",
-		E: `ERROR: <input>:1:5: Syntax error: extraneous input ':' expecting {'}', IDENTIFIER}
+		E: `ERROR: <input>:1:5: Syntax error: extraneous input ':' expecting {'}', ',', IDENTIFIER}
 		| msg{:a}
 		| ....^
 	   ERROR: <input>:1:7: Syntax error: mismatched input '}' expecting ':'
@@ -1045,7 +1060,7 @@ ERROR: <input>:1:26: reserved identifier: var
 	},
 	{
 		I: "{:a}",
-		E: `ERROR: <input>:1:2: Syntax error: extraneous input ':' expecting {'[', '{', '}', '(', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}
+		E: `ERROR: <input>:1:2: Syntax error: extraneous input ':' expecting {'[', '{', '}', '(', '.', ',', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}
 		| {:a}
 		| .^
 	   ERROR: <input>:1:4: Syntax error: mismatched input '}' expecting ':'


### PR DESCRIPTION
Support trailing commas for `CreateMessage` and `CreateStruct` expressions:

```
Msg{a: b,}
{"a": "b",}
```

This change is consistent with how `CreateList` expressions support the trailing comma.

Closes #396 