### PR TITLE
Update timestamp to string conversion to preserve subsecond precision

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -109,7 +109,7 @@ go_repository(
 # CEL Spec deps
 go_repository(
   name = "com_google_cel_spec",
-  commit = "1b5a71c00310535ae98f892ff187d976e46ff37e",
+  commit = "1a26bb4e2a611b694367e7579e74b68b17ebc536",
   importpath = "github.com/google/cel-spec",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -109,7 +109,7 @@ go_repository(
 # CEL Spec deps
 go_repository(
   name = "com_google_cel_spec",
-  commit = "1a26bb4e2a611b694367e7579e74b68b17ebc536",
+  commit = "1b5a71c00310535ae98f892ff187d976e46ff37e",
   importpath = "github.com/google/cel-spec",
 )
 

--- a/common/types/timestamp.go
+++ b/common/types/timestamp.go
@@ -104,7 +104,7 @@ func (t Timestamp) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 func (t Timestamp) ConvertToType(typeVal ref.Type) ref.Val {
 	switch typeVal {
 	case StringType:
-		return String(t.Format(time.RFC3339))
+		return String(t.Format(time.RFC3339Nano))
 	case IntType:
 		// Return the Unix time in seconds since 1970
 		return Int(t.Unix())


### PR DESCRIPTION
Use time.RFC3339Nano instead of time.RFC3339 and update com_google_cel_spec commit to newest which includes appropriate conformance test