### PR TITLE
Support for accessing protobuf fields by their JSON names

### DIFF
--- a/common/types/pb/type.go
+++ b/common/types/pb/type.go
@@ -47,7 +47,9 @@ func NewTypeDescription(typeName string, desc protoreflect.MessageDescriptor) *T
 	fields := desc.Fields()
 	for i := 0; i < fields.Len(); i++ {
 		f := fields.Get(i)
-		fieldMap[string(f.Name())] = NewFieldDescription(f)
+		fd := NewFieldDescription(f)
+		fieldMap[string(f.Name())] = fd
+		fieldMap[string(f.JSONName())] = fd
 	}
 	return &TypeDescription{
 		typeName:    typeName,


### PR DESCRIPTION
This change makes it possible to access a protobuf field by its field name (snake case) or the JSON field name (camel case). For example, given a protobuf definition of `message foo { string some_field = 1}`, the field can be accessed as either `fooInstance.some_field` or `fooInstance.someField`.

This is useful when end users normally deal with JSON representations of protobufs and expect the fields to be camel cased rather than snake cased. I was going to implement this as a custom `TypeProvider` in my own code but it would require duplicating a lot of the code that already exists in `cel-go`. Since it's only a 3-line change, I opted to create a PR directly. Please let me know if you prefer to discuss it further in an issue. 



