### PR TITLE
Add REPL support for loading protobuf descriptors

### DIFF
--- a/repl/BUILD.bazel
+++ b/repl/BUILD.bazel
@@ -37,7 +37,9 @@ go_library(
         "//repl/parser:go_default_library",
         "@com_github_antlr_antlr4_runtime_go_antlr//:go_default_library",
         "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",
+        "@org_golang_google_protobuf//encoding/prototext:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
     ],
 )
 
@@ -49,5 +51,11 @@ go_test(
         "evaluator_test.go",
         "typefmt_test.go",
     ],
+    data = glob(["testdata/**"]),
     embed = [":go_default_library"],
+    deps = [
+        "//cel:go_default_library",
+        "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",
+        "@org_golang_google_protobuf//proto:go_default_library",
+    ],
 )

--- a/repl/commands.go
+++ b/repl/commands.go
@@ -55,7 +55,8 @@ type delCmd struct {
 }
 
 type simpleCmd struct {
-	cmd string
+	cmd  string
+	args []string
 }
 
 type evalCmd struct {
@@ -168,7 +169,18 @@ func (c *commandParseListener) EnterSimple(ctx *parser.SimpleContext) {
 	if ctx.GetCmd() != nil {
 		cmd = ctx.GetCmd().GetText()[1:]
 	}
-	c.cmd = &simpleCmd{cmd: cmd}
+	var args []string
+	for _, arg := range ctx.GetArgs() {
+		a := arg.GetText()
+		if strings.HasPrefix(a, "-") {
+			a = "--" + strings.ToLower(strings.TrimLeft(a, "-"))
+		} else {
+			a = strings.Trim(a, "\"'")
+		}
+		args = append(args, a)
+
+	}
+	c.cmd = &simpleCmd{cmd: cmd, args: args}
 }
 
 func (c *commandParseListener) EnterEmpty(ctx *parser.EmptyContext) {

--- a/repl/commands_test.go
+++ b/repl/commands_test.go
@@ -41,6 +41,14 @@ func cmdMatches(t testing.TB, got Cmder, expected Cmder) (result bool) {
 		return gotDel.identifier == want.identifier
 	case *simpleCmd:
 		gotSimple := got.(*simpleCmd)
+		if len(gotSimple.args) != len(want.args) {
+			return false
+		}
+		for i, a := range want.args {
+			if gotSimple.args[i] != a {
+				return false
+			}
+		}
 		return gotSimple.cmd == want.cmd
 	case *letFnCmd:
 		gotLetFn := got.(*letFnCmd)
@@ -95,7 +103,8 @@ func (c *delCmd) String() string {
 }
 
 func (c *simpleCmd) String() string {
-	return fmt.Sprintf("%%%s", c.cmd)
+	flagFmt := strings.Join(c.args, " ")
+	return fmt.Sprintf("%%%s %s", c.cmd, flagFmt)
 }
 
 func TestParse(t *testing.T) {
@@ -140,8 +149,16 @@ func TestParse(t *testing.T) {
 			wantCmd:     &simpleCmd{cmd: "exit"},
 		},
 		{
+			commandLine: `%arbitrary --flag -FLAG 'string literal\n'`,
+			wantCmd: &simpleCmd{cmd: "arbitrary",
+				args: []string{
+					"--flag", "--flag", "string literal\\n",
+				},
+			},
+		},
+		{
 			commandLine: "   ",
-			wantCmd:     &simpleCmd{"null"},
+			wantCmd:     &simpleCmd{cmd: "null"},
 		},
 		{
 			commandLine: `%delete x`,

--- a/repl/go.mod
+++ b/repl/go.mod
@@ -1,13 +1,19 @@
 module github.com/google/cel-go/repl
 
-go 1.15
+go 1.17
 
 require (
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220418222510-f25a4f6275ed
 	github.com/chzyer/readline v1.5.0
 	github.com/google/cel-go v0.11.4
-	google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21
+	google.golang.org/genproto v0.0.0-20220614165028-45ed7f3ff16e
 	google.golang.org/protobuf v1.28.0
+)
+
+require (
+	github.com/stoewer/go-strcase v1.2.0 // indirect
+	golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 // indirect
+	golang.org/x/text v0.3.7 // indirect
 )
 
 replace github.com/google/cel-go => ../.

--- a/repl/go.sum
+++ b/repl/go.sum
@@ -120,6 +120,8 @@ google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21 h1:hrbNEivu7Zn1pxvHk6MBrq9iE22woVILTHqexqBxe6I=
 google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
+google.golang.org/genproto v0.0.0-20220614165028-45ed7f3ff16e h1:ubR4JUtqN3ffdFjpKylv8scWk/mZstGmzXbgYSkuMl0=
+google.golang.org/genproto v0.0.0-20220614165028-45ed7f3ff16e/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
@@ -127,6 +129,7 @@ google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
+google.golang.org/grpc v1.47.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -141,7 +144,6 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/repl/main/BUILD.bazel
+++ b/repl/main/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 package(
     licenses = ["notice"],  # Apache 2.0
@@ -20,10 +20,18 @@ package(
 
 go_binary(
     name = "main",
+    embed = [":go_default_library"],
+    importpath = "github.com/google/cel-go/repl/main",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
     srcs = ["main.go"],
     importpath = "github.com/google/cel-go/repl/main",
+    visibility = ["//visibility:private"],
     deps = [
         "//repl:go_default_library",
-        "@com_github_chzyer_readline//:readline",
+        "@com_github_chzyer_readline//:go_default_library",
     ],
 )

--- a/repl/main/README.md
+++ b/repl/main/README.md
@@ -98,6 +98,35 @@ definition.
 
 `%status` prints a list of existing lets in the evaluation context.
 
+#### load_descriptors
+
+`%load_descriptors` loads a file descriptor set from file into the context.
+Message types from the file are available for use in later expressions as
+CEL structs.
+
+Accepts an argument for the filedescriptor file format: `--textproto` or
+`--binarypb`.
+
+example:
+
+`%load_descriptors --textproto "./testdata/attribute_context_fds.textproto"`
+
+#### option
+
+`%option` sets an environment option. Options are specified with flags that
+may take string arguments.
+
+`--container <string>` sets the expression container for name resolution.
+
+example:
+
+`%option --container 'google.protobuf'` 
+
+#### reset
+
+`%reset` drops all options and let expressions, returning the evaluator to a 
+starting empty state.
+
 ### Evaluation Model
 
 The evaluator considers the let expressions and declarations in order, with

--- a/repl/parser/BUILD.bazel
+++ b/repl/parser/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(
     default_visibility = ["//repl:__subpackages__"],
@@ -21,10 +21,17 @@ package(
 
 go_library(
     name = "go_default_library",
-    srcs = glob(["*.go"]),
+    srcs = glob(["*.go"], exclude=["*_test.go"]),
     data = glob(["*.tokens"]),
     importpath = "github.com/google/cel-go/repl/parser",
     deps = [
         "@com_github_antlr_antlr4_runtime_go_antlr//:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["commands_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_antlr_antlr4_runtime_go_antlr//:go_default_library"],
 )

--- a/repl/testdata/attribute_context_fds.textproto
+++ b/repl/testdata/attribute_context_fds.textproto
@@ -1,0 +1,751 @@
+file {
+  name: "google/protobuf/any.proto"
+  package: "google.protobuf"
+  message_type {
+    name: "Any"
+    field {
+      name: "type_url"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      options {
+        ctype: STRING_PIECE
+      }
+      json_name: "typeUrl"
+    }
+    field {
+      name: "value"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      options {
+        ctype: CORD
+      }
+      json_name: "value"
+    }
+  }
+  options {
+    java_package: "com.google.protobuf"
+    java_outer_classname: "AnyProto"
+    java_multiple_files: true
+    go_package: "google.golang.org/protobuf/types/known/anypb"
+    objc_class_prefix: "GPB"
+    csharp_namespace: "Google.Protobuf.WellKnownTypes"
+  }
+  syntax: "proto3"
+}
+file {
+  name: "google/protobuf/duration.proto"
+  package: "google.protobuf"
+  message_type {
+    name: "Duration"
+    field {
+      name: "seconds"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_INT64
+      json_name: "seconds"
+    }
+    field {
+      name: "nanos"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_INT32
+      json_name: "nanos"
+    }
+  }
+  options {
+    java_package: "com.google.protobuf"
+    java_outer_classname: "DurationProto"
+    java_multiple_files: true
+    go_package: "google.golang.org/protobuf/types/known/durationpb"
+    cc_enable_arenas: true
+    objc_class_prefix: "GPB"
+    csharp_namespace: "Google.Protobuf.WellKnownTypes"
+  }
+  syntax: "proto3"
+}
+file {
+  name: "google/protobuf/struct.proto"
+  package: "google.protobuf"
+  message_type {
+    name: "Struct"
+    field {
+      name: "fields"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Struct.FieldsEntry"
+      json_name: "fields"
+    }
+    nested_type {
+      name: "FieldsEntry"
+      field {
+        name: "key"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "key"
+      }
+      field {
+        name: "value"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".google.protobuf.Value"
+        json_name: "value"
+      }
+      options {
+        map_entry: true
+      }
+    }
+  }
+  message_type {
+    name: "Value"
+    field {
+      name: "null_value"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".google.protobuf.NullValue"
+      oneof_index: 0
+      json_name: "nullValue"
+    }
+    field {
+      name: "number_value"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_DOUBLE
+      oneof_index: 0
+      json_name: "numberValue"
+    }
+    field {
+      name: "string_value"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      oneof_index: 0
+      json_name: "stringValue"
+    }
+    field {
+      name: "bool_value"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      oneof_index: 0
+      json_name: "boolValue"
+    }
+    field {
+      name: "struct_value"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Struct"
+      oneof_index: 0
+      json_name: "structValue"
+    }
+    field {
+      name: "list_value"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.ListValue"
+      oneof_index: 0
+      json_name: "listValue"
+    }
+    oneof_decl {
+      name: "kind"
+    }
+  }
+  message_type {
+    name: "ListValue"
+    field {
+      name: "values"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Value"
+      json_name: "values"
+    }
+  }
+  enum_type {
+    name: "NullValue"
+    value {
+      name: "NULL_VALUE"
+      number: 0
+    }
+  }
+  options {
+    java_package: "com.google.protobuf"
+    java_outer_classname: "StructProto"
+    java_multiple_files: true
+    go_package: "google.golang.org/protobuf/types/known/structpb"
+    cc_enable_arenas: true
+    objc_class_prefix: "GPB"
+    csharp_namespace: "Google.Protobuf.WellKnownTypes"
+  }
+  syntax: "proto3"
+}
+file {
+  name: "google/protobuf/timestamp.proto"
+  package: "google.protobuf"
+  message_type {
+    name: "Timestamp"
+    field {
+      name: "seconds"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_INT64
+      json_name: "seconds"
+    }
+    field {
+      name: "nanos"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_INT32
+      json_name: "nanos"
+    }
+  }
+  options {
+    java_package: "com.google.protobuf"
+    java_outer_classname: "TimestampProto"
+    java_multiple_files: true
+    go_package: "google.golang.org/protobuf/types/known/timestamppb"
+    cc_enable_arenas: true
+    objc_class_prefix: "GPB"
+    csharp_namespace: "Google.Protobuf.WellKnownTypes"
+  }
+  syntax: "proto3"
+}
+file {
+  name: "google/rpc/context/attribute_context.proto"
+  package: "google.rpc.context"
+  dependency: "google/protobuf/any.proto"
+  dependency: "google/protobuf/duration.proto"
+  dependency: "google/protobuf/struct.proto"
+  dependency: "google/protobuf/timestamp.proto"
+  message_type {
+    name: "AttributeContext"
+    field {
+      name: "origin"
+      number: 7
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.rpc.context.AttributeContext.Peer"
+      json_name: "origin"
+    }
+    field {
+      name: "source"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.rpc.context.AttributeContext.Peer"
+      json_name: "source"
+    }
+    field {
+      name: "destination"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.rpc.context.AttributeContext.Peer"
+      json_name: "destination"
+    }
+    field {
+      name: "request"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.rpc.context.AttributeContext.Request"
+      json_name: "request"
+    }
+    field {
+      name: "response"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.rpc.context.AttributeContext.Response"
+      json_name: "response"
+    }
+    field {
+      name: "resource"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.rpc.context.AttributeContext.Resource"
+      json_name: "resource"
+    }
+    field {
+      name: "api"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.rpc.context.AttributeContext.Api"
+      json_name: "api"
+    }
+    field {
+      name: "extensions"
+      number: 8
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Any"
+      json_name: "extensions"
+    }
+    nested_type {
+      name: "Peer"
+      field {
+        name: "ip"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "ip"
+      }
+      field {
+        name: "port"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_INT64
+        json_name: "port"
+      }
+      field {
+        name: "labels"
+        number: 6
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: ".google.rpc.context.AttributeContext.Peer.LabelsEntry"
+        json_name: "labels"
+      }
+      field {
+        name: "principal"
+        number: 7
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "principal"
+      }
+      field {
+        name: "region_code"
+        number: 8
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "regionCode"
+      }
+      nested_type {
+        name: "LabelsEntry"
+        field {
+          name: "key"
+          number: 1
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "key"
+        }
+        field {
+          name: "value"
+          number: 2
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "value"
+        }
+        options {
+          map_entry: true
+        }
+      }
+      reserved_range {
+        start: 3
+        end: 4
+      }
+      reserved_range {
+        start: 4
+        end: 5
+      }
+      reserved_range {
+        start: 5
+        end: 6
+      }
+    }
+    nested_type {
+      name: "Api"
+      field {
+        name: "service"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "service"
+      }
+      field {
+        name: "operation"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "operation"
+      }
+      field {
+        name: "protocol"
+        number: 3
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "protocol"
+      }
+      field {
+        name: "version"
+        number: 4
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "version"
+      }
+    }
+    nested_type {
+      name: "Auth"
+      field {
+        name: "principal"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "principal"
+      }
+      field {
+        name: "audiences"
+        number: 2
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "audiences"
+      }
+      field {
+        name: "presenter"
+        number: 3
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "presenter"
+      }
+      field {
+        name: "claims"
+        number: 4
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".google.protobuf.Struct"
+        json_name: "claims"
+      }
+      field {
+        name: "access_levels"
+        number: 5
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "accessLevels"
+      }
+    }
+    nested_type {
+      name: "Request"
+      field {
+        name: "id"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "id"
+      }
+      field {
+        name: "method"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "method"
+      }
+      field {
+        name: "headers"
+        number: 3
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: ".google.rpc.context.AttributeContext.Request.HeadersEntry"
+        json_name: "headers"
+      }
+      field {
+        name: "path"
+        number: 4
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "path"
+      }
+      field {
+        name: "host"
+        number: 5
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "host"
+      }
+      field {
+        name: "scheme"
+        number: 6
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "scheme"
+      }
+      field {
+        name: "query"
+        number: 7
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "query"
+      }
+      field {
+        name: "time"
+        number: 9
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".google.protobuf.Timestamp"
+        json_name: "time"
+      }
+      field {
+        name: "size"
+        number: 10
+        label: LABEL_OPTIONAL
+        type: TYPE_INT64
+        json_name: "size"
+      }
+      field {
+        name: "protocol"
+        number: 11
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "protocol"
+      }
+      field {
+        name: "reason"
+        number: 12
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "reason"
+      }
+      field {
+        name: "auth"
+        number: 13
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".google.rpc.context.AttributeContext.Auth"
+        json_name: "auth"
+      }
+      nested_type {
+        name: "HeadersEntry"
+        field {
+          name: "key"
+          number: 1
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "key"
+        }
+        field {
+          name: "value"
+          number: 2
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "value"
+        }
+        options {
+          map_entry: true
+        }
+      }
+      reserved_range {
+        start: 8
+        end: 9
+      }
+    }
+    nested_type {
+      name: "Response"
+      field {
+        name: "code"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_INT64
+        json_name: "code"
+      }
+      field {
+        name: "size"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_INT64
+        json_name: "size"
+      }
+      field {
+        name: "headers"
+        number: 3
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: ".google.rpc.context.AttributeContext.Response.HeadersEntry"
+        json_name: "headers"
+      }
+      field {
+        name: "time"
+        number: 4
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".google.protobuf.Timestamp"
+        json_name: "time"
+      }
+      field {
+        name: "backend_latency"
+        number: 5
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".google.protobuf.Duration"
+        json_name: "backendLatency"
+      }
+      nested_type {
+        name: "HeadersEntry"
+        field {
+          name: "key"
+          number: 1
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "key"
+        }
+        field {
+          name: "value"
+          number: 2
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "value"
+        }
+        options {
+          map_entry: true
+        }
+      }
+    }
+    nested_type {
+      name: "Resource"
+      field {
+        name: "service"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "service"
+      }
+      field {
+        name: "name"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "name"
+      }
+      field {
+        name: "type"
+        number: 3
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "type"
+      }
+      field {
+        name: "labels"
+        number: 4
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: ".google.rpc.context.AttributeContext.Resource.LabelsEntry"
+        json_name: "labels"
+      }
+      field {
+        name: "uid"
+        number: 5
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "uid"
+      }
+      field {
+        name: "annotations"
+        number: 6
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: ".google.rpc.context.AttributeContext.Resource.AnnotationsEntry"
+        json_name: "annotations"
+      }
+      field {
+        name: "display_name"
+        number: 7
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "displayName"
+      }
+      field {
+        name: "create_time"
+        number: 8
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".google.protobuf.Timestamp"
+        json_name: "createTime"
+      }
+      field {
+        name: "update_time"
+        number: 9
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".google.protobuf.Timestamp"
+        json_name: "updateTime"
+      }
+      field {
+        name: "delete_time"
+        number: 10
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".google.protobuf.Timestamp"
+        json_name: "deleteTime"
+      }
+      field {
+        name: "etag"
+        number: 11
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "etag"
+      }
+      field {
+        name: "location"
+        number: 12
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "location"
+      }
+      nested_type {
+        name: "LabelsEntry"
+        field {
+          name: "key"
+          number: 1
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "key"
+        }
+        field {
+          name: "value"
+          number: 2
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "value"
+        }
+        options {
+          map_entry: true
+        }
+      }
+      nested_type {
+        name: "AnnotationsEntry"
+        field {
+          name: "key"
+          number: 1
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "key"
+        }
+        field {
+          name: "value"
+          number: 2
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "value"
+        }
+        options {
+          map_entry: true
+        }
+      }
+    }
+  }
+  options {
+    java_package: "com.google.rpc.context"
+    java_outer_classname: "AttributeContextProto"
+    java_multiple_files: true
+    go_package: "google.golang.org/genproto/googleapis/rpc/context/attribute_context;attribute_context"
+    cc_enable_arenas: true
+  }
+  syntax: "proto3"
+}
+


### PR DESCRIPTION
Adds the ability to load protobuf file descriptors from disk e.g.

`%load_descriptors "path/to/file_descriptor_set.textproto"`.

closes #538 -- with this the REPL tool has enough basic support for most use cases. We can address specific feature requests as they come up from use.