### PR TITLE
Ensure that the CheckedType is populated for group fields

### DIFF
--- a/cel/options.go
+++ b/cel/options.go
@@ -442,7 +442,7 @@ func CostLimit(costLimit uint64) ProgramOption {
 }
 
 func fieldToCELType(field protoreflect.FieldDescriptor) (*exprpb.Type, error) {
-	if field.Kind() == protoreflect.MessageKind {
+	if field.Kind() == protoreflect.MessageKind || field.Kind() == protoreflect.GroupKind {
 		msgName := (string)(field.Message().FullName())
 		wellKnownType, found := pb.CheckedWellKnowns[msgName]
 		if found {

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -2021,6 +2021,21 @@ _&&_(_==_(list~type(list(dyn))^list,
 			]~list(list(bool))
 		  )~list(list(bool))^add_list`,
 	},
+	{
+		in: "type(testAllTypes.nestedgroup.nested_id) == int",
+		env: testEnv{
+			idents: []*exprpb.Decl{
+				decls.NewVar("testAllTypes", decls.NewObjectType("google.expr.proto2.test.TestAllTypes")),
+			},
+		},
+		outType: decls.Bool,
+		out: `_==_(
+			type(
+			  testAllTypes~google.expr.proto2.test.TestAllTypes^testAllTypes.nestedgroup~google.expr.proto2.test.TestAllTypes.NestedGroup.nested_id~int
+			)~type(int)^type,
+			int~type(int)^int
+		  )~bool^equals`,
+	},
 }
 
 var testEnvs = map[string]testEnv{

--- a/common/types/pb/type.go
+++ b/common/types/pb/type.go
@@ -317,7 +317,7 @@ func (fd *FieldDescription) Zero() proto.Message {
 }
 
 func (fd *FieldDescription) typeDefToType() *exprpb.Type {
-	if fd.desc.Kind() == protoreflect.MessageKind {
+	if fd.desc.Kind() == protoreflect.MessageKind || fd.desc.Kind() == protoreflect.GroupKind {
 		msgType := string(fd.desc.Message().FullName())
 		if wk, found := CheckedWellKnowns[msgType]; found {
 			return wk

--- a/common/types/pb/type_test.go
+++ b/common/types/pb/type_test.go
@@ -69,6 +69,9 @@ func TestTypeDescriptionGroupFields(t *testing.T) {
 	if !field.IsMessage() {
 		t.Errorf("Group field 'nestedgroup' is type %v, wanted message type", field.Descriptor())
 	}
+	if !proto.Equal(field.CheckedType(), decls.NewObjectType("google.expr.proto2.test.TestAllTypes.NestedGroup")) {
+		t.Errorf("field.CheckedType() got %v, wanted 'google.expr.proto2.test.TestAllTypes.NestedGroup'", field.CheckedType())
+	}
 	ng, found := pbdb.DescribeType(string(field.Descriptor().Message().FullName()))
 	if !found {
 		t.Fatalf("pbdb.DescribeType(%v) not found", field.Descriptor().Message().FullName())


### PR DESCRIPTION
The `CheckedType` call was returning `nil` for `group` fields causing the type-checker
to erroneously indicate that the field itself was undefined even though the underlying libraries
were correctly identifying the field and its subfields.