### PR TITLE
Fix protobuf merge when types have different descriptor instances

### DIFF
--- a/common/types/pb/type.go
+++ b/common/types/pb/type.go
@@ -87,7 +87,7 @@ func (td *TypeDescription) FieldByName(name string) (*FieldDescription, bool) {
 // MaybeUnwrap accepts a proto message as input and unwraps it to a primitive CEL type if possible.
 //
 // This method returns the unwrapped value and 'true', else the original value and 'false'.
-func (td *TypeDescription) MaybeUnwrap(msg proto.Message) (interface{}, bool) {
+func (td *TypeDescription) MaybeUnwrap(msg proto.Message) (interface{}, bool, error) {
 	return unwrap(td, msg)
 }
 
@@ -248,8 +248,8 @@ func (fd *FieldDescription) GetFrom(target interface{}) (interface{}, error) {
 		return &Map{Map: fv, KeyType: fd.KeyType, ValueType: fd.ValueType}, nil
 	case protoreflect.Message:
 		// Make sure to unwrap well-known protobuf types before returning.
-		unwrapped, _ := fd.MaybeUnwrapDynamic(fv)
-		return unwrapped, nil
+		unwrapped, _, err := fd.MaybeUnwrapDynamic(fv)
+		return unwrapped, err
 	default:
 		return fv, nil
 	}
@@ -288,7 +288,7 @@ func (fd *FieldDescription) IsList() bool {
 //
 // This function returns the unwrapped value and 'true' on success, or the original value
 // and 'false' otherwise.
-func (fd *FieldDescription) MaybeUnwrapDynamic(msg protoreflect.Message) (interface{}, bool) {
+func (fd *FieldDescription) MaybeUnwrapDynamic(msg protoreflect.Message) (interface{}, bool, error) {
 	return unwrapDynamic(fd, msg)
 }
 
@@ -361,63 +361,63 @@ func checkedWrap(t *exprpb.Type) *exprpb.Type {
 // input message is a *dynamicpb.Message which obscures the typing information from Go.
 //
 // Returns the unwrapped value and 'true' if unwrapped, otherwise the input value and 'false'.
-func unwrap(desc description, msg proto.Message) (interface{}, bool) {
+func unwrap(desc description, msg proto.Message) (interface{}, bool, error) {
 	switch v := msg.(type) {
 	case *anypb.Any:
 		dynMsg, err := v.UnmarshalNew()
 		if err != nil {
-			return v, false
+			return v, false, err
 		}
 		return unwrapDynamic(desc, dynMsg.ProtoReflect())
 	case *dynamicpb.Message:
 		return unwrapDynamic(desc, v)
 	case *dpb.Duration:
-		return v.AsDuration(), true
+		return v.AsDuration(), true, nil
 	case *tpb.Timestamp:
-		return v.AsTime(), true
+		return v.AsTime(), true, nil
 	case *structpb.Value:
 		switch v.GetKind().(type) {
 		case *structpb.Value_BoolValue:
-			return v.GetBoolValue(), true
+			return v.GetBoolValue(), true, nil
 		case *structpb.Value_ListValue:
-			return v.GetListValue(), true
+			return v.GetListValue(), true, nil
 		case *structpb.Value_NullValue:
-			return structpb.NullValue_NULL_VALUE, true
+			return structpb.NullValue_NULL_VALUE, true, nil
 		case *structpb.Value_NumberValue:
-			return v.GetNumberValue(), true
+			return v.GetNumberValue(), true, nil
 		case *structpb.Value_StringValue:
-			return v.GetStringValue(), true
+			return v.GetStringValue(), true, nil
 		case *structpb.Value_StructValue:
-			return v.GetStructValue(), true
+			return v.GetStructValue(), true, nil
 		default:
-			return structpb.NullValue_NULL_VALUE, true
+			return structpb.NullValue_NULL_VALUE, true, nil
 		}
 	case *wrapperspb.BoolValue:
-		return v.GetValue(), true
+		return v.GetValue(), true, nil
 	case *wrapperspb.BytesValue:
-		return v.GetValue(), true
+		return v.GetValue(), true, nil
 	case *wrapperspb.DoubleValue:
-		return v.GetValue(), true
+		return v.GetValue(), true, nil
 	case *wrapperspb.FloatValue:
-		return float64(v.GetValue()), true
+		return float64(v.GetValue()), true, nil
 	case *wrapperspb.Int32Value:
-		return int64(v.GetValue()), true
+		return int64(v.GetValue()), true, nil
 	case *wrapperspb.Int64Value:
-		return v.GetValue(), true
+		return v.GetValue(), true, nil
 	case *wrapperspb.StringValue:
-		return v.GetValue(), true
+		return v.GetValue(), true, nil
 	case *wrapperspb.UInt32Value:
-		return uint64(v.GetValue()), true
+		return uint64(v.GetValue()), true, nil
 	case *wrapperspb.UInt64Value:
-		return v.GetValue(), true
+		return v.GetValue(), true, nil
 	}
-	return msg, false
+	return msg, false, nil
 }
 
 // unwrapDynamic unwraps a reflected protobuf Message value.
 //
 // Returns the unwrapped value and 'true' if unwrapped, otherwise the input value and 'false'.
-func unwrapDynamic(desc description, refMsg protoreflect.Message) (interface{}, bool) {
+func unwrapDynamic(desc description, refMsg protoreflect.Message) (interface{}, bool, error) {
 	msg := refMsg.Interface()
 	if !refMsg.IsValid() {
 		msg = desc.Zero()
@@ -432,18 +432,22 @@ func unwrapDynamic(desc description, refMsg protoreflect.Message) (interface{}, 
 		// unwrapped before being returned to the caller. Otherwise, the dynamic protobuf object
 		// represented by the Any will be returned.
 		unwrappedAny := &anypb.Any{}
-		proto.Merge(unwrappedAny, msg)
+		err := Merge(unwrappedAny, msg)
+		if err != nil {
+			return nil, false, err
+		}
 		dynMsg, err := unwrappedAny.UnmarshalNew()
 		if err != nil {
 			// Allow the error to move further up the stack as it should result in an type
 			// conversion error if the caller does not recover it somehow.
-			return unwrappedAny, true
+			return nil, false, err
 		}
 		// Attempt to unwrap the dynamic type, otherwise return the dynamic message.
-		if unwrapped, nested := unwrapDynamic(desc, dynMsg.ProtoReflect()); nested {
-			return unwrapped, true
+		unwrapped, nested, err := unwrapDynamic(desc, dynMsg.ProtoReflect())
+		if err == nil && nested {
+			return unwrapped, true, nil
 		}
-		return dynMsg, true
+		return dynMsg, true, err
 	case "google.protobuf.BoolValue",
 		"google.protobuf.BytesValue",
 		"google.protobuf.DoubleValue",
@@ -456,34 +460,49 @@ func unwrapDynamic(desc description, refMsg protoreflect.Message) (interface{}, 
 		// The msg value is ignored when dealing with wrapper types as they have a null or value
 		// behavior, rather than the standard zero value behavior of other proto message types.
 		if !refMsg.IsValid() {
-			return structpb.NullValue_NULL_VALUE, true
+			return structpb.NullValue_NULL_VALUE, true, nil
 		}
 		valueField := refMsg.Descriptor().Fields().ByName("value")
-		return refMsg.Get(valueField).Interface(), true
+		return refMsg.Get(valueField).Interface(), true, nil
 	case "google.protobuf.Duration":
 		unwrapped := &dpb.Duration{}
-		proto.Merge(unwrapped, msg)
-		return unwrapped.AsDuration(), true
+		err := Merge(unwrapped, msg)
+		if err != nil {
+			return nil, false, err
+		}
+		return unwrapped.AsDuration(), true, nil
 	case "google.protobuf.ListValue":
 		unwrapped := &structpb.ListValue{}
-		proto.Merge(unwrapped, msg)
-		return unwrapped, true
+		err := Merge(unwrapped, msg)
+		if err != nil {
+			return nil, false, err
+		}
+		return unwrapped, true, nil
 	case "google.protobuf.NullValue":
-		return structpb.NullValue_NULL_VALUE, true
+		return structpb.NullValue_NULL_VALUE, true, nil
 	case "google.protobuf.Struct":
 		unwrapped := &structpb.Struct{}
-		proto.Merge(unwrapped, msg)
-		return unwrapped, true
+		err := Merge(unwrapped, msg)
+		if err != nil {
+			return nil, false, err
+		}
+		return unwrapped, true, nil
 	case "google.protobuf.Timestamp":
 		unwrapped := &tpb.Timestamp{}
-		proto.Merge(unwrapped, msg)
-		return unwrapped.AsTime(), true
+		err := Merge(unwrapped, msg)
+		if err != nil {
+			return nil, false, err
+		}
+		return unwrapped.AsTime(), true, nil
 	case "google.protobuf.Value":
 		unwrapped := &structpb.Value{}
-		proto.Merge(unwrapped, msg)
+		err := Merge(unwrapped, msg)
+		if err != nil {
+			return nil, false, err
+		}
 		return unwrap(desc, unwrapped)
 	}
-	return msg, false
+	return msg, false, nil
 }
 
 // reflectTypeOf intercepts the reflect.Type call to ensure that dynamicpb.Message types preserve

--- a/common/types/pb/type_test.go
+++ b/common/types/pb/type_test.go
@@ -249,6 +249,7 @@ func TestTypeDescriptionMaybeUnwrap(t *testing.T) {
 	if !found {
 		t.Fatalf("pbdb.DescribeType(%q) not found", msgType)
 	}
+
 	tests := []struct {
 		in  proto.Message
 		out interface{}
@@ -368,7 +369,10 @@ func TestTypeDescriptionMaybeUnwrap(t *testing.T) {
 		if !found {
 			t.Fatalf("pbdb.DescribeType(%q) not found", typeName)
 		}
-		msg, unwrapped := td.MaybeUnwrap(tc.in)
+		msg, unwrapped, err := td.MaybeUnwrap(tc.in)
+		if err != nil {
+			t.Fatalf("MaybeUnwrap(%v) failed: %v", tc.in, err)
+		}
 		if !unwrapped {
 			t.Errorf("value %v not unwrapped", tc.in)
 		}

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -206,7 +206,10 @@ func (p *protoTypeRegistry) NativeToValue(value interface{}) ref.Val {
 		if !found {
 			return NewErr("unknown type: '%s'", typeName)
 		}
-		unwrapped, isUnwrapped := td.MaybeUnwrap(v)
+		unwrapped, isUnwrapped, err := td.MaybeUnwrap(v)
+		if err != nil {
+			return UnsupportedRefValConversionErr(v)
+		}
 		if isUnwrapped {
 			return p.NativeToValue(unwrapped)
 		}
@@ -394,7 +397,10 @@ func nativeToValue(a ref.TypeAdapter, value interface{}) (ref.Val, bool) {
 		if !found {
 			return nil, false
 		}
-		val, unwrapped := td.MaybeUnwrap(v)
+		val, unwrapped, err := td.MaybeUnwrap(v)
+		if err != nil {
+			return UnsupportedRefValConversionErr(v), true
+		}
 		if !unwrapped {
 			return nil, false
 		}


### PR DESCRIPTION
When two proto messages have different descriptor instances it's not possible
to merge from one proto to the other without raising a `panic`. The fallback strategy
is to merge using the `proto.Marshal` and `proto.Unmarshal` calls to serialize to bytes
first.

The existing `proto.Merge` semantics might benefit from relaxing their constraints,
but I can see how in some cases the merge result might be undefined.