### PR TITLE
Export the built-in parser macros individually

### DIFF
--- a/cel/BUILD.bazel
+++ b/cel/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "env.go",
         "io.go",
         "library.go",
+        "macro.go",
         "options.go",
         "program.go",
     ],

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -160,15 +160,7 @@ func TestAbbrevs_Disambiguation(t *testing.T) {
 	// This expression will return either a string or a protobuf Expr value depending on the value
 	// of the 'test' argument. The fully qualified type name is used indicate that the protobuf
 	// typed 'Expr' should be used rather than the abbreviatation for 'external.Expr'.
-	ast, iss := env.Compile(`test ? dyn(Expr) : google.api.expr.v1alpha1.Expr{id: 1}`)
-	if iss.Err() != nil {
-		t.Fatal(iss.Err())
-	}
-	prg, err := env.Program(ast)
-	if err != nil {
-		t.Fatal(err)
-	}
-	out, _, err := prg.Eval(
+	out, err := interpret(t, env, `test ? dyn(Expr) : google.api.expr.v1alpha1.Expr{id: 1}`,
 		map[string]interface{}{
 			"test":          true,
 			"external.Expr": "string expr",
@@ -180,7 +172,7 @@ func TestAbbrevs_Disambiguation(t *testing.T) {
 	if out.Value() != "string expr" {
 		t.Errorf("got %v, wanted 'string expr'", out)
 	}
-	out, _, err = prg.Eval(
+	out, err = interpret(t, env, `test ? dyn(Expr) : google.api.expr.v1alpha1.Expr{id: 1}`,
 		map[string]interface{}{
 			"test":          false,
 			"external.Expr": "wrong expr",
@@ -190,7 +182,10 @@ func TestAbbrevs_Disambiguation(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := &exprpb.Expr{Id: 1}
-	got, _ := out.ConvertToNative(reflect.TypeOf(want))
+	got, err := out.ConvertToNative(reflect.TypeOf(want))
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !proto.Equal(got.(*exprpb.Expr), want) {
 		t.Errorf("got %v, wanted '%v'", out, want)
 	}
@@ -218,12 +213,10 @@ func TestCustomEnv(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		ast, iss := e.Compile("a.b.c")
-		if iss.Err() != nil {
-			t.Fatal(iss.Err())
+		out, err := interpret(t, e, "a.b.c", map[string]interface{}{"a.b.c": true})
+		if err != nil {
+			t.Fatal(err)
 		}
-		prg, _ := e.Program(ast)
-		out, _, _ := prg.Eval(map[string]interface{}{"a.b.c": true})
 		if out != types.True {
 			t.Errorf("got '%v', wanted 'true'", out.Value())
 		}
@@ -697,45 +690,31 @@ func TestGlobalVars(t *testing.T) {
 	})
 }
 
-func TestClearMacros(t *testing.T) {
-	e, err := NewEnv(ClearMacros())
+func TestMacroSubset(t *testing.T) {
+	// Only enable the 'has' macro rather than all parser macros.
+	env, err := NewEnv(
+		ClearMacros(),
+		Macros(parser.HasMacro),
+		Variable("name", MapType(StringType, StringType)),
+	)
 	if err != nil {
-		t.Fatalf("NewEnv(ClearMacros()) failed: %v", err)
+		t.Fatalf("NewEnv() failed: %v", err)
 	}
-	ast, iss := e.Parse("has(a.b)")
-	if iss.Err() != nil {
-		t.Fatalf("Parse(`has(a.b)`) failed: %v", iss.Err())
-	}
-	pe, err := AstToParsedExpr(ast)
-	if err != nil {
-		t.Fatalf("AstToParsedExpr(ast) failed: %v", err)
-	}
-	want := &exprpb.Expr{
-		Id: 1,
-		ExprKind: &exprpb.Expr_CallExpr{
-			CallExpr: &exprpb.Expr_Call{
-				Function: "has",
-				Args: []*exprpb.Expr{
-					{
-						Id: 3,
-						ExprKind: &exprpb.Expr_SelectExpr{
-							SelectExpr: &exprpb.Expr_Select{
-								Operand: &exprpb.Expr{
-									Id: 2,
-									ExprKind: &exprpb.Expr_IdentExpr{
-										IdentExpr: &exprpb.Expr_Ident{Name: "a"},
-									},
-								},
-								Field: "b",
-							},
-						},
-					},
-				},
+	out, err := interpret(t, env, `has(name.first)`,
+		map[string]interface{}{
+			"name": map[string]string{
+				"first": "Jim",
 			},
-		},
+		})
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !proto.Equal(pe.GetExpr(), want) {
-		t.Errorf("Parse() produced AST with macro replacement rather than call. got %v, wanted %v", pe, want)
+	if out != types.True {
+		t.Errorf("got %v, wanted true", out)
+	}
+	out, err = interpret(t, env, `[1, 2].all(i, i > 0)`, NoVars())
+	if err == nil {
+		t.Errorf("got %v, wanted err", out)
 	}
 }
 
@@ -994,7 +973,7 @@ func TestResidualAst(t *testing.T) {
 	}
 }
 
-func TestResidualAst_Complex(t *testing.T) {
+func TestResidualAstComplex(t *testing.T) {
 	e, _ := NewEnv(
 		Variable("resource.name", StringType),
 		Variable("request.time", TimestampType),
@@ -1602,4 +1581,21 @@ func TestRegexOptimizer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func interpret(t *testing.T, env *Env, expr string, vars interface{}) (ref.Val, error) {
+	t.Helper()
+	ast, iss := env.Compile(expr)
+	if iss.Err() != nil {
+		return nil, fmt.Errorf("env.Compile(%s) failed: %v", expr, iss.Err())
+	}
+	prg, err := env.Program(ast)
+	if err != nil {
+		return nil, fmt.Errorf("env.Program() failed: %v", err)
+	}
+	out, _, err := prg.Eval(vars)
+	if err != nil {
+		return nil, fmt.Errorf("prg.Eval(%v) failed: %v", vars, err)
+	}
+	return out, nil
 }

--- a/cel/library.go
+++ b/cel/library.go
@@ -17,7 +17,6 @@ package cel
 import (
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/interpreter/functions"
-	"github.com/google/cel-go/parser"
 )
 
 // Library provides a collection of EnvOption and ProgramOption values used to configure a CEL
@@ -65,7 +64,7 @@ type stdLibrary struct{}
 func (stdLibrary) CompileOptions() []EnvOption {
 	return []EnvOption{
 		Declarations(checker.StandardDeclarations()...),
-		Macros(parser.AllMacros...),
+		Macros(StandardMacros...),
 	}
 }
 

--- a/cel/macro.go
+++ b/cel/macro.go
@@ -1,0 +1,88 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cel
+
+import "github.com/google/cel-go/parser"
+
+type Macro = parser.Macro
+
+// MacroExpander converts a call and its associated arguments into a new CEL abstract syntax tree, or an error
+// if the input arguments are not suitable for the expansion requirements for the macro in question.
+//
+// The MacroExpander accepts as arguments a MacroExprHelper as well as the arguments used in the function call
+// and produces as output an Expr ast node.
+//
+// Note: when the Macro.IsReceiverStyle() method returns true, the target argument will be nil.
+type MacroExpander = parser.MacroExpander
+
+// MacroExprHelper exposes helper methods for creating new expressions within a CEL abstract syntax tree.
+type MacroExprHelper = parser.ExprHelper
+
+var (
+	// Factory functions for creating new cel.Macro instances that will match against the CEL abstract syntax tree
+	// at parse time and then be expanded into an alternative AST defined by the MacroExpander
+
+	NewGlobalMacro         = parser.NewGlobalMacro
+	NewReceiverMacro       = parser.NewReceiverMacro
+	NewGlobalVarArgMacro   = parser.NewGlobalVarArgMacro
+	NewReceiverVarArgMacro = parser.NewReceiverVarArgMacro
+
+	// Aliases to the functions used to create the CEL standard macros.
+
+	MakeHas       = parser.MakeHas
+	MakeExists    = parser.MakeExists
+	MakeExistsOne = parser.MakeExistsOne
+	MakeFilter    = parser.MakeFilter
+	MakeMap       = parser.MakeMap
+
+	// Aliases to each macro in the CEL standard environment.
+
+	// HasMacro expands "has(m.f)" which tests the presence of a field, avoiding the need to
+	// specify the field as a string.
+	HasMacro = parser.HasMacro
+
+	// AllMacro expands "range.all(var, predicate)" into a comprehension which ensures that all
+	// elements in the range satisfy the predicate.
+	AllMacro = parser.AllMacro
+
+	// ExistsMacro expands "range.exists(var, predicate)" into a comprehension which ensures that
+	// some element in the range satisfies the predicate.
+	ExistsMacro = parser.ExistsMacro
+
+	// ExistsOneMacro expands "range.exists_one(var, predicate)", which is true if for exactly one
+	// element in range the predicate holds.
+	ExistsOneMacro = parser.ExistsOneMacro
+
+	// MapMacro expands "range.map(var, function)" into a comprehension which applies the function
+	// to each element in the range to produce a new list.
+	MapMacro = parser.MapMacro
+
+	// MapFilterMacro expands "range.map(var, predicate, function)" into a comprehension which
+	// first filters the elements in the range by the predicate, then applies the transform function
+	// to produce a new list.
+	MapFilterMacro = parser.MapFilterMacro
+
+	// FilterMacro expands "range.filter(var, predicate)" into a comprehension which filters
+	// elements in the range, producing a new list from the elements that satisfy the predicate.
+	FilterMacro = parser.FilterMacro
+
+	// StandardMacros provides an alias to all the CEL macros defined in the standard environment.
+	StandardMacros = []Macro{
+		HasMacro, AllMacro, ExistsMacro, ExistsOneMacro, MapMacro, MapFilterMacro, FilterMacro,
+	}
+
+	// NoMacros provides an alias to an empty list of macros
+	NoMacros = []Macro{}
+)

--- a/cel/options.go
+++ b/cel/options.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter"
 	"github.com/google/cel-go/interpreter/functions"
-	"github.com/google/cel-go/parser"
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	descpb "google.golang.org/protobuf/types/descriptorpb"
@@ -68,7 +67,7 @@ type EnvOption func(e *Env) (*Env, error)
 // comprehensions such as `all` and `exists` are enabled only via macros.
 func ClearMacros() EnvOption {
 	return func(e *Env) (*Env, error) {
-		e.macros = parser.NoMacros
+		e.macros = NoMacros
 		return e, nil
 	}
 }
@@ -130,7 +129,7 @@ func HomogeneousAggregateLiterals() EnvOption {
 // Macros option extends the macro set configured in the environment.
 //
 // Note: This option must be specified after ClearMacros if used together.
-func Macros(macros ...parser.Macro) EnvOption {
+func Macros(macros ...Macro) EnvOption {
 	return func(e *Env) (*Env, error) {
 		e.macros = append(e.macros, macros...)
 		return e, nil
@@ -331,7 +330,7 @@ func CustomDecorator(dec interpreter.InterpretableDecorator) ProgramOption {
 
 // Functions adds function overloads that extend or override the set of CEL built-ins.
 //
-// Deprecated: use DeclareFunctions instead to declare the function, its overload signatures,
+// Deprecated: use Function() instead to declare the function, its overload signatures,
 // and the overload implementations.
 func Functions(funcs ...*functions.Overload) ProgramOption {
 	return func(p *prog) (*prog, error) {

--- a/parser/helper.go
+++ b/parser/helper.go
@@ -435,6 +435,11 @@ func (e *exprHelper) Ident(name string) *exprpb.Expr {
 	return e.parserHelper.newIdent(e.nextMacroID(), name)
 }
 
+// AccuIdent implements the ExprHelper interface method.
+func (e *exprHelper) AccuIdent() *exprpb.Expr {
+	return e.parserHelper.newIdent(e.nextMacroID(), AccumulatorName)
+}
+
 // GlobalCall implements the ExprHelper interface method.
 func (e *exprHelper) GlobalCall(function string, args ...*exprpb.Expr) *exprpb.Expr {
 	return e.parserHelper.newGlobalCall(e.nextMacroID(), function, args...)

--- a/parser/macro.go
+++ b/parser/macro.go
@@ -48,8 +48,7 @@ func NewGlobalVarArgMacro(function string, expander MacroExpander) Macro {
 		varArgStyle: true}
 }
 
-// NewReceiverVarArgMacro creates a Macro for a receiver function matching a variable arg
-// count.
+// NewReceiverVarArgMacro creates a Macro for a receiver function matching a variable arg count.
 func NewReceiverVarArgMacro(function string, expander MacroExpander) Macro {
 	return &macro{
 		function:      function,

--- a/parser/macro.go
+++ b/parser/macro.go
@@ -23,8 +23,6 @@ import (
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
-// TODO: Consider moving macros to common.
-
 // NewGlobalMacro creates a Macro for a global function with the specified arg count.
 func NewGlobalMacro(function string, argCount int, expander MacroExpander) Macro {
 	return &macro{
@@ -135,9 +133,13 @@ func makeVarArgMacroKey(name string, receiverStyle bool) string {
 	return fmt.Sprintf("%s:*:%v", name, receiverStyle)
 }
 
-// MacroExpander converts the target and args of a function call that matches a Macro.
+// MacroExpander converts a call and its associated arguments into a new CEL abstract syntax tree, or an error
+// if the input arguments are not suitable for the expansion requirements for the macro in question.
 //
-// Note: when the Macros.IsReceiverStyle() is true, the target argument will be nil.
+// The MacroExpander accepts as arguments a MacroExprHelper as well as the arguments used in the function call
+// and produces as output an Expr ast node.
+//
+// Note: when the Macro.IsReceiverStyle() method returns true, the target argument will be nil.
 type MacroExpander func(eh ExprHelper,
 	target *exprpb.Expr,
 	args []*exprpb.Expr) (*exprpb.Expr, *common.Error)
@@ -208,6 +210,9 @@ type ExprHelper interface {
 	// Ident creates an identifier Expr value.
 	Ident(name string) *exprpb.Expr
 
+	// AccuIdent returns an accumulator identifier for use with comprehension results.
+	AccuIdent() *exprpb.Expr
+
 	// GlobalCall creates a function call Expr value for a global (free) function.
 	GlobalCall(function string, args ...*exprpb.Expr) *exprpb.Expr
 
@@ -227,32 +232,32 @@ type ExprHelper interface {
 var (
 	// HasMacro expands "has(m.f)" which tests the presence of a field, avoiding the need to
 	// specify the field as a string.
-	HasMacro = NewGlobalMacro(operators.Has, 1, makeHas)
+	HasMacro = NewGlobalMacro(operators.Has, 1, MakeHas)
 
 	// AllMacro expands "range.all(var, predicate)" into a comprehension which ensures that all
 	// elements in the range satisfy the predicate.
-	AllMacro = NewReceiverMacro(operators.All, 2, makeAll)
+	AllMacro = NewReceiverMacro(operators.All, 2, MakeAll)
 
 	// ExistsMacro expands "range.exists(var, predicate)" into a comprehension which ensures that
 	// some element in the range satisfies the predicate.
-	ExistsMacro = NewReceiverMacro(operators.Exists, 2, makeExists)
+	ExistsMacro = NewReceiverMacro(operators.Exists, 2, MakeExists)
 
 	// ExistsOneMacro expands "range.exists_one(var, predicate)", which is true if for exactly one
 	// element in range the predicate holds.
-	ExistsOneMacro = NewReceiverMacro(operators.ExistsOne, 2, makeExistsOne)
+	ExistsOneMacro = NewReceiverMacro(operators.ExistsOne, 2, MakeExistsOne)
 
 	// MapMacro expands "range.map(var, function)" into a comprehension which applies the function
 	// to each element in the range to produce a new list.
-	MapMacro = NewReceiverMacro(operators.Map, 2, makeMap)
+	MapMacro = NewReceiverMacro(operators.Map, 2, MakeMap)
 
 	// MapFilterMacro expands "range.map(var, predicate, function)" into a comprehension which
 	// first filters the elements in the range by the predicate, then applies the transform function
 	// to produce a new list.
-	MapFilterMacro = NewReceiverMacro(operators.Map, 3, makeMap)
+	MapFilterMacro = NewReceiverMacro(operators.Map, 3, MakeMap)
 
 	// FilterMacro expands "range.filter(var, predicate)" into a comprehension which filters
 	// elements in the range, producing a new list from the elements that satisfy the predicate.
-	FilterMacro = NewReceiverMacro(operators.Filter, 2, makeFilter)
+	FilterMacro = NewReceiverMacro(operators.Filter, 2, MakeFilter)
 
 	// AllMacros includes the list of all spec-supported macros.
 	AllMacros = []Macro{
@@ -280,62 +285,36 @@ const (
 	quantifierExistsOne
 )
 
-func makeAll(eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
+// MakeExists expands the input call arguments into a comprehension that returns true if all of the
+// elements in the range match the predicate expressions:
+// <iterRange>.all(<iterVar>, <predicate>)
+func MakeAll(eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
 	return makeQuantifier(quantifierAll, eh, target, args)
 }
 
-func makeExists(eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
+// MakeExists expands the input call arguments into a comprehension that returns true if any of the
+// elements in the range match the predicate expressions:
+// <iterRange>.exists(<iterVar>, <predicate>)
+func MakeExists(eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
 	return makeQuantifier(quantifierExists, eh, target, args)
 }
 
-func makeExistsOne(eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
+// MakeExistsOne expands the input call arguments into a comprehension that returns true if exactly
+// one of the elements in the range match the predicate expressions:
+// <iterRange>.exists_one(<iterVar>, <predicate>)
+func MakeExistsOne(eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
 	return makeQuantifier(quantifierExistsOne, eh, target, args)
 }
 
-func makeQuantifier(kind quantifierKind, eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
-	v, found := extractIdent(args[0])
-	if !found {
-		location := eh.OffsetLocation(args[0].GetId())
-		return nil, &common.Error{
-			Message:  "argument must be a simple name",
-			Location: location}
-	}
-	accuIdent := func() *exprpb.Expr {
-		return eh.Ident(AccumulatorName)
-	}
-
-	var init *exprpb.Expr
-	var condition *exprpb.Expr
-	var step *exprpb.Expr
-	var result *exprpb.Expr
-	switch kind {
-	case quantifierAll:
-		init = eh.LiteralBool(true)
-		condition = eh.GlobalCall(operators.NotStrictlyFalse, accuIdent())
-		step = eh.GlobalCall(operators.LogicalAnd, accuIdent(), args[1])
-		result = accuIdent()
-	case quantifierExists:
-		init = eh.LiteralBool(false)
-		condition = eh.GlobalCall(
-			operators.NotStrictlyFalse,
-			eh.GlobalCall(operators.LogicalNot, accuIdent()))
-		step = eh.GlobalCall(operators.LogicalOr, accuIdent(), args[1])
-		result = accuIdent()
-	case quantifierExistsOne:
-		zeroExpr := eh.LiteralInt(0)
-		oneExpr := eh.LiteralInt(1)
-		init = zeroExpr
-		condition = eh.LiteralBool(true)
-		step = eh.GlobalCall(operators.Conditional, args[1],
-			eh.GlobalCall(operators.Add, accuIdent(), oneExpr), accuIdent())
-		result = eh.GlobalCall(operators.Equals, accuIdent(), oneExpr)
-	default:
-		return nil, &common.Error{Message: fmt.Sprintf("unrecognized quantifier '%v'", kind)}
-	}
-	return eh.Fold(v, target, AccumulatorName, init, condition, step, result), nil
-}
-
-func makeMap(eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
+// MakeMap expands the input call arguments into a comprehension that transforms each element in the
+// input to produce an output list.
+//
+// There are two call patterns supported by map:
+//   <iterRange>.map(<iterVar>, <transform>)
+//   <iterRange>.map(<iterVar>, <predicate>, <transform>)
+// In the second form only iterVar values which return true when provided to the predicate expression
+// are transformed.
+func MakeMap(eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
 	v, found := extractIdent(args[0])
 	if !found {
 		return nil, &common.Error{Message: "argument is not an identifier"}
@@ -355,7 +334,6 @@ func makeMap(eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.E
 	accuExpr := eh.Ident(AccumulatorName)
 	init := eh.NewList()
 	condition := eh.LiteralBool(true)
-	// TODO: use compiler internal method for faster, stateful add.
 	step := eh.GlobalCall(operators.Add, accuExpr, eh.NewList(fn))
 
 	if filter != nil {
@@ -364,7 +342,10 @@ func makeMap(eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.E
 	return eh.Fold(v, target, AccumulatorName, init, condition, step, accuExpr), nil
 }
 
-func makeFilter(eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
+// MakeFilter expands the input call arguments into a comprehension which produces a list which contains
+// only elements which match the provided predicate expression:
+// <iterRange>.filter(<iterVar>, <predicate>)
+func MakeFilter(eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
 	v, found := extractIdent(args[0])
 	if !found {
 		return nil, &common.Error{Message: "argument is not an identifier"}
@@ -374,10 +355,58 @@ func makeFilter(eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprp
 	accuExpr := eh.Ident(AccumulatorName)
 	init := eh.NewList()
 	condition := eh.LiteralBool(true)
-	// TODO: use compiler internal method for faster, stateful add.
 	step := eh.GlobalCall(operators.Add, accuExpr, eh.NewList(args[0]))
 	step = eh.GlobalCall(operators.Conditional, filter, step, accuExpr)
 	return eh.Fold(v, target, AccumulatorName, init, condition, step, accuExpr), nil
+}
+
+// MakeHas expands the input call arguments into a presence test, e.g. has(<operand>.field)
+func MakeHas(eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
+	if s, ok := args[0].ExprKind.(*exprpb.Expr_SelectExpr); ok {
+		return eh.PresenceTest(s.SelectExpr.GetOperand(), s.SelectExpr.GetField()), nil
+	}
+	return nil, &common.Error{Message: "invalid argument to has() macro"}
+}
+
+func makeQuantifier(kind quantifierKind, eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
+	v, found := extractIdent(args[0])
+	if !found {
+		location := eh.OffsetLocation(args[0].GetId())
+		return nil, &common.Error{
+			Message:  "argument must be a simple name",
+			Location: location,
+		}
+	}
+
+	var init *exprpb.Expr
+	var condition *exprpb.Expr
+	var step *exprpb.Expr
+	var result *exprpb.Expr
+	switch kind {
+	case quantifierAll:
+		init = eh.LiteralBool(true)
+		condition = eh.GlobalCall(operators.NotStrictlyFalse, eh.AccuIdent())
+		step = eh.GlobalCall(operators.LogicalAnd, eh.AccuIdent(), args[1])
+		result = eh.AccuIdent()
+	case quantifierExists:
+		init = eh.LiteralBool(false)
+		condition = eh.GlobalCall(
+			operators.NotStrictlyFalse,
+			eh.GlobalCall(operators.LogicalNot, eh.AccuIdent()))
+		step = eh.GlobalCall(operators.LogicalOr, eh.AccuIdent(), args[1])
+		result = eh.AccuIdent()
+	case quantifierExistsOne:
+		zeroExpr := eh.LiteralInt(0)
+		oneExpr := eh.LiteralInt(1)
+		init = zeroExpr
+		condition = eh.LiteralBool(true)
+		step = eh.GlobalCall(operators.Conditional, args[1],
+			eh.GlobalCall(operators.Add, eh.AccuIdent(), oneExpr), eh.AccuIdent())
+		result = eh.GlobalCall(operators.Equals, eh.AccuIdent(), oneExpr)
+	default:
+		return nil, &common.Error{Message: fmt.Sprintf("unrecognized quantifier '%v'", kind)}
+	}
+	return eh.Fold(v, target, AccumulatorName, init, condition, step, result), nil
 }
 
 func extractIdent(e *exprpb.Expr) (string, bool) {
@@ -386,11 +415,4 @@ func extractIdent(e *exprpb.Expr) (string, bool) {
 		return e.GetIdentExpr().GetName(), true
 	}
 	return "", false
-}
-
-func makeHas(eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
-	if s, ok := args[0].ExprKind.(*exprpb.Expr_SelectExpr); ok {
-		return eh.PresenceTest(s.SelectExpr.GetOperand(), s.SelectExpr.GetField()), nil
-	}
-	return nil, &common.Error{Message: "invalid argument to has() macro"}
 }

--- a/parser/macro.go
+++ b/parser/macro.go
@@ -225,34 +225,44 @@ type ExprHelper interface {
 }
 
 var (
+	// HasMacro expands "has(m.f)" which tests the presence of a field, avoiding the need to
+	// specify the field as a string.
+	HasMacro = NewGlobalMacro(operators.Has, 1, makeHas)
+
+	// AllMacro expands "range.all(var, predicate)" into a comprehension which ensures that all
+	// elements in the range satisfy the predicate.
+	AllMacro = NewReceiverMacro(operators.All, 2, makeAll)
+
+	// ExistsMacro expands "range.exists(var, predicate)" into a comprehension which ensures that
+	// some element in the range satisfies the predicate.
+	ExistsMacro = NewReceiverMacro(operators.Exists, 2, makeExists)
+
+	// ExistsOneMacro expands "range.exists_one(var, predicate)", which is true if for exactly one
+	// element in range the predicate holds.
+	ExistsOneMacro = NewReceiverMacro(operators.ExistsOne, 2, makeExistsOne)
+
+	// MapMacro expands "range.map(var, function)" into a comprehension which applies the function
+	// to each element in the range to produce a new list.
+	MapMacro = NewReceiverMacro(operators.Map, 2, makeMap)
+
+	// MapFilterMacro expands "range.map(var, predicate, function)" into a comprehension which
+	// first filters the elements in the range by the predicate, then applies the transform function
+	// to produce a new list.
+	MapFilterMacro = NewReceiverMacro(operators.Map, 3, makeMap)
+
+	// FilterMacro expands "range.filter(var, predicate)" into a comprehension which filters
+	// elements in the range, producing a new list from the elements that satisfy the predicate.
+	FilterMacro = NewReceiverMacro(operators.Filter, 2, makeFilter)
+
 	// AllMacros includes the list of all spec-supported macros.
 	AllMacros = []Macro{
-		// The macro "has(m.f)" which tests the presence of a field, avoiding the need to specify
-		// the field as a string.
-		NewGlobalMacro(operators.Has, 1, makeHas),
-
-		// The macro "range.all(var, predicate)", which is true if for all elements in range the
-		// predicate holds.
-		NewReceiverMacro(operators.All, 2, makeAll),
-
-		// The macro "range.exists(var, predicate)", which is true if for at least one element in
-		// range the predicate holds.
-		NewReceiverMacro(operators.Exists, 2, makeExists),
-
-		// The macro "range.exists_one(var, predicate)", which is true if for exactly one element
-		// in range the predicate holds.
-		NewReceiverMacro(operators.ExistsOne, 2, makeExistsOne),
-
-		// The macro "range.map(var, function)", applies the function to the vars in the range.
-		NewReceiverMacro(operators.Map, 2, makeMap),
-
-		// The macro "range.map(var, predicate, function)", applies the function to the vars in
-		// the range for which the predicate holds true. The other variables are filtered out.
-		NewReceiverMacro(operators.Map, 3, makeMap),
-
-		// The macro "range.filter(var, predicate)", filters out the variables for which the
-		// predicate is false.
-		NewReceiverMacro(operators.Filter, 2, makeFilter),
+		HasMacro,
+		AllMacro,
+		ExistsMacro,
+		ExistsOneMacro,
+		MapMacro,
+		MapFilterMacro,
+		FilterMacro,
 	}
 
 	// NoMacros list.


### PR DESCRIPTION
Currently marcos are either custom, all, or none. This change exposes the builtin `parser` macros by name, making it easier to customize the macro set enabled for the application.