### PR TITLE
Implement recursion limits and error recovery attempt limits in the parser

### DIFF
--- a/parser/BUILD.bazel
+++ b/parser/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "helper.go",
         "input.go",
         "macro.go",
+        "options.go",
         "parser.go",
         "unescape.go",
         "unparser.go",
@@ -19,8 +20,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//common:go_default_library",
-        "//common/runes:go_default_library",
         "//common/operators:go_default_library",
+        "//common/runes:go_default_library",
         "//parser/gen:go_default_library",
         "@com_github_antlr//runtime/Go/antlr:go_default_library",
         "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",

--- a/parser/options.go
+++ b/parser/options.go
@@ -1,0 +1,65 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import "fmt"
+
+type options struct {
+	maxRecursionDepth  int
+	errorRecoveryLimit int
+	macros             map[string]Macro
+}
+
+// Option configures the behavior of the parser.
+type Option func(*options) error
+
+// MaxRecursionDepth is an option which limits the maximum depth the parser will attempt to
+// parse the expression before giving up.
+func MaxRecursionDepth(maxRecursionDepth int) Option {
+	return func(opts *options) error {
+		if maxRecursionDepth < -1 {
+			return fmt.Errorf("max recursion depth must be greater than or equal to -1: %d", maxRecursionDepth)
+		}
+		opts.maxRecursionDepth = maxRecursionDepth
+		return nil
+	}
+}
+
+// ErrorRecoveryLimit is an option which limits the number of attempts the parser will perform
+// to recover from an error.
+func ErrorRecoveryLimit(errorRecoveryLimit int) Option {
+	return func(opts *options) error {
+		if errorRecoveryLimit < -1 {
+			return fmt.Errorf("error recovery limit must be greater than or equal to -1: %d", errorRecoveryLimit)
+		}
+		opts.errorRecoveryLimit = errorRecoveryLimit
+		return nil
+	}
+}
+
+// Macros adds the given macros to the parser.
+func Macros(macros ...Macro) Option {
+	return func(opts *options) error {
+		for _, m := range macros {
+			if m != nil {
+				if opts.macros == nil {
+					opts.macros = make(map[string]Macro)
+				}
+				opts.macros[m.MacroKey()] = m
+			}
+		}
+		return nil
+	}
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1093,6 +1093,16 @@ ERROR: <input>:1:26: reserved identifier: var
 		| ?
 		| .^`,
 	},
+	{
+		I: `[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[
+		[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[
+		[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[
+		[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[['too many']]]]]]]]]]]]]]]]]]]]]]]]]]]]
+		]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]
+		]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]
+		]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]`,
+		E: "ERROR: <input>:-1:0: expression recursion limit exceeded: 250",
+	},
 }
 
 type testInfo struct {
@@ -1171,6 +1181,10 @@ func (l *locationAdorner) GetMetadata(elem interface{}) string {
 }
 
 func TestParse(t *testing.T) {
+	p, err := NewParser(Macros(AllMacros...))
+	if err != nil {
+		t.Fatal(err)
+	}
 	for i, tst := range testCases {
 		name := fmt.Sprintf("%d %s", i, tst.I)
 		// Local variable required as the closure will reference the value for the last
@@ -1182,7 +1196,7 @@ func TestParse(t *testing.T) {
 			tt.Parallel()
 
 			src := common.NewTextSource(tc.I)
-			expression, errors := Parse(src)
+			expression, errors := p.Parse(src)
 			if len(errors.GetErrors()) > 0 {
 				actualErr := errors.ToDisplayString()
 				if tc.E == "" {


### PR DESCRIPTION
This pull request ports the recursion limit and recovery attempt limit to the Go parser. This allows users to protect themselves from arbitrarily complex expressions that could cause stack limits to be exceeded or time complexity to drastically increase.