### PR TITLE
Improve mutatable list documentation

### DIFF
--- a/common/types/list.go
+++ b/common/types/list.go
@@ -110,6 +110,17 @@ func NewMutableList(adapter ref.TypeAdapter) traits.MutableLister {
 	}
 }
 
+func (*mutableList) Contains(ref.Val) ref.Val { panic("invalid use of mutable list") }
+func (*mutableList) ConvertToNative(reflect.Type) (interface{}, error) {
+	panic("invalid use of mutable list")
+}
+func (*mutableList) ConvertToType(ref.Type) ref.Val { panic("invalid use of mutable list") }
+func (*mutableList) Equal(ref.Val) ref.Val          { panic("invalid use of mutable list") }
+func (*mutableList) Get(ref.Val) ref.Val            { panic("invalid use of mutable list") }
+func (*mutableList) Iterator() traits.Iterator      { panic("invalid use of mutable list") }
+func (*mutableList) Size() ref.Val                  { panic("invalid use of mutable list") }
+func (*mutableList) Value() interface{}             { panic("invalid use of mutable list") }
+
 // baseList points to a list containing elements of any type.
 // The `value` is an array of native values, and refValue is its reflection object.
 // The `ref.TypeAdapter` enables native type to CEL type conversions.
@@ -273,7 +284,6 @@ func (l *baseList) Value() interface{} {
 
 // mutableList aggregates values into its internal storage. For use with internal CEL variables only.
 type mutableList struct {
-	traits.Lister
 	ref.TypeAdapter
 	mutableValues []ref.Val
 }

--- a/common/types/traits/lister.go
+++ b/common/types/traits/lister.go
@@ -28,5 +28,6 @@ type Lister interface {
 
 // MutableLister interface which emits an immutable result after an intermediate computation.
 type MutableLister interface {
+	Lister
 	ToImmutableList() Lister
 }


### PR DESCRIPTION
<!--
# Pull Requests Guidelines

See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details about when to create
a GitHub [Pull Request][1] and when other kinds of contributions or
consultation might be more desirable.

When creating a new pull request, please fork the repo and work within a
development branch.

## Commit Messages

* Most changes should be accompanied by tests.
* Commit messages should explain _why_ the changes were made.
```
Summary of change in 50 characters or less

Background on why the change is being made with additional detail on
consequences of the changes elsewhere in the code or to the general
functionality of the library. Multiple paragraphs may be used, but
please keep lines to 72 characters or less.
```

- [x] Satisfied.

## Reviews

* Perform a self-review.
* Make sure the Travis CI build passes.
* Assign a reviewer once both the above have been completed.

- [x] Passes locally.

## Merging

* If a CEL maintaner approves the change, it may be merged by the author if
  they have write access. Otherwise, the change will be merged by a maintainer.
* Multiple commits should be squashed before merging.
* Please append the line `closes #<issue-num>: description` in the merge message,
  if applicable.

[1]:  https://help.github.com/articles/about-pull-requests
-->

This is a development of the change suggested at https://groups.google.com/g/cel-go-discuss/c/6sA9XhqVRek/m/-uB0yuAoIQAJ including documentation additions to clarify what uses are valid.

The first commit makes all non-valid calls panic via a nil-pointer deref and highlighted that there are calls to `.Type()` in the runtime, so that method was added.

The second commit improves the error reporting to the user at the cost of some stub methods; with this change, an invalid use is reported like:
```
2022/03/21 19:35:43 codelab.go:108: internal error: invalid use of mutable list
```
rather than with a runtime error:
```
2022/03/21 13:45:29 codelab.go:107: internal error: runtime error: invalid memory address or nil pointer 
```
making it easier for users to find the error and bug reports/discussion list queries simpler to handle.

I did start out implementing testing for the panic behaviour, but it got pretty contrived.

Please take a look.