### PR TITLE
Prevent clobbering vars maps provided by previous libs

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -667,9 +667,17 @@ func TestGlobalVars(t *testing.T) {
 			}})
 
 	// Global variables can be configured as a ProgramOption and optionally overridden on Eval.
-	prg, _ := e.Program(ast, funcs, Globals(map[string]interface{}{
-		"default": "third",
-	}))
+	// Add a previous globals map to confirm the order of shadowing and a final empty global
+	// map to show that globals are not clobbered.
+	prg, _ := e.Program(ast, funcs,
+		Globals(map[string]interface{}{
+			"default": "shadow me",
+		}),
+		Globals(map[string]interface{}{
+			"default": "third",
+		}),
+		Globals(map[string]interface{}{}),
+	)
 
 	t.Run("global_default", func(t *testing.T) {
 		vars := map[string]interface{}{

--- a/cel/options.go
+++ b/cel/options.go
@@ -342,7 +342,8 @@ func Functions(funcs ...*functions.Overload) ProgramOption {
 }
 
 // Globals sets the global variable values for a given program. These values may be shadowed by
-// variables with the same name provided to the Eval() call.
+// variables with the same name provided to the Eval() call. If Globals is used in a Library with
+// a Lib EnvOption, vars may shadow variables provided by previously added libraries.
 //
 // The vars value may either be an `interpreter.Activation` instance or a `map[string]interface{}`.
 func Globals(vars interface{}) ProgramOption {
@@ -350,6 +351,9 @@ func Globals(vars interface{}) ProgramOption {
 		defaultVars, err := interpreter.NewActivation(vars)
 		if err != nil {
 			return nil, err
+		}
+		if p.defaultVars != nil {
+			defaultVars = interpreter.NewHierarchicalActivation(p.defaultVars, defaultVars)
 		}
 		p.defaultVars = defaultVars
 		return p, nil


### PR DESCRIPTION
<!--
# Pull Requests Guidelines

See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details about when to create
a GitHub [Pull Request][1] and when other kinds of contributions or
consultation might be more desirable.

When creating a new pull request, please fork the repo and work within a
development branch.

## Commit Messages

* Most changes should be accompanied by tests.
* Commit messages should explain _why_ the changes were made.
```
Summary of change in 50 characters or less

Background on why the change is being made with additional detail on
consequences of the changes elsewhere in the code or to the general
functionality of the library. Multiple paragraphs may be used, but
please keep lines to 72 characters or less.
```

## Reviews

* Perform a self-review.
* Make sure the Travis CI build passes.
* Assign a reviewer once both the above have been completed.

## Merging

* If a CEL maintaner approves the change, it may be merged by the author if
  they have write access. Otherwise, the change will be merged by a maintainer.
* Multiple commits should be squashed before merging.
* Please append the line `closes #<issue-num>: description` in the merge message,
  if applicable.

[1]:  https://help.github.com/articles/about-pull-requests
-->

Before this, when a lib is loaded with a Globals program option it would replace any existing global var maps, preventing the previously set maps from being available.

Happy to change docs wording if needed.

Closes #527.

Please take a look.