### PR TITLE
Add missing type specializations into the type-checker.

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -187,7 +187,7 @@ func (c *checker) checkSelect(e *exprpb.Expr) {
 
 	// Interpret as field selection, first traversing down the operand.
 	c.check(sel.Operand)
-	targetType := c.getType(sel.Operand)
+	targetType := substitute(c.mappings, c.getType(sel.Operand), false)
 	// Assume error type by default as most types do not support field selection.
 	resultType := decls.Error
 	switch kindOf(targetType) {
@@ -224,7 +224,7 @@ func (c *checker) checkSelect(e *exprpb.Expr) {
 	if sel.TestOnly {
 		resultType = decls.Bool
 	}
-	c.setType(e, resultType)
+	c.setType(e, substitute(c.mappings, resultType, false))
 }
 
 func (c *checker) checkCall(e *exprpb.Expr) {
@@ -472,7 +472,7 @@ func (c *checker) checkComprehension(e *exprpb.Expr) {
 	c.check(comp.IterRange)
 	c.check(comp.AccuInit)
 	accuType := c.getType(comp.AccuInit)
-	rangeType := c.getType(comp.IterRange)
+	rangeType := substitute(c.mappings, c.getType(comp.IterRange), false)
 	var varType *exprpb.Type
 
 	switch kindOf(rangeType) {

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1908,6 +1908,61 @@ _&&_(_==_(list~type(list(dyn))^list,
 			__result__~list(list(list(int)))^__result__)~list(list(list(int)))
 		  `,
 	},
+	{
+		in:      `values.filter(i, i.content != "").map(i, i.content)`,
+		outType: decls.NewListType(decls.String),
+		env: testEnv{
+			idents: []*exprpb.Decl{
+				decls.NewVar("values", decls.NewListType(decls.NewMapType(decls.String, decls.String))),
+			},
+		},
+		out: `__comprehension__(
+			// Variable
+			i,
+			// Target
+			__comprehension__(
+			  // Variable
+			  i,
+			  // Target
+			  values~list(map(string, string))^values,
+			  // Accumulator
+			  __result__,
+			  // Init
+			  []~list(map(string, string)),
+			  // LoopCondition
+			  true~bool,
+			  // LoopStep
+			  _?_:_(
+				_!=_(
+				  i~map(string, string)^i.content~string,
+				  ""~string
+				)~bool^not_equals,
+				_+_(
+				  __result__~list(map(string, string))^__result__,
+				  [
+					i~map(string, string)^i
+				  ]~list(map(string, string))
+				)~list(map(string, string))^add_list,
+				__result__~list(map(string, string))^__result__
+			  )~list(map(string, string))^conditional,
+			  // Result
+			  __result__~list(map(string, string))^__result__)~list(map(string, string)),
+			// Accumulator
+			__result__,
+			// Init
+			[]~list(string),
+			// LoopCondition
+			true~bool,
+			// LoopStep
+			_+_(
+			  __result__~list(string)^__result__,
+			  [
+				i~map(string, string)^i.content~string
+			  ]~list(string)
+			)~list(string)^add_list,
+			// Result
+			__result__~list(string)^__result__)~list(string)`,
+	},
 }
 
 var testEnvs = map[string]testEnv{

--- a/test/compare.go
+++ b/test/compare.go
@@ -22,18 +22,18 @@ import (
 // Compare compares two strings, a for actual, e for expected, and returns true or false. The comparison is done,
 // by filtering out whitespace (i.e. space, tabs and newline).
 func Compare(a string, e string) bool {
-	a = strings.Replace(a, " ", "", -1)
-	a = strings.Replace(a, "\n", "", -1)
-	a = strings.Replace(a, "\t", "", -1)
-
-	e = strings.Replace(e, " ", "", -1)
-	e = strings.Replace(e, "\n", "", -1)
-	e = strings.Replace(e, "\t", "", -1)
-
-	return a == e
+	return stripWhitespace(a) == stripWhitespace(e)
 }
 
 // DiffMessage creates a diff dump message for test failures.
 func DiffMessage(context string, actual interface{}, expected interface{}) string {
-	return fmt.Sprintf("%s: \ngot %q, \nwanted %q", context, actual, expected)
+	return fmt.Sprintf("%s: \ngot %q, \nwanted %q",
+		context, stripWhitespace(actual.(string)), stripWhitespace(expected.(string)))
+}
+
+func stripWhitespace(a string) string {
+	a = strings.Replace(a, " ", "", -1)
+	a = strings.Replace(a, "\n", "", -1)
+	a = strings.Replace(a, "\t", "", -1)
+	return strings.Replace(a, "\r", "", -1)
 }


### PR DESCRIPTION
There were a couple of places where type-specializations were present within Java which
were not present within Go. The locations have been updated to ensure that when a type
variable is known (has been resolved) for a select operand, comprehension range, or
comprehension result, that the appropriate type is used.
