### PR TITLE
Add nil check and fix costTracker in contextEval 

### DIFF
--- a/cel/program.go
+++ b/cel/program.go
@@ -293,6 +293,9 @@ func (p *prog) Eval(input interface{}) (v ref.Val, det *EvalDetails, err error) 
 
 // ContextEval implements the Program interface.
 func (p *prog) ContextEval(ctx context.Context, input interface{}) (ref.Val, *EvalDetails, error) {
+	if ctx == nil {
+		return nil, nil, fmt.Errorf("context can not be nil")
+	}
 	// Configure the input, making sure to wrap Activation inputs in the special ctxActivation which
 	// exposes the #interrupted variable and manages rate-limited checks of the ctx.Done() state.
 	var vars interpreter.Activation
@@ -362,6 +365,9 @@ func (gen *progGen) Eval(input interface{}) (ref.Val, *EvalDetails, error) {
 
 // ContextEval implements the Program interface method.
 func (gen *progGen) ContextEval(ctx context.Context, input interface{}) (ref.Val, *EvalDetails, error) {
+	if ctx == nil {
+		return nil, nil, fmt.Errorf("context can not be nil")
+	}
 	// The factory based Eval() differs from the standard evaluation model in that it generates a
 	// new EvalState instance for each call to ensure that unique evaluations yield unique stateful
 	// results.

--- a/cel/program.go
+++ b/cel/program.go
@@ -372,12 +372,13 @@ func (gen *progGen) ContextEval(ctx context.Context, input interface{}) (ref.Val
 	// new EvalState instance for each call to ensure that unique evaluations yield unique stateful
 	// results.
 	state := interpreter.NewEvalState()
-	det := &EvalDetails{state: state}
+	costTracker := &interpreter.CostTracker{}
+	det := &EvalDetails{state: state, costTracker: costTracker}
 
 	// Generate a new instance of the interpretable using the factory configured during the call to
 	// newProgram(). It is incredibly unlikely that the factory call will generate an error given
 	// the factory test performed within the Program() call.
-	p, err := gen.factory(state, &interpreter.CostTracker{})
+	p, err := gen.factory(state, costTracker)
 	if err != nil {
 		return nil, det, err
 	}


### PR DESCRIPTION
Return proper err for nil context when ContextEval be called.