### PR TITLE
Omit large error strings

### DIFF
--- a/common/error.go
+++ b/common/error.go
@@ -31,6 +31,9 @@ type Error struct {
 const (
 	dot = "."
 	ind = "^"
+
+	// maxSnippetLength is the largest number of characters which can be rendered in an error message snippet.
+	maxSnippetLength = 16384
 )
 
 var (
@@ -45,7 +48,7 @@ func (e *Error) ToDisplayString(source Source) string {
 		e.Location.Line(),
 		e.Location.Column()+1, // add one to the 0-based column for display
 		e.Message)
-	if snippet, found := source.Snippet(e.Location.Line()); found {
+	if snippet, found := source.Snippet(e.Location.Line()); found && len(snippet) <= maxSnippetLength {
 		snippet := strings.Replace(snippet, "\t", " ", -1)
 		srcLine := "\n | " + snippet
 		var bytes = []byte(snippet)


### PR DESCRIPTION
Closes #536 which is produced when a large errant single-line string contains many errors and the rendering of the error string dominates execution time.