### PR TITLE
Heterogeneous equality

### DIFF
--- a/common/types/bool.go
+++ b/common/types/bool.go
@@ -111,10 +111,7 @@ func (b Bool) ConvertToType(typeVal ref.Type) ref.Val {
 // Equal implements the ref.Val interface method.
 func (b Bool) Equal(other ref.Val) ref.Val {
 	otherBool, ok := other.(Bool)
-	if !ok {
-		return ValOrErr(other, "no such overload")
-	}
-	return Bool(b == otherBool)
+	return Bool(ok && b == otherBool)
 }
 
 // Negate implements the traits.Negater interface method.

--- a/common/types/bool_test.go
+++ b/common/types/bool_test.go
@@ -128,8 +128,8 @@ func TestBoolEqual(t *testing.T) {
 	if False.Equal(True).(Bool) {
 		t.Error("False was equal to true")
 	}
-	if !IsError(Double(0.0).Equal(False)) {
-		t.Error("Cross-type equality yielded non-error value.")
+	if Double(0.0).Equal(False) != False {
+		t.Error("Cross-type equality yielded error value.")
 	}
 }
 

--- a/common/types/bytes.go
+++ b/common/types/bytes.go
@@ -113,10 +113,7 @@ func (b Bytes) ConvertToType(typeVal ref.Type) ref.Val {
 // Equal implements the ref.Val interface method.
 func (b Bytes) Equal(other ref.Val) ref.Val {
 	otherBytes, ok := other.(Bytes)
-	if !ok {
-		return ValOrErr(other, "no such overload")
-	}
-	return Bool(bytes.Equal(b, otherBytes))
+	return Bool(ok && bytes.Equal(b, otherBytes))
 }
 
 // Size implements the traits.Sizer interface method.

--- a/common/types/double.go
+++ b/common/types/double.go
@@ -178,7 +178,7 @@ func (d Double) Equal(other ref.Val) ref.Val {
 	case Uint:
 		return Bool(compareDoubleUint(d, ov) == 0)
 	default:
-		return MaybeNoSuchOverloadErr(other)
+		return False
 	}
 }
 

--- a/common/types/double_test.go
+++ b/common/types/double_test.go
@@ -406,11 +406,6 @@ func TestDoubleEqual(t *testing.T) {
 			b:   Int(10),
 			out: False,
 		},
-		{
-			a:   Double(10),
-			b:   Unknown{2},
-			out: Unknown{2},
-		},
 	}
 	for _, tc := range tests {
 		got := tc.a.Equal(tc.b)

--- a/common/types/duration.go
+++ b/common/types/duration.go
@@ -135,10 +135,7 @@ func (d Duration) ConvertToType(typeVal ref.Type) ref.Val {
 // Equal implements ref.Val.Equal.
 func (d Duration) Equal(other ref.Val) ref.Val {
 	otherDur, ok := other.(Duration)
-	if !ok {
-		return MaybeNoSuchOverloadErr(other)
-	}
-	return Bool(d.Duration == otherDur.Duration)
+	return Bool(ok && d.Duration == otherDur.Duration)
 }
 
 // Negate implements traits.Negater.Negate.

--- a/common/types/int.go
+++ b/common/types/int.go
@@ -222,7 +222,7 @@ func (i Int) Equal(other ref.Val) ref.Val {
 	case Uint:
 		return Bool(compareIntUint(i, ov) == 0)
 	default:
-		return MaybeNoSuchOverloadErr(other)
+		return False
 	}
 }
 

--- a/common/types/int_test.go
+++ b/common/types/int_test.go
@@ -398,11 +398,6 @@ func TestIntEqual(t *testing.T) {
 			b:   Double(math.NaN()),
 			out: False,
 		},
-		{
-			a:   Int(10),
-			b:   Unknown{2},
-			out: Unknown{2},
-		},
 	}
 	for _, tc := range tests {
 		got := tc.a.Equal(tc.b)

--- a/common/types/json_list_test.go
+++ b/common/types/json_list_test.go
@@ -91,8 +91,8 @@ func TestJsonListValueContains_MixedElemType(t *testing.T) {
 	// each element in the list. When the value is present, the result
 	// can be True. When the value is not present and the list is of
 	// mixed element type, the result is an error.
-	if !IsError(list.Contains(Double(2))) {
-		t.Error("Expected value list to not contain number '2' and error", list)
+	if list.Contains(Double(2)).(Bool) {
+		t.Error("Expected value list to not contain number '2'", list)
 	}
 }
 
@@ -185,8 +185,8 @@ func TestJsonListValueEqual(t *testing.T) {
 	if listA.Add(listA).Equal(listB).(Bool) {
 		t.Error("Lists of different size were equal.")
 	}
-	if !IsError(listA.Equal(True)) {
-		t.Error("Equality of different type returned non-error.")
+	if IsError(listA.Equal(True)) {
+		t.Error("Equality of different type returned error.")
 	}
 }
 

--- a/common/types/json_struct_test.go
+++ b/common/types/json_struct_test.go
@@ -121,8 +121,8 @@ func TestJsonStructEqual(t *testing.T) {
 	if mapVal.Equal(NewJSONStruct(reg, &structpb.Struct{})) != False {
 		t.Error("Map with key-value pairs was equal to empty map")
 	}
-	if !IsError(mapVal.Equal(String(""))) {
-		t.Error("Map equal to a non-map type returned non-error.")
+	if IsError(mapVal.Equal(String(""))) {
+		t.Error("Map equal to a non-map type returned error, wanted 'false'")
 	}
 
 	other := NewJSONStruct(reg,
@@ -145,8 +145,8 @@ func TestJsonStructEqual(t *testing.T) {
 		map[int]interface{}{
 			1: "hello",
 			2: "world"})
-	if !IsError(mapVal.Equal(mismatch)) {
-		t.Error("Key type mismatch did not result in error")
+	if IsError(mapVal.Equal(mismatch)) {
+		t.Error("Key type mismatch resulted in error, wanted 'false'")
 	}
 }
 

--- a/common/types/list.go
+++ b/common/types/list.go
@@ -131,27 +131,13 @@ func (l *baseList) Add(other ref.Val) ref.Val {
 
 // Contains implements the traits.Container interface method.
 func (l *baseList) Contains(elem ref.Val) ref.Val {
-	if IsUnknownOrError(elem) {
-		return elem
-	}
-	var err ref.Val
 	for i := 0; i < l.size; i++ {
 		val := l.NativeToValue(l.get(i))
 		cmp := elem.Equal(val)
 		b, ok := cmp.(Bool)
-		// When there is an error on the contain check, this is not necessarily terminal.
-		// The contains call could find the element and return True, just as though the user
-		// had written a per-element comparison in an exists() macro or logical ||, e.g.
-		//    list.exists(e, e == elem)
-		if !ok && err == nil {
-			err = ValOrErr(cmp, "no such overload")
-		}
-		if b == True {
+		if ok && b == True {
 			return True
 		}
-	}
-	if err != nil {
-		return err
 	}
 	return False
 }
@@ -222,12 +208,11 @@ func (l *baseList) ConvertToType(typeVal ref.Type) ref.Val {
 func (l *baseList) Equal(other ref.Val) ref.Val {
 	otherList, ok := other.(traits.Lister)
 	if !ok {
-		return MaybeNoSuchOverloadErr(other)
+		return False
 	}
 	if l.Size() != otherList.Size() {
 		return False
 	}
-	var maybeErr ref.Val
 	for i := IntZero; i < l.Size().(Int); i++ {
 		thisElem := l.Get(i)
 		otherElem := otherList.Get(i)
@@ -235,12 +220,6 @@ func (l *baseList) Equal(other ref.Val) ref.Val {
 		if elemEq == False {
 			return False
 		}
-		if maybeErr == nil && IsUnknownOrError(elemEq) {
-			maybeErr = elemEq
-		}
-	}
-	if maybeErr != nil {
-		return maybeErr
 	}
 	return True
 }

--- a/common/types/list.go
+++ b/common/types/list.go
@@ -328,7 +328,7 @@ func (l *concatList) ConvertToType(typeVal ref.Type) ref.Val {
 func (l *concatList) Equal(other ref.Val) ref.Val {
 	otherList, ok := other.(traits.Lister)
 	if !ok {
-		return MaybeNoSuchOverloadErr(other)
+		return False
 	}
 	if l.Size() != otherList.Size() {
 		return False

--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -377,6 +377,9 @@ func TestConcatListEqual(t *testing.T) {
 	if list.Equal(listD) != True {
 		t.Errorf("list.Equal(listD) got %v, wanted true", list.Equal(listD))
 	}
+	if list.Equal(NullValue) != False {
+		t.Errorf("list.Equal(NullValue) got %v, wanted false", list.Equal(NullValue))
+	}
 }
 
 func TestConcatListGet(t *testing.T) {

--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -83,11 +83,7 @@ func TestBaseListContains(t *testing.T) {
 		},
 		{
 			in:  String("3"),
-			out: NoSuchOverloadErr(),
-		},
-		{
-			in:  Unknown{1},
-			out: Unknown{1},
+			out: False,
 		},
 	}
 	for _, tc := range tests {
@@ -174,8 +170,8 @@ func TestBaseListEqual(t *testing.T) {
 	if listA.Equal(listD) != False {
 		t.Error("listA.Equal(listD) did not return true")
 	}
-	if !IsError(listB.Equal(listD)) {
-		t.Error("listA.Equal(listD) did not error on single element type difference")
+	if IsError(listB.Equal(listD)) {
+		t.Error("listA.Equal(listD) errored, wanted 'false'")
 	}
 }
 
@@ -355,8 +351,8 @@ func TestConcatListContainsNonBool(t *testing.T) {
 	listA := NewDynamicList(reg, []float32{1.0, 2.0})
 	listB := NewDynamicList(reg, []string{"3"})
 	listConcat := listA.Add(listB).(traits.Lister)
-	if !IsError(listConcat.Contains(String("4"))) {
-		t.Error("Contains did not error with list of mixed types an not found input.")
+	if IsError(listConcat.Contains(String("4"))) {
+		t.Error("Contains errored with a not-found element, wanted 'false'")
 	}
 }
 

--- a/common/types/map_test.go
+++ b/common/types/map_test.go
@@ -50,11 +50,8 @@ func TestDynamicMapContains(t *testing.T) {
 	if mapVal.Contains(String("unknown")) != False {
 		t.Error("mapVal.Contains('unknown') got true, wanted false")
 	}
-	if !IsError(mapVal.Contains(Int(123))) {
-		t.Error("mapVal.Contains(123) expected error")
-	}
-	if !reflect.DeepEqual(mapVal.Contains(Unknown{1}), Unknown{1}) {
-		t.Error("mapVal.Contains(Unknown) did not return unknown input.")
+	if IsError(mapVal.Contains(Int(123))) {
+		t.Error("mapVal.Contains(123) errored, wanted false")
 	}
 }
 
@@ -69,11 +66,8 @@ func TestStringMapContains(t *testing.T) {
 	if mapVal.Contains(String("third")) != False {
 		t.Error("mapVal.Contains('third') did not return false")
 	}
-	if !IsError(mapVal.Contains(Int(123))) {
-		t.Error("mapVal.Contains(123) did not error, wanted 'unsupported key type: int'.")
-	}
-	if !reflect.DeepEqual(mapVal.Contains(Unknown{1}), Unknown{1}) {
-		t.Error("mapVal.Contains(Unknown) did not return unknown out.")
+	if IsError(mapVal.Contains(Int(123))) {
+		t.Error("mapVal.Contains(123) errored, wanted false'.")
 	}
 }
 
@@ -369,8 +363,8 @@ func TestStringMapEqual_NotTrue(t *testing.T) {
 	other = NewDynamicMap(reg, map[string]interface{}{
 		"first":  "hello",
 		"second": 1})
-	if !IsError(mapVal.Equal(other)) {
-		t.Error("mapVal.Equal(other) between maps with same keys and different value types did not error")
+	if IsError(mapVal.Equal(other)) {
+		t.Error("mapVal.Equal(other) between maps with same keys and different value types errored, wanted 'false'")
 	}
 }
 
@@ -392,8 +386,8 @@ func TestDynamicMapGet(t *testing.T) {
 		t.Errorf("mapVal.Get('absent') got %v, wanted no such key: absent.", err)
 	}
 	err = nestedVal.Get(String("bad_key"))
-	if !IsError(err) || err.(*Err).Error() != "unsupported key type: string" {
-		t.Errorf("nestedVal.Get('bad_key') got %v, wanted unsupported key type: string.", err)
+	if !IsError(err) || err.(*Err).Error() != "no such key: bad_key" {
+		t.Errorf("nestedVal.Get('bad_key') errored %v, wanted no such key: bad_key.", err)
 	}
 	empty, ok := mapVal.Get(String("empty")).(traits.Mapper)
 	if !ok {
@@ -428,8 +422,8 @@ func TestStringIfaceMapGet(t *testing.T) {
 		t.Errorf("mapVal.Get('absent') got %v, wanted no such key: absent.", err)
 	}
 	err = nestedVal.Get(String("bad_key"))
-	if !IsError(err) || err.(*Err).Error() != "unsupported key type: string" {
-		t.Errorf("nestedVal.Get('bad_key') got %v, wanted unsupported key type: string.", err)
+	if !IsError(err) || err.(*Err).Error() != "no such key: bad_key" {
+		t.Errorf("nestedVal.Get('bad_key') got %v, no such key: bad_key", err)
 	}
 	empty, ok := mapVal.Get(String("empty")).(traits.Mapper)
 	if !ok {
@@ -440,8 +434,8 @@ func TestStringIfaceMapGet(t *testing.T) {
 		t.Errorf("empty.Get('hello') got %v, wanted no such key: hello", err)
 	}
 	err = empty.Get(Double(-1.0))
-	if !IsError(err) || err.(*Err).Error() != "unsupported key type: double" {
-		t.Errorf("empty.Get(-1.0) got %v, wanted unsupported key type: double", err)
+	if !IsError(err) || err.(*Err).Error() != "no such key: -1" {
+		t.Errorf("empty.Get(-1.0) got %v, wanted no such key: -1", err)
 	}
 }
 
@@ -483,8 +477,8 @@ func TestRefValMapGet(t *testing.T) {
 		t.Errorf("mapVal.Get('absent') got %v, wanted no such key: absent.", err)
 	}
 	err = nestedVal.Get(String("bad_key"))
-	if !IsError(err) || err.(*Err).Error() != "unsupported key type: string" {
-		t.Errorf("nestedVal.Get('bad_key') got %v, wanted unsupported key type: string.", err)
+	if !IsError(err) || err.(*Err).Error() != "no such key: bad_key" {
+		t.Errorf("nestedVal.Get('bad_key') got %v, wanted no such key: bad_key.", err)
 	}
 	empty, ok := mapVal.Get(String("empty")).(traits.Mapper)
 	if !ok {
@@ -678,8 +672,8 @@ func TestProtoMap(t *testing.T) {
 		3: 1,
 	}
 	mapNeVal = reg.NativeToValue(mapNeMap)
-	if !IsError(mapNeVal.Equal(mapVal)) || !IsError(mapVal.Equal(mapNeVal)) {
-		t.Error("mapNeVal.Equal(mapVal) returned non-error, wanted error")
+	if IsError(mapNeVal.Equal(mapVal)) || IsError(mapVal.Equal(mapNeVal)) {
+		t.Error("mapNeVal.Equal(mapVal) returned error, wanted false")
 	}
 }
 
@@ -706,8 +700,8 @@ func TestProtoMapGet(t *testing.T) {
 		t.Errorf("mapVal.Get('not_found') got %v, wanted no such key error", notFound)
 	}
 	badKey := mapVal.Get(Int(42))
-	if !IsError(badKey) || !strings.Contains(badKey.(*Err).Error(), "unsupported key type") {
-		t.Errorf("mapVal.Get(42) got %v, wanted no such overload", badKey)
+	if !IsError(badKey) || !strings.Contains(badKey.(*Err).Error(), "no such key: 42") {
+		t.Errorf("mapVal.Get(42) got %v, wanted no such key: 42", badKey)
 	}
 
 }

--- a/common/types/null.go
+++ b/common/types/null.go
@@ -83,10 +83,7 @@ func (n Null) ConvertToType(typeVal ref.Type) ref.Val {
 
 // Equal implements ref.Val.Equal.
 func (n Null) Equal(other ref.Val) ref.Val {
-	if NullType != other.Type() {
-		return ValOrErr(other, "no such overload")
-	}
-	return True
+	return Bool(NullType == other.Type())
 }
 
 // Type implements ref.Val.Type.

--- a/common/types/object.go
+++ b/common/types/object.go
@@ -109,7 +109,8 @@ func (o *protoObj) ConvertToType(typeVal ref.Type) ref.Val {
 }
 
 func (o *protoObj) Equal(other ref.Val) ref.Val {
-	return Bool(pb.Equal(o.value, other.Value().(proto.Message)))
+	otherPB, ok := other.Value().(proto.Message)
+	return Bool(ok && pb.Equal(o.value, otherPB))
 }
 
 // IsSet tests whether a field which is defined is set to a non-default value.

--- a/common/types/overflow.go
+++ b/common/types/overflow.go
@@ -355,3 +355,35 @@ func uint64ToInt64Checked(v uint64) (int64, error) {
 	}
 	return int64(v), nil
 }
+
+func doubleToUint64Lossless(v float64) (uint64, bool) {
+	u, err := doubleToUint64Checked(v)
+	if err != nil {
+		return 0, false
+	}
+	if float64(u) != v {
+		return 0, false
+	}
+	return u, true
+}
+
+func doubleToInt64Lossless(v float64) (int64, bool) {
+	i, err := doubleToInt64Checked(v)
+	if err != nil {
+		return 0, false
+	}
+	if float64(i) != v {
+		return 0, false
+	}
+	return i, true
+}
+
+func int64ToUint64Lossless(v int64) (uint64, bool) {
+	u, err := int64ToUint64Checked(v)
+	return u, err == nil
+}
+
+func uint64ToInt64Lossless(v uint64) (int64, bool) {
+	i, err := uint64ToInt64Checked(v)
+	return i, err == nil
+}

--- a/common/types/string.go
+++ b/common/types/string.go
@@ -151,10 +151,7 @@ func (s String) ConvertToType(typeVal ref.Type) ref.Val {
 // Equal implements ref.Val.Equal.
 func (s String) Equal(other ref.Val) ref.Val {
 	otherString, ok := other.(String)
-	if !ok {
-		return MaybeNoSuchOverloadErr(other)
-	}
-	return Bool(s == otherString)
+	return Bool(ok && s == otherString)
 }
 
 // Match implements traits.Matcher.Match.

--- a/common/types/string_test.go
+++ b/common/types/string_test.go
@@ -158,8 +158,8 @@ func TestString_Equal(t *testing.T) {
 	if String("hello").Equal(String("hell")).(Bool) {
 		t.Error("Two inqueal strings were found equal")
 	}
-	if !IsError(String("c").Equal(Int(99))) {
-		t.Error("String 'c' equal to int 99 resulted in non-error")
+	if IsError(String("c").Equal(Int(99))) {
+		t.Error("String 'c' equal to int 99 resulted in error, wanted 'false'")
 	}
 }
 

--- a/common/types/timestamp.go
+++ b/common/types/timestamp.go
@@ -134,10 +134,8 @@ func (t Timestamp) ConvertToType(typeVal ref.Type) ref.Val {
 
 // Equal implements ref.Val.Equal.
 func (t Timestamp) Equal(other ref.Val) ref.Val {
-	if TimestampType != other.Type() {
-		return MaybeNoSuchOverloadErr(other)
-	}
-	return Bool(t.Time.Equal(other.(Timestamp).Time))
+	otherTime, ok := other.(Timestamp)
+	return Bool(ok && t.Time.Equal(otherTime.Time))
 }
 
 // Receive implements traits.Reciever.Receive.

--- a/common/types/type.go
+++ b/common/types/type.go
@@ -71,10 +71,8 @@ func (t *TypeValue) ConvertToType(typeVal ref.Type) ref.Val {
 
 // Equal implements ref.Val.Equal.
 func (t *TypeValue) Equal(other ref.Val) ref.Val {
-	if TypeType != other.Type() {
-		return ValOrErr(other, "no such overload")
-	}
-	return Bool(t.TypeName() == other.(ref.Type).TypeName())
+	otherType, ok := other.(ref.Type)
+	return Bool(ok && t.TypeName() == otherType.TypeName())
 }
 
 // HasTrait indicates whether the type supports the given trait.

--- a/common/types/uint.go
+++ b/common/types/uint.go
@@ -190,7 +190,7 @@ func (i Uint) Equal(other ref.Val) ref.Val {
 	case Uint:
 		return Bool(i == ov)
 	default:
-		return MaybeNoSuchOverloadErr(other)
+		return False
 	}
 }
 

--- a/common/types/uint_test.go
+++ b/common/types/uint_test.go
@@ -346,11 +346,6 @@ func TestUint_Equal(t *testing.T) {
 			b:   Double(math.NaN()),
 			out: False,
 		},
-		{
-			a:   Uint(10),
-			b:   Unknown{2},
-			out: Unknown{2},
-		},
 	}
 	for _, tc := range tests {
 		got := tc.a.Equal(tc.b)

--- a/conformance/BUILD.bazel
+++ b/conformance/BUILD.bazel
@@ -27,7 +27,10 @@ sh_test(
         "$(location @com_google_cel_spec//tests/simple:simple_test)",
         "--server=$(location //server/main:cel_server)",
         # Tests that need to be removed as the spec has changed
-        "--skip_test=comparisons/eq_literal/eq_mixed_types_error,eq_list_elem_mixed_types_error;ne_literal/ne_mixed_types_error",
+        "--skip_test=comparisons/eq_literal/eq_mixed_types_error,eq_list_elem_mixed_types_error,eq_map_value_mixed_types_error;ne_literal/ne_mixed_types_error",
+        "--skip_test=comparisons/in_list_literal/elem_in_mixed_type_list_error",
+        "--skip_test=comparisons/in_map_literal/key_in_mixed_key_type_map_error",
+        "--skip_test=macros/exists/list_elem_type_exhaustive,map_key_type_exhaustive",
 
         # Failing conformance tests.
         "--skip_test=fields/qualified_identifier_resolution/map_key_float,map_key_null,map_value_repeat_key",

--- a/interpreter/attribute_patterns.go
+++ b/interpreter/attribute_patterns.go
@@ -157,14 +157,23 @@ func (q *stringQualifier) QualifierValueEquals(value interface{}) bool {
 
 // QualifierValueEquals implementation for int qualifiers.
 func (q *intQualifier) QualifierValueEquals(value interface{}) bool {
-	ival, ok := value.(int64)
-	return ok && q.value == ival
+	return numericValueEquals(value, q.celValue)
 }
 
 // QualifierValueEquals implementation for uint qualifiers.
 func (q *uintQualifier) QualifierValueEquals(value interface{}) bool {
-	uval, ok := value.(uint64)
-	return ok && q.value == uval
+	return numericValueEquals(value, q.celValue)
+}
+
+// QualifierValueEquals implementation for double qualifiers.
+func (q *doubleQualifier) QualifierValueEquals(value interface{}) bool {
+	return numericValueEquals(value, q.celValue)
+}
+
+// numericValueEquals uses CEL equality to determine whether two number values are
+func numericValueEquals(value interface{}, celValue ref.Val) bool {
+	val := types.DefaultTypeAdapter.NativeToValue(value)
+	return celValue.Equal(val) == types.True
 }
 
 // NewPartialAttributeFactory returns an AttributeFactory implementation capable of performing

--- a/interpreter/attribute_patterns_test.go
+++ b/interpreter/attribute_patterns_test.go
@@ -97,10 +97,11 @@ var patternTests = map[string]patternTest{
 		matches: []attr{
 			{name: "var"},
 			{name: "var", quals: []interface{}{int64(0)}},
+			{name: "var", quals: []interface{}{float64(0)}},
 			{name: "var", quals: []interface{}{int64(0), false}},
+			{name: "var", quals: []interface{}{uint64(0)}},
 		},
 		misses: []attr{
-			{name: "var", quals: []interface{}{uint64(0)}},
 			{name: "var", quals: []interface{}{int64(1), false}},
 		},
 	},
@@ -110,10 +111,10 @@ var patternTests = map[string]patternTest{
 			{name: "var"},
 			{name: "var", quals: []interface{}{uint64(1)}},
 			{name: "var", quals: []interface{}{uint64(1), true}},
+			{name: "var", quals: []interface{}{int64(1), false}},
 		},
 		misses: []attr{
 			{name: "var", quals: []interface{}{uint64(0)}},
-			{name: "var", quals: []interface{}{int64(1), false}},
 		},
 	},
 	"var_index_bool": {
@@ -186,16 +187,16 @@ func TestAttributePattern_UnknownResolution(t *testing.T) {
 	reg := newTestRegistry(t)
 	for nm, tc := range patternTests {
 		tst := tc
-		t.Run(nm, func(tt *testing.T) {
+		t.Run(nm, func(t *testing.T) {
 			for i, match := range tst.matches {
 				m := match
-				tt.Run(fmt.Sprintf("match[%d]", i), func(ttt *testing.T) {
+				t.Run(fmt.Sprintf("match[%d]", i), func(t *testing.T) {
 					var err error
 					cont := containers.DefaultContainer
 					if m.unchecked {
 						cont, err = containers.NewContainer(containers.Name(m.container))
 						if err != nil {
-							ttt.Fatal(err)
+							t.Fatal(err)
 						}
 					}
 					fac := NewPartialAttributeFactory(cont, reg, reg)
@@ -203,23 +204,23 @@ func TestAttributePattern_UnknownResolution(t *testing.T) {
 					partVars, _ := NewPartialActivation(EmptyActivation(), tst.pattern)
 					val, err := attr.Resolve(partVars)
 					if err != nil {
-						ttt.Fatalf("Got error: %s, wanted unknown", err)
+						t.Fatalf("Got error: %s, wanted unknown", err)
 					}
 					_, isUnk := val.(types.Unknown)
 					if !isUnk {
-						ttt.Fatalf("Got value %v, wanted unknown", val)
+						t.Fatalf("Got value %v, wanted unknown", val)
 					}
 				})
 			}
 			for i, miss := range tst.misses {
 				m := miss
-				tt.Run(fmt.Sprintf("miss[%d]", i), func(ttt *testing.T) {
+				t.Run(fmt.Sprintf("miss[%d]", i), func(t *testing.T) {
 					cont := containers.DefaultContainer
 					if m.unchecked {
 						var err error
 						cont, err = containers.NewContainer(containers.Name(m.container))
 						if err != nil {
-							ttt.Fatal(err)
+							t.Fatal(err)
 						}
 					}
 					fac := NewPartialAttributeFactory(cont, reg, reg)
@@ -227,7 +228,7 @@ func TestAttributePattern_UnknownResolution(t *testing.T) {
 					partVars, _ := NewPartialActivation(EmptyActivation(), tst.pattern)
 					val, err := attr.Resolve(partVars)
 					if err == nil {
-						ttt.Fatalf("Got value: %s, wanted error", val)
+						t.Fatalf("Got value: %s, wanted error", val)
 					}
 				})
 			}

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -15,7 +15,6 @@
 package interpreter
 
 import (
-	"errors"
 	"fmt"
 	"math"
 
@@ -487,9 +486,7 @@ func (a *maybeAttribute) AddQualifier(qual Qualifier) (Attribute, error) {
 		}
 	}
 	// Next, ensure the most specific variable / type reference is searched first.
-	a.attrs = append([]NamespacedAttribute{
-		a.fac.AbsoluteAttribute(qual.ID(), augmentedNames...),
-	}, a.attrs...)
+	a.attrs = append([]NamespacedAttribute{a.fac.AbsoluteAttribute(qual.ID(), augmentedNames...)}, a.attrs...)
 	return a, nil
 }
 
@@ -628,6 +625,10 @@ func newQualifier(adapter ref.TypeAdapter, id int64, v interface{}) (Qualifier, 
 		qual = &uintQualifier{id: id, value: val, celValue: types.Uint(val), adapter: adapter}
 	case bool:
 		qual = &boolQualifier{id: id, value: val, celValue: types.Bool(val), adapter: adapter}
+	case float32:
+		qual = &doubleQualifier{id: id, value: float64(val), celValue: types.Double(val), adapter: adapter}
+	case float64:
+		qual = &doubleQualifier{id: id, value: val, celValue: types.Double(val), adapter: adapter}
 	case types.String:
 		qual = &stringQualifier{id: id, value: string(val), celValue: val, adapter: adapter}
 	case types.Int:
@@ -713,9 +714,6 @@ func (q *stringQualifier) Qualify(vars Activation, obj interface{}) (interface{}
 		elem, err := refResolve(q.adapter, q.celValue, obj)
 		if err != nil {
 			return nil, err
-		}
-		if types.IsUnknown(elem) {
-			return elem, nil
 		}
 		return elem, nil
 	}
@@ -829,9 +827,6 @@ func (q *intQualifier) Qualify(vars Activation, obj interface{}) (interface{}, e
 		if err != nil {
 			return nil, err
 		}
-		if types.IsUnknown(elem) {
-			return elem, nil
-		}
 		return elem, nil
 	}
 	if isMap && !isKey {
@@ -891,9 +886,6 @@ func (q *uintQualifier) Qualify(vars Activation, obj interface{}) (interface{}, 
 		if err != nil {
 			return nil, err
 		}
-		if types.IsUnknown(elem) {
-			return elem, nil
-		}
 		return elem, nil
 	}
 	if isMap && !isKey {
@@ -941,9 +933,6 @@ func (q *boolQualifier) Qualify(vars Activation, obj interface{}) (interface{}, 
 		elem, err := refResolve(q.adapter, q.celValue, obj)
 		if err != nil {
 			return nil, err
-		}
-		if types.IsUnknown(elem) {
-			return elem, nil
 		}
 		return elem, nil
 	}
@@ -996,6 +985,37 @@ func (q *fieldQualifier) Cost() (min, max int64) {
 	return 0, 0
 }
 
+// doubleQualifier qualifies a CEL object, map, or list using a double value.
+//
+// This qualifier is used for working with dynamic data like JSON or protobuf.Any where the value
+// type may not be known ahead of time and may not conform to the standard types supported as valid
+// protobuf map key types.
+type doubleQualifier struct {
+	id       int64
+	value    float64
+	celValue ref.Val
+	adapter  ref.TypeAdapter
+}
+
+// ID is an implementation of the Qualifier interface method.
+func (q *doubleQualifier) ID() int64 {
+	return q.id
+}
+
+// Qualify implements the Qualifier interface method.
+func (q *doubleQualifier) Qualify(vars Activation, obj interface{}) (interface{}, error) {
+	switch o := obj.(type) {
+	case types.Unknown:
+		return o, nil
+	default:
+		elem, err := refResolve(q.adapter, q.celValue, obj)
+		if err != nil {
+			return nil, err
+		}
+		return elem, nil
+	}
+}
+
 // refResolve attempts to convert the value to a CEL value and then uses reflection methods
 // to try and resolve the qualifier.
 func refResolve(adapter ref.TypeAdapter, idx ref.Val, obj interface{}) (ref.Val, error) {
@@ -1005,9 +1025,6 @@ func refResolve(adapter ref.TypeAdapter, idx ref.Val, obj interface{}) (ref.Val,
 		elem, found := mapper.Find(idx)
 		if !found {
 			return nil, fmt.Errorf("no such key: %v", idx)
-		}
-		if types.IsError(elem) {
-			return nil, elem.(*types.Err)
 		}
 		return elem, nil
 	}
@@ -1028,5 +1045,5 @@ func refResolve(adapter ref.TypeAdapter, idx ref.Val, obj interface{}) (ref.Val,
 	if types.IsError(celVal) {
 		return nil, celVal.(*types.Err)
 	}
-	return nil, errors.New("no such overload")
+	return nil, fmt.Errorf("no such key: %v", idx)
 }

--- a/interpreter/functions/standard.go
+++ b/interpreter/functions/standard.go
@@ -100,8 +100,6 @@ func StandardOverloads() []*Overload {
 				return cmp
 			}},
 
-		// TODO: Verify overflow, NaN, underflow cases for numeric values.
-
 		// Add operator
 		{Operator: operators.Add,
 			OperandTrait: traits.AdderType,

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -298,6 +298,12 @@ func (eq *evalEq) ID() int64 {
 func (eq *evalEq) Eval(ctx Activation) ref.Val {
 	lVal := eq.lhs.Eval(ctx)
 	rVal := eq.rhs.Eval(ctx)
+	if types.IsUnknownOrError(lVal) {
+		return lVal
+	}
+	if types.IsUnknownOrError(rVal) {
+		return rVal
+	}
 	return types.Equal(lVal, rVal)
 }
 
@@ -336,12 +342,13 @@ func (ne *evalNe) ID() int64 {
 func (ne *evalNe) Eval(ctx Activation) ref.Val {
 	lVal := ne.lhs.Eval(ctx)
 	rVal := ne.rhs.Eval(ctx)
-	eqVal := types.Equal(lVal, rVal)
-	eqBool, ok := eqVal.(types.Bool)
-	if !ok {
-		return types.ValOrErr(eqVal, "no such overload: _!=_")
+	if types.IsUnknownOrError(lVal) {
+		return lVal
 	}
-	return !eqBool
+	if types.IsUnknownOrError(rVal) {
+		return rVal
+	}
+	return types.Bool(types.Equal(lVal, rVal) != types.True)
 }
 
 // Cost implements the Coster interface method.

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -780,10 +780,9 @@ func (fold *evalFold) Cost() (min, max int64) {
 // evalSetMembership is an Interpretable implementation which tests whether an input value
 // exists within the set of map keys used to model a set.
 type evalSetMembership struct {
-	inst        Interpretable
-	arg         Interpretable
-	argTypeName string
-	valueSet    map[ref.Val]ref.Val
+	inst     Interpretable
+	arg      Interpretable
+	valueSet map[ref.Val]ref.Val
 }
 
 // ID implements the Interpretable interface method.
@@ -794,9 +793,6 @@ func (e *evalSetMembership) ID() int64 {
 // Eval implements the Interpretable interface method.
 func (e *evalSetMembership) Eval(ctx Activation) ref.Val {
 	val := e.arg.Eval(ctx)
-	if val.Type().TypeName() != e.argTypeName {
-		return types.ValOrErr(val, "no such overload")
-	}
 	if ret, found := e.valueSet[val]; found {
 		return ret
 	}

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -327,7 +327,7 @@ var (
 		{
 			name: "not_in_heterogeneous_map",
 			expr: `!('hello' in {1: 'one', false: true})`,
-			err:  "unsupported key type: string",
+			out:  types.True,
 		},
 		{
 			name: "not_in_heterogeneous_map_with_same_key_type",
@@ -364,7 +364,7 @@ var (
 		{
 			name: "list_eq_error",
 			expr: `['string', true] == [2, 3]`,
-			err:  "no such overload",
+			out:  types.False,
 		},
 		{
 			name: "literal_bool_false",

--- a/interpreter/prune_test.go
+++ b/interpreter/prune_test.go
@@ -79,7 +79,7 @@ var testCases = []testInfo{
 	{
 		in:   unknownActivation(),
 		expr: `test == null`,
-		out:  `false`,
+		out:  `test == null`,
 	},
 	{
 		in:   unknownActivation(),


### PR DESCRIPTION
Enable heterogeneous equality within the runtime. 

The type-checker will raise errors when cross-type comparisons are made within strongly typed
expressions; however, for dynamically typed data such inferences are not possible meaning they
must be handled appropriately at runtime.

Heterogeneous equality is being introduced to ensure that CEL and proto equality are better 
aligned, that CEL's notion of runtime equality is consistent with Zeta SQLs, and to make it easier
to work with dynamically typed data: e.g.`json.string_value != 2`

This change is a semantic change which has not yet been reflected in the cel-spec but will be
soon. The change is generally regarded as safe as it shifts error states to non-error states, but
in very rare circumstances it is possible that an application may rely on this error to be produced.