### PR TITLE
Fixes for map and list indexing across numeric types

### DIFF
--- a/common/types/json_list_test.go
+++ b/common/types/json_list_test.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"math"
 	"reflect"
 	"testing"
 
@@ -200,8 +201,15 @@ func TestJsonListValueGet_OutOfRange(t *testing.T) {
 	if !IsError(list.Get(Int(2))) {
 		t.Error("Index out of range did not result in error.")
 	}
-	if !IsError(list.Get(Uint(1))) {
-		t.Error("Index of incorrect type did not result in error.")
+	if !IsError(list.Get(String("1"))) {
+		t.Error("Invalid index type did not return error.")
+	}
+	if !IsError(list.Get(Uint(math.MaxUint64))) {
+		t.Error("Index out of range did not return error.")
+	}
+	got := list.Get(Uint(1))
+	if got.Equal(Double(1)) != True {
+		t.Errorf("list.Get(1u) got %v, wanted 1.0", got)
 	}
 }
 

--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -387,9 +387,9 @@ func TestConcatListGet(t *testing.T) {
 	listA := NewDynamicList(reg, []float32{1.0, 2.0})
 	listB := NewDynamicList(reg, []float64{3.0})
 	list := listA.Add(listB).(traits.Lister)
-	if getElem(t, list, 0) != Double(1.0) ||
-		getElem(t, list, 1) != Double(2.0) ||
-		getElem(t, list, 2) != Double(3.0) {
+	if getElem(t, list, Int(0)) != Double(1.0) ||
+		getElem(t, list, Uint(1)) != Double(2.0) ||
+		getElem(t, list, Double(2.0)) != Double(3.0) {
 		t.Errorf("List values by index did not match expectations")
 	}
 	if val := list.Get(Int(-1)); !IsError(val) {
@@ -556,7 +556,10 @@ func TestStringListGet_OutOfRange(t *testing.T) {
 	if !IsError(list.Get(Int(2))) {
 		t.Error("Index out of range did not return error.")
 	}
-	if !IsError(list.Get(Uint(1))) {
+	if !IsError(list.Get(Double(0.9))) {
+		t.Error("Index out of range did not return error.")
+	}
+	if !IsError(list.Get(String("1"))) {
 		t.Error("Invalid index type did not return error.")
 	}
 }
@@ -596,7 +599,7 @@ func TestValueListConvertToNative_Json(t *testing.T) {
 	}
 }
 
-func getElem(t *testing.T, list traits.Indexer, index Int) interface{} {
+func getElem(t *testing.T, list traits.Indexer, index ref.Val) interface{} {
 	t.Helper()
 	val := list.Get(index)
 	if IsError(val) {
@@ -608,9 +611,9 @@ func getElem(t *testing.T, list traits.Indexer, index Int) interface{} {
 
 func validateList123(t *testing.T, list traits.Lister) {
 	t.Helper()
-	if getElem(t, list, 0) != Int(1) ||
-		getElem(t, list, 1) != Int(2) ||
-		getElem(t, list, 2) != Int(3) {
+	if getElem(t, list, Int(0)) != Int(1) ||
+		getElem(t, list, Uint(1)) != Int(2) ||
+		getElem(t, list, Double(2.0)) != Int(3) {
 		t.Errorf("List values by index did not match expectations")
 	}
 	if val := list.Get(Int(-1)); !IsError(val) {

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -429,7 +429,7 @@ func (a *refValMapAccessor) Find(key ref.Val) (ref.Val, bool) {
 	case Double:
 		if ik, ok := doubleToInt64Lossless(float64(k)); ok {
 			if keyVal, found := a.mapVal[Int(ik)]; found {
-				return keyVal, true
+				return keyVal, found
 			}
 		}
 		if uk, ok := doubleToUint64Lossless(float64(k)); ok {

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -637,6 +637,8 @@ func newQualifier(adapter ref.TypeAdapter, id int64, v interface{}) (Qualifier, 
 		qual = &uintQualifier{id: id, value: uint64(val), celValue: val, adapter: adapter}
 	case types.Bool:
 		qual = &boolQualifier{id: id, value: bool(val), celValue: val, adapter: adapter}
+	case types.Double:
+		qual = &doubleQualifier{id: id, value: float64(val), celValue: val, adapter: adapter}
 	default:
 		return nil, fmt.Errorf("invalid qualifier type: %T", v)
 	}

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -70,6 +70,11 @@ type testCase struct {
 var (
 	testData = []testCase{
 		{
+			name: "double_ne_nan",
+			expr: `0.0/0.0 == 0.0/0.0`,
+			out:  types.False,
+		},
+		{
 			name:           "and_false_1st",
 			expr:           `false && true`,
 			cost:           []int64{0, 1},
@@ -554,6 +559,10 @@ var (
 			in: map[string]interface{}{
 				"x": 1.0,
 			},
+		},
+		{
+			name: "index_cross_type_double_const",
+			expr: `{1: 'hello', 2: 'world'}[dyn(2.0)] == 'world'`,
 		},
 		{
 			name: "index_cross_type_uint",


### PR DESCRIPTION
Support indexing across types with constant double values as indices into maps, as well as doubles and uints into lists.

These were edge cases discovered during the creation of new conformance tests.