### PR TITLE
Fix infinite loop in AST prune

### DIFF
--- a/interpreter/prune.go
+++ b/interpreter/prune.go
@@ -382,12 +382,11 @@ func (p *astPruner) existsWithKnownValue(id int64) bool {
 func (p *astPruner) nextID() int64 {
 	for {
 		_, found := p.state.Value(p.nextExprID)
-		if found {
-			break
+		if !found {
+			next := p.nextExprID
+			p.nextExprID++
+			return next
 		}
 		p.nextExprID++
 	}
-	next := p.nextExprID
-	p.nextExprID++
-	return next
 }


### PR DESCRIPTION
The termination condition for generating ids when pruning an AST was incorrect. It was trying to find the next id after the last one observed in the eval state, but it should have just been picking the first id not recorded in the eval state and returning it.

Fixes #418 