### PR TITLE
Fix list and map equality to preserve the logical ANDing of elements

### DIFF
--- a/common/types/list.go
+++ b/common/types/list.go
@@ -227,13 +227,20 @@ func (l *baseList) Equal(other ref.Val) ref.Val {
 	if l.Size() != otherList.Size() {
 		return False
 	}
+	var maybeErr ref.Val
 	for i := IntZero; i < l.Size().(Int); i++ {
 		thisElem := l.Get(i)
 		otherElem := otherList.Get(i)
 		elemEq := thisElem.Equal(otherElem)
-		if elemEq != True {
-			return elemEq
+		if elemEq == False {
+			return False
 		}
+		if maybeErr == nil && IsUnknownOrError(elemEq) {
+			maybeErr = elemEq
+		}
+	}
+	if maybeErr != nil {
+		return maybeErr
 	}
 	return True
 }
@@ -347,13 +354,20 @@ func (l *concatList) Equal(other ref.Val) ref.Val {
 	if l.Size() != otherList.Size() {
 		return False
 	}
+	var maybeErr ref.Val
 	for i := IntZero; i < l.Size().(Int); i++ {
 		thisElem := l.Get(i)
 		otherElem := otherList.Get(i)
 		elemEq := thisElem.Equal(otherElem)
-		if elemEq != True {
-			return elemEq
+		if elemEq == False {
+			return False
 		}
+		if maybeErr == nil && IsUnknownOrError(elemEq) {
+			maybeErr = elemEq
+		}
+	}
+	if maybeErr != nil {
+		return maybeErr
 	}
 	return True
 }

--- a/conformance/BUILD.bazel
+++ b/conformance/BUILD.bazel
@@ -4,8 +4,6 @@ sh_test(
     args = [
         "$(location @com_google_cel_spec//tests/simple:simple_test)",
         "--server=$(location //server/main:cel_server)",
-        "--skip_test=comparisons/eq_literal/not_eq_list_false_vs_types,not_eq_map_false_vs_types",
-        "--skip_test=comparisons/in_map_literal/key_in_mixed_key_type_map_error",
         "--skip_test=dynamic/int32/field_assign_proto2_range,field_assign_proto3_range",
         "--skip_test=dynamic/uint32/field_assign_proto2_range,field_assign_proto3_range",
         "--skip_test=dynamic/float/field_assign_proto2_range,field_assign_proto3_range",

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -317,6 +317,22 @@ var (
 			name: "in_map",
 			expr: `'other-key' in {'key': null, 'other-key': 42}`,
 			cost: []int64{1, 1},
+			out:  types.True,
+		},
+		{
+			name: "in_heterogeneous_map",
+			expr: `'hello' in {1: 'one', false: true, 'hello': 'world'}`,
+			out:  types.True,
+		},
+		{
+			name: "not_in_heterogeneous_map",
+			expr: `!('hello' in {1: 'one', false: true})`,
+			err:  "unsupported key type: string",
+		},
+		{
+			name: "not_in_heterogeneous_map_with_same_key_type",
+			expr: `!('hello' in {1: 'one', 'world': true})`,
+			out:  types.True,
 		},
 		{
 			name:           "index",
@@ -339,6 +355,16 @@ var (
 			name: "index_relative",
 			expr: `([[[1]], [[2]], [[3]]][0][0] + [2, 3, {'four': {'five': 'six'}}])[3].four.five == 'six'`,
 			cost: []int64{2, 2},
+		},
+		{
+			name: "list_eq_false_with_error",
+			expr: `['string', 1] == [2, 3]`,
+			out:  types.False,
+		},
+		{
+			name: "list_eq_error",
+			expr: `['string', true] == [2, 3]`,
+			err:  "no such overload",
 		},
 		{
 			name: "literal_bool_false",


### PR DESCRIPTION
Fix list and map equality to preserve the logical ANDing of elements.

Since the cel-spec indicates that equality for aggregate types should be the same as the ANDing of
pair-wise element equality, the error / unknown behavior for short-circuiting to `false` rather than
error should be preserved as well.

This PR also fixes an issue with how element type should be considered before determine presence
or absence of a value.