### PR TITLE
Add option to compile regex constants at program creation time

### DIFF
--- a/cel/options.go
+++ b/cel/options.go
@@ -362,7 +362,9 @@ const (
 	OptExhaustiveEval EvalOption = 1<<iota | OptTrackState
 
 	// OptOptimize precomputes functions and operators with constants as arguments at program
-	// creation time. This flag is useful when the expression will be evaluated repeatedly against
+	// creation time. It also pre-compiles regex pattern constants passed to 'matches', reports any compilation errors
+	// at program creation and uses the compiled regex pattern for all 'matches' function invocations.
+	// This flag is useful when the expression will be evaluated repeatedly against
 	// a series of different inputs.
 	OptOptimize EvalOption = 1 << iota
 

--- a/cel/options.go
+++ b/cel/options.go
@@ -17,6 +17,12 @@ package cel
 import (
 	"fmt"
 
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/dynamicpb"
+
 	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/containers"
 	"github.com/google/cel-go/common/types/pb"
@@ -24,11 +30,6 @@ import (
 	"github.com/google/cel-go/interpreter"
 	"github.com/google/cel-go/interpreter/functions"
 	"github.com/google/cel-go/parser"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protodesc"
-	"google.golang.org/protobuf/reflect/protoreflect"
-	"google.golang.org/protobuf/reflect/protoregistry"
-	"google.golang.org/protobuf/types/dynamicpb"
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	descpb "google.golang.org/protobuf/types/descriptorpb"
@@ -335,6 +336,16 @@ func Globals(vars interface{}) ProgramOption {
 			return nil, err
 		}
 		p.defaultVars = defaultVars
+		return p, nil
+	}
+}
+
+// OptimizeRegex provides a way to replace the InterpretableCall for regex functions. This can be used
+// to compile regex string constants at program creation time and report any errors and then use the
+// compiled regex for all regex function invocations.
+func OptimizeRegex(regexOptimizations ...*interpreter.RegexOptimization) ProgramOption {
+	return func(p *prog) (*prog, error) {
+		p.regexOptimizations = append(p.regexOptimizations, regexOptimizations...)
 		return p, nil
 	}
 }

--- a/cel/program.go
+++ b/cel/program.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"math"
 
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter"
-
-	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 // Program is an evaluable view of an Ast.
@@ -188,6 +188,7 @@ func newProgram(e *Env, ast *Ast, opts []ProgramOption) (Program, error) {
 	// Enable constant folding first.
 	if p.evalOpts&OptOptimize == OptOptimize {
 		decorators = append(decorators, interpreter.Optimize())
+		p.regexOptimizations = append(p.regexOptimizations, interpreter.MatchesRegexOptimization)
 	}
 	// Enable regex compilation of constants immediately after folding constants.
 	if len(p.regexOptimizations) > 0 {

--- a/interpreter/BUILD.bazel
+++ b/interpreter/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "evalstate.go",
         "interpretable.go",
         "interpreter.go",
+        "optimizations.go",
         "planner.go",
         "prune.go",
     ],

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -534,13 +534,12 @@ type evalVarArgs struct {
 }
 
 // NewCall creates a new call Interpretable.
-func NewCall(id int64, function, overload string, args []Interpretable, trait int, impl functions.FunctionOp) InterpretableCall {
+func NewCall(id int64, function, overload string, args []Interpretable, impl functions.FunctionOp) InterpretableCall {
 	return &evalVarArgs{
 		id:       id,
 		function: function,
 		overload: overload,
 		args:     args,
-		trait:    trait,
 		impl:     impl,
 	}
 }

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -533,6 +533,18 @@ type evalVarArgs struct {
 	impl     functions.FunctionOp
 }
 
+// NewCall creates a new call Interpretable.
+func NewCall(id int64, function, overload string, args []Interpretable, trait int, impl functions.FunctionOp) InterpretableCall {
+	return &evalVarArgs{
+		id:       id,
+		function: function,
+		overload: overload,
+		args:     args,
+		trait:    trait,
+		impl:     impl,
+	}
+}
+
 // ID implements the Interpretable interface method.
 func (fn *evalVarArgs) ID() int64 {
 	return fn.id

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -73,14 +73,23 @@ func Optimize() InterpretableDecorator {
 	return decOptimize()
 }
 
-// RegexOptimization provides a way to replace an InterpretableCall for a regex function if the
-// RegexIndex is a string constant argument. Typically, the Factory would compile the regex pattern at
+// RegexOptimization provides a way to replace an InterpretableCall for a regex function when the
+// RegexIndex argument is a string constant. Typically, the Factory would compile the regex pattern at
 // RegexIndex and report any errors (at program creation time) and then use the compiled regex for
 // all regex function invocations.
 type RegexOptimization struct {
-	Function   string
+	// Function is the name of the function to optimize.
+	Function string
+	// OverloadID is the ID of the overload to optimize.
+	OverloadID string
+	// RegexIndex is the index position of the regex pattern argument. Only calls to the function where this argument is
+	// a string constant will be delegated to this optimizer.
 	RegexIndex int
-	Factory    func(call InterpretableCall, regexIndex int, pattern ref.Val) (Interpretable, error)
+	// Factory constructs a replacement InterpretableCall node that optimizes the regex function call. Factory is
+	// provided with the unoptimized regex call and the string constant at the RegexIndex argument.
+	// The Factory may compile the regex for use across all invocations of the call, return any errors and
+	// return an interpreter.NewCall with the desired regex optimized function impl.
+	Factory func(call InterpretableCall, regexPattern string) (InterpretableCall, error)
 }
 
 // CompileRegexConstants compiles regex pattern string constants at program creation time and reports any regex pattern

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -73,6 +73,22 @@ func Optimize() InterpretableDecorator {
 	return decOptimize()
 }
 
+// RegexOptimization provides a way to replace an InterpretableCall for a regex function if the
+// RegexIndex is a string constant argument. Typically, the Factory would compile the regex pattern at
+// RegexIndex and report any errors (at program creation time) and then use the compiled regex for
+// all regex function invocations.
+type RegexOptimization struct {
+	Function   string
+	RegexIndex int
+	Factory    func(call InterpretableCall, regexIndex int, pattern ref.Val) (Interpretable, error)
+}
+
+// CompileRegexConstants compiles regex pattern string constants at program creation time and reports any regex pattern
+// compile errors.
+func CompileRegexConstants(regexOptimizations ...*RegexOptimization) InterpretableDecorator {
+	return decRegexOptimizer(regexOptimizations...)
+}
+
 type exprInterpreter struct {
 	dispatcher  Dispatcher
 	container   *containers.Container

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -1332,7 +1332,7 @@ var (
 
 func BenchmarkInterpreter(b *testing.B) {
 	for _, tst := range testData {
-		prg, vars, err := program(b, &tst, Optimize())
+		prg, vars, err := program(b, &tst, Optimize(), CompileRegexConstants(MatchesRegexOptimization))
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -1349,7 +1349,7 @@ func BenchmarkInterpreter(b *testing.B) {
 
 func BenchmarkInterpreter_Parallel(b *testing.B) {
 	for _, tst := range testData {
-		prg, vars, err := program(b, &tst, Optimize())
+		prg, vars, err := program(b, &tst, Optimize(), CompileRegexConstants(MatchesRegexOptimization))
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common"
@@ -33,14 +35,14 @@ import (
 	"github.com/google/cel-go/common/types/traits"
 	"github.com/google/cel-go/interpreter/functions"
 	"github.com/google/cel-go/parser"
-	"google.golang.org/protobuf/proto"
 
-	proto2pb "github.com/google/cel-go/test/proto2pb"
-	proto3pb "github.com/google/cel-go/test/proto3pb"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	structpb "google.golang.org/protobuf/types/known/structpb"
 	tpb "google.golang.org/protobuf/types/known/timestamppb"
 	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
+
+	proto2pb "github.com/google/cel-go/test/proto2pb"
+	proto3pb "github.com/google/cel-go/test/proto3pb"
 )
 
 type testCase struct {
@@ -56,10 +58,12 @@ type testCase struct {
 	funcs          []*functions.Overload
 	attrs          AttributeFactory
 	unchecked      bool
+	extraOpts      []InterpretableDecorator
 
-	in  map[string]interface{}
-	out interface{}
-	err string
+	in      map[string]interface{}
+	out     interface{}
+	err     string
+	progErr string
 }
 
 var (
@@ -861,6 +865,21 @@ var (
 			},
 		},
 		{
+			name: "matches error",
+			expr: `input.matches(')k.*')`,
+			env: []*exprpb.Decl{
+				decls.NewVar("input", decls.String),
+			},
+			in: map[string]interface{}{
+				"input": "kathmandu",
+			},
+			extraOpts: []InterpretableDecorator{CompileRegexConstants(MatchesRegexOptimization)},
+			// unoptimized program should report a regex compile error at runtime
+			err: "unexpected ): `)k.*`",
+			// optimized program should report a regex compile at program creation time
+			progErr: "unexpected ): `)k.*`",
+		},
+		{
 			name:  "nested_proto_field",
 			expr:  `pb3.single_nested_message.bb`,
 			cost:  []int64{1, 1},
@@ -1387,7 +1406,17 @@ func TestInterpreter(t *testing.T) {
 				"track":      TrackState(state),
 			}
 			for mode, opt := range opts {
-				prg, vars, err = program(t, &tc, opt)
+				opts := []InterpretableDecorator{opt}
+				if tc.extraOpts != nil {
+					opts = append(opts, tc.extraOpts...)
+				}
+				prg, vars, err = program(t, &tc, opts...)
+				if tc.progErr != "" {
+					if !types.IsError(got) || !strings.Contains(got.(*types.Err).String(), tc.progErr) {
+						t.Errorf("Got %v (%T), wanted error: %s", got, got, tc.progErr)
+					}
+					continue
+				}
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/interpreter/optimizations.go
+++ b/interpreter/optimizations.go
@@ -1,0 +1,43 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interpreter
+
+import (
+	"regexp"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+var MatchesRegexOptimization = &RegexOptimization{
+	Function:   "matches",
+	RegexIndex: 1,
+	Factory: func(call InterpretableCall, regexPattern string) (InterpretableCall, error) {
+		compiledRegex, err := regexp.Compile(regexPattern)
+		if err != nil {
+			return nil, err
+		}
+		return NewCall(call.ID(), call.Function(), call.OverloadID(), call.Args(), 0, func(values ...ref.Val) ref.Val {
+			if len(values) != 2 {
+				return types.NoSuchOverloadErr()
+			}
+			in, ok := values[0].Value().(string)
+			if !ok {
+				return types.NoSuchOverloadErr()
+			}
+			return types.Bool(compiledRegex.MatchString(in))
+		}), nil
+	},
+}

--- a/interpreter/optimizations.go
+++ b/interpreter/optimizations.go
@@ -21,6 +21,9 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 )
 
+// MatchesRegexOptimization optimizes the 'matches' standard library function by compiling the regex pattern and
+// reporting any compilation errors at program creation time, and using the compiled regex pattern for all function
+// call invocations.
 var MatchesRegexOptimization = &RegexOptimization{
 	Function:   "matches",
 	RegexIndex: 1,
@@ -29,7 +32,7 @@ var MatchesRegexOptimization = &RegexOptimization{
 		if err != nil {
 			return nil, err
 		}
-		return NewCall(call.ID(), call.Function(), call.OverloadID(), call.Args(), 0, func(values ...ref.Val) ref.Val {
+		return NewCall(call.ID(), call.Function(), call.OverloadID(), call.Args(), func(values ...ref.Val) ref.Val {
 			if len(values) != 2 {
 				return types.NoSuchOverloadErr()
 			}


### PR DESCRIPTION
This provides a program option to inject an optimization (by way of a Interpretable factory) for any regex function.

A `matches` optimization is provided and enabled when `OptOptimize` is set.

unoptimized matches:

```
BenchmarkInterpreter/matches
BenchmarkInterpreter/matches-8  165296	      7135 ns/op	    5845 B/op	
```

optimized matches:
```
BenchmarkInterpreter/matches
BenchmarkInterpreter/matches-8  898917	      1413 ns/op	     210 B/op	
```