### PR TITLE
call RemoveErrorListeners() on lexer and parser when createtion

### DIFF
--- a/common/errors_test.go
+++ b/common/errors_test.go
@@ -46,13 +46,13 @@ func TestErrors(t *testing.T) {
 }
 
 func TestErrors_WideAndNarrowCharacters(t *testing.T) {
-	source := NewStringSource("你好吗\n我b很好\n", "errors-test")
+	source := NewStringSource("你好吗\n我a很好\n", "errors-test")
 	errors := NewErrors(source)
 	errors.ReportError(NewLocation(2, 3), "Unexpected character '好'")
 
 	got := errors.ToDisplayString()
 	want := "ERROR: errors-test:2:4: Unexpected character '好'\n" +
-		" | 我b很好\n" +
+		" | 我a很好\n" +
 		" | ．.．＾"
 	if got != want {
 		t.Errorf("%s got %s, wanted %s", t.Name(), got, want)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -241,13 +241,17 @@ var (
 
 	lexerPool *sync.Pool = &sync.Pool{
 		New: func() interface{} {
-			return gen.NewCELLexer(nil)
+			l := gen.NewCELLexer(nil)
+			l.RemoveErrorListeners()
+			return l
 		},
 	}
 
 	parserPool *sync.Pool = &sync.Pool{
 		New: func() interface{} {
-			return gen.NewCELParser(nil)
+			p := gen.NewCELParser(nil)
+			p.RemoveErrorListeners()
+			return p
 		},
 	}
 )


### PR DESCRIPTION
This issue is caused by antlr4.

- antlr4 will add ConsoleErrorListener (output err to stderr) to recgnizer when BaseRecognizer create. [link](https://github.com/antlr/antlr4/blob/dc66788476a7e98755bdc45f26affecaba6d2b71/runtime/Go/antlr/recognizer.go#L43)
- cel parser create lexer and celparser in pool [link](https://github.com/google/cel-go/blob/e29cf1a6f316e5c43d1be484f384404183780dad/parser/parser.go#L242-L252)
- cel will cleanup errorhandlers after each use which removed the ConsoleErrorListener [link](https://github.com/google/cel-go/blob/e29cf1a6f316e5c43d1be484f384404183780dad/parser/parser.go#L267-L269)

The simple fix should be calling remove event listener when lexer and celparser create.

Closes #438 