### PR TITLE
Context-based evaluation support

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -15,12 +15,14 @@
 package cel
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common"
@@ -820,12 +822,58 @@ func TestEvalOptions(t *testing.T) {
 	}
 }
 
+func TestContextEval(t *testing.T) {
+	env, err := NewEnv(
+		Declarations(
+			decls.NewVar("items", decls.NewListType(decls.Int)),
+		),
+	)
+	if err != nil {
+		t.Fatalf("NewEnv() failed: %v", err)
+	}
+	ast, iss := env.Compile("items.map(i, i * 2).filter(i, i >= 50).size()")
+	if iss.Err() != nil {
+		t.Fatalf("env.Compile(expr) failed: %v", iss.Err())
+	}
+	prg, err := env.Program(ast, EvalOptions(OptOptimize))
+	if err != nil {
+		t.Fatalf("env.Program() failed: %v", err)
+	}
+
+	ctx := context.TODO()
+	items := make([]int64, 100)
+	for i := int64(0); i < 100; i++ {
+		items[i] = i
+	}
+	out, _, err := ContextEval(ctx, prg, map[string]interface{}{"items": items})
+	if err != nil {
+		t.Fatalf("ContextEval() failed: %v", err)
+	}
+	if out != types.Int(75) {
+		t.Errorf("ContextEval() got %v, wanted 75", out)
+	}
+
+	evalCtx, cancel := context.WithTimeout(ctx, 100*time.Microsecond)
+	defer cancel()
+
+	out, _, err = ContextEval(evalCtx, prg, map[string]interface{}{"items": items})
+	if err == nil {
+		t.Errorf("Got result %v, wanted timeout error", out)
+	}
+	if err != nil && err.Error() != "operation cancelled" {
+		t.Errorf("Got %v, wanted operation cancelled error", err)
+	}
+}
+
 func TestEvalRecover(t *testing.T) {
-	e, _ := NewEnv(
+	e, err := NewEnv(
 		Declarations(
 			decls.NewFunction("panic",
 				decls.NewOverload("panic", []*exprpb.Type{}, decls.Bool)),
 		))
+	if err != nil {
+		t.Fatalf("NewEnv() failed: %v", err)
+	}
 	funcs := Functions(&functions.Overload{
 		Operator: "panic",
 		Function: func(args ...ref.Val) ref.Val {
@@ -835,7 +883,7 @@ func TestEvalRecover(t *testing.T) {
 	// Test standard evaluation.
 	pAst, _ := e.Parse("panic()")
 	prgm, _ := e.Program(pAst, funcs)
-	_, _, err := prgm.Eval(map[string]interface{}{})
+	_, _, err = prgm.Eval(map[string]interface{}{})
 	if err.Error() != "internal error: watch me recover" {
 		t.Errorf("got '%v', wanted 'internal error: watch me recover'", err)
 	}

--- a/cel/io_test.go
+++ b/cel/io_test.go
@@ -57,7 +57,7 @@ func TestRefValueToValueRoundTrip(t *testing.T) {
 			}
 			actual, err := ValueToRefValue(env.TypeAdapter(), val)
 			if err != nil {
-				t.Fatalf("ValueToRefValue() failed: &v", err)
+				t.Fatalf("ValueToRefValue() failed: %v", err)
 			}
 			if refVal.Equal(actual) != types.True {
 				t.Errorf("got val %v, wanted %v", actual, refVal)


### PR DESCRIPTION
Allow CEL program evaluation to occur within a Golang `Context` to support the
cancellation and timeout requirements of latency critical applications.