### PR TITLE
Return errors when duration or timestamp overflow is detected

### DIFF
--- a/common/types/BUILD.bazel
+++ b/common/types/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "map.go",
         "null.go",
         "object.go",
+        "overflow.go",
         "provider.go",
         "string.go",
         "timestamp.go",

--- a/common/types/bool.go
+++ b/common/types/bool.go
@@ -41,7 +41,7 @@ var (
 )
 
 // Boolean constants
-var (
+const (
 	False = Bool(false)
 	True  = Bool(true)
 )

--- a/common/types/duration.go
+++ b/common/types/duration.go
@@ -55,16 +55,16 @@ func (d Duration) Add(other ref.Val) ref.Val {
 	switch other.Type() {
 	case DurationType:
 		dur2 := other.(Duration)
-		if val, ok := addDurationOverflow(d.Duration, dur2.Duration); ok {
+		if val, ok := addDurationChecked(d.Duration, dur2.Duration); ok {
 			return durationOf(val)
 		}
-		return NewErr("duration overflow")
+		return errDurationOverflow
 	case TimestampType:
 		ts := other.(Timestamp).Time
-		if val, ok := addTimeDurationOverflow(ts, d.Duration); ok {
+		if val, ok := addTimeDurationChecked(ts, d.Duration); ok {
 			return timestampOf(val)
 		}
-		return NewErr("timestamp overflow")
+		return errTimestampOverflow
 	}
 	return ValOrErr(other, "no such overload")
 }
@@ -141,10 +141,10 @@ func (d Duration) Equal(other ref.Val) ref.Val {
 
 // Negate implements traits.Negater.Negate.
 func (d Duration) Negate() ref.Val {
-	if val, ok := negateDurationOverflow(d.Duration); ok {
+	if val, ok := negateDurationChecked(d.Duration); ok {
 		return durationOf(val)
 	}
-	return NewErr("duration overflow")
+	return errDurationOverflow
 }
 
 // Receive implements traits.Receiver.Receive.
@@ -163,10 +163,10 @@ func (d Duration) Subtract(subtrahend ref.Val) ref.Val {
 	if !ok {
 		return ValOrErr(subtrahend, "no such overload")
 	}
-	if val, ok := subtractDurationOverflow(d.Duration, subtraDur.Duration); ok {
+	if val, ok := subtractDurationChecked(d.Duration, subtraDur.Duration); ok {
 		return durationOf(val)
 	}
-	return NewErr("duration overflow")
+	return errDurationOverflow
 }
 
 // Type implements ref.Val.Type.

--- a/common/types/duration.go
+++ b/common/types/duration.go
@@ -36,6 +36,10 @@ type Duration struct {
 	time.Duration
 }
 
+func durationOf(d time.Duration) Duration {
+	return Duration{Duration: d}
+}
+
 var (
 	// DurationType singleton.
 	DurationType = NewTypeValue("google.protobuf.Duration",
@@ -51,10 +55,16 @@ func (d Duration) Add(other ref.Val) ref.Val {
 	switch other.Type() {
 	case DurationType:
 		dur2 := other.(Duration)
-		return Duration{Duration: d.Duration + dur2.Duration}
+		if val, ok := addDurationOverflow(d.Duration, dur2.Duration); ok {
+			return durationOf(val)
+		}
+		return NewErr("duration overflow")
 	case TimestampType:
 		ts := other.(Timestamp).Time
-		return Timestamp{Time: ts.Add(d.Duration)}
+		if val, ok := addTimeDurationOverflow(ts, d.Duration); ok {
+			return timestampOf(val)
+		}
+		return NewErr("timestamp overflow")
 	}
 	return ValOrErr(other, "no such overload")
 }
@@ -65,14 +75,16 @@ func (d Duration) Compare(other ref.Val) ref.Val {
 	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	dur := d.Duration - otherDur.Duration
-	if dur < 0 {
+	d1 := d.Duration
+	d2 := otherDur.Duration
+	switch {
+	case d1 < d2:
 		return IntNegOne
-	}
-	if dur > 0 {
+	case d1 > d2:
 		return IntOne
+	default:
+		return IntZero
 	}
-	return IntZero
 }
 
 // ConvertToNative implements ref.Val.ConvertToNative.
@@ -129,7 +141,10 @@ func (d Duration) Equal(other ref.Val) ref.Val {
 
 // Negate implements traits.Negater.Negate.
 func (d Duration) Negate() ref.Val {
-	return Duration{Duration: -d.Duration}
+	if val, ok := negateDurationOverflow(d.Duration); ok {
+		return durationOf(val)
+	}
+	return NewErr("duration overflow")
 }
 
 // Receive implements traits.Receiver.Receive.
@@ -148,7 +163,10 @@ func (d Duration) Subtract(subtrahend ref.Val) ref.Val {
 	if !ok {
 		return ValOrErr(subtrahend, "no such overload")
 	}
-	return d.Add(subtraDur.Negate())
+	if val, ok := subtractDurationOverflow(d.Duration, subtraDur.Duration); ok {
+		return durationOf(val)
+	}
+	return NewErr("duration overflow")
 }
 
 // Type implements ref.Val.Type.

--- a/common/types/err.go
+++ b/common/types/err.go
@@ -29,6 +29,15 @@ type Err struct {
 var (
 	// ErrType singleton.
 	ErrType = NewTypeValue("error")
+
+	// errIntOverflow is an error representing integer overflow.
+	errIntOverflow = NewErr("integer overflow")
+	// errUintOverflow is an error representing unsigned integer overflow.
+	errUintOverflow = NewErr("unsigned integer overflow")
+	// errDurationOverflow is an error representing duration overflow.
+	errDurationOverflow = NewErr("duration overflow")
+	// errTimestampOverflow is an error representing timestamp overflow.
+	errTimestampOverflow = NewErr("timestamp overflow")
 )
 
 // NewErr creates a new Err described by the format string and args.

--- a/common/types/int.go
+++ b/common/types/int.go
@@ -63,10 +63,10 @@ func (i Int) Add(other ref.Val) ref.Val {
 	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	if val, ok := addInt64Overflow(int64(i), int64(otherInt)); ok {
+	if val, ok := addInt64Checked(int64(i), int64(otherInt)); ok {
 		return Int(val)
 	}
-	return NewErr("integer overflow")
+	return errIntOverflow
 }
 
 // Compare implements traits.Comparer.Compare.
@@ -168,7 +168,7 @@ func (i Int) ConvertToType(typeVal ref.Type) ref.Val {
 		// The maximum positive value that can be passed to time.Unix is math.MaxInt64 minus the number
 		// of seconds between year 1 and year 1970. See comments on unixToInternal.
 		if int64(i) < minUnixTime || int64(i) > maxUnixTime {
-			return NewErr("timestamp overflow")
+			return errTimestampOverflow
 		}
 		return timestampOf(time.Unix(int64(i), 0).UTC())
 	case TypeType:
@@ -186,10 +186,10 @@ func (i Int) Divide(other ref.Val) ref.Val {
 	if otherInt == IntZero {
 		return NewErr("divide by zero")
 	}
-	if val, ok := divideInt64Overflow(int64(i), int64(otherInt)); ok {
+	if val, ok := divideInt64Checked(int64(i), int64(otherInt)); ok {
 		return Int(val)
 	}
-	return NewErr("integer overflow")
+	return errIntOverflow
 }
 
 // Equal implements ref.Val.Equal.
@@ -210,10 +210,10 @@ func (i Int) Modulo(other ref.Val) ref.Val {
 	if otherInt == IntZero {
 		return NewErr("modulus by zero")
 	}
-	if val, ok := moduloInt64Overflow(int64(i), int64(otherInt)); ok {
+	if val, ok := moduloInt64Checked(int64(i), int64(otherInt)); ok {
 		return Int(val)
 	}
-	return NewErr("integer overflow")
+	return errIntOverflow
 }
 
 // Multiply implements traits.Multiplier.Multiply.
@@ -222,18 +222,18 @@ func (i Int) Multiply(other ref.Val) ref.Val {
 	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	if val, ok := multiplyInt64Overflow(int64(i), int64(otherInt)); ok {
+	if val, ok := multiplyInt64Checked(int64(i), int64(otherInt)); ok {
 		return Int(val)
 	}
-	return NewErr("integer overflow")
+	return errIntOverflow
 }
 
 // Negate implements traits.Negater.Negate.
 func (i Int) Negate() ref.Val {
-	if val, ok := negateInt64Overflow(int64(i)); ok {
+	if val, ok := negateInt64Checked(int64(i)); ok {
 		return Int(val)
 	}
-	return NewErr("integer overflow")
+	return errIntOverflow
 }
 
 // Subtract implements traits.Subtractor.Subtract.
@@ -242,10 +242,10 @@ func (i Int) Subtract(subtrahend ref.Val) ref.Val {
 	if !ok {
 		return ValOrErr(subtrahend, "no such overload")
 	}
-	if val, ok := subtractInt64Overflow(int64(i), int64(subtraInt)); ok {
+	if val, ok := subtractInt64Checked(int64(i), int64(subtraInt)); ok {
 		return Int(val)
 	}
-	return NewErr("integer overflow")
+	return errIntOverflow
 }
 
 // Type implements ref.Val.Type.

--- a/common/types/int_test.go
+++ b/common/types/int_test.go
@@ -250,7 +250,13 @@ func TestIntMultiply(t *testing.T) {
 		t.Errorf("Expected multiplying %d and %d to yield %d", lhs, rhs, math.MaxInt64-1)
 	}
 	if lhs, rhs := math.MinInt64/2, 2; !Int(lhs).Multiply(Int(rhs)).Equal(Int(math.MinInt64)).(Bool) {
-		t.Errorf("Expected multiplying %d and %d to yield %d", lhs, rhs, math.MaxInt64)
+		t.Errorf("Expected multiplying %d and %d to yield %d", lhs, rhs, math.MinInt64)
+	}
+	if lhs, rhs := math.MaxInt64/2, -2; !Int(lhs).Multiply(Int(rhs)).Equal(Int(math.MinInt64 + 2)).(Bool) {
+		t.Errorf("Expected multiplying %d and %d to yield %d", lhs, rhs, math.MinInt64+2)
+	}
+	if lhs, rhs := (math.MinInt64+2)/2, -2; !Int(lhs).Multiply(Int(rhs)).Equal(Int(math.MaxInt64 - 1)).(Bool) {
+		t.Errorf("Expected multiplying %d and %d to yield %d", lhs, rhs, math.MaxInt64-1)
 	}
 	if lhs, rhs := math.MinInt64, -1; !IsError(Int(lhs).Multiply(Int(rhs))) {
 		t.Errorf("Expected multiplying %d and %d result in overflow.", lhs, rhs)
@@ -286,6 +292,6 @@ func TestIntSubtract(t *testing.T) {
 		t.Errorf("Expected subtracting %d and %d to yield %d", lhs, rhs, math.MaxInt64)
 	}
 	if lhs, rhs := math.MinInt64+1, 1; !Int(lhs).Subtract(Int(rhs)).Equal(Int(math.MinInt64)).(Bool) {
-		t.Errorf("Expected subtracting %d and %d to yield %d", lhs, rhs, math.MaxInt64)
+		t.Errorf("Expected subtracting %d and %d to yield %d", lhs, rhs, math.MinInt64)
 	}
 }

--- a/common/types/overflow.go
+++ b/common/types/overflow.go
@@ -1,0 +1,237 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"math"
+	"time"
+)
+
+const (
+	nanosPerSecond = 1000000000
+)
+
+func addInt64Overflow(x, y int64) (int64, bool) {
+	if (y > 0 && x > math.MaxInt64-y) || (y < 0 && x < math.MinInt64-y) {
+		return 0, false
+	}
+	return x + y, true
+}
+
+func subtractInt64Overflow(x, y int64) (int64, bool) {
+	if (y < 0 && x > math.MaxInt64+y) || (y > 0 && x < math.MinInt64+y) {
+		return 0, false
+	}
+	return x - y, true
+}
+
+func negateInt64Overflow(x int64) (int64, bool) {
+	// In twos complement, negating MinInt64 would result in a valid of MaxInt64+1.
+	if x == math.MinInt64 {
+		return 0, false
+	}
+	return -x, true
+}
+
+func multiplyInt64Overflow(x, y int64) (int64, bool) {
+	// Detecting multiplication overflow is more complicated than the others. The first two detect
+	// attempting to negate MinInt64, which would result in MaxInt64+1. The other four detect normal
+	// overflow conditions.
+	if (x == -1 && y == math.MinInt64) || (y == -1 && x == math.MinInt64) ||
+		// x is positive, y is positive
+		(x > 0 && y > 0 && x > math.MaxInt64/y) ||
+		// x is positive, y is negative
+		(x > 0 && y < 0 && y < math.MinInt64/x) ||
+		// x is negative, y is positive
+		(x < 0 && y > 0 && x < math.MinInt64/y) ||
+		// x is negative, y is negative
+		(x < 0 && y < 0 && y < math.MaxInt64/x) {
+		return 0, false
+	}
+	return x * y, true
+}
+
+func divideInt64Overflow(x, y int64) (int64, bool) {
+	// In twos complement, negating MinInt64 would result in a valid of MaxInt64+1.
+	if x == math.MinInt64 && y == -1 {
+		return 0, false
+	}
+	return x / y, true
+}
+
+func moduloInt64Overflow(x, y int64) (int64, bool) {
+	// In twos complement, negating MinInt64 would result in a valid of MaxInt64+1.
+	if x == math.MinInt64 && y == -1 {
+		return 0, false
+	}
+	return x % y, true
+}
+
+func addUint64Overflow(x, y uint64) (uint64, bool) {
+	if y > 0 && x > math.MaxUint64-y {
+		return 0, false
+	}
+	return x + y, true
+}
+
+func subtractUint64Overflow(x, y uint64) (uint64, bool) {
+	if y > x {
+		return 0, false
+	}
+	return x - y, true
+}
+
+func multiplyUint64Overflow(x, y uint64) (uint64, bool) {
+	if y != 0 && x > math.MaxUint64/y {
+		return 0, false
+	}
+	return x * y, true
+}
+
+func addDurationOverflow(x, y time.Duration) (time.Duration, bool) {
+	if val, ok := addInt64Overflow(int64(x), int64(y)); ok {
+		return time.Duration(val), true
+	}
+	return time.Duration(0), false
+}
+
+func subtractDurationOverflow(x, y time.Duration) (time.Duration, bool) {
+	if val, ok := subtractInt64Overflow(int64(x), int64(y)); ok {
+		return time.Duration(val), true
+	}
+	return time.Duration(0), false
+}
+
+func negateDurationOverflow(x time.Duration) (time.Duration, bool) {
+	if val, ok := negateInt64Overflow(int64(x)); ok {
+		return time.Duration(val), true
+	}
+	return time.Duration(0), false
+}
+
+func addTimeDurationOverflow(x time.Time, y time.Duration) (time.Time, bool) {
+	// This is tricky. A time is represented as (int64, int32) where the first is seconds and second
+	// is nanoseconds. A duration is int64 representing nanoseconds. We cannot normalize time to int64
+	// as it could potentially overflow. The only way to proceed is to break time and duration into
+	// second and nanosecond components.
+
+	// First we break time into its components by truncating and subtracting.
+	sec1 := x.Truncate(time.Second).Unix()                // Truncate to seconds.
+	nsec1 := x.Sub(x.Truncate(time.Second)).Nanoseconds() // Get nanoseconds by truncating and subtracting.
+
+	// Second we break duration into its components by dividing and modulo.
+	sec2 := int64(y) / nanosPerSecond  // Truncate to seconds.
+	nsec2 := int64(y) % nanosPerSecond // Get remainder.
+
+	// Add seconds first, detecting any overflow.
+	sec, ok := addInt64Overflow(sec1, sec2)
+	if !ok {
+		return time.Time{}, false
+	}
+
+	// Nanoseconds cannot overflow.
+	nsec := nsec1 + nsec2
+
+	// We need to normalize nanoseconds to be positive and carry extra nanoseconds to seconds.
+	// Adapted from time.Unix(int64, int64).
+	if nsec < 0 || nsec >= nanosPerSecond {
+		// Add seconds.
+		sec, ok = addInt64Overflow(sec, nsec/nanosPerSecond)
+		if !ok {
+			return time.Time{}, false
+		}
+		nsec -= (nsec / nanosPerSecond) * nanosPerSecond
+		if nsec < 0 {
+			// Subtract an extra second
+			sec, ok = addInt64Overflow(sec, -1)
+			if !ok {
+				return time.Time{}, false
+			}
+			nsec += nanosPerSecond
+		}
+	}
+
+	// Check if the the number of seconds from Unix epoch is within our acceptable range.
+	if sec < minUnixTime || sec > maxUnixTime {
+		return time.Time{}, false
+	}
+
+	// Return resulting time and propagate time zone.
+	return time.Unix(sec, nsec).In(x.Location()), true
+}
+
+func subtractTimeOverflow(x, y time.Time) (time.Duration, bool) {
+	// Similar to addTimeDurationOverflow() above.
+
+	// First we break time into its components by truncating and subtracting.
+	sec1 := x.Truncate(time.Second).Unix()                // Truncate to seconds.
+	nsec1 := x.Sub(x.Truncate(time.Second)).Nanoseconds() // Get nanoseconds by truncating and subtracting.
+
+	// Second we break duration into its components by truncating and subtracting.
+	sec2 := y.Truncate(time.Second).Unix()                // Truncate to seconds.
+	nsec2 := y.Sub(y.Truncate(time.Second)).Nanoseconds() // Get nanoseconds by truncating and subtracting.
+
+	// Subtract seconds first, detecting any overflow.
+	sec, ok := subtractInt64Overflow(sec1, sec2)
+	if !ok {
+		return time.Duration(0), false
+	}
+
+	// Nanoseconds cannot overflow.
+	nsec := nsec1 - nsec2
+
+	// We need to normalize nanoseconds to be positive and carry extra nanoseconds to seconds.
+	// Adapted from time.Unix(int64, int64).
+	if nsec < 0 || nsec >= nanosPerSecond {
+		// Add an extra second.
+		sec, ok = addInt64Overflow(sec, nsec/nanosPerSecond)
+		if !ok {
+			return time.Duration(0), false
+		}
+		nsec -= (nsec / nanosPerSecond) * nanosPerSecond
+		if nsec < 0 {
+			// Subtract an extra second
+			sec, ok = addInt64Overflow(sec, -1)
+			if !ok {
+				return time.Duration(0), false
+			}
+			nsec += nanosPerSecond
+		}
+	}
+
+	// Scale seconds to nanoseconds detecting overflow.
+	tsec, ok := multiplyInt64Overflow(sec, nanosPerSecond)
+	if !ok {
+		return time.Duration(0), false
+	}
+
+	// Lastly we need to add the two nanoseconds together.
+	val, ok := addInt64Overflow(tsec, nsec)
+	if !ok {
+		return time.Duration(0), false
+	}
+
+	return time.Duration(val), true
+}
+
+func subtractTimeDurationOverflow(x time.Time, y time.Duration) (time.Time, bool) {
+	// The easiest way to implement this is to negate y and add them.
+	// x - y = x + -y
+	val, ok := negateDurationOverflow(y)
+	if !ok {
+		return time.Time{}, false
+	}
+	return addTimeDurationOverflow(x, val)
+}

--- a/common/types/overflow.go
+++ b/common/types/overflow.go
@@ -19,25 +19,30 @@ import (
 	"time"
 )
 
-const (
-	nanosPerSecond = 1000000000
-)
-
-func addInt64Overflow(x, y int64) (int64, bool) {
+// addInt64Checked performs addition with overflow detection of two int64, returning the result of
+// the addition if no overflow occurred as the first return value and a bool indicating whether no
+// overflow occurred as the second return value.
+func addInt64Checked(x, y int64) (int64, bool) {
 	if (y > 0 && x > math.MaxInt64-y) || (y < 0 && x < math.MinInt64-y) {
 		return 0, false
 	}
 	return x + y, true
 }
 
-func subtractInt64Overflow(x, y int64) (int64, bool) {
+// subtractInt64Checked performs subtraction with overflow detection of two int64, returning the
+// result of the subtraction if no overflow occurred as the first return value and a bool indicating
+// whether no overflow occurred as the second return value.
+func subtractInt64Checked(x, y int64) (int64, bool) {
 	if (y < 0 && x > math.MaxInt64+y) || (y > 0 && x < math.MinInt64+y) {
 		return 0, false
 	}
 	return x - y, true
 }
 
-func negateInt64Overflow(x int64) (int64, bool) {
+// negateInt64Checked performs negation with overflow detection of an int64, returning the
+// result of the negation if no overflow occurred as the first return value and a bool indicating
+// whether no overflow occurred as the second return value.
+func negateInt64Checked(x int64) (int64, bool) {
 	// In twos complement, negating MinInt64 would result in a valid of MaxInt64+1.
 	if x == math.MinInt64 {
 		return 0, false
@@ -45,7 +50,10 @@ func negateInt64Overflow(x int64) (int64, bool) {
 	return -x, true
 }
 
-func multiplyInt64Overflow(x, y int64) (int64, bool) {
+// multiplyInt64Checked performs multiplication with overflow detection of two int64, returning the
+// result of the multiplication if no overflow occurred as the first return value and a bool
+// indicating whether no overflow occurred as the second return value.
+func multiplyInt64Checked(x, y int64) (int64, bool) {
 	// Detecting multiplication overflow is more complicated than the others. The first two detect
 	// attempting to negate MinInt64, which would result in MaxInt64+1. The other four detect normal
 	// overflow conditions.
@@ -63,7 +71,10 @@ func multiplyInt64Overflow(x, y int64) (int64, bool) {
 	return x * y, true
 }
 
-func divideInt64Overflow(x, y int64) (int64, bool) {
+// divideInt64Checked performs division with overflow detection of two int64, returning the
+// result of the division if no overflow occurred as the first return value and a bool
+// indicating whether no overflow occurred as the second return value.
+func divideInt64Checked(x, y int64) (int64, bool) {
 	// In twos complement, negating MinInt64 would result in a valid of MaxInt64+1.
 	if x == math.MinInt64 && y == -1 {
 		return 0, false
@@ -71,7 +82,10 @@ func divideInt64Overflow(x, y int64) (int64, bool) {
 	return x / y, true
 }
 
-func moduloInt64Overflow(x, y int64) (int64, bool) {
+// moduloInt64Checked performs modulo with overflow detection of two int64, returning the
+// result of the modulo if no overflow occurred as the first return value and a bool
+// indicating whether no overflow occurred as the second return value.
+func moduloInt64Checked(x, y int64) (int64, bool) {
 	// In twos complement, negating MinInt64 would result in a valid of MaxInt64+1.
 	if x == math.MinInt64 && y == -1 {
 		return 0, false
@@ -79,49 +93,70 @@ func moduloInt64Overflow(x, y int64) (int64, bool) {
 	return x % y, true
 }
 
-func addUint64Overflow(x, y uint64) (uint64, bool) {
+// addUint64Checked performs addition with overflow detection of two uint64, returning the result of
+// the addition if no overflow occurred as the first return value and a bool indicating whether no
+// overflow occurred as the second return value.
+func addUint64Checked(x, y uint64) (uint64, bool) {
 	if y > 0 && x > math.MaxUint64-y {
 		return 0, false
 	}
 	return x + y, true
 }
 
-func subtractUint64Overflow(x, y uint64) (uint64, bool) {
+// subtractUint64Checked performs subtraction with overflow detection of two uint64, returning the
+// result of the subtraction if no overflow occurred as the first return value and a bool indicating
+// whether no overflow occurred as the second return value.
+func subtractUint64Checked(x, y uint64) (uint64, bool) {
 	if y > x {
 		return 0, false
 	}
 	return x - y, true
 }
 
-func multiplyUint64Overflow(x, y uint64) (uint64, bool) {
+// multiplyUint64Checked performs multiplication with overflow detection of two uint64, returning
+// the result of the multiplication if no overflow occurred as the first return value and a bool
+// indicating whether no overflow occurred as the second return value.
+func multiplyUint64Checked(x, y uint64) (uint64, bool) {
 	if y != 0 && x > math.MaxUint64/y {
 		return 0, false
 	}
 	return x * y, true
 }
 
-func addDurationOverflow(x, y time.Duration) (time.Duration, bool) {
-	if val, ok := addInt64Overflow(int64(x), int64(y)); ok {
+// addDurationChecked performs addition with overflow detection of two time.Duration, returning the
+// result of the addition if no overflow occurred as the first return value and a bool indicating
+// whether no overflow occurred as the second return value.
+func addDurationChecked(x, y time.Duration) (time.Duration, bool) {
+	if val, ok := addInt64Checked(int64(x), int64(y)); ok {
 		return time.Duration(val), true
 	}
 	return time.Duration(0), false
 }
 
-func subtractDurationOverflow(x, y time.Duration) (time.Duration, bool) {
-	if val, ok := subtractInt64Overflow(int64(x), int64(y)); ok {
+// subtractDurationChecked performs subtraction with overflow detection of two time.Duration,
+// returning the result of the subtraction if no overflow occurred as the first return value and a
+// bool indicating whether no overflow occurred as the second return value.
+func subtractDurationChecked(x, y time.Duration) (time.Duration, bool) {
+	if val, ok := subtractInt64Checked(int64(x), int64(y)); ok {
 		return time.Duration(val), true
 	}
 	return time.Duration(0), false
 }
 
-func negateDurationOverflow(x time.Duration) (time.Duration, bool) {
-	if val, ok := negateInt64Overflow(int64(x)); ok {
+// negateDurationChecked performs negation with overflow detection of a time.Duration, returning the
+// result of the negation if no overflow occurred as the first return value and a bool indicating
+// whether no overflow occurred as the second return value.
+func negateDurationChecked(x time.Duration) (time.Duration, bool) {
+	if val, ok := negateInt64Checked(int64(x)); ok {
 		return time.Duration(val), true
 	}
 	return time.Duration(0), false
 }
 
-func addTimeDurationOverflow(x time.Time, y time.Duration) (time.Time, bool) {
+// addDurationChecked performs addition with overflow detection of a time.Time and time.Duration,
+// returning the result of the addition if no overflow occurred as the first return value and a bool
+// indicating whether no overflow occurred as the second return value.
+func addTimeDurationChecked(x time.Time, y time.Duration) (time.Time, bool) {
 	// This is tricky. A time is represented as (int64, int32) where the first is seconds and second
 	// is nanoseconds. A duration is int64 representing nanoseconds. We cannot normalize time to int64
 	// as it could potentially overflow. The only way to proceed is to break time and duration into
@@ -132,34 +167,34 @@ func addTimeDurationOverflow(x time.Time, y time.Duration) (time.Time, bool) {
 	nsec1 := x.Sub(x.Truncate(time.Second)).Nanoseconds() // Get nanoseconds by truncating and subtracting.
 
 	// Second we break duration into its components by dividing and modulo.
-	sec2 := int64(y) / nanosPerSecond  // Truncate to seconds.
-	nsec2 := int64(y) % nanosPerSecond // Get remainder.
+	sec2 := int64(y) / int64(time.Second)  // Truncate to seconds.
+	nsec2 := int64(y) % int64(time.Second) // Get remainder.
 
 	// Add seconds first, detecting any overflow.
-	sec, ok := addInt64Overflow(sec1, sec2)
+	sec, ok := addInt64Checked(sec1, sec2)
 	if !ok {
 		return time.Time{}, false
 	}
 
-	// Nanoseconds cannot overflow.
+	// Nanoseconds cannot overflow as time.Time normalizes them to [0, 999999999].
 	nsec := nsec1 + nsec2
 
 	// We need to normalize nanoseconds to be positive and carry extra nanoseconds to seconds.
 	// Adapted from time.Unix(int64, int64).
-	if nsec < 0 || nsec >= nanosPerSecond {
+	if nsec < 0 || nsec >= int64(time.Second) {
 		// Add seconds.
-		sec, ok = addInt64Overflow(sec, nsec/nanosPerSecond)
+		sec, ok = addInt64Checked(sec, nsec/int64(time.Second))
 		if !ok {
 			return time.Time{}, false
 		}
-		nsec -= (nsec / nanosPerSecond) * nanosPerSecond
+		nsec -= (nsec / int64(time.Second)) * int64(time.Second)
 		if nsec < 0 {
 			// Subtract an extra second
-			sec, ok = addInt64Overflow(sec, -1)
+			sec, ok = addInt64Checked(sec, -1)
 			if !ok {
 				return time.Time{}, false
 			}
-			nsec += nanosPerSecond
+			nsec += int64(time.Second)
 		}
 	}
 
@@ -172,7 +207,10 @@ func addTimeDurationOverflow(x time.Time, y time.Duration) (time.Time, bool) {
 	return time.Unix(sec, nsec).In(x.Location()), true
 }
 
-func subtractTimeOverflow(x, y time.Time) (time.Duration, bool) {
+// subtractTimeChecked performs subtraction with overflow detection of two time.Time, returning the
+// result of the subtraction if no overflow occurred as the first return value and a bool indicating
+// whether no overflow occurred as the second return value.
+func subtractTimeChecked(x, y time.Time) (time.Duration, bool) {
 	// Similar to addTimeDurationOverflow() above.
 
 	// First we break time into its components by truncating and subtracting.
@@ -184,41 +222,41 @@ func subtractTimeOverflow(x, y time.Time) (time.Duration, bool) {
 	nsec2 := y.Sub(y.Truncate(time.Second)).Nanoseconds() // Get nanoseconds by truncating and subtracting.
 
 	// Subtract seconds first, detecting any overflow.
-	sec, ok := subtractInt64Overflow(sec1, sec2)
+	sec, ok := subtractInt64Checked(sec1, sec2)
 	if !ok {
 		return time.Duration(0), false
 	}
 
-	// Nanoseconds cannot overflow.
+	// Nanoseconds cannot overflow as time.Time normalizes them to [0, 999999999].
 	nsec := nsec1 - nsec2
 
 	// We need to normalize nanoseconds to be positive and carry extra nanoseconds to seconds.
 	// Adapted from time.Unix(int64, int64).
-	if nsec < 0 || nsec >= nanosPerSecond {
+	if nsec < 0 || nsec >= int64(time.Second) {
 		// Add an extra second.
-		sec, ok = addInt64Overflow(sec, nsec/nanosPerSecond)
+		sec, ok = addInt64Checked(sec, nsec/int64(time.Second))
 		if !ok {
 			return time.Duration(0), false
 		}
-		nsec -= (nsec / nanosPerSecond) * nanosPerSecond
+		nsec -= (nsec / int64(time.Second)) * int64(time.Second)
 		if nsec < 0 {
 			// Subtract an extra second
-			sec, ok = addInt64Overflow(sec, -1)
+			sec, ok = addInt64Checked(sec, -1)
 			if !ok {
 				return time.Duration(0), false
 			}
-			nsec += nanosPerSecond
+			nsec += int64(time.Second)
 		}
 	}
 
 	// Scale seconds to nanoseconds detecting overflow.
-	tsec, ok := multiplyInt64Overflow(sec, nanosPerSecond)
+	tsec, ok := multiplyInt64Checked(sec, int64(time.Second))
 	if !ok {
 		return time.Duration(0), false
 	}
 
 	// Lastly we need to add the two nanoseconds together.
-	val, ok := addInt64Overflow(tsec, nsec)
+	val, ok := addInt64Checked(tsec, nsec)
 	if !ok {
 		return time.Duration(0), false
 	}
@@ -226,12 +264,15 @@ func subtractTimeOverflow(x, y time.Time) (time.Duration, bool) {
 	return time.Duration(val), true
 }
 
-func subtractTimeDurationOverflow(x time.Time, y time.Duration) (time.Time, bool) {
+// subtractTimeDurationChecked performs subtraction with overflow detection of a time.Time and
+// time.Duration, returning the result of the subtraction if no overflow occurred as the first
+// return value and a bool indicating whether no overflow occurred as the second return value.
+func subtractTimeDurationChecked(x time.Time, y time.Duration) (time.Time, bool) {
 	// The easiest way to implement this is to negate y and add them.
 	// x - y = x + -y
-	val, ok := negateDurationOverflow(y)
+	val, ok := negateDurationChecked(y)
 	if !ok {
 		return time.Time{}, false
 	}
-	return addTimeDurationOverflow(x, val)
+	return addTimeDurationChecked(x, val)
 }

--- a/common/types/string.go
+++ b/common/types/string.go
@@ -136,7 +136,7 @@ func (s String) ConvertToType(typeVal ref.Type) ref.Val {
 	case TimestampType:
 		if t, err := time.Parse(time.RFC3339, s.Value().(string)); err == nil {
 			if t.Unix() < minUnixTime || t.Unix() > maxUnixTime {
-				return NewErr("timestamp overflow")
+				return errTimestampOverflow
 			}
 			return timestampOf(t)
 		}

--- a/common/types/string.go
+++ b/common/types/string.go
@@ -131,11 +131,14 @@ func (s String) ConvertToType(typeVal ref.Type) ref.Val {
 		return Bytes(s)
 	case DurationType:
 		if d, err := time.ParseDuration(s.Value().(string)); err == nil {
-			return Duration{Duration: d}
+			return durationOf(d)
 		}
 	case TimestampType:
 		if t, err := time.Parse(time.RFC3339, s.Value().(string)); err == nil {
-			return Timestamp{Time: t}
+			if t.Unix() < minUnixTime || t.Unix() > maxUnixTime {
+				return NewErr("timestamp overflow")
+			}
+			return timestampOf(t)
 		}
 	case StringType:
 		return s

--- a/common/types/timestamp.go
+++ b/common/types/timestamp.go
@@ -43,7 +43,8 @@ func timestampOf(t time.Time) Timestamp {
 }
 
 const (
-	// The number of seconds between year 1 and year 1970.
+	// The number of seconds between year 1 and year 1970. This is borrowed from
+	// https://golang.org/src/time/time.go.
 	unixToInternal int64 = (1969*365 + 1969/4 - 1969/100 + 1969/400) * (60 * 60 * 24)
 
 	// Number of seconds between `0001-01-01T00:00:00Z` and the Unix epoch.
@@ -159,16 +160,16 @@ func (t Timestamp) Subtract(subtrahend ref.Val) ref.Val {
 	switch subtrahend.Type() {
 	case DurationType:
 		dur := subtrahend.(Duration)
-		if val, ok := subtractTimeDurationOverflow(t.Time, dur.Duration); ok {
+		if val, ok := subtractTimeDurationChecked(t.Time, dur.Duration); ok {
 			return timestampOf(val)
 		}
-		return NewErr("timestamp overflow")
+		return errTimestampOverflow
 	case TimestampType:
 		t2 := subtrahend.(Timestamp).Time
-		if val, ok := subtractTimeOverflow(t.Time, t2); ok {
+		if val, ok := subtractTimeChecked(t.Time, t2); ok {
 			return durationOf(val)
 		}
-		return NewErr("duration overflow")
+		return errDurationOverflow
 	}
 	return ValOrErr(subtrahend, "no such overload")
 }

--- a/common/types/timestamp_test.go
+++ b/common/types/timestamp_test.go
@@ -42,6 +42,18 @@ func TestTimestampAdd(t *testing.T) {
 	if !IsError(ts.Add(expected)) {
 		t.Error("Cannot add two timestamps together")
 	}
+	if lhs, rhs := time.Unix(maxUnixTime, 999999999), 1*time.Nanosecond; !IsError(timestampOf(lhs).Add(durationOf(rhs))) {
+		t.Errorf("Expected adding %s and %s to result in overflow.", lhs, rhs)
+	}
+	if lhs, rhs := time.Unix(minUnixTime, 0), -1*time.Nanosecond; !IsError(timestampOf(lhs).Add(durationOf(rhs))) {
+		t.Errorf("Expected adding %s and %s to result in overflow.", lhs, rhs)
+	}
+	if lhs, rhs := time.Unix(maxUnixTime, 999999999), -1*time.Nanosecond; !timestampOf(lhs).Add(durationOf(rhs)).Equal(timestampOf(lhs.Add(rhs))).(Bool) {
+		t.Errorf("Expected adding %s and %s to yield %s", lhs, rhs, lhs.Add(rhs))
+	}
+	if lhs, rhs := time.Unix(minUnixTime, 0), 1*time.Nanosecond; !timestampOf(lhs).Add(durationOf(rhs)).Equal(timestampOf(lhs.Add(rhs))).(Bool) {
+		t.Errorf("Expected adding %s and %s to yield %s", lhs, rhs, lhs.Add(rhs))
+	}
 }
 
 func TestTimestampConvertToNative_Any(t *testing.T) {

--- a/common/types/uint.go
+++ b/common/types/uint.go
@@ -57,10 +57,10 @@ func (i Uint) Add(other ref.Val) ref.Val {
 	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	if val, ok := addUint64Overflow(uint64(i), uint64(otherUint)); ok {
+	if val, ok := addUint64Checked(uint64(i), uint64(otherUint)); ok {
 		return Uint(val)
 	}
-	return NewErr("unsigned integer overflow")
+	return errUintOverflow
 }
 
 // Compare implements traits.Comparer.Compare.
@@ -186,10 +186,10 @@ func (i Uint) Multiply(other ref.Val) ref.Val {
 	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	if val, ok := multiplyUint64Overflow(uint64(i), uint64(otherUint)); ok {
+	if val, ok := multiplyUint64Checked(uint64(i), uint64(otherUint)); ok {
 		return Uint(val)
 	}
-	return NewErr("unsigned integer overflow")
+	return errUintOverflow
 }
 
 // Subtract implements traits.Subtractor.Subtract.
@@ -198,10 +198,10 @@ func (i Uint) Subtract(subtrahend ref.Val) ref.Val {
 	if !ok {
 		return ValOrErr(subtrahend, "no such overload")
 	}
-	if val, ok := subtractUint64Overflow(uint64(i), uint64(subtraUint)); ok {
+	if val, ok := subtractUint64Checked(uint64(i), uint64(subtraUint)); ok {
 		return Uint(val)
 	}
-	return NewErr("unsigned integer overflow")
+	return errUintOverflow
 }
 
 // Type implements ref.Val.Type.

--- a/common/types/uint.go
+++ b/common/types/uint.go
@@ -57,10 +57,10 @@ func (i Uint) Add(other ref.Val) ref.Val {
 	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	if otherUint > 0 && i > math.MaxUint64-otherUint {
-		return NewErr("unsigned integer overflow")
+	if val, ok := addUint64Overflow(uint64(i), uint64(otherUint)); ok {
+		return Uint(val)
 	}
-	return i + otherUint
+	return NewErr("unsigned integer overflow")
 }
 
 // Compare implements traits.Comparer.Compare.
@@ -186,10 +186,10 @@ func (i Uint) Multiply(other ref.Val) ref.Val {
 	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	if otherUint != 0 && i > math.MaxUint64/otherUint {
-		return NewErr("unsigned integer overflow")
+	if val, ok := multiplyUint64Overflow(uint64(i), uint64(otherUint)); ok {
+		return Uint(val)
 	}
-	return i * otherUint
+	return NewErr("unsigned integer overflow")
 }
 
 // Subtract implements traits.Subtractor.Subtract.
@@ -198,10 +198,10 @@ func (i Uint) Subtract(subtrahend ref.Val) ref.Val {
 	if !ok {
 		return ValOrErr(subtrahend, "no such overload")
 	}
-	if subtraUint > i {
-		return NewErr("unsigned integer overflow")
+	if val, ok := subtractUint64Overflow(uint64(i), uint64(subtraUint)); ok {
+		return Uint(val)
 	}
-	return i - subtraUint
+	return NewErr("unsigned integer overflow")
 }
 
 // Type implements ref.Val.Type.

--- a/conformance/BUILD.bazel
+++ b/conformance/BUILD.bazel
@@ -15,7 +15,6 @@ sh_test(
         "--skip_test=enums/strong_proto2",
         "--skip_test=enums/strong_proto3",
         "--skip_test=fields/qualified_identifier_resolution/map_key_float,map_key_null,map_value_repeat_key",
-        "--skip_test=timestamps/timestamp_range/from_string_under,add_duration_under,add_duration_over",
         "$(location @com_google_cel_spec//tests/simple:testdata/plumbing.textproto)",
         "$(location @com_google_cel_spec//tests/simple:testdata/basic.textproto)",
         "$(location @com_google_cel_spec//tests/simple:testdata/comparisons.textproto)",

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -26,6 +26,8 @@ go_library(
         "@org_golang_google_grpc//status:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
         "@org_golang_google_protobuf//types/known/anypb:go_default_library",
+        "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
     ],
 )
 

--- a/server/server.go
+++ b/server/server.go
@@ -34,9 +34,9 @@ import (
 	confpb "google.golang.org/genproto/googleapis/api/expr/conformance/v1alpha1"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	rpc "google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/protobuf/types/known/anypb"
-	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // ConformanceServer contains the server state.

--- a/server/server.go
+++ b/server/server.go
@@ -33,7 +33,7 @@ import (
 	test3pb "github.com/google/cel-spec/proto/test/v1/proto3/test_all_types"
 	confpb "google.golang.org/genproto/googleapis/api/expr/conformance/v1alpha1"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
-	rpc "google.golang.org/genproto/googleapis/rpc/status"
+	rpcpb "google.golang.org/genproto/googleapis/rpc/status"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	dpb "google.golang.org/protobuf/types/known/durationpb"
 	tpb "google.golang.org/protobuf/types/known/timestamppb"
@@ -142,7 +142,7 @@ func (s *ConformanceServer) Eval(ctx context.Context, in *confpb.EvalRequest) (*
 
 // appendErrors converts the errors from errs to Status messages
 // and appends them to the list of issues.
-func appendErrors(errs []common.Error, issues *[]*rpc.Status) {
+func appendErrors(errs []common.Error, issues *[]*rpcpb.Status) {
 	for _, e := range errs {
 		status := ErrToStatus(e, confpb.IssueDetails_ERROR)
 		*issues = append(*issues, status)
@@ -150,7 +150,7 @@ func appendErrors(errs []common.Error, issues *[]*rpc.Status) {
 }
 
 // ErrToStatus converts an Error to a Status message with the given severity.
-func ErrToStatus(e common.Error, severity confpb.IssueDetails_Severity) *rpc.Status {
+func ErrToStatus(e common.Error, severity confpb.IssueDetails_Severity) *rpcpb.Status {
 	detail := confpb.IssueDetails{
 		Severity: severity,
 		Position: &exprpb.SourcePosition{
@@ -177,7 +177,7 @@ func RefValueToExprValue(res ref.Val, err error) (*exprpb.ExprValue, error) {
 		return &exprpb.ExprValue{
 			Kind: &exprpb.ExprValue_Error{
 				Error: &exprpb.ErrorSet{
-					Errors: []*rpc.Status{s},
+					Errors: []*rpcpb.Status{s},
 				},
 			},
 		}, nil
@@ -280,7 +280,7 @@ func RefValueToValue(res ref.Val) (*exprpb.Value, error) {
 		if !ok {
 			return nil, status.New(codes.InvalidArgument, "Expected time.Duration").Err()
 		}
-		any, err := anypb.New(durationpb.New(d))
+		any, err := anypb.New(dpb.New(d))
 		if err != nil {
 			return nil, err
 		}
@@ -291,7 +291,7 @@ func RefValueToValue(res ref.Val) (*exprpb.Value, error) {
 		if !ok {
 			return nil, status.New(codes.InvalidArgument, "Expected time.Time").Err()
 		}
-		any, err := anypb.New(timestamppb.New(t))
+		any, err := anypb.New(tpb.New(t))
 		if err != nil {
 			return nil, err
 		}
@@ -318,7 +318,7 @@ func ExprValueToRefValue(adapter ref.TypeAdapter, ev *exprpb.ExprValue) (ref.Val
 	case *exprpb.ExprValue_Value:
 		return ValueToRefValue(adapter, ev.GetValue())
 	case *exprpb.ExprValue_Error:
-		// An error ExprValue is a repeated set of rpc.Status
+		// An error ExprValue is a repeated set of rpcpb.Status
 		// messages, with no convention for the status details.
 		// To convert this to a types.Err, we need to convert
 		// these Status messages to a single string, and be

--- a/server/server.go
+++ b/server/server.go
@@ -35,8 +35,8 @@ import (
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	rpc "google.golang.org/genproto/googleapis/rpc/status"
 	anypb "google.golang.org/protobuf/types/known/anypb"
-	durationpb "google.golang.org/protobuf/types/known/durationpb"
-	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	dpb "google.golang.org/protobuf/types/known/durationpb"
+	tpb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // ConformanceServer contains the server state.


### PR DESCRIPTION
Duration evaluation, if arithmetic on duration or timestamp causes overflow return an error. Additionally this pull request enables the timestamp and duration conformance tests and implements the functionality in the conformance server.

Timestamp range is defined per `google.protobuf.Timestamp` to be the range `0001-01-01T00:00:00Z` to `9999-12-31T23:59:59.999999999Z`.