### PR TITLE
Use gazelle-compatible repository name for antlr

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -99,11 +99,12 @@ go_repository(
     version = "v0.3.2",
 )
 
-# Antlr deps to pickup golang concurrency fixes 4/30/2020
+# Antlr deps
 go_repository(
-    name = "com_github_antlr",
-    commit = "621b933c7a7f01c67ae9de15103151fa0f9d6d90",
-    importpath = "github.com/antlr/antlr4",
+    name = "com_github_antlr_antlr4_runtime_go_antlr",
+    importpath = "github.com/antlr/antlr4/runtime/Go/antlr",
+    sum = "h1:zvkJv+9Pxm1nnEMcKnShREt4qtduHKz4iw4AB4ul0Ao=",
+    version = "v0.0.0-20220209173558-ad29539cd2e9",
 )
 
 # CEL Spec deps

--- a/checker/BUILD.bazel
+++ b/checker/BUILD.bazel
@@ -54,7 +54,7 @@ go_test(
         "//test:go_default_library",
         "//test/proto2pb:go_default_library",
         "//test/proto3pb:go_default_library",
-        "@com_github_antlr//runtime/Go/antlr:go_default_library",
+        "@com_github_antlr_antlr4_runtime_go_antlr//:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
     ],
 )

--- a/parser/BUILD.bazel
+++ b/parser/BUILD.bazel
@@ -23,7 +23,7 @@ go_library(
         "//common/operators:go_default_library",
         "//common/runes:go_default_library",
         "//parser/gen:go_default_library",
-        "@com_github_antlr//runtime/Go/antlr:go_default_library",
+        "@com_github_antlr_antlr4_runtime_go_antlr//:go_default_library",
         "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
         "@org_golang_google_protobuf//types/known/structpb:go_default_library",
@@ -45,7 +45,7 @@ go_test(
         "//common/debug:go_default_library",
         "//parser/gen:go_default_library",
         "//test:go_default_library",
-        "@com_github_antlr//runtime/Go/antlr:go_default_library",
+        "@com_github_antlr_antlr4_runtime_go_antlr//:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
     ],
 )

--- a/parser/gen/BUILD.bazel
+++ b/parser/gen/BUILD.bazel
@@ -21,6 +21,6 @@ go_library(
     ],
     importpath = "github.com/google/cel-go/parser/gen",
     deps = [
-        "@com_github_antlr//runtime/Go/antlr:go_default_library",
+        "@com_github_antlr_antlr4_runtime_go_antlr//:go_default_library",
     ],
 )


### PR DESCRIPTION
Currently the external Antlr repository is pulled in with a repository name incompatible with Gazelle. This is an issue when this project is used as part of a larger Bazel project managed by Gazelle. This changes the repository name to conform to Gazelle conventions. The version is also changed to the one from go.mod.