### PR TITLE
Minor adjustment to type-tests to support custom Bool types

### DIFF
--- a/common/types/bool.go
+++ b/common/types/bool.go
@@ -131,9 +131,11 @@ func (b Bool) Value() interface{} {
 
 // IsBool returns whether the input ref.Val or ref.Type is equal to BoolType.
 func IsBool(elem ref.Val) bool {
-	switch elem.(type) {
+	switch v := elem.(type) {
 	case Bool:
 		return true
+	case ref.Val:
+		return v.Type() == BoolType
 	default:
 		return false
 	}


### PR DESCRIPTION
It looks like some teams have attempted to create their own custom `Bool` types
which means that the `types.IsBool` updates for performance would have broken
these users. Re-adding the fallback type test case. 

Note: The tests for `IsError`, `IsUnknown`, and `IsUnknownOrError` exclusively
use the CEL defined type for both error and unknown and users should not create
custom values derivations for these types.