### PR TITLE
Add function name and result to CallCost and EstimatedCallCost

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -1438,7 +1438,7 @@ func (tc testCostEstimator) EstimateSize(element checker.AstNode) *checker.SizeE
 	return nil
 }
 
-func (tc testCostEstimator) EstimateCallCost(overloadID string, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
+func (tc testCostEstimator) EstimateCallCost(function, overloadID string, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
 	switch overloadID {
 	case overloads.TimestampToYear:
 		return &checker.CallEstimate{CostEstimate: checker.CostEstimate{Min: 7, Max: 7}}
@@ -1451,7 +1451,7 @@ type testRuntimeCostEstimator struct {
 
 var timeToYearCost uint64 = 7
 
-func (e testRuntimeCostEstimator) CallCost(overloadID string, args []ref.Val) *uint64 {
+func (e testRuntimeCostEstimator) CallCost(function, overloadID string, args []ref.Val, result ref.Val) *uint64 {
 	argsSize := make([]uint64, len(args))
 	for i, arg := range args {
 		reflectV := reflect.ValueOf(arg.Value())

--- a/checker/cost_test.go
+++ b/checker/cost_test.go
@@ -411,7 +411,7 @@ func (tc testCostEstimator) EstimateSize(element AstNode) *SizeEstimate {
 	return nil
 }
 
-func (tc testCostEstimator) EstimateCallCost(overloadID string, target *AstNode, args []AstNode) *CallEstimate {
+func (tc testCostEstimator) EstimateCallCost(function, overloadID string, target *AstNode, args []AstNode) *CallEstimate {
 	switch overloadID {
 	case overloads.TimestampToYear:
 		return &CallEstimate{CostEstimate: CostEstimate{Min: 7, Max: 7}}

--- a/interpreter/runtimecost_test.go
+++ b/interpreter/runtimecost_test.go
@@ -183,7 +183,7 @@ type testRuntimeCostEstimator struct {
 
 var timeToYearCost uint64 = 7
 
-func (e testRuntimeCostEstimator) CallCost(overloadID string, args []ref.Val) *uint64 {
+func (e testRuntimeCostEstimator) CallCost(function, overloadID string, args []ref.Val, result ref.Val) *uint64 {
 	argsSize := make([]uint64, len(args))
 	for i, arg := range args {
 		reflectV := reflect.ValueOf(arg.Value())
@@ -216,7 +216,7 @@ func (tc testCostEstimator) EstimateSize(element checker.AstNode) *checker.SizeE
 	return nil
 }
 
-func (tc testCostEstimator) EstimateCallCost(overloadID string, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
+func (tc testCostEstimator) EstimateCallCost(function, overloadID string, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
 	switch overloadID {
 	case overloads.TimestampToYear:
 		return &checker.CallEstimate{CostEstimate: checker.CostEstimate{Min: 7, Max: 7}}


### PR DESCRIPTION
This makes it much easier to calculate costs for functions where all the overloads use the same calculation, and for functions where information about the result value (the size in particular) are useful for estimating the cost of the function call.

cc @TristonianJones 