### PR TITLE
Fix runtime cost ref.Val stack

### DIFF
--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -677,7 +677,15 @@ func (m *evalMap) Eval(ctx Activation) ref.Val {
 }
 
 func (m *evalMap) InitVals() []Interpretable {
-	return append(m.keys, m.vals...)
+	if len(m.keys) != len(m.vals) {
+		return nil
+	}
+	var result []Interpretable
+	for i, k := range m.keys {
+		v := m.vals[i]
+		result = append(result, k, v)
+	}
+	return result
 }
 
 func (m *evalMap) Type() ref.Type {

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -680,10 +680,14 @@ func (m *evalMap) InitVals() []Interpretable {
 	if len(m.keys) != len(m.vals) {
 		return nil
 	}
-	var result []Interpretable
+	result := make([]Interpretable, len(m.keys)+len(m.vals))
+	idx := 0
 	for i, k := range m.keys {
 		v := m.vals[i]
-		result = append(result, k, v)
+		result[idx] = k
+		idx++
+		result[idx] = v
+		idx++
 	}
 	return result
 }

--- a/interpreter/runtimecost.go
+++ b/interpreter/runtimecost.go
@@ -72,11 +72,11 @@ func CostObserver(tracker *CostTracker) EvalObserver {
 		case Qualifier:
 			tracker.cost++
 		case InterpretableCall:
-			if argVals, ok := tracker.stack.popArgs(t.Args()); ok {
+			if argVals, ok := tracker.stack.dropArgs(t.Args()); ok {
 				tracker.cost += tracker.costCall(t, argVals, val)
 			}
 		case InterpretableConstructor:
-			tracker.stack.popArgs(t.InitVals())
+			tracker.stack.dropArgs(t.InitVals())
 			switch t.Type() {
 			case types.ListType:
 				tracker.cost += common.ListCreateBaseCost
@@ -199,7 +199,7 @@ func (s *refValStack) push(val ref.Val, id int64) {
 	*s = append(*s, value)
 }
 
-// TODO: Allowing drop and popArgs to remove stack items above the IDs they are provided is a workaround. drop and popArgs
+// TODO: Allowing drop and dropArgs to remove stack items above the IDs they are provided is a workaround. drop and dropArgs
 // should find and remove only the stack items matching the provided IDs once all attributes are properly pushed and popped from stack.
 
 // drop searches the stack for each ID and removes the ID and all stack items above it.
@@ -217,13 +217,13 @@ func (s *refValStack) drop(ids ...int64) {
 	}
 }
 
-// popArgs searches the stack for all the args by their IDs, accumulates their associated ref.Vals and drops any
+// dropArgs searches the stack for all the args by their IDs, accumulates their associated ref.Vals and drops any
 // stack items above any of the arg IDs. If any of the IDs are not found the stack, false is returned.
 // Args are assumed to be found in the stack in reverse order, i.e. the last arg is expected to be found highest in
 // the stack.
 // WARNING: It is possible for multiple expressions with the same ID to exist (due to how macros are implemented) so it's
 // possible that a dropped ID will remain on the stack.  They should be removed when IDs on the stack are popped.
-func (s *refValStack) popArgs(args []Interpretable) ([]ref.Val, bool) {
+func (s *refValStack) dropArgs(args []Interpretable) ([]ref.Val, bool) {
 	result := make([]ref.Val, len(args))
 argloop:
 	for nIdx := len(args) - 1; nIdx >= 0; nIdx-- {


### PR DESCRIPTION
I discovered that the [stack](https://github.com/google/cel-go/blob/5e263d3f4e26e8fa248d52b2b02a41531ab89921/interpreter/runtimecost.go#L174) that I had introduced in https://github.com/google/cel-go/pull/494 as part of the introduction of runtime cost budgeting was not being managed correctly. Specifically, not all stack items pushed were being properly popped.

This PR fixes the stack by tracking the expression IDs associated with each stack value. The `pop` operations then specify the expression IDs of the stack items they wish to pop. If any spurious values are above the stack item being popped, they are removed from the stack as part of the `pop`.

This solves a bunch of problems and generally makes the stack much safer to use.

I have also improved the stack handling overall, which helps keep memory usage to a minimum. The only remaining case where I am certain that spurious stack items are left behind is the case where top-level variable lookup not being accounted for correctly.