### PR TITLE
Use a zero-size type for variable-free activations

### DIFF
--- a/interpreter/activation.go
+++ b/interpreter/activation.go
@@ -35,12 +35,16 @@ type Activation interface {
 	Parent() Activation
 }
 
-// EmptyActivation returns a variable free activation.
+// EmptyActivation returns a variable-free activation.
 func EmptyActivation() Activation {
-	// This call cannot fail.
-	a, _ := NewActivation(map[string]interface{}{})
-	return a
+	return emptyActivation{}
 }
+
+// emptyActivation is a variable-free activation.
+type emptyActivation struct{}
+
+func (emptyActivation) ResolveName(string) (interface{}, bool) { return nil, false }
+func (emptyActivation) Parent() Activation                     { return nil }
 
 // NewActivation returns an activation based on a map-based binding where the map keys are
 // expected to be qualified names used with ResolveName calls.


### PR DESCRIPTION
<!--
# Pull Requests Guidelines

See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details about when to create
a GitHub [Pull Request][1] and when other kinds of contributions or
consultation might be more desirable.

When creating a new pull request, please fork the repo and work within a
development branch.

- [x] Read

## Commit Messages

* Most changes should be accompanied by tests.
* Commit messages should explain _why_ the changes were made.
```
Summary of change in 50 characters or less

Background on why the change is being made with additional detail on
consequences of the changes elsewhere in the code or to the general
functionality of the library. Multiple paragraphs may be used, but
please keep lines to 72 characters or less.
```

- [?] Hopefully satisfied.

## Reviews

* Perform a self-review.
* Make sure the Travis CI build passes.
* Assign a reviewer once both the above have been completed.

- [x] Passes locally.

## Merging

* If a CEL maintaner approves the change, it may be merged by the author if
  they have write access. Otherwise, the change will be merged by a maintainer.
* Multiple commits should be squashed before merging.
* Please append the line `closes #<issue-num>: description` in the merge message,
  if applicable.

[1]:  https://help.github.com/articles/about-pull-requests
-->

This is a minor allocation optimisation to reduce allocs for variable-free activations as it avoids the map allocations needed for the parameter to `interpreter.NewActivation` and for the returned `*mapActivation` from that function.

Please take a look.