### PR TITLE
Ensure the recursion depth is being checked during parser AST visit 

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1551,6 +1551,15 @@ var testCases = []testInfo{
 			a^#3:*expr.Expr_IdentExpr#.b^#4:*expr.Expr_SelectExpr#
 		  )^#5:has#`,
 	},
+	{
+		I: `y!=y!=y!=y!=y!=y!=y!=y!=y!=-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y
+		!=-y!=-y-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y
+		!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y!=-y
+		!=-y-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y
+		!=-y!=-y-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y
+		!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y!=-y!=-y-y!=-y`,
+		E: `ERROR: <input>:-1:0: max recursion depth exceeded`,
+	},
 }
 
 type testInfo struct {


### PR DESCRIPTION
Parser recursion limits were previously only being checked during ANTLR rule entry / exit,
but this does not adequately protect against the construction of deeply recursive ASTs.

The C++ implementation enforces recursion limiting during AST visit calls, and so Go now
will do the same.

Closes #541 