### PR TITLE
Fix the occurs check to prevent tagging types as substitutions for themselves

### DIFF
--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1856,6 +1856,58 @@ _&&_(_==_(list~type(list(dyn))^list,
 			)~bool^logical_and
 		  )~bool^logical_and`,
 	},
+	{
+		in:      `[1].map(x, [x, x]).map(x, [x, x])`,
+		outType: decls.NewListType(decls.NewListType(decls.NewListType(decls.Int))),
+		out: `__comprehension__(
+			// Variable
+			x,
+			// Target
+			__comprehension__(
+			  // Variable
+			  x,
+			  // Target
+			  [
+				1~int
+			  ]~list(int),
+			  // Accumulator
+			  __result__,
+			  // Init
+			  []~list(list(int)),
+			  // LoopCondition
+			  true~bool,
+			  // LoopStep
+			  _+_(
+				__result__~list(list(int))^__result__,
+				[
+				  [
+					x~int^x,
+					x~int^x
+				  ]~list(int)
+				]~list(list(int))
+			  )~list(list(int))^add_list,
+			  // Result
+			  __result__~list(list(int))^__result__)~list(list(int)),
+			// Accumulator
+			__result__,
+			// Init
+			[]~list(list(list(int))),
+			// LoopCondition
+			true~bool,
+			// LoopStep
+			_+_(
+			  __result__~list(list(list(int)))^__result__,
+			  [
+				[
+				  x~list(int)^x,
+				  x~list(int)^x
+				]~list(list(int))
+			  ]~list(list(list(int)))
+			)~list(list(list(int)))^add_list,
+			// Result
+			__result__~list(list(list(int)))^__result__)~list(list(list(int)))
+		  `,
+	},
 }
 
 var testEnvs = map[string]testEnv{

--- a/checker/types.go
+++ b/checker/types.go
@@ -238,9 +238,15 @@ func internalIsAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) bool {
 // - t2 has a type substitution (t2sub) assignable to t1
 // - t2 does not occur within t1.
 func isValidTypeSubstitution(m *mapping, t1, t2 *exprpb.Type) (valid, hasSub bool) {
+	// Early return if the t1 and t2 are the same instance.
+	kind1, kind2 := kindOf(t1), kindOf(t2)
+	if kind1 == kind2 && (t1 == t2 || proto.Equal(t1, t2)) {
+		return true, true
+	}
 	if t2Sub, found := m.find(t2); found {
-		kind1, kind2 := kindOf(t1), kindOf(t2)
-		if kind1 == kind2 && proto.Equal(t1, t2Sub) {
+		// Early return if t1 and t2Sub are the same instance as otherwise the mapping
+		// might mark a type as being a subtitution for itself.
+		if kind1 == kindOf(t2Sub) && (t1 == t2Sub || proto.Equal(t1, t2Sub)) {
 			return true, true
 		}
 		// If the types are compatible, pick the more general type and return true


### PR DESCRIPTION
There are two locations where a type parameter can get accidentally tagged as a substitution for itself. The original code caught one location, and the code since https://github.com/google/cel-go/releases/tag/v0.11.1 caught a different one. 

This change catches the problematic tagging at both locations, thus avoiding a stack overflow when a type is marked
as a substitution of itself.