### PR TITLE
Update cel-go to point to the latest version of cel-spec

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -109,7 +109,7 @@ go_repository(
 # CEL Spec deps
 go_repository(
     name = "com_google_cel_spec",
-    commit = "1b5a71c00310535ae98f892ff187d976e46ff37e",
+    commit = "1a26bb4e2a611b694367e7579e74b68b17ebc536",
     importpath = "github.com/google/cel-spec",
 )
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/antlr/antlr4 v0.0.0-20200503195918-621b933c7a7f
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.4.3
-	github.com/google/cel-spec v0.5.0
+	github.com/google/cel-spec v0.5.1
 	github.com/stoewer/go-strcase v1.2.0
 	golang.org/x/text v0.3.2
 	google.golang.org/genproto v0.0.0-20201102152239-715cce707fb0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/golang/protobuf v1.4.1 h1:ZFgWrT+bLgsYPirOnRfKLYJLvssAegOj/hgyMFdJZe0
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
-github.com/google/cel-spec v0.5.0 h1:hWEzw+1L1UNxfHAbKXYbirsPGlG8ArXNcTnBKvBqRJ0=
-github.com/google/cel-spec v0.5.0/go.mod h1:Nwjgxy5CbjlPrtCWjeDjUyKMl8w41YBYGjsyDdqk0xA=
+github.com/google/cel-spec v0.5.1 h1:3uwWs3lBmX2dY3l9ppOAOa3sGivFoeYz8NSpD/uD68E=
+github.com/google/cel-spec v0.5.1/go.mod h1:Nwjgxy5CbjlPrtCWjeDjUyKMl8w41YBYGjsyDdqk0xA=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 type serverTest struct {
-	client *celrpc.ConfClient
+	client celrpc.ConfClient
 }
 
 var (
@@ -45,7 +45,7 @@ func TestMain(m *testing.M) {
 }
 
 func mainHelper(m *testing.M) int {
-	client, err := celrpc.NewClientFromPath(os.Args[1])
+	client, err := celrpc.NewGrpcClient(os.Args[1])
 	globals.client = client
 	defer client.Shutdown()
 	if err != nil {


### PR DESCRIPTION
Update references to cel-spec in workspace to use latest version of the test tooling.