### PR TITLE
List append optimizations for comprehension loops

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -857,7 +857,7 @@ func TestContextEval(t *testing.T) {
 		t.Errorf("ContextEval() got %v, wanted 75", out)
 	}
 
-	evalCtx, cancel := context.WithTimeout(ctx, 100*time.Microsecond)
+	evalCtx, cancel := context.WithTimeout(ctx, 50*time.Microsecond)
 	defer cancel()
 
 	out, _, err = ContextEval(evalCtx, prg, map[string]interface{}{"items": items})
@@ -866,6 +866,40 @@ func TestContextEval(t *testing.T) {
 	}
 	if err != nil && err.Error() != "operation cancelled" {
 		t.Errorf("Got %v, wanted operation cancelled error", err)
+	}
+}
+
+func BenchmarkContextEval(b *testing.B) {
+	env, err := NewEnv(
+		Declarations(
+			decls.NewVar("items", decls.NewListType(decls.Int)),
+		),
+	)
+	if err != nil {
+		b.Fatalf("NewEnv() failed: %v", err)
+	}
+	ast, iss := env.Compile("items.map(i, i * 2).filter(i, i >= 50).size()")
+	if iss.Err() != nil {
+		b.Fatalf("env.Compile(expr) failed: %v", iss.Err())
+	}
+	prg, err := env.Program(ast, EvalOptions(OptOptimize))
+	if err != nil {
+		b.Fatalf("env.Program() failed: %v", err)
+	}
+
+	ctx := context.TODO()
+	items := make([]int64, 100)
+	for i := int64(0); i < 100; i++ {
+		items[i] = i
+	}
+	for i := 0; i < b.N; i++ {
+		out, _, err := ContextEval(ctx, prg, map[string]interface{}{"items": items})
+		if err != nil {
+			b.Fatalf("ContextEval() failed: %v", err)
+		}
+		if out != types.Int(75) {
+			b.Errorf("ContextEval() got %v, wanted 75", out)
+		}
 	}
 }
 

--- a/common/types/traits/lister.go
+++ b/common/types/traits/lister.go
@@ -25,3 +25,8 @@ type Lister interface {
 	Iterable
 	Sizer
 }
+
+// MutableLister interface which emits an immutable result after an intermediate computation.
+type MutableLister interface {
+	ToImmutableList() Lister
+}

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -557,7 +557,7 @@ var (
 		},
 		{
 			name: "macro_filter",
-			expr: `[1, 2, 3].filter(x, x > 2) == [3]`,
+			expr: `[-10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3].filter(x, x > 0) == [1, 2, 3]`,
 		},
 		{
 			name:           "macro_has_map_key",
@@ -1104,10 +1104,10 @@ func BenchmarkInterpreter(b *testing.B) {
 			b.Fatal(err)
 		}
 		// Benchmark the eval.
-		b.Run(tst.name, func(bb *testing.B) {
+		b.Run(tst.name, func(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
-			for i := 0; i < bb.N; i++ {
+			for i := 0; i < b.N; i++ {
 				prg.Eval(vars)
 			}
 		})

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -617,6 +617,7 @@ func (p *planner) planComprehension(expr *exprpb.Expr) (Interpretable, error) {
 		cond:      cond,
 		step:      step,
 		result:    result,
+		adapter:   p.adapter,
 	}, nil
 }
 


### PR DESCRIPTION
Introduce the list append optimizations used within C++ to ensure that comprehensions are able to treat internal
CEL variables as mutable for the purposes of list construction. Closes #488 

Before the optimization:
```
BenchmarkContextEval-8   	     250	   4680999 ns/op	   43948 B/op	    1323 allocs/op
```

After the optimization:
```
BenchmarkContextEval-8   	   10233	    116829 ns/op	   35516 B/op	    1038 allocs/op
```

The memory usage is not that different between the before and after, but the overall evaluation time (117us vs. 4.58ms) represents a 40x improvement in evaluation speed which will significantly help comprehension-heavy uses of CEL with even moderately sized inputs.