### PR TITLE
Update ContextEval to halt CEL evaluation when cancelled

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -1017,6 +1017,17 @@ func TestContextEval(t *testing.T) {
 	if err != nil && err.Error() != "operation cancelled" {
 		t.Errorf("Got %v, wanted operation cancelled error", err)
 	}
+
+	//  Run CEL evaluation in the foreground (don't run it in a background go routine) and
+	// verify cancellation halts evaluation.
+	ctxPrg := prg.(programWithContext)
+	out, _, err = ctxPrg.ContextEval(evalCtx, map[string]interface{}{"items": items})
+	if err == nil {
+		t.Errorf("Got result %v, wanted timeout error", out)
+	}
+	if err != nil && err.Error() != "operation cancelled" {
+		t.Errorf("Got %v, wanted operation cancelled error", err)
+	}
 }
 
 func BenchmarkContextEval(b *testing.B) {

--- a/cel/options.go
+++ b/cel/options.go
@@ -17,6 +17,12 @@ package cel
 import (
 	"fmt"
 
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/dynamicpb"
+
 	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/containers"
 	"github.com/google/cel-go/common/types/pb"
@@ -24,11 +30,6 @@ import (
 	"github.com/google/cel-go/interpreter"
 	"github.com/google/cel-go/interpreter/functions"
 	"github.com/google/cel-go/parser"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protodesc"
-	"google.golang.org/protobuf/reflect/protoreflect"
-	"google.golang.org/protobuf/reflect/protoregistry"
-	"google.golang.org/protobuf/types/dynamicpb"
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	descpb "google.golang.org/protobuf/types/descriptorpb"

--- a/cel/program.go
+++ b/cel/program.go
@@ -273,7 +273,11 @@ func (p *prog) Eval(input interface{}) (v ref.Val, det *EvalDetails, err error) 
 	// function.
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("internal error: %v", r)
+			if r == "operation canceled" {
+				err = fmt.Errorf("%v", r)
+			} else {
+				err = fmt.Errorf("internal error: %v", r)
+			}
 		}
 	}()
 	// Build a hierarchical activation if there are default vars set.

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -73,6 +73,11 @@ func Optimize() InterpretableDecorator {
 	return decOptimize()
 }
 
+// Stoppable decorates all operations with one that returns an "operation cancelled" error if stopCh is closed.
+func Stoppable(stopCh <-chan struct{}) InterpretableDecorator {
+	return decStoppable(stopCh)
+}
+
 type exprInterpreter struct {
 	dispatcher  Dispatcher
 	container   *containers.Container


### PR DESCRIPTION
Add a decorator that checks the context Done() channel every 100 InterpretableCall invocations to halt CEL evaluation when the context is cancelled.
