### PR TITLE
Ensure that type substitutions consistently perform the 'occurs' check.

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -469,18 +469,18 @@ func (c *checker) checkCreateMessage(e *exprpb.Expr) {
 
 func (c *checker) checkComprehension(e *exprpb.Expr) {
 	comp := e.GetComprehensionExpr()
-	c.check(comp.IterRange)
-	c.check(comp.AccuInit)
-	accuType := c.getType(comp.AccuInit)
-	rangeType := substitute(c.mappings, c.getType(comp.IterRange), false)
+	c.check(comp.GetIterRange())
+	c.check(comp.GetAccuInit())
+	accuType := c.getType(comp.GetAccuInit())
+	rangeType := substitute(c.mappings, c.getType(comp.GetIterRange()), false)
 	var varType *exprpb.Type
 
 	switch kindOf(rangeType) {
 	case kindList:
-		varType = rangeType.GetListType().ElemType
+		varType = rangeType.GetListType().GetElemType()
 	case kindMap:
 		// Ranges over the keys.
-		varType = rangeType.GetMapType().KeyType
+		varType = rangeType.GetMapType().GetKeyType()
 	case kindDyn, kindError, kindTypeParam:
 		// Set the range type to DYN to prevent assignment to a potentially incorrect type
 		// at a later point in type-checking. The isAssignable call will update the type
@@ -489,28 +489,28 @@ func (c *checker) checkComprehension(e *exprpb.Expr) {
 		// Set the range iteration variable to type DYN as well.
 		varType = decls.Dyn
 	default:
-		c.errors.notAComprehensionRange(c.location(comp.IterRange), rangeType)
+		c.errors.notAComprehensionRange(c.location(comp.GetIterRange()), rangeType)
 		varType = decls.Error
 	}
 
 	// Create a scope for the comprehension since it has a local accumulation variable.
 	// This scope will contain the accumulation variable used to compute the result.
 	c.env = c.env.enterScope()
-	c.env.Add(decls.NewVar(comp.AccuVar, accuType))
+	c.env.Add(decls.NewVar(comp.GetAccuVar(), accuType))
 	// Create a block scope for the loop.
 	c.env = c.env.enterScope()
-	c.env.Add(decls.NewVar(comp.IterVar, varType))
+	c.env.Add(decls.NewVar(comp.GetIterVar(), varType))
 	// Check the variable references in the condition and step.
-	c.check(comp.LoopCondition)
-	c.assertType(comp.LoopCondition, decls.Bool)
-	c.check(comp.LoopStep)
-	c.assertType(comp.LoopStep, accuType)
+	c.check(comp.GetLoopCondition())
+	c.assertType(comp.GetLoopCondition(), decls.Bool)
+	c.check(comp.GetLoopStep())
+	c.assertType(comp.GetLoopStep(), accuType)
 	// Exit the loop's block scope before checking the result.
 	c.env = c.env.exitScope()
-	c.check(comp.Result)
+	c.check(comp.GetResult())
 	// Exit the comprehension scope.
 	c.env = c.env.exitScope()
-	c.setType(e, c.getType(comp.Result))
+	c.setType(e, substitute(c.mappings, c.getType(comp.GetResult()), false))
 }
 
 // Checks compatibility of joined types, and returns the most general common type.

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1397,7 +1397,7 @@ _&&_(_==_(list~type(list(dyn))^list,
 	{
 		in: `[].map(x, [].map(y, x in y && y in x))`,
 		err: `
-		ERROR: <input>:1:33: found no matching overload for '@in' applied to '(type_param:"_var2" , type_param:"_var0" )'
+		ERROR: <input>:1:33: found no matching overload for '@in' applied to '(_var2, _var0)'
 		| [].map(x, [].map(y, x in y && y in x))
 		| ................................^`,
 	},
@@ -1962,6 +1962,64 @@ _&&_(_==_(list~type(list(dyn))^list,
 			)~list(string)^add_list,
 			// Result
 			__result__~list(string)^__result__)~list(string)`,
+	},
+	{
+		in:      `[{}.map(c,c,c)]+[{}.map(c,c,c)]`,
+		outType: decls.NewListType(decls.NewListType(decls.Bool)),
+		out: `_+_(
+			[
+			  __comprehension__(
+				// Variable
+				c,
+				// Target
+				{}~map(bool, dyn),
+				// Accumulator
+				__result__,
+				// Init
+				[]~list(bool),
+				// LoopCondition
+				true~bool,
+				// LoopStep
+				_?_:_(
+				  c~bool^c,
+				  _+_(
+					__result__~list(bool)^__result__,
+					[
+					  c~bool^c
+					]~list(bool)
+				  )~list(bool)^add_list,
+				  __result__~list(bool)^__result__
+				)~list(bool)^conditional,
+				// Result
+				__result__~list(bool)^__result__)~list(bool)
+			]~list(list(bool)),
+			[
+			  __comprehension__(
+				// Variable
+				c,
+				// Target
+				{}~map(bool, dyn),
+				// Accumulator
+				__result__,
+				// Init
+				[]~list(bool),
+				// LoopCondition
+				true~bool,
+				// LoopStep
+				_?_:_(
+				  c~bool^c,
+				  _+_(
+					__result__~list(bool)^__result__,
+					[
+					  c~bool^c
+					]~list(bool)
+				  )~list(bool)^add_list,
+				  __result__~list(bool)^__result__
+				)~list(bool)^conditional,
+				// Result
+				__result__~list(bool)^__result__)~list(bool)
+			]~list(list(bool))
+		  )~list(list(bool))^add_list`,
 	},
 }
 

--- a/test/compare.go
+++ b/test/compare.go
@@ -27,8 +27,7 @@ func Compare(a string, e string) bool {
 
 // DiffMessage creates a diff dump message for test failures.
 func DiffMessage(context string, actual interface{}, expected interface{}) string {
-	return fmt.Sprintf("%s: \ngot %q, \nwanted %q",
-		context, stripWhitespace(actual.(string)), stripWhitespace(expected.(string)))
+	return fmt.Sprintf("%s: \ngot %v, \nwanted %v", context, actual, expected)
 }
 
 func stripWhitespace(a string) string {


### PR DESCRIPTION
In a limited number of circumstances, it's possible for CEL to attempt to widen a type substitution to more general type which happens to occur within the target type. This check ensures that the type-agreement is acknowledged, but that cyclic type references are not created.

The following expression is problematic with the current type-checker: `[{}.map(c,c,c)]+[{}.map(c,c,c)]` as it will loop infinitely and result in a stack overflow. 

This change ensures that the 'occurs' check is consistently performed before type substitutions are recorded.