### PR TITLE
Fix formatting and spelling lint

### DIFF
--- a/cel/env.go
+++ b/cel/env.go
@@ -56,7 +56,7 @@ func (ast *Ast) IsChecked() bool {
 	return ast.typeMap != nil && len(ast.typeMap) > 0
 }
 
-// SourceInfo returns character offset and newling position information about expression elements.
+// SourceInfo returns character offset and newline position information about expression elements.
 func (ast *Ast) SourceInfo() *exprpb.SourceInfo {
 	return ast.info
 }

--- a/cel/library.go
+++ b/cel/library.go
@@ -20,14 +20,14 @@ import (
 	"github.com/google/cel-go/parser"
 )
 
-// Library provides a collection of EnvOption and ProgramOption values used to confiugre a CEL
+// Library provides a collection of EnvOption and ProgramOption values used to configure a CEL
 // environment for a particular use case or with a related set of functionality.
 //
 // Note, the ProgramOption values provided by a library are expected to be static and not vary
 // between calls to Env.Program(). If there is a need for such dynamic configuration, prefer to
 // configure these options outside the Library and within the Env.Program() call directly.
 type Library interface {
-	// CompileOptions returns a collection of funcitional options for configuring the Parse / Check
+	// CompileOptions returns a collection of functional options for configuring the Parse / Check
 	// environment.
 	CompileOptions() []EnvOption
 

--- a/cel/program.go
+++ b/cel/program.go
@@ -49,7 +49,7 @@ type Program interface {
 	// to support cancellation and timeouts. This method must be used in conjunction with the
 	// InterruptCheckFrequency() option for cancellation interrupts to be impact evaluation.
 	//
-	// The vars value may eitehr be an `interpreter.Activation` or `map[string]interface{}`.
+	// The vars value may either be an `interpreter.Activation` or `map[string]interface{}`.
 	//
 	// The output contract for `ContextEval` is otherwise identical to the `Eval` method.
 	ContextEval(context.Context, interface{}) (ref.Val, *EvalDetails, error)

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -208,7 +208,7 @@ func (c *checker) checkSelect(e *exprpb.Expr) {
 			resultType = fieldType.Type
 		}
 	case kindTypeParam:
-		// Set the operand type to DYN to prevent assignment to a potentionally incorrect type
+		// Set the operand type to DYN to prevent assignment to a potentially incorrect type
 		// at a later point in type-checking. The isAssignable call will update the type
 		// substitutions for the type param under the covers.
 		c.isAssignable(decls.Dyn, targetType)
@@ -478,7 +478,7 @@ func (c *checker) checkComprehension(e *exprpb.Expr) {
 		// Ranges over the keys.
 		varType = rangeType.GetMapType().KeyType
 	case kindDyn, kindError, kindTypeParam:
-		// Set the range type to DYN to prevent assignment to a potentionally incorrect type
+		// Set the range type to DYN to prevent assignment to a potentially incorrect type
 		// at a later point in type-checking. The isAssignable call will update the type
 		// substitutions for the type param under the covers.
 		c.isAssignable(decls.Dyn, rangeType)

--- a/checker/cost.go
+++ b/checker/cost.go
@@ -121,7 +121,7 @@ type SizeEstimate struct {
 }
 
 // Add adds to another SizeEstimate and returns the sum.
-// If add would result in an uint64 overflow, the result is Maxuint64.
+// If add would result in an uint64 overflow, the result is math.MaxUint64.
 func (se SizeEstimate) Add(sizeEstimate SizeEstimate) SizeEstimate {
 	return SizeEstimate{
 		addUint64NoOverflow(se.Min, sizeEstimate.Min),
@@ -130,7 +130,7 @@ func (se SizeEstimate) Add(sizeEstimate SizeEstimate) SizeEstimate {
 }
 
 // Multiply multiplies by another SizeEstimate and returns the product.
-// If multiply would result in an uint64 overflow, the result is Maxuint64.
+// If multiply would result in an uint64 overflow, the result is math.MaxUint64.
 func (se SizeEstimate) Multiply(sizeEstimate SizeEstimate) SizeEstimate {
 	return SizeEstimate{
 		multiplyUint64NoOverflow(se.Min, sizeEstimate.Min),
@@ -148,7 +148,7 @@ func (se SizeEstimate) MultiplyByCostFactor(costPerUnit float64) CostEstimate {
 }
 
 // MultiplyByCost multiplies by the cost and returns the product.
-// If multiply would result in an uint64 overflow, the result is Maxuint64.
+// If multiply would result in an uint64 overflow, the result is math.MaxUint64.
 func (se SizeEstimate) MultiplyByCost(cost CostEstimate) CostEstimate {
 	return CostEstimate{
 		multiplyUint64NoOverflow(se.Min, cost.Min),
@@ -175,7 +175,7 @@ type CostEstimate struct {
 }
 
 // Add adds the costs and returns the sum.
-// If add would result in an uint64 overflow for the min or max, the value is set to Maxuint64.
+// If add would result in an uint64 overflow for the min or max, the value is set to math.MaxUint64.
 func (ce CostEstimate) Add(cost CostEstimate) CostEstimate {
 	return CostEstimate{
 		addUint64NoOverflow(ce.Min, cost.Min),
@@ -184,7 +184,7 @@ func (ce CostEstimate) Add(cost CostEstimate) CostEstimate {
 }
 
 // Multiply multiplies by the cost and returns the product.
-// If multiply would result in an uint64 overflow, the result is Maxuint64.
+// If multiply would result in an uint64 overflow, the result is math.MaxUint64.
 func (ce CostEstimate) Multiply(cost CostEstimate) CostEstimate {
 	return CostEstimate{
 		multiplyUint64NoOverflow(ce.Min, cost.Min),

--- a/checker/decls/scopes.go
+++ b/checker/decls/scopes.go
@@ -100,7 +100,7 @@ func (s *Scopes) FindFunction(name string) *exprpb.Decl {
 }
 
 // Group is a set of Decls that is pushed on or popped off a Scopes as a unit.
-// Contains separate namespaces for idenifier and function Decls.
+// Contains separate namespaces for identifier and function Decls.
 // (Should be named "Scope" perhaps?)
 type Group struct {
 	idents    map[string]*exprpb.Decl

--- a/common/location.go
+++ b/common/location.go
@@ -27,7 +27,7 @@ type SourceLocation struct {
 }
 
 var (
-	// Location implements the SourcceLocation interface.
+	// Location implements the SourceLocation interface.
 	_ Location = &SourceLocation{}
 	// NoLocation is a particular illegal location.
 	NoLocation = &SourceLocation{-1, -1}

--- a/common/operators/operators.go
+++ b/common/operators/operators.go
@@ -14,7 +14,7 @@
 
 // Package operators defines the internal function names of operators.
 //
-// ALl operators in the expression language are modelled as function calls.
+// All operators in the expression language are modelled as function calls.
 package operators
 
 // String "names" for CEL operators.

--- a/common/source_test.go
+++ b/common/source_test.go
@@ -75,7 +75,7 @@ func TestStringSource_LocationOffset(t *testing.T) {
 	// expected.
 	charStart, _ := source.LocationOffset(NewLocation(1, 2))
 	charEnd, _ := source.LocationOffset(NewLocation(3, 2))
-	if "d &&\n\t b.c.arg(10) &&\n\t " != string(contents[charStart:charEnd]) {
+	if string(contents[charStart:charEnd]) != "d &&\n\t b.c.arg(10) &&\n\t " {
 		t.Errorf(unexpectedValue, t.Name(),
 			string(contents[charStart:charEnd]),
 			"d &&\n\t b.c.arg(10) &&\n\t ")
@@ -125,9 +125,9 @@ func TestStringSource_SnippetSingleline(t *testing.T) {
 		t.Errorf(unexpectedSnippet, t.Name(), str, "hello, world")
 	}
 	if str2, found := source.Snippet(2); found {
-		t.Error(snippetFound, t.Name(), 2)
+		t.Errorf(snippetFound, t.Name(), 2)
 	} else if str2 != "" {
-		t.Error(unexpectedSnippet, t.Name(), str2, "")
+		t.Errorf(unexpectedSnippet, t.Name(), str2, "")
 	}
 }
 

--- a/common/types/bytes.go
+++ b/common/types/bytes.go
@@ -53,7 +53,7 @@ func (b Bytes) Add(other ref.Val) ref.Val {
 	return append(b, otherBytes...)
 }
 
-// Compare implments traits.Comparer interface method by lexicographic ordering.
+// Compare implements traits.Comparer interface method by lexicographic ordering.
 func (b Bytes) Compare(other ref.Val) ref.Val {
 	otherBytes, ok := other.(Bytes)
 	if !ok {

--- a/common/types/list.go
+++ b/common/types/list.go
@@ -321,7 +321,7 @@ func (l *concatList) Add(other ref.Val) ref.Val {
 		nextList:    otherList}
 }
 
-// Contains implments the traits.Container interface method.
+// Contains implements the traits.Container interface method.
 func (l *concatList) Contains(elem ref.Val) ref.Val {
 	// The concat list relies on the IsErrorOrUnknown checks against the input element to be
 	// performed by the `prevList` and/or `nextList`.

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -105,7 +105,7 @@ var (
 // This interface implements portions of the API surface area required by the traits.Mapper
 // interface.
 type mapAccessor interface {
-	// Find returns a value, if one exists, for the inpput key.
+	// Find returns a value, if one exists, for the input key.
 	//
 	// If the key is not found the function returns (nil, false).
 	Find(ref.Val) (ref.Val, bool)

--- a/common/types/overflow.go
+++ b/common/types/overflow.go
@@ -316,7 +316,7 @@ func doubleToUint64Checked(v float64) (uint64, error) {
 	return uint64(v), nil
 }
 
-// int64toUint64Checked converts an int64 to a uint64 value.
+// int64ToUint64Checked converts an int64 to a uint64 value.
 //
 // If the conversion fails due to overflow the error return value will be non-nil.
 func int64ToUint64Checked(v int64) (uint64, error) {
@@ -326,7 +326,7 @@ func int64ToUint64Checked(v int64) (uint64, error) {
 	return uint64(v), nil
 }
 
-// int64toInt32Checked converts an int64 to an int32 value.
+// int64ToInt32Checked converts an int64 to an int32 value.
 //
 // If the conversion fails due to overflow the error return value will be non-nil.
 func int64ToInt32Checked(v int64) (int32, error) {
@@ -336,7 +336,7 @@ func int64ToInt32Checked(v int64) (int32, error) {
 	return int32(v), nil
 }
 
-// uint64toUint32Checked converts a uint64 to a uint32 value.
+// uint64ToUint32Checked converts a uint64 to a uint32 value.
 //
 // If the conversion fails due to overflow the error return value will be non-nil.
 func uint64ToUint32Checked(v uint64) (uint32, error) {
@@ -346,7 +346,7 @@ func uint64ToUint32Checked(v uint64) (uint32, error) {
 	return uint32(v), nil
 }
 
-// uint64toInt64Checked converts a uint64 to an int64 value.
+// uint64ToInt64Checked converts a uint64 to an int64 value.
 //
 // If the conversion fails due to overflow the error return value will be non-nil.
 func uint64ToInt64Checked(v uint64) (int64, error) {

--- a/common/types/string.go
+++ b/common/types/string.go
@@ -167,7 +167,7 @@ func (s String) Match(pattern ref.Val) ref.Val {
 	return Bool(matched)
 }
 
-// Receive implements traits.Reciever.Receive.
+// Receive implements traits.Receiver.Receive.
 func (s String) Receive(function string, overload string, args []ref.Val) ref.Val {
 	switch len(args) {
 	case 1:

--- a/common/types/timestamp.go
+++ b/common/types/timestamp.go
@@ -138,7 +138,7 @@ func (t Timestamp) Equal(other ref.Val) ref.Val {
 	return Bool(ok && t.Time.Equal(otherTime.Time))
 }
 
-// Receive implements traits.Reciever.Receive.
+// Receive implements traits.Receiver.Receive.
 func (t Timestamp) Receive(function string, overload string, args []ref.Val) ref.Val {
 	switch len(args) {
 	case 0:

--- a/common/types/util.go
+++ b/common/types/util.go
@@ -18,7 +18,7 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 )
 
-// IsUnknownOrError returns whether the input element ref.Val is an ErrType or UnknonwType.
+// IsUnknownOrError returns whether the input element ref.Val is an ErrType or UnknownType.
 func IsUnknownOrError(val ref.Val) bool {
 	switch val.Type() {
 	case UnknownType, ErrType:

--- a/interpreter/attribute_patterns.go
+++ b/interpreter/attribute_patterns.go
@@ -105,7 +105,7 @@ func (apat *AttributePattern) QualifierPatterns() []*AttributeQualifierPattern {
 	return apat.qualifierPatterns
 }
 
-// AttributeQualifierPattern holds a wilcard or valued qualifier pattern.
+// AttributeQualifierPattern holds a wildcard or valued qualifier pattern.
 type AttributeQualifierPattern struct {
 	wildcard bool
 	value    interface{}
@@ -125,7 +125,7 @@ func (qpat *AttributeQualifierPattern) Matches(q Qualifier) bool {
 // type, is equal to the value held in the Qualifier. This interface is used by the
 // AttributeQualifierPattern to determine pattern matches for non-wildcard qualifier patterns.
 //
-// Note: Attribute values are also Qualifier values; however, Attriutes are resolved before
+// Note: Attribute values are also Qualifier values; however, Attributes are resolved before
 // qualification happens. This is an implementation detail, but one relevant to why the Attribute
 // types do not surface in the list of implementations.
 //
@@ -206,7 +206,7 @@ func (fac *partialAttributeFactory) AbsoluteAttribute(id int64, names ...string)
 }
 
 // MaybeAttribute implementation of the AttributeFactory interface which ensure that the set of
-// 'maybe' NamespacedAttribute values are produced using the PartialAttributeFactory rather than
+// 'maybe' NamespacedAttribute values are produced using the partialAttributeFactory rather than
 // the base AttributeFactory implementation.
 func (fac *partialAttributeFactory) MaybeAttribute(id int64, name string) Attribute {
 	return &maybeAttribute{

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -587,7 +587,7 @@ func (a *relativeAttribute) Resolve(vars Activation) (interface{}, error) {
 	if types.IsUnknown(v) {
 		return v, nil
 	}
-	// Next, qualify it. Qualification handles unkonwns as well, so there's no need to recheck.
+	// Next, qualify it. Qualification handles unknowns as well, so there's no need to recheck.
 	var err error
 	var obj interface{} = v
 	for _, qual := range a.qualifiers {

--- a/interpreter/decorators.go
+++ b/interpreter/decorators.go
@@ -98,7 +98,7 @@ func decDisableShortcircuits() InterpretableDecorator {
 }
 
 // decOptimize optimizes the program plan by looking for common evaluation patterns and
-// conditionally precomputating the result.
+// conditionally precomputing the result.
 // - build list and map values with constant elements.
 // - convert 'in' operations to set membership tests if possible.
 func decOptimize() InterpretableDecorator {

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -852,7 +852,7 @@ func (fold *evalFold) Cost() (min, max int64) {
 		iMax + aMax + cMax*rangeCnt + sMax*rangeCnt + rMax
 }
 
-// Optional Intepretable implementations that specialize, subsume, or extend the core evaluation
+// Optional Interpretable implementations that specialize, subsume, or extend the core evaluation
 // plan via decorators.
 
 // evalSetMembership is an Interpretable implementation which tests whether an input value
@@ -969,7 +969,7 @@ func (e *evalWatchConstQual) Qualify(vars Activation, obj interface{}) (interfac
 	return out, err
 }
 
-// QualifierValueEquals tests whether the incoming value is equal to the qualificying constant.
+// QualifierValueEquals tests whether the incoming value is equal to the qualifying constant.
 func (e *evalWatchConstQual) QualifierValueEquals(value interface{}) bool {
 	qve, ok := e.ConstantQualifier.(qualifierValueEquator)
 	return ok && qve.QualifierValueEquals(value)

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -162,7 +162,7 @@ type exprInterpreter struct {
 }
 
 // NewInterpreter builds an Interpreter from a Dispatcher and TypeProvider which will be used
-// throughout the Eval of all Interpretable instances gerenated from it.
+// throughout the Eval of all Interpretable instances generated from it.
 func NewInterpreter(dispatcher Dispatcher,
 	container *containers.Container,
 	provider ref.TypeProvider,

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -77,7 +77,7 @@ func newUncheckedPlanner(disp Dispatcher,
 	}
 }
 
-// planner is an implementatio of the interpretablePlanner interface.
+// planner is an implementation of the interpretablePlanner interface.
 type planner struct {
 	disp        Dispatcher
 	provider    ref.TypeProvider

--- a/interpreter/prune.go
+++ b/interpreter/prune.go
@@ -228,7 +228,7 @@ func (p *astPruner) prune(node *exprpb.Expr) (*exprpb.Expr, bool) {
 		}
 	}
 
-	// We have either an unknown/error value, or something we dont want to
+	// We have either an unknown/error value, or something we don't want to
 	// transform, or expression was not evaluated. If possible, drill down
 	// more.
 


### PR DESCRIPTION
<!--

# Pull Requests Guidelines

See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details about when to create
a GitHub [Pull Request][1] and when other kinds of contributions or
consultation might be more desirable.

When creating a new pull request, please fork the repo and work within a
development branch.

- [x] Read.

## Commit Messages

* Most changes should be accompanied by tests.
* Commit messages should explain _why_ the changes were made.
```
Summary of change in 50 characters or less

Background on why the change is being made with additional detail on
consequences of the changes elsewhere in the code or to the general
functionality of the library. Multiple paragraphs may be used, but
please keep lines to 72 characters or less.
```

- [x] Satisfied.

## Reviews

* Perform a self-review.
* Make sure the Travis CI build passes.
* Assign a reviewer once both the above have been completed.

- [x] Tests pass locally.

## Merging

* If a CEL maintaner approves the change, it may be merged by the author if
  they have write access. Otherwise, the change will be merged by a maintainer.
* Multiple commits should be squashed before merging.
* Please append the line `closes #<issue-num>: description` in the merge message,
  if applicable.

[1]:  https://help.github.com/articles/about-pull-requests

-->

This fixes a collection of spelling errors in user-facing and internal documentation and fixes a test-failing vet error (incorrect `*testing.T` method used), and fixes a style lint error.

There are also a bunch of non-fatal lint vet errors that are reasonably arguably false positive but which the Go team will not fix vet for (see https://github.com/golang/go/issues/49350). I am happy to send fixes for those here as well if wanted.

<details><pre>
# github.com/google/cel-go/codelab
codelab/codelab.go:60:2: fmt.Println arg list ends with redundant newline
codelab/codelab.go:70:2: fmt.Println arg list ends with redundant newline
codelab/codelab.go:85:2: fmt.Println arg list ends with redundant newline
codelab/codelab.go:95:2: fmt.Println arg list ends with redundant newline
codelab/codelab.go:104:2: fmt.Println arg list ends with redundant newline
codelab/codelab.go:115:2: fmt.Println arg list ends with redundant newline
codelab/codelab.go:126:2: fmt.Println arg list ends with redundant newline
codelab/codelab.go:140:2: fmt.Println arg list ends with redundant newline
# github.com/google/cel-go/codelab/solution
codelab/solution/codelab.go:60:2: fmt.Println arg list ends with redundant newline
codelab/solution/codelab.go:99:2: fmt.Println arg list ends with redundant newline
codelab/solution/codelab.go:132:2: fmt.Println arg list ends with redundant newline
codelab/solution/codelab.go:163:2: fmt.Println arg list ends with redundant newline
codelab/solution/codelab.go:219:2: fmt.Println arg list ends with redundant newline
codelab/solution/codelab.go:259:2: fmt.Println arg list ends with redundant newline
codelab/solution/codelab.go:328:2: fmt.Println arg list ends with redundant newline
codelab/solution/codelab.go:366:2: fmt.Println arg list ends with redundant newline
</pre></details>

Please take a look.