### PR TITLE
Dispatcher refactor to improve function declaration, definition, and extension

### DIFF
--- a/cel/BUILD.bazel
+++ b/cel/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "cel.go",
+        "decls.go",
         "env.go",
         "io.go",
         "library.go",
@@ -46,6 +47,7 @@ go_test(
     srcs = [
         "cel_example_test.go",
         "cel_test.go",
+        "decls_test.go",
         "env_test.go",
         "io_test.go",
     ],
@@ -56,13 +58,11 @@ go_test(
         ":go_default_library",
     ],
     deps = [
-        "//checker/decls:go_default_library",
         "//common/operators:go_default_library",
         "//common/overloads:go_default_library",
         "//common/types:go_default_library",
         "//common/types/ref:go_default_library",
         "//common/types/traits:go_default_library",
-        "//interpreter/functions:go_default_library",
         "//test:go_default_library",
         "//test/proto2pb:go_default_library",
         "//test/proto3pb:go_default_library",

--- a/cel/cel_example_test.go
+++ b/cel/cel_example_test.go
@@ -33,7 +33,7 @@ func Example() {
 		// Function to generate a greeting from one person to another: i.greet(you)
 		cel.Function("greet",
 			cel.MemberOverload("string_greet_string", []*cel.Type{cel.StringType, cel.StringType}, cel.StringType,
-				cel.BinaryImpl(func(lhs, rhs ref.Val) ref.Val {
+				cel.BinaryBinding(func(lhs, rhs ref.Val) ref.Val {
 					return types.String(fmt.Sprintf("Hello %s! Nice to meet you, I'm %s.\n", rhs, lhs))
 				}),
 			),
@@ -83,7 +83,7 @@ func Example_globalOverload() {
 		//    shake_hands(i,you)
 		cel.Function("shake_hands",
 			cel.Overload("shake_hands_string_string", []*cel.Type{cel.StringType, cel.StringType}, cel.StringType,
-				cel.BinaryImpl(func(arg1, arg2 ref.Val) ref.Val {
+				cel.BinaryBinding(func(arg1, arg2 ref.Val) ref.Val {
 					return types.String(fmt.Sprintf("%v and %v are shaking hands.\n", arg1, arg2))
 				}),
 			),

--- a/cel/cel_example_test.go
+++ b/cel/cel_example_test.go
@@ -19,29 +19,26 @@ import (
 	"log"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
-	"github.com/google/cel-go/interpreter/functions"
-
-	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 func Example() {
-	// Create the CEL environment with declarations for the input attributes and
-	// the desired extension functions. In many cases the desired functionality will
-	// be present in a built-in function.
-	decls := cel.Declarations(
-		// Identifiers used within this expression.
-		decls.NewVar("i", decls.String),
-		decls.NewVar("you", decls.String),
-		// Function to generate a greeting from one person to another.
-		//    i.greet(you)
-		decls.NewFunction("greet",
-			decls.NewInstanceOverload("string_greet_string",
-				[]*exprpb.Type{decls.String, decls.String},
-				decls.String)))
-	e, err := cel.NewEnv(decls)
+	// Create the CEL environment with declarations for the input attributes and the extension functions.
+	// In many cases the desired functionality will be present in a built-in function.
+	e, err := cel.NewEnv(
+		// Variable identifiers used within this expression.
+		cel.Variable("i", cel.StringType),
+		cel.Variable("you", cel.StringType),
+		// Function to generate a greeting from one person to another: i.greet(you)
+		cel.Function("greet",
+			cel.MemberOverload("string_greet_string", []*cel.Type{cel.StringType, cel.StringType}, cel.StringType,
+				cel.BinaryImpl(func(lhs, rhs ref.Val) ref.Val {
+					return types.String(fmt.Sprintf("Hello %s! Nice to meet you, I'm %s.\n", rhs, lhs))
+				}),
+			),
+		),
+	)
 	if err != nil {
 		log.Fatalf("environment creation error: %s\n", err)
 	}
@@ -53,14 +50,7 @@ func Example() {
 	}
 
 	// Create the program.
-	funcs := cel.Functions(
-		&functions.Overload{
-			Operator: "string_greet_string",
-			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
-				return types.String(
-					fmt.Sprintf("Hello %s! Nice to meet you, I'm %s.\n", rhs, lhs))
-			}})
-	prg, err := e.Program(ast, funcs)
+	prg, err := e.Program(ast)
 	if err != nil {
 		log.Fatalf("program creation error: %s\n", err)
 	}
@@ -85,17 +75,20 @@ func Example_globalOverload() {
 	// Create the CEL environment with declarations for the input attributes and
 	// the desired extension functions. In many cases the desired functionality will
 	// be present in a built-in function.
-	decls := cel.Declarations(
+	e, err := cel.NewEnv(
 		// Identifiers used within this expression.
-		decls.NewVar("i", decls.String),
-		decls.NewVar("you", decls.String),
+		cel.Variable("i", cel.StringType),
+		cel.Variable("you", cel.StringType),
 		// Function to generate shake_hands between two people.
 		//    shake_hands(i,you)
-		decls.NewFunction("shake_hands",
-			decls.NewOverload("shake_hands_string_string",
-				[]*exprpb.Type{decls.String, decls.String},
-				decls.String)))
-	e, err := cel.NewEnv(decls)
+		cel.Function("shake_hands",
+			cel.Overload("shake_hands_string_string", []*cel.Type{cel.StringType, cel.StringType}, cel.StringType,
+				cel.BinaryImpl(func(arg1, arg2 ref.Val) ref.Val {
+					return types.String(fmt.Sprintf("%v and %v are shaking hands.\n", arg1, arg2))
+				}),
+			),
+		),
+	)
 	if err != nil {
 		log.Fatalf("environment creation error: %s\n", err)
 	}
@@ -107,22 +100,7 @@ func Example_globalOverload() {
 	}
 
 	// Create the program.
-	funcs := cel.Functions(
-		&functions.Overload{
-			Operator: "shake_hands_string_string",
-			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
-				s1, ok := lhs.(types.String)
-				if !ok {
-					return types.ValOrErr(lhs, "unexpected type '%v' passed to shake_hands", lhs.Type())
-				}
-				s2, ok := rhs.(types.String)
-				if !ok {
-					return types.ValOrErr(rhs, "unexpected type '%v' passed to shake_hands", rhs.Type())
-				}
-				return types.String(
-					fmt.Sprintf("%s and %s are shaking hands.\n", s1, s2))
-			}})
-	prg, err := e.Program(ast, funcs)
+	prg, err := e.Program(ast)
 	if err != nil {
 		log.Fatalf("program creation error: %s\n", err)
 	}

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -235,12 +235,12 @@ func TestHomogeneousAggregateLiterals(t *testing.T) {
 		Variable("name", StringType),
 		Function(operators.In,
 			Overload(overloads.InList, []*Type{StringType, ListType(StringType)}, BoolType,
-				BinaryImpl(func(lhs, rhs ref.Val) ref.Val {
+				BinaryBinding(func(lhs, rhs ref.Val) ref.Val {
 					return rhs.(traits.Container).Contains(lhs)
 				}),
 			),
 			Overload(overloads.InMap, []*Type{StringType, MapType(StringType, BoolType)}, BoolType,
-				BinaryImpl(func(lhs, rhs ref.Val) ref.Val {
+				BinaryBinding(func(lhs, rhs ref.Val) ref.Val {
 					return rhs.(traits.Container).Contains(lhs)
 				}),
 			),
@@ -614,7 +614,7 @@ func TestGlobalVars(t *testing.T) {
 		Variable("default", DynType),
 		Function("get",
 			MemberOverload("get_map", []*Type{MapType(StringType, DynType), StringType, DynType}, DynType,
-				FunctionImpl(func(args ...ref.Val) ref.Val {
+				FunctionBinding(func(args ...ref.Val) ref.Val {
 					attrs, ok := args[0].(traits.Mapper)
 					if !ok {
 						return types.NewErr(
@@ -934,7 +934,7 @@ func TestEvalRecover(t *testing.T) {
 	e, err := NewEnv(
 		Function("panic",
 			Overload("global_panic", []*Type{}, BoolType,
-				FunctionImpl(func(args ...ref.Val) ref.Val {
+				FunctionBinding(func(args ...ref.Val) ref.Val {
 					panic("watch me recover")
 				}),
 			),

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -29,7 +29,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/google/cel-go/checker"
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/overloads"
@@ -37,7 +36,6 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 	"github.com/google/cel-go/interpreter"
-	"github.com/google/cel-go/interpreter/functions"
 	"github.com/google/cel-go/parser"
 	"github.com/google/cel-go/test"
 
@@ -51,10 +49,10 @@ import (
 
 func Test_ExampleWithBuiltins(t *testing.T) {
 	// Variables used within this expression environment.
-	decls := Declarations(
-		decls.NewVar("i", decls.String),
-		decls.NewVar("you", decls.String))
-	env, err := NewEnv(decls)
+	env, err := NewEnv(
+		Variable("i", StringType),
+		Variable("you", StringType),
+	)
 	if err != nil {
 		t.Fatalf("environment creation error: %s\n", err)
 	}
@@ -90,9 +88,7 @@ func TestAbbrevsCompiled(t *testing.T) {
 	// Test whether abbreviations successfully resolve at type-check time (compile time).
 	env, err := NewEnv(
 		Abbrevs("qualified.identifier.name"),
-		Declarations(
-			decls.NewVar("qualified.identifier.name.first", decls.String),
-		),
+		Variable("qualified.identifier.name.first", StringType),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -154,10 +150,9 @@ func TestAbbrevs_Disambiguation(t *testing.T) {
 		Abbrevs("external.Expr"),
 		Container("google.api.expr.v1alpha1"),
 		Types(&exprpb.Expr{}),
-		Declarations(
-			decls.NewVar("test", decls.Bool),
-			decls.NewVar("external.Expr", decls.String),
-		),
+
+		Variable("test", BoolType),
+		Variable("external.Expr", StringType),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -213,8 +208,7 @@ func TestCustomEnvError(t *testing.T) {
 }
 
 func TestCustomEnv(t *testing.T) {
-	e, _ := NewCustomEnv(
-		Declarations(decls.NewVar("a.b.c", decls.Bool)))
+	e, _ := NewCustomEnv(Variable("a.b.c", BoolType))
 
 	t.Run("err", func(t *testing.T) {
 		_, iss := e.Compile("a.b.c == true")
@@ -238,30 +232,24 @@ func TestCustomEnv(t *testing.T) {
 
 func TestHomogeneousAggregateLiterals(t *testing.T) {
 	e, err := NewCustomEnv(
-		Declarations(
-			decls.NewVar("name", decls.String),
-			decls.NewFunction(
-				operators.In,
-				decls.NewOverload(overloads.InList, []*exprpb.Type{
-					decls.String, decls.NewListType(decls.String),
-				}, decls.Bool),
-				decls.NewOverload(overloads.InMap, []*exprpb.Type{
-					decls.String, decls.NewMapType(decls.String, decls.Bool),
-				}, decls.Bool))),
-		HomogeneousAggregateLiterals())
+		Variable("name", StringType),
+		Function(operators.In,
+			Overload(overloads.InList, []*Type{StringType, ListType(StringType)}, BoolType,
+				BinaryImpl(func(lhs, rhs ref.Val) ref.Val {
+					return rhs.(traits.Container).Contains(lhs)
+				}),
+			),
+			Overload(overloads.InMap, []*Type{StringType, MapType(StringType, BoolType)}, BoolType,
+				BinaryImpl(func(lhs, rhs ref.Val) ref.Val {
+					return rhs.(traits.Container).Contains(lhs)
+				}),
+			),
+		),
+		HomogeneousAggregateLiterals(),
+	)
 	if err != nil {
 		t.Fatalf("NewCustomEnv() failed: %v", err)
 	}
-
-	funcs := Functions(&functions.Overload{
-		Operator: operators.In,
-		Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
-			if rhs.Type().HasTrait(traits.ContainerType) {
-				return rhs.(traits.Container).Contains(lhs)
-			}
-			return types.ValOrErr(rhs, "no such overload")
-		},
-	})
 
 	tests := []struct {
 		name string
@@ -326,7 +314,7 @@ func TestHomogeneousAggregateLiterals(t *testing.T) {
 			if iss.Err() != nil {
 				t.Fatalf("e.Compile(%v) failed: %v", tc.expr, iss.Err())
 			}
-			prg, err := e.Program(ast, funcs)
+			prg, err := e.Program(ast)
 			if err != nil {
 				t.Fatalf("e.Program() failed: %v", err)
 			}
@@ -415,7 +403,6 @@ func TestCrossTypeNumericComparisons(t *testing.T) {
 }
 
 func TestCustomTypes(t *testing.T) {
-	exprType := decls.NewObjectType("google.api.expr.v1alpha1.Expr")
 	reg := types.NewEmptyRegistry()
 	e, _ := NewEnv(
 		CustomTypeAdapter(reg),
@@ -426,8 +413,8 @@ func TestCustomTypes(t *testing.T) {
 			types.BoolType,
 			types.IntType,
 			types.StringType),
-		Declarations(
-			decls.NewVar("expr", exprType)))
+		Variable("expr", ObjectType("google.api.expr.v1alpha1.Expr")),
+	)
 
 	ast, _ := e.Compile(`
 		expr == Expr{id: 2,
@@ -437,8 +424,8 @@ func TestCustomTypes(t *testing.T) {
 					Expr{id: 1, ident_expr: Expr.Ident{ name: "a" }},
 					Expr{id: 3, ident_expr: Expr.Ident{ name: "b" }}]
 			}}`)
-	if !proto.Equal(ast.ResultType(), decls.Bool) {
-		t.Fatalf("got %v, wanted type bool", ast.ResultType())
+	if ast.OutputType() != BoolType {
+		t.Fatalf("got %v, wanted type bool", ast.OutputType())
 	}
 	prg, _ := e.Program(ast)
 	vars := map[string]interface{}{"expr": &exprpb.Expr{
@@ -481,9 +468,8 @@ func TestTypeIsolation(t *testing.T) {
 
 	e, err := NewEnv(
 		TypeDescs(&fds),
-		Declarations(
-			decls.NewVar("myteam",
-				decls.NewObjectType("cel.testdata.Team"))))
+		Variable("myteam", ObjectType("cel.testdata.Team")),
+	)
 	if err != nil {
 		t.Fatalf("NewEnv() failed: %v", err)
 	}
@@ -495,10 +481,7 @@ func TestTypeIsolation(t *testing.T) {
 	}
 
 	// Ensure that isolated types don't leak through.
-	e2, _ := NewEnv(
-		Declarations(
-			decls.NewVar("myteam",
-				decls.NewObjectType("cel.testdata.Team"))))
+	e2, _ := NewEnv(Variable("myteam", ObjectType("cel.testdata.Team")))
 	_, iss = e2.Compile(src)
 	if iss == nil || iss.Err() == nil {
 		t.Errorf("wanted compile failure for unknown message.")
@@ -596,7 +579,7 @@ func TestDynamicProto_Input(t *testing.T) {
 		// however, it tests a different code path which aggregates individual
 		// FileDescriptorProto values together.
 		TypeDescs(fileCopy...),
-		Declarations(decls.NewVar("mutant", decls.NewObjectType("cel.testdata.Mutant"))),
+		Variable("mutant", ObjectType("cel.testdata.Mutant")),
 	)
 	if err != nil {
 		t.Fatalf("NewEnv() failed: %v", err)
@@ -626,50 +609,40 @@ func TestDynamicProto_Input(t *testing.T) {
 }
 
 func TestGlobalVars(t *testing.T) {
-	mapStrDyn := decls.NewMapType(decls.String, decls.Dyn)
-	e, _ := NewEnv(
-		Declarations(
-			decls.NewVar("attrs", mapStrDyn),
-			decls.NewVar("default", decls.Dyn),
-			decls.NewFunction(
-				"get",
-				decls.NewInstanceOverload(
-					"get_map",
-					[]*exprpb.Type{mapStrDyn, decls.String, decls.Dyn},
-					decls.Dyn))))
-	ast, _ := e.Compile(`attrs.get("first", attrs.get("second", default))`)
-
-	// Create the program.
-	funcs := Functions(
-		&functions.Overload{
-			Operator: "get",
-			Function: func(args ...ref.Val) ref.Val {
-				if len(args) != 3 {
-					return types.NewErr("invalid arguments to 'get'")
-				}
-				attrs, ok := args[0].(traits.Mapper)
-				if !ok {
-					return types.NewErr(
-						"invalid operand of type '%v' to obj.get(key, def)",
-						args[0].Type())
-				}
-				key, ok := args[1].(types.String)
-				if !ok {
-					return types.NewErr(
-						"invalid key of type '%v' to obj.get(key, def)",
-						args[1].Type())
-				}
-				defVal := args[2]
-				if attrs.Contains(key) == types.True {
-					return attrs.Get(key)
-				}
-				return defVal
-			}})
+	e, err := NewEnv(
+		Variable("attrs", MapType(StringType, DynType)),
+		Variable("default", DynType),
+		Function("get",
+			MemberOverload("get_map", []*Type{MapType(StringType, DynType), StringType, DynType}, DynType,
+				FunctionImpl(func(args ...ref.Val) ref.Val {
+					attrs, ok := args[0].(traits.Mapper)
+					if !ok {
+						return types.NewErr(
+							"invalid operand of type '%v' to obj.get(key, def)",
+							args[0].Type())
+					}
+					key := args[1]
+					defVal := args[2]
+					if attrs.Contains(key) == types.True {
+						return attrs.Get(key)
+					}
+					return defVal
+				}),
+			),
+		),
+	)
+	if err != nil {
+		t.Fatalf("NewEnv() failed: %v", err)
+	}
+	ast, iss := e.Compile(`attrs.get("first", attrs.get("second", default))`)
+	if iss.Err() != nil {
+		t.Fatalf("e.Parse() failed: %v", iss.Err())
+	}
 
 	// Global variables can be configured as a ProgramOption and optionally overridden on Eval.
 	// Add a previous globals map to confirm the order of shadowing and a final empty global
 	// map to show that globals are not clobbered.
-	prg, _ := e.Program(ast, funcs,
+	prg, err := e.Program(ast,
 		Globals(map[string]interface{}{
 			"default": "shadow me",
 		}),
@@ -678,11 +651,27 @@ func TestGlobalVars(t *testing.T) {
 		}),
 		Globals(map[string]interface{}{}),
 	)
+	if err != nil {
+		t.Fatalf("e.Program() failed: %v", err)
+	}
+
+	t.Run("bad_attrs", func(t *testing.T) {
+		out, _, err := prg.Eval(map[string]interface{}{
+			"attrs": []string{"one", "two"},
+		})
+		if err == nil {
+			t.Errorf("prg.Eval() of incorrect arg type invoked function, wanted error, got %v", out)
+		}
+	})
 
 	t.Run("global_default", func(t *testing.T) {
 		vars := map[string]interface{}{
-			"attrs": map[string]interface{}{}}
-		out, _, _ := prg.Eval(vars)
+			"attrs": map[string]interface{}{},
+		}
+		out, _, err := prg.Eval(vars)
+		if err != nil {
+			t.Fatalf("prg.Eval() failed: %v", err)
+		}
 		if out.Equal(types.String("third")) != types.True {
 			t.Errorf("got '%v', expected 'third'.", out.Value())
 		}
@@ -829,9 +818,9 @@ func TestAstIsChecked(t *testing.T) {
 
 func TestEvalOptions(t *testing.T) {
 	e, _ := NewEnv(
-		Declarations(
-			decls.NewVar("k", decls.String),
-			decls.NewVar("v", decls.Bool)))
+		Variable("k", StringType),
+		Variable("v", BoolType),
+	)
 	ast, _ := e.Compile(`{k: true}[k] || v != false`)
 
 	prg, err := e.Program(ast, EvalOptions(OptExhaustiveEval))
@@ -871,11 +860,7 @@ func TestEvalOptions(t *testing.T) {
 }
 
 func TestContextEval(t *testing.T) {
-	env, err := NewEnv(
-		Declarations(
-			decls.NewVar("items", decls.NewListType(decls.Int)),
-		),
-	)
+	env, err := NewEnv(Variable("items", ListType(IntType)))
 	if err != nil {
 		t.Fatalf("NewEnv() failed: %v", err)
 	}
@@ -915,9 +900,7 @@ func TestContextEval(t *testing.T) {
 
 func BenchmarkContextEval(b *testing.B) {
 	env, err := NewEnv(
-		Declarations(
-			decls.NewVar("items", decls.NewListType(decls.Int)),
-		),
+		Variable("items", ListType(IntType)),
 	)
 	if err != nil {
 		b.Fatalf("NewEnv() failed: %v", err)
@@ -949,28 +932,32 @@ func BenchmarkContextEval(b *testing.B) {
 
 func TestEvalRecover(t *testing.T) {
 	e, err := NewEnv(
-		Declarations(
-			decls.NewFunction("panic",
-				decls.NewOverload("panic", []*exprpb.Type{}, decls.Bool)),
-		))
+		Function("panic",
+			Overload("global_panic", []*Type{}, BoolType,
+				FunctionImpl(func(args ...ref.Val) ref.Val {
+					panic("watch me recover")
+				}),
+			),
+		),
+	)
 	if err != nil {
 		t.Fatalf("NewEnv() failed: %v", err)
 	}
-	funcs := Functions(&functions.Overload{
-		Operator: "panic",
-		Function: func(args ...ref.Val) ref.Val {
-			panic("watch me recover")
-		},
-	})
 	// Test standard evaluation.
-	pAst, _ := e.Parse("panic()")
-	prgm, _ := e.Program(pAst, funcs)
+	pAst, iss := e.Parse("panic()")
+	if iss.Err() != nil {
+		t.Fatalf("e.Parse('panic()') failed: %v", iss.Err())
+	}
+	prgm, err := e.Program(pAst)
+	if err != nil {
+		t.Fatalf("e.Program(Ast) failed: %v", err)
+	}
 	_, _, err = prgm.Eval(map[string]interface{}{})
 	if err.Error() != "internal error: watch me recover" {
 		t.Errorf("got '%v', wanted 'internal error: watch me recover'", err)
 	}
 	// Test the factory-based evaluation.
-	prgm, _ = e.Program(pAst, funcs, EvalOptions(OptTrackState))
+	prgm, _ = e.Program(pAst, EvalOptions(OptTrackState))
 	_, _, err = prgm.Eval(map[string]interface{}{})
 	if err.Error() != "internal error: watch me recover" {
 		t.Errorf("got '%v', wanted 'internal error: watch me recover'", err)
@@ -979,10 +966,8 @@ func TestEvalRecover(t *testing.T) {
 
 func TestResidualAst(t *testing.T) {
 	e, _ := NewEnv(
-		Declarations(
-			decls.NewVar("x", decls.Int),
-			decls.NewVar("y", decls.Int),
-		),
+		Variable("x", IntType),
+		Variable("y", IntType),
 	)
 	unkVars := e.UnknownVars()
 	ast, _ := e.Parse(`x < 10 && (y == 0 || 'hello' != 'goodbye')`)
@@ -1011,12 +996,9 @@ func TestResidualAst(t *testing.T) {
 
 func TestResidualAst_Complex(t *testing.T) {
 	e, _ := NewEnv(
-		Declarations(
-			decls.NewVar("resource.name", decls.String),
-			decls.NewVar("request.time", decls.Timestamp),
-			decls.NewVar("request.auth.claims",
-				decls.NewMapType(decls.String, decls.String)),
-		),
+		Variable("resource.name", StringType),
+		Variable("request.time", TimestampType),
+		Variable("request.auth.claims", MapType(StringType, StringType)),
 	)
 	unkVars, _ := PartialVars(
 		map[string]interface{}{
@@ -1059,10 +1041,8 @@ func TestResidualAst_Complex(t *testing.T) {
 
 func Benchmark_EvalOptions(b *testing.B) {
 	e, _ := NewEnv(
-		Declarations(
-			decls.NewVar("ai", decls.Int),
-			decls.NewVar("ar", decls.NewMapType(decls.String, decls.String)),
-		),
+		Variable("ai", IntType),
+		Variable("ar", MapType(StringType, StringType)),
 	)
 	ast, _ := e.Compile("ai == 20 || ar['foo'] == 'bar'")
 	vars := map[string]interface{}{
@@ -1096,10 +1076,7 @@ func TestEnvExtension(t *testing.T) {
 	e, _ := NewEnv(
 		Container("google.api.expr.v1alpha1"),
 		Types(&exprpb.Expr{}),
-		Declarations(
-			decls.NewVar("expr",
-				decls.NewObjectType("google.api.expr.v1alpha1.Expr")),
-		),
+		Variable("expr", ObjectType("google.api.expr.v1alpha1.Expr")),
 	)
 	e2, _ := e.Extend(
 		CustomTypeAdapter(types.DefaultTypeAdapter),
@@ -1126,24 +1103,24 @@ func TestEnvExtension(t *testing.T) {
 func TestEnvExtensionIsolation(t *testing.T) {
 	baseEnv, err := NewEnv(
 		Container("google.expr"),
-		Declarations(
-			decls.NewVar("age", decls.Int),
-			decls.NewVar("gender", decls.String),
-			decls.NewVar("country", decls.String),
-		),
+		Variable("age", IntType),
+		Variable("gender", StringType),
+		Variable("country", StringType),
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	env1, err := baseEnv.Extend(
 		Types(&proto2pb.TestAllTypes{}),
-		Declarations(decls.NewVar("name", decls.String)))
+		Variable("name", StringType),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	env2, err := baseEnv.Extend(
 		Types(&proto3pb.TestAllTypes{}),
-		Declarations(decls.NewVar("group", decls.String)))
+		Variable("group", StringType),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1223,10 +1200,7 @@ func TestParseAndCheckConcurrently(t *testing.T) {
 	e, err := NewEnv(
 		Container("google.api.expr.v1alpha1"),
 		Types(&exprpb.Expr{}),
-		Declarations(
-			decls.NewVar("expr",
-				decls.NewObjectType("google.api.expr.v1alpha1.Expr")),
-		),
+		Variable("expr", ObjectType("google.api.expr.v1alpha1.Expr")),
 	)
 	if err != nil {
 		t.Fatalf("NewEnv() failed: %v", err)
@@ -1286,7 +1260,7 @@ func TestCustomInterpreterDecorator(t *testing.T) {
 		}
 	}
 
-	env, _ := NewEnv(Declarations(decls.NewVar("foo", decls.Int)))
+	env, _ := NewEnv(Variable("foo", IntType))
 	ast, _ := env.Compile(`foo == -1 + 2 * 3 / 3`)
 	_, err := env.Program(ast,
 		EvalOptions(OptPartialEval),
@@ -1369,12 +1343,12 @@ func (e testRuntimeCostEstimator) CallCost(function, overloadID string, args []r
 
 // TestEstimateCostAndRuntimeCost sanity checks that the cost systems are usable from the program API.
 func TestEstimateCostAndRuntimeCost(t *testing.T) {
-	intList := decls.NewListType(decls.Int)
+	intList := ListType(IntType)
 	zeroCost := checker.CostEstimate{}
 	cases := []struct {
 		name  string
 		expr  string
-		decls []*exprpb.Decl
+		decls []EnvOption
 		hints map[string]int64
 		want  checker.CostEstimate
 		in    interface{}
@@ -1388,16 +1362,16 @@ func TestEstimateCostAndRuntimeCost(t *testing.T) {
 		{
 			name:  "identity",
 			expr:  `input`,
-			decls: []*exprpb.Decl{decls.NewVar("input", intList)},
+			decls: []EnvOption{Variable("input", intList)},
 			want:  checker.CostEstimate{Min: 1, Max: 1},
 			in:    map[string]interface{}{"input": []int{1, 2}},
 		},
 		{
 			name: "str concat",
 			expr: `"abcdefg".contains(str1 + str2)`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("str1", decls.String),
-				decls.NewVar("str2", decls.String),
+			decls: []EnvOption{
+				Variable("str1", StringType),
+				Variable("str2", StringType),
 			},
 			hints: map[string]int64{"str1": 10, "str2": 10},
 			want:  checker.CostEstimate{Min: 2, Max: 6},
@@ -1410,9 +1384,7 @@ func TestEstimateCostAndRuntimeCost(t *testing.T) {
 			if tc.hints == nil {
 				tc.hints = map[string]int64{}
 			}
-			e, err := NewEnv(
-				Declarations(tc.decls...),
-				Types(&proto3pb.TestAllTypes{}))
+			e, err := NewEnv(append(tc.decls, Types(&proto3pb.TestAllTypes{}))...)
 			if err != nil {
 				t.Fatalf("NewEnv(opts ...EnvOption) failed to create an environment: %s\n", err)
 			}
@@ -1457,11 +1429,9 @@ func TestEstimateCostAndRuntimeCost(t *testing.T) {
 
 func TestResidualAst_AttributeQualifiers(t *testing.T) {
 	e, _ := NewEnv(
-		Declarations(
-			decls.NewVar("x", decls.NewMapType(decls.String, decls.Dyn)),
-			decls.NewVar("y", decls.NewListType(decls.Int)),
-			decls.NewVar("u", decls.Int),
-		),
+		Variable("x", MapType(StringType, DynType)),
+		Variable("y", ListType(IntType)),
+		Variable("u", IntType),
 	)
 	ast, _ := e.Parse(`x.abc == u && x["abc"] == u && x[x.string] == u && y[0] == u && y[x.zero] == u && (true ? x : y).abc == u && (false ? y : x).abc == u`)
 	prg, _ := e.Program(ast,
@@ -1498,10 +1468,8 @@ func TestResidualAst_AttributeQualifiers(t *testing.T) {
 
 func TestResidualAst_Modified(t *testing.T) {
 	e, _ := NewEnv(
-		Declarations(
-			decls.NewVar("x", decls.NewMapType(decls.String, decls.Int)),
-			decls.NewVar("y", decls.Int),
-		),
+		Variable("x", MapType(StringType, IntType)),
+		Variable("y", IntType),
 	)
 	ast, _ := e.Parse("x == y")
 	prg, _ := e.Program(ast,

--- a/cel/decls.go
+++ b/cel/decls.go
@@ -1,0 +1,1135 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cel
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/interpreter/functions"
+
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+// Kind indicates a CEL type's kind which is used to differentiate quickly between simple and complex types.
+type Kind uint
+
+const (
+	// DynKind represents a dynamic type. This kind only exists at type-check time.
+	DynKind Kind = iota
+
+	// AnyKind represents a google.protobuf.Any type. This kind only exists at type-check time.
+	AnyKind
+
+	// BoolKind represents a boolean type.
+	BoolKind
+
+	// BytesKind represents a bytes type.
+	BytesKind
+
+	// DoubleKind represents a double type.
+	DoubleKind
+
+	// DurationKind represents a CEL duration type.
+	DurationKind
+
+	// IntKind represents an integer type.
+	IntKind
+
+	// ListKind represents a list type.
+	ListKind
+
+	// MapKind represents a map type.
+	MapKind
+
+	// NullTypeKind represents a null type.
+	NullTypeKind
+
+	// OpaqueKind represents an abstract type which has no accessible fields.
+	OpaqueKind
+
+	// StringKind represents a string type.
+	StringKind
+
+	// StructKind represents a structured object with typed fields.
+	StructKind
+
+	// TimestampKind represents a a CEL time type.
+	TimestampKind
+
+	// TypeKind represents the CEL type.
+	TypeKind
+
+	// TypeParamKind represents a parameterized type whose type name will be resolved at type-check time, if possible.
+	TypeParamKind
+
+	// UintKind represents a uint type.
+	UintKind
+)
+
+var (
+	// AnyType represents the google.protobuf.Any type.
+	AnyType = &Type{
+		kind:        AnyKind,
+		runtimeType: types.NewTypeValue("google.protobuf.Any"),
+	}
+	// BoolType represents the bool type.
+	BoolType = &Type{
+		kind:        BoolKind,
+		runtimeType: types.BoolType,
+	}
+	// BytesType represents the bytes type.
+	BytesType = &Type{
+		kind:        BytesKind,
+		runtimeType: types.BytesType,
+	}
+	// DoubleType represents the double type.
+	DoubleType = &Type{
+		kind:        DoubleKind,
+		runtimeType: types.DoubleType,
+	}
+	// DurationType represents the CEL duration type.
+	DurationType = &Type{
+		kind:        DurationKind,
+		runtimeType: types.DurationType,
+	}
+	// DynType represents a dynamic CEL type whose type will be determined at runtime from context.
+	DynType = &Type{
+		kind:        DynKind,
+		runtimeType: types.NewTypeValue("dyn"),
+	}
+	// IntType represents the int type.
+	IntType = &Type{
+		kind:        IntKind,
+		runtimeType: types.IntType,
+	}
+	// NullType represents the type of a null value.
+	NullType = &Type{
+		kind:        NullTypeKind,
+		runtimeType: types.NullType,
+	}
+	// StringType represents the string type.
+	StringType = &Type{
+		kind:        StringKind,
+		runtimeType: types.StringType,
+	}
+	// TimestampType represents the time type.
+	TimestampType = &Type{
+		kind:        TimestampKind,
+		runtimeType: types.TimestampType,
+	}
+	// TypeType represents a CEL type
+	TypeType = &Type{
+		kind:        TypeKind,
+		runtimeType: types.TypeType,
+	}
+	//UintType represents a uint type.
+	UintType = &Type{
+		kind:        UintKind,
+		runtimeType: types.UintType,
+	}
+)
+
+// Type holds a reference to a runtime type with an optional type-checked set of type parameters.
+type Type struct {
+	// kind indicates general category of the type.
+	kind Kind
+
+	// runtimeType is the runtime type of the declaration.
+	runtimeType ref.Type
+
+	// parameters holds the optional type-checked set of type parameters that are used during static analysis.
+	parameters []*Type
+
+	// isAssignableType function determines whether one type is assignable to this type.
+	// A nil value for the isAssignableType function falls back to equality of kind, runtimeType, and parameters.
+	isAssignableType func(other *Type) bool
+
+	// isAssignableRuntimeType function determines whether the runtime type (with erasure) is assignable to this type.
+	// A nil value for the isAssignableRuntimeType function falls back to the equality of the type or type name.
+	isAssignableRuntimeType func(other ref.Type) bool
+}
+
+// IsAssignableFrom determines whether the current type is type-check assignable from the input fromType.
+func (t *Type) IsAssignableType(fromType *Type) bool {
+	if t.isAssignableType != nil {
+		return t.isAssignableType(fromType)
+	}
+	return t.defaultIsAssignableType(fromType)
+}
+
+// IsAssignableRuntimeType determines whether the current type is runtime assignable from the input runtimeType.
+//
+// At runtime, parameterized types are erased and so a function which type-checks to support a map(string, string)
+// will have a runtime assignable type of a map.
+func (t *Type) IsAssignableRuntimeType(runtimeType ref.Type) bool {
+	if t.isAssignableRuntimeType != nil {
+		return t.isAssignableRuntimeType(runtimeType)
+	}
+	return t.defaultIsAssignableRuntimeType(runtimeType)
+}
+
+// String returns a human-readable definition of the type name.
+func (t *Type) String() string {
+	if len(t.parameters) == 0 {
+		return t.runtimeType.TypeName()
+	}
+	params := make([]string, len(t.parameters))
+	for i, p := range t.parameters {
+		params[i] = p.String()
+	}
+	return fmt.Sprintf("%s(%s)", t.runtimeType.TypeName(), strings.Join(params, ", "))
+}
+
+// isDyn indicates whether the type is dynamic in any way.
+func (t *Type) isDyn() bool {
+	return t.kind == DynKind || t.kind == AnyKind || t.kind == TypeParamKind
+}
+
+// equals indicates whether two types have the same kind, type name, and parameters.
+func (t *Type) equals(other *Type) bool {
+	if t.kind != other.kind ||
+		t.runtimeType.TypeName() != other.runtimeType.TypeName() ||
+		len(t.parameters) != len(other.parameters) {
+		return false
+	}
+	for i, p := range t.parameters {
+		if !p.equals(other.parameters[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// defaultIsAssignableType provides the standard definition of what it means for one type to be assignable to another
+// where any of the following may return a true result:
+// - The from types are the same instance
+// - The target type is dynamic
+// - The fromType has the same kind and type name as the target type, and all parameters of the target type
+//   are IsAssignableType() from the parameters of the fromType.
+func (t *Type) defaultIsAssignableType(fromType *Type) bool {
+	if t == fromType || t.isDyn() {
+		return true
+	}
+	if t.kind != fromType.kind ||
+		t.runtimeType.TypeName() != fromType.runtimeType.TypeName() ||
+		len(t.parameters) != len(fromType.parameters) {
+		return false
+	}
+	for i, tp := range t.parameters {
+		fp := fromType.parameters[i]
+		if !tp.IsAssignableType(fp) {
+			return false
+		}
+	}
+	return true
+}
+
+func (t *Type) defaultIsAssignableRuntimeType(runtimeType ref.Type) bool {
+	return t.runtimeType == runtimeType || t.isDyn() || t.runtimeType.TypeName() == runtimeType.TypeName()
+}
+
+// ListType creates an instances of a list type value with the provided element type.
+func ListType(elemType *Type) *Type {
+	return &Type{
+		kind:        ListKind,
+		runtimeType: types.ListType,
+		parameters:  []*Type{elemType},
+	}
+}
+
+// MapType creates an instance of a map type value with the provided key and value types.
+func MapType(keyType, valueType *Type) *Type {
+	return &Type{
+		kind:        MapKind,
+		runtimeType: types.MapType,
+		parameters:  []*Type{keyType, valueType},
+	}
+}
+
+// NullableType creates an instance of a nullable type with the provided wrapped type.
+//
+// Note: only primitive types are supported as wrapped types.
+func NullableType(wrapped *Type) *Type {
+	return &Type{
+		kind:        wrapped.kind,
+		runtimeType: wrapped.runtimeType,
+		parameters:  wrapped.parameters,
+		isAssignableType: func(other *Type) bool {
+			return NullType.IsAssignableType(other) || wrapped.IsAssignableType(other)
+		},
+		isAssignableRuntimeType: func(other ref.Type) bool {
+			return NullType.IsAssignableRuntimeType(other) || wrapped.IsAssignableRuntimeType(other)
+		},
+	}
+}
+
+// OpaqueType creates an abstract parameterized type with a given name.
+func OpaqueType(name string, params ...*Type) *Type {
+	return &Type{
+		kind:        OpaqueKind,
+		runtimeType: types.NewTypeValue(name),
+		parameters:  params,
+	}
+}
+
+// ObjectType creates a type references to an externally defined type, e.g. a protobuf message type.
+func ObjectType(typeName string) *Type {
+	return &Type{
+		kind:        StructKind,
+		runtimeType: types.NewObjectTypeValue(typeName),
+	}
+}
+
+// TypeParamType creates a parameterized type instance.
+func TypeParamType(paramName string) *Type {
+	return &Type{
+		kind:        TypeParamKind,
+		runtimeType: types.NewTypeValue(paramName),
+	}
+}
+
+// Variable creates an instance of a variable declaration with a variable name and type.
+func Variable(name string, t *Type) EnvOption {
+	return func(e *Env) (*Env, error) {
+		et, err := TypeToExprType(t)
+		if err != nil {
+			return nil, err
+		}
+		e.declarations = append(e.declarations, decls.NewVar(name, et))
+		return e, nil
+	}
+}
+
+// Function defines a function and overloads with optional singleton or per-overload implementations.
+//
+// Using Function is roughly equivalent to calling Declarations() to declare the function signatures
+// and Functions() to define the function implementations, if they have been defined. Specifying the
+// same function name more than once will result in the aggregation of the function overloads. If any
+// signatures conflict between the existing and new function definition an error will be raised.
+// However, if the signatures are identical and the overload ids are the same, the redefinition will
+// be considered a no-op.
+//
+// One key difference with using Function() is that each FunctionDecl provided will handle dynamic
+// dispatch based on the type-signatures of the overloads provided which means overload resolution at
+// runtime is handled out of the box rather than via a custom implementation for overload resolution
+// via Functions().
+func Function(name string, opts ...FunctionOpt) EnvOption {
+	return func(e *Env) (*Env, error) {
+		fn := &functionDecl{
+			name:      name,
+			overloads: map[string]*overloadDecl{},
+			options:   opts,
+		}
+		err := fn.init()
+		if err != nil {
+			return nil, err
+		}
+		_, err = functionDeclToExprDecl(fn)
+		if err != nil {
+			return nil, err
+		}
+		if existing, found := e.functions[fn.name]; found {
+			fn, err = existing.merge(fn)
+			if err != nil {
+				return nil, err
+			}
+		}
+		e.functions[name] = fn
+		return e, nil
+	}
+}
+
+// FunctionOpt defines a functional  option for configuring a function declaration.
+type FunctionOpt func(*functionDecl) (*functionDecl, error)
+
+// SingletonUnaryImpl creates a singleton function defintion to be used for all function overloads.
+//
+// Note, this approach works well if operand is expected to have a specific trait which it implements,
+// e.g. traits.ContainerType. Otherwise, prefer per-overload implementations.
+func SingletonUnaryImpl(fn functions.UnaryOp, traits ...int) FunctionOpt {
+	trait := 0
+	for _, t := range traits {
+		trait = trait | t
+	}
+	return func(f *functionDecl) (*functionDecl, error) {
+		if f.singleton != nil {
+			return nil, fmt.Errorf("function already has an implementation: %s", f.name)
+		}
+		f.singleton = &functions.Overload{
+			Operator:     f.name,
+			Unary:        fn,
+			OperandTrait: trait,
+		}
+		return f, nil
+	}
+}
+
+// SingletonBinaryImpl creates a singleton function definition to be used with all function overloads.
+//
+// Note, this approach works well if operand is expected to have a specific trait which it implements,
+// e.g. traits.ContainerType. Otherwise, prefer per-overload implementations.
+func SingletonBinaryImpl(fn functions.BinaryOp, traits ...int) FunctionOpt {
+	trait := 0
+	for _, t := range traits {
+		trait = trait | t
+	}
+	return func(f *functionDecl) (*functionDecl, error) {
+		if f.singleton != nil {
+			return nil, fmt.Errorf("function already has an implementation: %s", f.name)
+		}
+		f.singleton = &functions.Overload{
+			Operator:     f.name,
+			Binary:       fn,
+			OperandTrait: trait,
+		}
+		return f, nil
+	}
+}
+
+// SingletonFunctionImpl creates a singleton function definition to be used with all function overloads.
+//
+// Note, this approach works well if operand is expected to have a specific trait which it implements,
+// e.g. traits.ContainerType. Otherwise, prefer per-overload implementations.
+func SingletonFunctionImpl(fn functions.FunctionOp, traits ...int) FunctionOpt {
+	trait := 0
+	for _, t := range traits {
+		trait = trait | t
+	}
+	return func(f *functionDecl) (*functionDecl, error) {
+		if f.singleton != nil {
+			return nil, fmt.Errorf("function already has an implementation: %s", f.name)
+		}
+		f.singleton = &functions.Overload{
+			Operator:     f.name,
+			Function:     fn,
+			OperandTrait: trait,
+		}
+		return f, nil
+	}
+}
+
+// Overload defines a new global overload with an overload id, argument types, and result type. Through the
+// use of OverloadOpt options, the overload may also be configured with an implementation, an operand trait,
+// and to be non-strict.
+//
+// Note: implementations should be commonly configured with Overload instances whereas operand traits and
+// strict-ness should be rare occurrences.
+func Overload(overloadID string, args []*Type, resultType *Type, opts ...OverloadOpt) FunctionOpt {
+	return newOverload(overloadID, false, args, resultType, opts...)
+}
+
+// MemberOverload defines a new receiver-style overload (or member function) with an overload id, argument types,
+// and result type. Through the use of OverloadOpt options, the overload may also be configured with an
+// implementation, an operand trait, and to be non-strict.
+//
+// Note: implementations should be commonly configured with Overload instances whereas operand traits and
+// strict-ness should be rare occurrences.
+func MemberOverload(overloadID string, args []*Type, resultType *Type, opts ...OverloadOpt) FunctionOpt {
+	return newOverload(overloadID, true, args, resultType, opts...)
+}
+
+// OverloadOpt is a functional option for configuring a function overload.
+type OverloadOpt func(*overloadDecl) (*overloadDecl, error)
+
+// UnaryImpl provides the implementation of a unary overload. The provided function is protected by a runtime
+// type-guard which ensures runtime type agreement between the overload signature and runtime argument types.
+func UnaryImpl(impl functions.UnaryOp) OverloadOpt {
+	return func(o *overloadDecl) (*overloadDecl, error) {
+		if o.hasImpl() {
+			return nil, fmt.Errorf("overload already has an implementation: %s", o.id)
+		}
+		if len(o.argTypes) != 1 {
+			return nil, fmt.Errorf("unary function bound to non-unary overload: %s", o.id)
+		}
+		o.unaryOp = impl
+		return o, nil
+	}
+}
+
+// BinaryImpl provides the implementation of a binary overload. The provided function is protected by a runtime
+// type-guard which ensures runtime type agreement between the overload signature and runtime argument types.
+func BinaryImpl(impl functions.BinaryOp) OverloadOpt {
+	return func(o *overloadDecl) (*overloadDecl, error) {
+		if o.hasImpl() {
+			return nil, fmt.Errorf("overload already has an implementation: %s", o.id)
+		}
+		if len(o.argTypes) != 2 {
+			return nil, fmt.Errorf("binary function bound to non-binary overload: %s", o.id)
+		}
+		o.binaryOp = impl
+		return o, nil
+	}
+}
+
+// FunctionImpl provides the implementation of a variadic overload. The provided function is protected by a runtime
+// type-guard which ensures runtime type agreement between the overload signature and runtime argument types.
+func FunctionImpl(impl functions.FunctionOp) OverloadOpt {
+	return func(o *overloadDecl) (*overloadDecl, error) {
+		if o.hasImpl() {
+			return nil, fmt.Errorf("overload already has an implementation: %s", o.id)
+		}
+		o.functionOp = impl
+		return o, nil
+	}
+}
+
+// OverloadIsNonStrict enables the function to be called with error and unknown argument values.
+//
+// Note: do not use this option unless absoluately necessary as it should be an uncommon feature.
+func OverloadIsNonStrict() OverloadOpt {
+	return func(o *overloadDecl) (*overloadDecl, error) {
+		o.nonStrict = true
+		return o, nil
+	}
+}
+
+// OverloadOperandTrait configures a set of traits which the first argument to the overload must implement in order to be
+// successfully invoked.
+func OverloadOperandTrait(trait int) OverloadOpt {
+	return func(o *overloadDecl) (*overloadDecl, error) {
+		o.operandTrait = trait
+		return o, nil
+	}
+}
+
+type functionDecl struct {
+	name        string
+	overloads   map[string]*overloadDecl
+	options     []FunctionOpt
+	singleton   *functions.Overload
+	initialized bool
+}
+
+// init ensures that a function's options have been applied.
+//
+// This function is used in both the environment configuration and internally for function merges.
+func (f *functionDecl) init() error {
+	if f.initialized {
+		return nil
+	}
+	f.initialized = true
+
+	var err error
+	for _, opt := range f.options {
+		f, err = opt(f)
+		if err != nil {
+			return err
+		}
+	}
+	if len(f.overloads) == 0 {
+		return fmt.Errorf("function %s must have at least one overload", f.name)
+	}
+	return nil
+}
+
+// bindings produces a set of function overload implementations, if any are defined.
+func (f *functionDecl) bindings() ([]*functions.Overload, error) {
+	overloads := []*functions.Overload{}
+	nonStrict := false
+	for _, o := range f.overloads {
+		if o.hasImpl() {
+			overload := &functions.Overload{
+				Operator:     o.id,
+				Unary:        o.guardedUnaryOp(f.name),
+				Binary:       o.guardedBinaryOp(f.name),
+				Function:     o.guardedFunctionOp(f.name),
+				OperandTrait: o.operandTrait,
+				NonStrict:    o.nonStrict,
+			}
+			overloads = append(overloads, overload)
+			nonStrict = nonStrict || o.nonStrict
+		}
+	}
+	if f.singleton != nil {
+		if len(overloads) != 0 {
+			return nil, fmt.Errorf("singleton function incompatible with specialized overloads: %s", f.name)
+		}
+		return []*functions.Overload{
+			{
+				Operator:     f.name,
+				Unary:        f.singleton.Unary,
+				Binary:       f.singleton.Binary,
+				Function:     f.singleton.Function,
+				OperandTrait: f.singleton.OperandTrait,
+			},
+		}, nil
+	}
+	if len(overloads) == 0 {
+		return overloads, nil
+	}
+	// Single overload. Replicate an entry for it using the function name as well.
+	if len(overloads) == 1 {
+		if overloads[0].Operator == f.name {
+			return overloads, nil
+		}
+		return append(overloads, &functions.Overload{
+			Operator:     f.name,
+			Unary:        overloads[0].Unary,
+			Binary:       overloads[0].Binary,
+			Function:     overloads[0].Function,
+			NonStrict:    overloads[0].NonStrict,
+			OperandTrait: overloads[0].OperandTrait,
+		}), nil
+	}
+	// All of the defined overloads are wrapped into a top-level function which
+	// performs dynamic dispatch to the proper overload based on the argument types.
+	bindings := append([]*functions.Overload{}, overloads...)
+	funcDispatch := func(args ...ref.Val) ref.Val {
+		for _, overloadDecl := range f.overloads {
+			if !overloadDecl.matchesRuntimeSignature(args...) {
+				continue
+			}
+			switch len(args) {
+			case 1:
+				if overloadDecl.unaryOp != nil {
+					return overloadDecl.unaryOp(args[0])
+				}
+			case 2:
+				if overloadDecl.binaryOp != nil {
+					return overloadDecl.binaryOp(args[0], args[1])
+				}
+			}
+			if overloadDecl.functionOp != nil {
+				return overloadDecl.functionOp(args...)
+			}
+			// eventually this will fall through to the noSuchOverload below.
+		}
+		return noSuchOverload(f.name, args...)
+	}
+	function := &functions.Overload{
+		Operator:  f.name,
+		Function:  funcDispatch,
+		NonStrict: nonStrict,
+	}
+	return append(bindings, function), nil
+}
+
+// merge one function declaration with another.
+//
+// If a function is extended, by say adding new overloads to an existing function, then it is merged with the
+// prior definition of the function at which point its overloads must not collide with pre-existing overloads
+// and its implementations (singleton, or per-overload) must not conflict with previous definitions either.
+func (f *functionDecl) merge(other *functionDecl) (*functionDecl, error) {
+	if f.name != other.name {
+		return nil, fmt.Errorf("cannot merge unrelated functions. %s and %s", f.name, other.name)
+	}
+	err := f.init()
+	if err != nil {
+		return nil, err
+	}
+	err = other.init()
+	if err != nil {
+		return nil, err
+	}
+	merged := &functionDecl{
+		name:        f.name,
+		overloads:   map[string]*overloadDecl{},
+		options:     []FunctionOpt{},
+		initialized: true,
+		singleton:   f.singleton,
+	}
+	for id, o := range f.overloads {
+		merged.overloads[id] = o
+	}
+	for _, o := range other.overloads {
+		err := merged.addOverload(o)
+		if err != nil {
+			return nil, fmt.Errorf("function declration merge failed: %v", err)
+		}
+	}
+	if other.singleton != nil {
+		if merged.singleton != nil {
+			return nil, fmt.Errorf("function already has an implementation: %s", f.name)
+		}
+		merged.singleton = other.singleton
+	}
+	return merged, nil
+}
+
+// addOverload ensures that the new overload does not collide with an existing overload signature,
+// nor does it redefine an existing overload implementation.
+func (f *functionDecl) addOverload(overload *overloadDecl) error {
+	for id, o := range f.overloads {
+		if id != overload.id && o.signatureOverlaps(overload) {
+			return fmt.Errorf("overload signature collision in function %s: %s collides with %s", f.name, o.id, overload.id)
+		}
+		if id == overload.id {
+			if o.signatureEquals(overload) && o.nonStrict == overload.nonStrict {
+				if !o.hasImpl() && overload.hasImpl() {
+					f.overloads[id] = overload
+				} else if o.hasImpl() && overload.hasImpl() && o != overload {
+					return fmt.Errorf("overload implementation collision in function %s: %s has multiple implementations", f.name, o.id)
+				}
+			} else {
+				return fmt.Errorf("overload redefinition in function. %s: %s has multiple definitions", f.name, o.id)
+			}
+		}
+	}
+	f.overloads[overload.id] = overload
+	return nil
+}
+
+func noSuchOverload(funcName string, args ...ref.Val) ref.Val {
+	argTypes := make([]string, len(args))
+	for i, arg := range args {
+		argTypes[i] = arg.Type().TypeName()
+	}
+	signature := strings.Join(argTypes, ", ")
+	return types.NewErr("no such overload: %s(%s)", funcName, signature)
+}
+
+// overloadDecl contains all of the relevant information regarding a specific function overload.
+type overloadDecl struct {
+	id             string
+	argTypes       []*Type
+	resultType     *Type
+	memberFunction bool
+
+	// implementation options, optional but encouraged.
+	unaryOp    functions.UnaryOp
+	binaryOp   functions.BinaryOp
+	functionOp functions.FunctionOp
+
+	// behavioral options, uncommon
+	nonStrict    bool
+	operandTrait int
+}
+
+func (o *overloadDecl) hasImpl() bool {
+	return o.unaryOp != nil || o.binaryOp != nil || o.functionOp != nil
+}
+
+// guardedUnaryOp creates an invocation guard around the provided unary operator, if one is defined.
+func (o *overloadDecl) guardedUnaryOp(funcName string) functions.UnaryOp {
+	if o.unaryOp == nil {
+		return nil
+	}
+	return func(arg ref.Val) ref.Val {
+		if !o.matchesRuntimeUnarySignature(arg) {
+			return noSuchOverload(funcName, arg)
+		}
+		return o.unaryOp(arg)
+	}
+}
+
+// guardedBinaryOp creates an invocation guard around the provided binary operator, if one is defined.
+func (o *overloadDecl) guardedBinaryOp(funcName string) functions.BinaryOp {
+	if o.binaryOp == nil {
+		return nil
+	}
+	return func(arg1, arg2 ref.Val) ref.Val {
+		if !o.matchesRuntimeBinarySignature(arg1, arg2) {
+			return noSuchOverload(funcName, arg1, arg2)
+		}
+		return o.binaryOp(arg1, arg2)
+	}
+}
+
+// guardedFunctionOp creates an invocation guard around the provided variadic function implementation, if one is provided.
+func (o *overloadDecl) guardedFunctionOp(funcName string) functions.FunctionOp {
+	if o.functionOp == nil {
+		return nil
+	}
+	return func(args ...ref.Val) ref.Val {
+		if !o.matchesRuntimeSignature(args...) {
+			return noSuchOverload(funcName, args...)
+		}
+		return o.functionOp(args...)
+	}
+}
+
+// matchesRuntimeUnarySignature indicates whether the argument type is runtime assiganble to the overload's expected argument.
+func (o *overloadDecl) matchesRuntimeUnarySignature(arg ref.Val) bool {
+	if o.nonStrict && types.IsUnknownOrError(arg) {
+		return true
+	}
+	return o.argTypes[0].IsAssignableRuntimeType(arg.Type()) && (o.operandTrait == 0 || arg.Type().HasTrait(o.operandTrait))
+}
+
+// matchesRuntimeBinarySignature indicates whether the argument types are runtime assiganble to the overload's expected arguments.
+func (o *overloadDecl) matchesRuntimeBinarySignature(arg1, arg2 ref.Val) bool {
+	if o.nonStrict {
+		if types.IsUnknownOrError(arg1) {
+			return types.IsUnknownOrError(arg2) || o.argTypes[1].IsAssignableRuntimeType(arg2.Type())
+		}
+	} else if !o.argTypes[1].IsAssignableRuntimeType(arg2.Type()) {
+		return false
+	}
+	return o.argTypes[0].IsAssignableRuntimeType(arg1.Type()) && (o.operandTrait == 0 || arg1.Type().HasTrait(o.operandTrait))
+}
+
+// matchesRuntimeSignature indicates whether the argument types are runtime assiganble to the overload's expected arguments.
+func (o *overloadDecl) matchesRuntimeSignature(args ...ref.Val) bool {
+	if len(args) != len(o.argTypes) {
+		return false
+	}
+	if len(args) == 0 {
+		return true
+	}
+	allArgsMatch := true
+	for i, arg := range args {
+		if o.nonStrict && types.IsUnknownOrError(arg) {
+			continue
+		}
+		allArgsMatch = allArgsMatch && o.argTypes[i].IsAssignableRuntimeType(arg.Type())
+	}
+
+	arg := args[0]
+	return allArgsMatch && (o.operandTrait == 0 || (o.nonStrict && types.IsUnknownOrError(arg)) || arg.Type().HasTrait(o.operandTrait))
+}
+
+// signatureEquals indicates whether one overload has an identical signature to another overload.
+//
+// Providing a duplicate signature is not an issue, but an overloapping signature is problematic.
+func (o *overloadDecl) signatureEquals(other *overloadDecl) bool {
+	if o.id != other.id || o.memberFunction != other.memberFunction || len(o.argTypes) != len(other.argTypes) {
+		return false
+	}
+	for i, at := range o.argTypes {
+		oat := other.argTypes[i]
+		if !at.equals(oat) {
+			return false
+		}
+	}
+	return o.resultType.equals(other.resultType)
+}
+
+// signatureOverlaps indicates whether one overload has an overlapping signature with another overload.
+//
+// The 'other' overload must first be checked for equality before determining whether it overlaps in order to be completely accurate.
+func (o *overloadDecl) signatureOverlaps(other *overloadDecl) bool {
+	if o.memberFunction != other.memberFunction || len(o.argTypes) != len(other.argTypes) {
+		return false
+	}
+	argsOverlap := true
+	for i, argType := range o.argTypes {
+		otherArgType := other.argTypes[i]
+		argsOverlap = argsOverlap &&
+			(argType.IsAssignableRuntimeType(otherArgType.runtimeType) ||
+				otherArgType.IsAssignableRuntimeType(argType.runtimeType))
+	}
+	return argsOverlap
+}
+
+func newOverload(overloadID string, memberFunction bool, args []*Type, resultType *Type, opts ...OverloadOpt) FunctionOpt {
+	return func(f *functionDecl) (*functionDecl, error) {
+		overload := &overloadDecl{
+			id:             overloadID,
+			argTypes:       args,
+			resultType:     resultType,
+			memberFunction: memberFunction,
+		}
+		var err error
+		for _, opt := range opts {
+			overload, err = opt(overload)
+			if err != nil {
+				return nil, err
+			}
+		}
+		err = f.addOverload(overload)
+		if err != nil {
+			return nil, err
+		}
+		return f, nil
+	}
+}
+
+func maybeWrapper(t *Type, pbType *exprpb.Type) *exprpb.Type {
+	if t.IsAssignableType(NullType) {
+		return decls.NewWrapperType(pbType)
+	}
+	return pbType
+}
+
+// TypeToExprType converts a CEL-native type representation to a protobuf CEL Type representation.
+func TypeToExprType(t *Type) (*exprpb.Type, error) {
+	switch t.kind {
+	case AnyKind:
+		return decls.Any, nil
+	case BoolKind:
+		return maybeWrapper(t, decls.Bool), nil
+	case BytesKind:
+		return maybeWrapper(t, decls.Bytes), nil
+	case DoubleKind:
+		return maybeWrapper(t, decls.Double), nil
+	case DurationKind:
+		return decls.Duration, nil
+	case DynKind:
+		return decls.Dyn, nil
+	case IntKind:
+		return maybeWrapper(t, decls.Int), nil
+	case ListKind:
+		et, err := TypeToExprType(t.parameters[0])
+		if err != nil {
+			return nil, err
+		}
+		return decls.NewListType(et), nil
+	case MapKind:
+		kt, err := TypeToExprType(t.parameters[0])
+		if err != nil {
+			return nil, err
+		}
+		vt, err := TypeToExprType(t.parameters[1])
+		if err != nil {
+			return nil, err
+		}
+		return decls.NewMapType(kt, vt), nil
+	case NullTypeKind:
+		return decls.Null, nil
+	case OpaqueKind:
+		params := make([]*exprpb.Type, len(t.parameters))
+		for i, p := range t.parameters {
+			pt, err := TypeToExprType(p)
+			if err != nil {
+				return nil, err
+			}
+			params[i] = pt
+		}
+		return decls.NewAbstractType(t.runtimeType.TypeName(), params...), nil
+	case StringKind:
+		return maybeWrapper(t, decls.String), nil
+	case StructKind:
+		switch t.runtimeType.TypeName() {
+		case "google.protobuf.Any":
+			return decls.Any, nil
+		case "google.protobuf.Duration":
+			return decls.Duration, nil
+		case "google.protobuf.Timestamp":
+			return decls.Timestamp, nil
+		case "google.protobuf.Value":
+			return decls.Dyn, nil
+		case "google.protobuf.ListValue":
+			return decls.NewListType(decls.Dyn), nil
+		case "google.protobuf.Struct":
+			return decls.NewMapType(decls.String, decls.Dyn), nil
+		case "google.protobuf.BoolValue":
+			return decls.NewWrapperType(decls.Bool), nil
+		case "google.protobuf.BytesValue":
+			return decls.NewWrapperType(decls.Bytes), nil
+		case "google.protobuf.DoubleValue", "google.protobuf.FloatValue":
+			return decls.NewWrapperType(decls.Double), nil
+		case "google.protobuf.Int32Value", "google.protobuf.Int64Value":
+			return decls.NewWrapperType(decls.Int), nil
+		case "google.protobuf.StringValue":
+			return decls.NewWrapperType(decls.String), nil
+		case "google.protobuf.UInt32Value", "google.protobuf.UInt64Value":
+			return decls.NewWrapperType(decls.Uint), nil
+		default:
+			return decls.NewObjectType(t.runtimeType.TypeName()), nil
+		}
+	case TimestampKind:
+		return decls.Timestamp, nil
+	case TypeParamKind:
+		return decls.NewTypeParamType(t.runtimeType.TypeName()), nil
+	case TypeKind:
+		return decls.NewTypeType(decls.Dyn), nil
+	case UintKind:
+		return maybeWrapper(t, decls.Uint), nil
+	}
+	return nil, fmt.Errorf("missing type conversion to proto: %v", t)
+}
+
+// ExprTypeToType converts a protobuf CEL type representation to a CEL-native type representation.
+func ExprTypeToType(t *exprpb.Type) (*Type, error) {
+	switch t.GetTypeKind().(type) {
+	case *exprpb.Type_Dyn:
+		return DynType, nil
+	case *exprpb.Type_AbstractType_:
+		paramTypes := make([]*Type, len(t.GetAbstractType().GetParameterTypes()))
+		for i, p := range t.GetAbstractType().GetParameterTypes() {
+			pt, err := ExprTypeToType(p)
+			if err != nil {
+				return nil, err
+			}
+			paramTypes[i] = pt
+		}
+		return OpaqueType(t.GetAbstractType().GetName(), paramTypes...), nil
+	case *exprpb.Type_ListType_:
+		et, err := ExprTypeToType(t.GetListType().GetElemType())
+		if err != nil {
+			return nil, err
+		}
+		return ListType(et), nil
+	case *exprpb.Type_MapType_:
+		kt, err := ExprTypeToType(t.GetMapType().GetKeyType())
+		if err != nil {
+			return nil, err
+		}
+		vt, err := ExprTypeToType(t.GetMapType().GetValueType())
+		if err != nil {
+			return nil, err
+		}
+		return MapType(kt, vt), nil
+	case *exprpb.Type_MessageType:
+		switch t.GetMessageType() {
+		case "google.protobuf.Any":
+			return AnyType, nil
+		case "google.protobuf.Duration":
+			return DurationType, nil
+		case "google.protobuf.Timestamp":
+			return TimestampType, nil
+		case "google.protobuf.Value":
+			return DynType, nil
+		case "google.protobuf.ListValue":
+			return ListType(DynType), nil
+		case "google.protobuf.Struct":
+			return MapType(StringType, DynType), nil
+		case "google.protobuf.BoolValue":
+			return NullableType(BoolType), nil
+		case "google.protobuf.BytesValue":
+			return NullableType(BytesType), nil
+		case "google.protobuf.DoubleValue", "google.protobuf.FloatValue":
+			return NullableType(DoubleType), nil
+		case "google.protobuf.Int32Value", "google.protobuf.Int64Value":
+			return NullableType(IntType), nil
+		case "google.protobuf.StringValue":
+			return NullableType(StringType), nil
+		case "google.protobuf.UInt32Value", "google.protobuf.UInt64Value":
+			return NullableType(UintType), nil
+		default:
+			return ObjectType(t.GetMessageType()), nil
+		}
+	case *exprpb.Type_Null:
+		return NullType, nil
+	case *exprpb.Type_Primitive:
+		switch t.GetPrimitive() {
+		case exprpb.Type_BOOL:
+			return BoolType, nil
+		case exprpb.Type_BYTES:
+			return BytesType, nil
+		case exprpb.Type_DOUBLE:
+			return DoubleType, nil
+		case exprpb.Type_INT64:
+			return IntType, nil
+		case exprpb.Type_STRING:
+			return StringType, nil
+		case exprpb.Type_UINT64:
+			return UintType, nil
+		default:
+			return nil, fmt.Errorf("unsupported primitive type: %v", t)
+		}
+	case *exprpb.Type_TypeParam:
+		return TypeParamType(t.GetTypeParam()), nil
+	case *exprpb.Type_Type:
+		return TypeType, nil
+	case *exprpb.Type_WellKnown:
+		switch t.GetWellKnown() {
+		case exprpb.Type_ANY:
+			return AnyType, nil
+		case exprpb.Type_DURATION:
+			return DurationType, nil
+		case exprpb.Type_TIMESTAMP:
+			return TimestampType, nil
+		default:
+			return nil, fmt.Errorf("unsupported well-known type: %v", t)
+		}
+	case *exprpb.Type_Wrapper:
+		t, err := ExprTypeToType(&exprpb.Type{TypeKind: &exprpb.Type_Primitive{Primitive: t.GetWrapper()}})
+		if err != nil {
+			return nil, err
+		}
+		return NullableType(t), nil
+	default:
+		return nil, fmt.Errorf("unsupported type: %v", t)
+	}
+}
+
+// ExprDeclToDeclaration converts a protobuf CEL declaration to a CEL-native declaration, either a Variable or Function.
+func ExprDeclToDeclaration(d *exprpb.Decl) (EnvOption, error) {
+	switch d.GetDeclKind().(type) {
+	case *exprpb.Decl_Function:
+		overloads := d.GetFunction().GetOverloads()
+		opts := make([]FunctionOpt, len(overloads))
+		for i, o := range overloads {
+			args := make([]*Type, len(o.GetParams()))
+			for j, p := range o.GetParams() {
+				a, err := ExprTypeToType(p)
+				if err != nil {
+					return nil, err
+				}
+				args[j] = a
+			}
+			res, err := ExprTypeToType(o.GetResultType())
+			if err != nil {
+				return nil, err
+			}
+			opts[i] = Overload(o.GetOverloadId(), args, res)
+		}
+		return Function(d.GetName(), opts...), nil
+	case *exprpb.Decl_Ident:
+		t, err := ExprTypeToType(d.GetIdent().GetType())
+		if err != nil {
+			return nil, err
+		}
+		return Variable(d.GetName(), t), nil
+	default:
+		return nil, fmt.Errorf("unsupported decl: %v", d)
+	}
+
+}
+
+func functionDeclToExprDecl(f *functionDecl) (*exprpb.Decl, error) {
+	overloads := make([]*exprpb.Decl_FunctionDecl_Overload, len(f.overloads))
+	i := 0
+	for _, o := range f.overloads {
+		paramNames := map[string]struct{}{}
+		argTypes := make([]*exprpb.Type, len(o.argTypes))
+		for j, a := range o.argTypes {
+			collectParamNames(paramNames, a)
+			at, err := TypeToExprType(a)
+			if err != nil {
+				return nil, err
+			}
+			argTypes[j] = at
+		}
+		collectParamNames(paramNames, o.resultType)
+		resultType, err := TypeToExprType(o.resultType)
+		if err != nil {
+			return nil, err
+		}
+		if len(paramNames) == 0 {
+			if o.memberFunction {
+				overloads[i] = decls.NewInstanceOverload(o.id, argTypes, resultType)
+			} else {
+				overloads[i] = decls.NewOverload(o.id, argTypes, resultType)
+			}
+		} else {
+			params := []string{}
+			for pn := range paramNames {
+				params = append(params, pn)
+			}
+			if o.memberFunction {
+				overloads[i] = decls.NewParameterizedInstanceOverload(o.id, argTypes, resultType, params)
+			} else {
+				overloads[i] = decls.NewParameterizedOverload(o.id, argTypes, resultType, params)
+			}
+		}
+		i++
+	}
+	return decls.NewFunction(f.name, overloads...), nil
+}
+
+func collectParamNames(paramNames map[string]struct{}, arg *Type) {
+	if arg.kind == TypeParamKind {
+		paramNames[arg.runtimeType.TypeName()] = struct{}{}
+	}
+	for _, param := range arg.parameters {
+		collectParamNames(paramNames, param)
+	}
+}

--- a/cel/decls_test.go
+++ b/cel/decls_test.go
@@ -1,0 +1,1128 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cel
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/operators"
+	"github.com/google/cel-go/common/overloads"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+	"github.com/google/cel-go/interpreter/functions"
+
+	"google.golang.org/protobuf/proto"
+
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+var dispatchTests = []struct {
+	expr string
+	out  interface{}
+}{
+	{
+		expr: "max(-1)",
+		out:  types.IntNegOne,
+	},
+	{
+		expr: "max(-1, 0)",
+		out:  types.IntZero,
+	},
+	{
+		expr: "max(-1, 0, 1)",
+		out:  types.IntOne,
+	},
+	{
+		expr: "max(dyn(1.2))",
+		out:  fmt.Errorf("no such overload: max(double)"),
+	},
+
+	{
+		expr: "max(1, dyn(1.2))",
+		out:  fmt.Errorf("no such overload: max(int, double)"),
+	},
+	{
+		expr: "max(1, 2, dyn(1.2))",
+		out:  fmt.Errorf("no such overload: max(int, int, double)"),
+	},
+	{
+		expr: "max(err, 1)",
+		out:  fmt.Errorf("error argument"),
+	},
+	{
+		expr: "max(err, unk)",
+		out:  fmt.Errorf("error argument"),
+	},
+	{
+		expr: "max(unk, unk)",
+		out:  types.Unknown{42},
+	},
+	{
+		expr: "max(unk, unk, unk)",
+		out:  types.Unknown{42},
+	},
+}
+
+func TestFunctionMerge(t *testing.T) {
+	size := Function("size",
+		Overload("size_map", []*Type{MapType(TypeParamType("K"), TypeParamType("V"))}, IntType),
+		Overload("size_list", []*Type{ListType(TypeParamType("V"))}, IntType),
+		Overload("size_string", []*Type{StringType}, IntType),
+		Overload("size_bytes", []*Type{BytesType}, IntType),
+		MemberOverload("map_size", []*Type{MapType(TypeParamType("K"), TypeParamType("V"))}, IntType),
+		MemberOverload("list_size", []*Type{ListType(TypeParamType("V"))}, IntType),
+		MemberOverload("string_size", []*Type{StringType}, IntType),
+		MemberOverload("bytes_size", []*Type{BytesType}, IntType),
+		SingletonUnaryImpl(func(arg ref.Val) ref.Val {
+			return arg.(traits.Sizer).Size()
+		}, traits.SizerType),
+	)
+	// Note, the size() implementation is inherited from the singleton implementation for the size function.
+	// It is possible to redefine the singleton, but the singleton approach is incompatible with specialized
+	// overloads as the singleton is compatible with the parse-only approach and compiled approach; but
+	// a mix of singleton and specialized overloads might result in a singleton which does not encompass
+	// dynamic dispatch to all possible overloads.
+	sizeExt := Function("size",
+		Overload("size_vector", []*Type{OpaqueType("vector", TypeParamType("V"))}, IntType),
+		MemberOverload("vector_size", []*Type{OpaqueType("vector", TypeParamType("V"))}, IntType))
+
+	vectorExt := Function("vector",
+		Overload("vector_list", []*Type{ListType(TypeParamType("V"))}, OpaqueType("vector", TypeParamType("V")),
+			UnaryImpl(func(list ref.Val) ref.Val {
+				return list
+			})))
+
+	eq := Function(operators.Equals,
+		Overload(operators.Equals, []*Type{TypeParamType("T"), TypeParamType("T")}, BoolType,
+			BinaryImpl(func(lhs, rhs ref.Val) ref.Val {
+				return lhs.Equal(rhs)
+			})))
+
+	e, err := NewCustomEnv(size, sizeExt, vectorExt, eq)
+	if err != nil {
+		t.Fatalf("NewCustomEnv() failed: %v", err)
+	}
+	ast, iss := e.Compile(`[[0].size() == 1,
+		{'a': true, 'b': false}.size() == 2,
+		'hello'.size() == 5,
+		b'hello'.size() == 5,
+		vector([1.2, 2.3, 3.4]).size() == 3]`)
+	if iss.Err() != nil {
+		t.Fatalf("Compile() errored: %v", iss.Err())
+	}
+	if !reflect.DeepEqual(ast.OutputType(), ListType(BoolType)) {
+		t.Errorf("Compile() produced a %v, wanted bool", ast.OutputType())
+	}
+	if ast.OutputType().String() != "list(bool)" {
+		t.Errorf("ast.OutputType().String() produced %s, wanted list(bool)", ast.OutputType())
+	}
+	prg, err := e.Program(ast)
+	if err != nil {
+		t.Fatalf("e.Program(ast) failed: %v", err)
+	}
+	out, _, err := prg.Eval(NoVars())
+	if err != nil {
+		t.Errorf("prg.Eval() errored: %v", err)
+	}
+	want := types.DefaultTypeAdapter.NativeToValue([]bool{true, true, true, true, true})
+	if out.Equal(want) != types.True {
+		t.Errorf("prg.Eval() got %v, wanted %v", out, want)
+	}
+
+	_, err = NewCustomEnv(vectorExt, vectorExt)
+	if err == nil || !strings.Contains(err.Error(), "overload implementation collision") {
+		t.Errorf("NewCustomEnv(vectorExt, vectorExt) did not produce expected error: %v", err)
+	}
+	_, err = NewCustomEnv(size, size)
+	if err == nil || !strings.Contains(err.Error(), "already has an implementation") {
+		t.Errorf("NewCustomEnv(size, size) did not produce the expected error: %v", err)
+	}
+	e, err = NewCustomEnv(size,
+		Function("size",
+			Overload("size_int", []*Type{IntType}, IntType,
+				UnaryImpl(func(arg ref.Val) ref.Val { return types.Int(2) }),
+			),
+		),
+	)
+	if err != nil {
+		t.Fatalf("NewCustomEnv(size, <custom>) failed: %v", err)
+	}
+	prg, err = e.Program(ast)
+	if err == nil || !strings.Contains(err.Error(), "incompatible with specialized overloads") {
+		t.Errorf("NewCustomEnv(size, size_specialization) did not produce the expected error: %v", err)
+	}
+}
+
+func TestFunctionMergeDuplicate(t *testing.T) {
+	maxFunc := Function("max",
+		Overload("max_int", []*Type{IntType}, IntType),
+		Overload("max_int", []*Type{IntType}, IntType),
+	)
+	_, err := NewCustomEnv(maxFunc, maxFunc)
+	if err != nil {
+		t.Fatalf("NewCustomEnv() failed: %v", err)
+	}
+}
+
+func TestFunctionMergeDeclarationAndDefinition(t *testing.T) {
+	idFuncDecl := Function("id", Overload("id", []*Type{TypeParamType("T")}, TypeParamType("T"), OverloadIsNonStrict()))
+	idFuncDef := Function("id",
+		Overload("id", []*Type{TypeParamType("T")}, TypeParamType("T"), OverloadIsNonStrict(),
+			UnaryImpl(func(arg ref.Val) ref.Val {
+				return arg
+			}),
+		),
+	)
+	env, err := NewCustomEnv(Variable("x", AnyType), idFuncDecl, idFuncDef)
+	if err != nil {
+		t.Fatalf("NewCustomEnv() failed: %v", err)
+	}
+	ast, iss := env.Compile("id(x)")
+	if iss.Err() != nil {
+		t.Fatalf("env.Compile(id(x)) failed: %v", iss.Err())
+	}
+	prg, err := env.Program(ast)
+	if err != nil {
+		t.Fatalf("env.Program() failed: %v", err)
+	}
+	out, _, err := prg.Eval(map[string]interface{}{"x": true})
+	if err != nil {
+		t.Fatalf("prg.Eval(x: true) errored: %v", err)
+	}
+	if out != types.True {
+		t.Errorf("prg.Eval() yielded %v, wanted true", out)
+	}
+}
+
+func TestFunctionMergeCollision(t *testing.T) {
+	maxFunc := Function("max",
+		Overload("max_int", []*Type{IntType}, IntType),
+		Overload("max_int2", []*Type{IntType}, IntType),
+	)
+	_, err := NewCustomEnv(maxFunc, maxFunc)
+	if err == nil {
+		t.Fatal("NewCustomEnv() succeeded, wanted collision error")
+	}
+}
+
+func TestFunctionNoOverloads(t *testing.T) {
+	_, err := NewCustomEnv(Function("right", SingletonBinaryImpl(func(arg1, arg2 ref.Val) ref.Val {
+		return arg2
+	})))
+	if err == nil || !strings.Contains(err.Error(), "must have at least one overload") {
+		t.Errorf("got %v for the error state, wanted 'no overloads'", err)
+	}
+}
+
+func TestSingletonUnaryImplRedefinition(t *testing.T) {
+	_, err := NewCustomEnv(
+		Function("id",
+			Overload("id_any", []*Type{AnyType}, AnyType),
+			SingletonUnaryImpl(func(arg ref.Val) ref.Val {
+				return arg
+			}),
+			SingletonUnaryImpl(func(arg ref.Val) ref.Val {
+				return arg
+			}),
+		),
+	)
+	if err == nil || !strings.Contains(err.Error(), "already has an implementation") {
+		t.Errorf("NewCustomEnv() got %v, wanted already had an implementation", err)
+	}
+}
+
+func TestSingletonUnaryImpl(t *testing.T) {
+	// Test the case where the singleton unary impl is merged with the earlier declaration.
+	e, err := NewCustomEnv(
+		Variable("x", AnyType),
+		Function("id", Overload("id_any", []*Type{AnyType}, AnyType)),
+		Function("id", Overload("id_any", []*Type{AnyType}, AnyType), SingletonUnaryImpl(func(arg ref.Val) ref.Val { return arg })),
+	)
+	if err != nil {
+		t.Errorf("NewCustomEnv() failed: %v", err)
+	}
+	ast, iss := e.Parse("id(x)")
+	if iss.Err() != nil {
+		t.Fatalf("Parse('id(x)') failed: %v", iss.Err())
+	}
+	prg, err := e.Program(ast)
+	if err != nil {
+		t.Fatalf("Program() failed: %v", err)
+	}
+	out, _, err := prg.Eval(map[string]interface{}{"x": "hello"})
+	if err != nil {
+		t.Errorf("prg.Eval(x=hello) failed: %v", err)
+	}
+	if out.Equal(types.String("hello")) != types.True {
+		t.Errorf("Eval got %v, wanted 'hello'", out)
+	}
+}
+
+func TestSingletonBinaryImplRedefinition(t *testing.T) {
+	_, err := NewCustomEnv(
+		Function("right",
+			Overload("right_double_double", []*Type{DoubleType, DoubleType}, DoubleType),
+			SingletonBinaryImpl(func(arg1, arg2 ref.Val) ref.Val {
+				return arg2
+			}, traits.ComparerType),
+			SingletonBinaryImpl(func(arg1, arg2 ref.Val) ref.Val {
+				return arg2
+			}),
+		))
+	if err == nil || !strings.Contains(err.Error(), "already has an implementation") {
+		t.Errorf("NewCustomEnv() got %v, wanted already had an implementation", err)
+	}
+}
+
+func TestSingletonBinaryImpl(t *testing.T) {
+	_, err := NewCustomEnv(
+		Function("right",
+			Overload("right_int_int", []*Type{IntType, IntType}, IntType),
+			Overload("right_double_double", []*Type{DoubleType, DoubleType}, DoubleType),
+			Overload("right_string_string", []*Type{StringType, StringType}, StringType),
+			SingletonBinaryImpl(func(arg1, arg2 ref.Val) ref.Val {
+				return arg2
+			}, traits.ComparerType),
+		),
+	)
+	if err != nil {
+		t.Errorf("NewCustomEnv() failed: %v", err)
+	}
+}
+
+func TestSingletonFunctionImplRedefinition(t *testing.T) {
+	_, err := NewCustomEnv(
+		Function("id",
+			Overload("id_any", []*Type{AnyType}, AnyType),
+			SingletonFunctionImpl(func(args ...ref.Val) ref.Val {
+				return args[0]
+			}, traits.ComparerType),
+			SingletonFunctionImpl(func(args ...ref.Val) ref.Val {
+				return args[0]
+			}, traits.ComparerType),
+		),
+	)
+	if err == nil || !strings.Contains(err.Error(), "already has an implementation") {
+		t.Errorf("NewCustomEnv() got %v, wanted already had an implementation", err)
+	}
+}
+
+func TestSingletonFunctionImpl(t *testing.T) {
+	env, err := NewCustomEnv(
+		Variable("unk", DynType),
+		Variable("err", DynType),
+		Function("dyn",
+			Overload("dyn", []*Type{DynType}, DynType),
+			SingletonUnaryImpl(func(arg ref.Val) ref.Val {
+				return arg
+			})),
+		Function("max",
+			Overload("max_int", []*Type{IntType}, IntType),
+			Overload("max_int_int", []*Type{IntType, IntType}, IntType),
+			Overload("max_int_int_int", []*Type{IntType, IntType, IntType}, IntType),
+			SingletonFunctionImpl(func(args ...ref.Val) ref.Val {
+				max := types.Int(math.MinInt64)
+				for _, arg := range args {
+					i, ok := arg.(types.Int)
+					if !ok {
+						// With a singleton implementation, the error handling must be explicitly
+						// performed as an implementation detail of the singleton function.
+						// With custom overload implementations, a function guard is automatically
+						// added to the function to validate that the runtime types are compatible
+						// to provide some basic invocation protections.
+						return noSuchOverload("max", args...)
+					}
+					if i > max {
+						max = i
+					}
+				}
+				return max
+			}),
+		),
+	)
+	if err != nil {
+		t.Fatalf("NewCustomEnv() failed: %v", err)
+	}
+
+	for _, tc := range dispatchTests {
+		tc := tc
+		t.Run(fmt.Sprintf("Parse(%s)", tc.expr), func(t *testing.T) {
+			testParse(t, env, tc.expr, tc.out)
+		})
+	}
+	for _, tc := range dispatchTests {
+		tc := tc
+		t.Run(fmt.Sprintf("Compile(%s)", tc.expr), func(t *testing.T) {
+			testCompile(t, env, tc.expr, tc.out)
+		})
+	}
+}
+
+func TestUnaryImplRedefinition(t *testing.T) {
+	_, err := NewCustomEnv(
+		Function("dyn",
+			Overload("dyn", []*Type{DynType}, DynType,
+				UnaryImpl(func(arg ref.Val) ref.Val { return arg }),
+				// redefinition.
+				UnaryImpl(func(arg ref.Val) ref.Val { return arg }),
+			),
+		),
+	)
+	if err == nil || !strings.Contains(err.Error(), "already has an implementation") {
+		t.Errorf("redefinition of function impl did not produce expected error: %v", err)
+	}
+}
+
+func TestUnaryImpl(t *testing.T) {
+	_, err := NewCustomEnv(
+		Function("dyn",
+			Overload("dyn", []*Type{}, DynType,
+				// wrong arg count
+				UnaryImpl(func(arg ref.Val) ref.Val { return arg }),
+			),
+		),
+	)
+	if err == nil || !strings.Contains(err.Error(), "function bound to non-unary overload") {
+		t.Errorf("bad binding did not produce expected error: %v", err)
+	}
+
+	e, err := NewCustomEnv(
+		Function("size",
+			Overload("size_non_strict", []*Type{ListType(DynType)}, IntType,
+				OverloadIsNonStrict(),
+				OverloadOperandTrait(traits.SizerType),
+				UnaryImpl(func(arg ref.Val) ref.Val {
+					if types.IsUnknownOrError(arg) {
+						return arg
+					}
+					return arg.(traits.Sizer).Size()
+				}),
+			),
+		),
+		Variable("x", ListType(DynType)),
+	)
+	ast, iss := e.Compile("size(x)")
+	if iss.Err() != nil {
+		t.Fatalf("Compile(size(x)) failed: %v", iss.Err())
+	}
+	prg, err := e.Program(ast)
+	if err != nil {
+		t.Fatalf("Program() failed: %v", err)
+	}
+	out, _, err := prg.Eval(map[string]interface{}{"x": types.Unknown{1}})
+	if err != nil {
+		t.Fatalf("prg.Eval(x=unk) failed: %v", err)
+	}
+	if !reflect.DeepEqual(out, types.Unknown{1}) {
+		t.Errorf("prg.Eval(x=unk) returned %v, wanted unknown{1}", out)
+	}
+}
+
+func TestBinaryImplRedefinition(t *testing.T) {
+	_, err := NewCustomEnv(
+		Function("right",
+			Overload("right_int_int", []*Type{IntType, IntType}, IntType,
+				BinaryImpl(func(arg1, arg2 ref.Val) ref.Val { return arg2 }),
+				// redefinition.
+				BinaryImpl(func(arg1, arg2 ref.Val) ref.Val { return arg2 }),
+			),
+		),
+	)
+	if err == nil || !strings.Contains(err.Error(), "already has an implementation") {
+		t.Errorf("redefinition of function impl did not produce expected error: %v", err)
+	}
+
+	_, err = NewCustomEnv(
+		Function("right",
+			Overload("right_int_int", []*Type{IntType, IntType}, IntType,
+				BinaryImpl(func(arg1, arg2 ref.Val) ref.Val { return arg2 }),
+			),
+			Overload("right_int_int", []*Type{IntType, IntType, DurationType}, IntType,
+				FunctionImpl(func(args ...ref.Val) ref.Val { return args[0] }),
+			),
+		),
+	)
+	if err == nil || !strings.Contains(err.Error(), "multiple definitions") {
+		t.Errorf("redefinition of right_int_int did not produce expected error: %v", err)
+	}
+
+	_, err = NewCustomEnv(
+		Function("elem_type",
+			Overload("elem_type_list", []*Type{ListType(TypeParamType("T"))}, TypeType),
+			Overload("elem_type_list", []*Type{ListType(DynType)}, TypeType),
+		),
+	)
+	if err == nil || !strings.Contains(err.Error(), "multiple definitions") {
+		t.Errorf("redefinition of elem_type_list did not produce expected error: %v", err)
+	}
+}
+
+func TestBinaryImpl(t *testing.T) {
+	e, err := NewCustomEnv(
+		Function("max",
+			Overload("max_int_int", []*Type{IntType, IntType}, IntType,
+				OverloadIsNonStrict(),
+				BinaryImpl(func(arg1, arg2 ref.Val) ref.Val {
+					if types.IsUnknownOrError(arg1) {
+						return arg2
+					}
+					if types.IsUnknownOrError(arg2) {
+						return arg1
+					}
+					i1 := arg1.(types.Int)
+					i2 := arg2.(types.Int)
+					if i1 > i2 {
+						return i1
+					}
+					return i2
+				}),
+			),
+		),
+		Variable("x", IntType),
+		Variable("y", IntType),
+	)
+	ast, iss := e.Parse("max(x, y)")
+	if iss.Err() != nil {
+		t.Fatalf("Parse(max(x, y))) failed: %v", iss.Err())
+	}
+	prg, err := e.Program(ast)
+	if err != nil {
+		t.Fatalf("Program() failed: %v", err)
+	}
+	out, _, err := prg.Eval(map[string]interface{}{"x": types.Unknown{1}, "y": 1})
+	if err != nil {
+		t.Fatalf("prg.Eval(x=unk) failed: %v", err)
+	}
+	if !reflect.DeepEqual(out, types.IntOne) {
+		t.Errorf("prg.Eval(x=unk, y=1) returned %v, wanted 1", out)
+	}
+	out, _, err = prg.Eval(map[string]interface{}{"x": 2, "y": types.Unknown{2}})
+	if err != nil {
+		t.Fatalf("prg.Eval(x=2, y=unk) failed: %v", err)
+	}
+	if !reflect.DeepEqual(out, types.Int(2)) {
+		t.Errorf("prg.Eval(x=2, y=unk) returned %v, wanted 2", out)
+	}
+	out, _, err = prg.Eval(map[string]interface{}{"x": 2, "y": 1})
+	if err != nil {
+		t.Fatalf("prg.Eval(x=2, y=1) failed: %v", err)
+	}
+	if !reflect.DeepEqual(out, types.Int(2)) {
+		t.Errorf("prg.Eval(x=2, y=1) returned %v, wanted 2", out)
+	}
+
+	_, err = NewCustomEnv(
+		Function("right",
+			Overload("right_int_int", []*Type{IntType, IntType, IntType}, IntType,
+				// wrong arg count
+				BinaryImpl(func(arg1, arg2 ref.Val) ref.Val { return arg2 }),
+			),
+		),
+	)
+	if err == nil || !strings.Contains(err.Error(), "function bound to non-binary overload") {
+		t.Errorf("bad binding did not produce expected error: %v", err)
+	}
+}
+
+func TestFunctionImplRedefinition(t *testing.T) {
+	_, err := NewCustomEnv(
+		Function("right",
+			Overload("right_int_int_int", []*Type{IntType, IntType, IntType}, IntType,
+				FunctionImpl(func(args ...ref.Val) ref.Val { return args[0] }),
+				// redefinition.
+				FunctionImpl(func(args ...ref.Val) ref.Val { return args[1] }),
+			),
+		),
+	)
+	if err == nil || !strings.Contains(err.Error(), "already has an implementation") {
+		t.Errorf("redefinition of function impl did not produce expected error: %v", err)
+	}
+}
+
+func TestFunctionImpl(t *testing.T) {
+	e, err := NewCustomEnv(
+		Variable("unk", DynType),
+		Variable("err", DynType),
+		Function("dyn",
+			Overload("dyn", []*Type{DynType}, DynType),
+			SingletonUnaryImpl(func(arg ref.Val) ref.Val {
+				return arg
+			})),
+		Function("max",
+			Overload("max_int", []*Type{IntType}, IntType,
+				UnaryImpl(func(arg ref.Val) ref.Val { return arg })),
+			Overload("max_int_int", []*Type{IntType, IntType}, IntType,
+				BinaryImpl(func(lhs, rhs ref.Val) ref.Val {
+					if lhs.(types.Int).Compare(rhs) == types.IntNegOne {
+						return rhs
+					}
+					return lhs
+				})),
+			Overload("max_int_int_int", []*Type{IntType, IntType, IntType}, IntType,
+				FunctionImpl(func(args ...ref.Val) ref.Val {
+					max := types.Int(math.MinInt64)
+					for _, arg := range args {
+						i := arg.(types.Int)
+						if i > max {
+							max = i
+						}
+					}
+					return max
+				})),
+		),
+	)
+	if err != nil {
+		t.Fatalf("NewCustomEnv() failed: %v", err)
+	}
+
+	for _, tc := range dispatchTests {
+		tc := tc
+		t.Run(fmt.Sprintf("Parse(%s)", tc.expr), func(t *testing.T) {
+			testParse(t, e, tc.expr, tc.out)
+		})
+	}
+	for _, tc := range dispatchTests {
+		tc := tc
+		t.Run(fmt.Sprintf("Compile(%s)", tc.expr), func(t *testing.T) {
+			testCompile(t, e, tc.expr, tc.out)
+		})
+	}
+}
+
+func TestIsAssignableType(t *testing.T) {
+	if !NullableType(DoubleType).IsAssignableType(NullType) {
+		t.Error("nullable double cannot be assigned from null")
+	}
+	if !NullableType(DoubleType).IsAssignableType(DoubleType) {
+		t.Error("nullable double cannot be assigned from double")
+	}
+	if !OpaqueType("vector", NullableType(DoubleType)).IsAssignableType(OpaqueType("vector", NullType)) {
+		t.Error("vector(nullable(double)) could not be assigned from vector(null)")
+	}
+	if !OpaqueType("vector", DynType).IsAssignableType(OpaqueType("vector", NullableType(IntType))) {
+		t.Error("vector(dyn) could not be assigned from vector(nullable(int))")
+	}
+	if OpaqueType("vector", NullableType(DoubleType)).IsAssignableType(OpaqueType("vector", IntType)) {
+		t.Error("vector(nullable(double)) should not be assignable from vector(int)")
+	}
+	if OpaqueType("vector", NullableType(DoubleType)).IsAssignableType(OpaqueType("vector", DynType)) {
+		t.Error("vector(nullable(double)) should not be assignable from vector(int)")
+	}
+}
+
+func TestIsAssignableRuntimeType(t *testing.T) {
+	if !NullableType(DoubleType).IsAssignableRuntimeType(types.NullType) {
+		t.Error("nullable double cannot be assigned from null")
+	}
+	if !NullableType(DoubleType).IsAssignableRuntimeType(types.DoubleType) {
+		t.Error("nullable double cannot be assigned from double")
+	}
+	if !MapType(StringType, DurationType).IsAssignableRuntimeType(types.MapType) {
+		t.Error("map(string, duration) not assibale to map at runtime")
+	}
+}
+
+func TestTypeToExprType(t *testing.T) {
+	tests := []struct {
+		in             *Type
+		out            *exprpb.Type
+		unidirectional bool
+	}{
+		{
+			in:  OpaqueType("vector", DoubleType, DoubleType),
+			out: decls.NewAbstractType("vector", decls.Double, decls.Double),
+		},
+		{
+			in:  AnyType,
+			out: decls.Any,
+		},
+		{
+			in:  BoolType,
+			out: decls.Bool,
+		},
+		{
+			in:  BytesType,
+			out: decls.Bytes,
+		},
+		{
+			in:  DoubleType,
+			out: decls.Double,
+		},
+		{
+			in:  DurationType,
+			out: decls.Duration,
+		},
+		{
+			in:  DynType,
+			out: decls.Dyn,
+		},
+		{
+			in:  IntType,
+			out: decls.Int,
+		},
+		{
+			in:  ListType(TypeParamType("T")),
+			out: decls.NewListType(decls.NewTypeParamType("T")),
+		},
+		{
+			in:  MapType(TypeParamType("K"), TypeParamType("V")),
+			out: decls.NewMapType(decls.NewTypeParamType("K"), decls.NewTypeParamType("V")),
+		},
+		{
+			in:  NullType,
+			out: decls.Null,
+		},
+		{
+			in:  ObjectType("google.type.Expr"),
+			out: decls.NewObjectType("google.type.Expr"),
+		},
+		{
+			in:  StringType,
+			out: decls.String,
+		},
+		{
+			in:  TimestampType,
+			out: decls.Timestamp,
+		},
+		{
+			in:  TypeType,
+			out: decls.NewTypeType(decls.Dyn),
+		},
+		{
+			in:  UintType,
+			out: decls.Uint,
+		},
+		{
+			in:  NullableType(BoolType),
+			out: decls.NewWrapperType(decls.Bool),
+		},
+		{
+			in:  NullableType(BytesType),
+			out: decls.NewWrapperType(decls.Bytes),
+		},
+		{
+			in:  NullableType(DoubleType),
+			out: decls.NewWrapperType(decls.Double),
+		},
+		{
+			in:  NullableType(IntType),
+			out: decls.NewWrapperType(decls.Int),
+		},
+		{
+			in:  NullableType(StringType),
+			out: decls.NewWrapperType(decls.String),
+		},
+		{
+			in:  NullableType(UintType),
+			out: decls.NewWrapperType(decls.Uint),
+		},
+		{
+			in:             ObjectType("google.protobuf.Any"),
+			out:            decls.Any,
+			unidirectional: true,
+		},
+		{
+			in:             ObjectType("google.protobuf.Duration"),
+			out:            decls.Duration,
+			unidirectional: true,
+		},
+		{
+			in:             ObjectType("google.protobuf.Timestamp"),
+			out:            decls.Timestamp,
+			unidirectional: true,
+		},
+		{
+			in:             ObjectType("google.protobuf.Value"),
+			out:            decls.Dyn,
+			unidirectional: true,
+		},
+		{
+			in:             ObjectType("google.protobuf.ListValue"),
+			out:            decls.NewListType(decls.Dyn),
+			unidirectional: true,
+		},
+		{
+			in:             ObjectType("google.protobuf.Struct"),
+			out:            decls.NewMapType(decls.String, decls.Dyn),
+			unidirectional: true,
+		},
+		{
+			in:             ObjectType("google.protobuf.BoolValue"),
+			out:            decls.NewWrapperType(decls.Bool),
+			unidirectional: true,
+		},
+		{
+			in:             ObjectType("google.protobuf.BytesValue"),
+			out:            decls.NewWrapperType(decls.Bytes),
+			unidirectional: true,
+		},
+		{
+			in:             ObjectType("google.protobuf.DoubleValue"),
+			out:            decls.NewWrapperType(decls.Double),
+			unidirectional: true,
+		},
+		{
+			in:             ObjectType("google.protobuf.FloatValue"),
+			out:            decls.NewWrapperType(decls.Double),
+			unidirectional: true,
+		},
+		{
+			in:             ObjectType("google.protobuf.Int32Value"),
+			out:            decls.NewWrapperType(decls.Int),
+			unidirectional: true,
+		},
+		{
+			in:             ObjectType("google.protobuf.Int64Value"),
+			out:            decls.NewWrapperType(decls.Int),
+			unidirectional: true,
+		},
+		{
+			in:             ObjectType("google.protobuf.StringValue"),
+			out:            decls.NewWrapperType(decls.String),
+			unidirectional: true,
+		},
+		{
+			in:             ObjectType("google.protobuf.UInt32Value"),
+			out:            decls.NewWrapperType(decls.Uint),
+			unidirectional: true,
+		},
+		{
+			in:             ObjectType("google.protobuf.UInt64Value"),
+			out:            decls.NewWrapperType(decls.Uint),
+			unidirectional: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.in.String(), func(t *testing.T) {
+			got, err := TypeToExprType(tc.in)
+			if err != nil {
+				t.Fatalf("TypeToExprType(%v) failed: %v", tc.in, err)
+			}
+			if !proto.Equal(got, tc.out) {
+				t.Errorf("TypeToExprType(%v) returned %v, wanted %v", tc.in, got, tc.out)
+			}
+			if tc.unidirectional {
+				return
+			}
+			roundTrip, err := ExprTypeToType(got)
+			if err != nil {
+				t.Fatalf("ExprTypeToType(%v) failed: %v", got, err)
+			}
+			if !tc.in.equals(roundTrip) {
+				t.Errorf("ExprTypeToType(%v) returned %v, wanted %v", got, roundTrip, tc.in)
+			}
+		})
+	}
+}
+
+func TestExprTypeToType(t *testing.T) {
+	tests := []struct {
+		in  *exprpb.Type
+		out *Type
+	}{
+		{
+			in:  decls.NewObjectType("google.protobuf.Any"),
+			out: AnyType,
+		},
+		{
+			in:  decls.NewObjectType("google.protobuf.Duration"),
+			out: DurationType,
+		},
+		{
+			in:  decls.NewObjectType("google.protobuf.Timestamp"),
+			out: TimestampType,
+		},
+		{
+			in:  decls.NewObjectType("google.protobuf.Value"),
+			out: DynType,
+		},
+		{
+			in:  decls.NewObjectType("google.protobuf.ListValue"),
+			out: ListType(DynType),
+		},
+		{
+			in:  decls.NewObjectType("google.protobuf.Struct"),
+			out: MapType(StringType, DynType),
+		},
+		{
+			in:  decls.NewObjectType("google.protobuf.BoolValue"),
+			out: NullableType(BoolType),
+		},
+		{
+			in:  decls.NewObjectType("google.protobuf.BytesValue"),
+			out: NullableType(BytesType),
+		},
+		{
+			in:  decls.NewObjectType("google.protobuf.DoubleValue"),
+			out: NullableType(DoubleType),
+		},
+		{
+			in:  decls.NewObjectType("google.protobuf.FloatValue"),
+			out: NullableType(DoubleType),
+		},
+		{
+			in:  decls.NewObjectType("google.protobuf.Int32Value"),
+			out: NullableType(IntType),
+		},
+		{
+			in:  decls.NewObjectType("google.protobuf.Int64Value"),
+			out: NullableType(IntType),
+		},
+		{
+			in:  decls.NewObjectType("google.protobuf.StringValue"),
+			out: NullableType(StringType),
+		},
+		{
+			in:  decls.NewObjectType("google.protobuf.UInt32Value"),
+			out: NullableType(UintType),
+		},
+		{
+			in:  decls.NewObjectType("google.protobuf.UInt64Value"),
+			out: NullableType(UintType),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.in.String(), func(t *testing.T) {
+			got, err := ExprTypeToType(tc.in)
+			if err != nil {
+				t.Fatalf("ExprTypeToType(%v) failed: %v", tc.in, err)
+			}
+			if !got.equals(tc.out) {
+				t.Errorf("ExprTypeToType(%v) returned %v, wanted %v", tc.in, got, tc.out)
+			}
+		})
+	}
+}
+
+func TestExprTypeToTypeInvalid(t *testing.T) {
+	tests := []struct {
+		in  *exprpb.Type
+		out string
+	}{
+		{
+			in:  &exprpb.Type{},
+			out: "unsupported type",
+		},
+		{
+			in:  &exprpb.Type{TypeKind: &exprpb.Type_Primitive{}},
+			out: "unsupported primitive type",
+		},
+		{
+			in:  &exprpb.Type{TypeKind: &exprpb.Type_WellKnown{}},
+			out: "unsupported well-known type",
+		},
+		{
+			in:  decls.NewListType(&exprpb.Type{}),
+			out: "unsupported type",
+		},
+		{
+			in:  decls.NewMapType(&exprpb.Type{}, decls.Dyn),
+			out: "unsupported type",
+		},
+		{
+			in:  decls.NewMapType(decls.Dyn, &exprpb.Type{}),
+			out: "unsupported type",
+		},
+		{
+			in:  decls.NewAbstractType("bad", &exprpb.Type{}),
+			out: "unsupported type",
+		},
+		{
+			in:  &exprpb.Type{TypeKind: &exprpb.Type_Wrapper{}},
+			out: "unsupported primitive type",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.in.String(), func(t *testing.T) {
+			_, err := ExprTypeToType(tc.in)
+			if err == nil || !strings.Contains(err.Error(), tc.out) {
+				t.Fatalf("ExprTypeToType(%v) got %v, wanted error %v", tc.in, err, tc.out)
+			}
+		})
+	}
+}
+
+func TestExprDeclToDeclaration(t *testing.T) {
+	size, err := ExprDeclToDeclaration(
+		decls.NewFunction("size", decls.NewOverload("size_string", []*exprpb.Type{decls.String}, decls.Int)),
+	)
+	if err != nil {
+		t.Fatalf("ExprDeclToDeclaration(size) failed: %v", err)
+	}
+	x, err := ExprDeclToDeclaration(decls.NewVar("x", decls.String))
+	if err != nil {
+		t.Fatalf("ExprDeclToDeclaration(x) failed: %v", err)
+	}
+	e, err := NewCustomEnv(size, x)
+	if err != nil {
+		t.Fatalf("NewCustomEnv() failed: %v", err)
+	}
+	ast, iss := e.Compile("size(x)")
+	if iss.Err() != nil {
+		t.Fatalf("Compile(size(x)) failed: %v", iss.Err())
+	}
+	prg, err := e.Program(ast, Functions(&functions.Overload{
+		Operator: overloads.SizeString,
+		Unary: func(arg ref.Val) ref.Val {
+			str, ok := arg.(types.String)
+			if !ok {
+				return types.MaybeNoSuchOverloadErr(arg)
+			}
+			return types.Int(len([]rune(string(str))))
+		},
+	}))
+	if err != nil {
+		t.Fatalf("Program(ast) failed: %v", err)
+	}
+	out, _, err := prg.Eval(map[string]interface{}{"x": "hello"})
+	if err != nil {
+		t.Fatalf("prg.Eval(x=hello) failed: %v", err)
+	}
+	if out.Equal(types.Int(5)) != types.True {
+		t.Errorf("prg.Eval(size(x)) got %v, wanted 5", out)
+	}
+}
+
+func TestExprDeclToDeclarationInvalid(t *testing.T) {
+	tests := []struct {
+		in  *exprpb.Decl
+		out string
+	}{
+		{
+			in:  &exprpb.Decl{},
+			out: "unsupported decl",
+		},
+		{
+			in: &exprpb.Decl{
+				Name: "bad_var",
+				DeclKind: &exprpb.Decl_Ident{
+					Ident: &exprpb.Decl_IdentDecl{
+						Type: decls.NewListType(&exprpb.Type{}),
+					},
+				},
+			},
+			out: "unsupported type",
+		},
+		{
+			in: &exprpb.Decl{
+				Name: "bad_func_return",
+				DeclKind: &exprpb.Decl_Function{
+					Function: &exprpb.Decl_FunctionDecl{
+						Overloads: []*exprpb.Decl_FunctionDecl_Overload{
+							{
+								OverloadId: "bad_overload",
+								ResultType: &exprpb.Type{},
+							},
+						},
+					},
+				},
+			},
+			out: "unsupported type",
+		},
+		{
+			in: &exprpb.Decl{
+				Name: "bad_func_arg",
+				DeclKind: &exprpb.Decl_Function{
+					Function: &exprpb.Decl_FunctionDecl{
+						Overloads: []*exprpb.Decl_FunctionDecl_Overload{
+							{
+								OverloadId: "bad_overload",
+								Params:     []*exprpb.Type{{}},
+								ResultType: decls.Dyn,
+							},
+						},
+					},
+				},
+			},
+			out: "unsupported type",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.in.String(), func(t *testing.T) {
+			_, err := ExprDeclToDeclaration(tc.in)
+			if err == nil || !strings.Contains(err.Error(), tc.out) {
+				t.Fatalf("ExprDeclToDeclarations(%v) got %v, wanted error %v", tc.in, err, tc.out)
+			}
+		})
+	}
+}
+
+func testParse(t testing.TB, env *Env, expr string, want interface{}) {
+	t.Helper()
+	ast, iss := env.Parse(expr)
+	if iss.Err() != nil {
+		t.Fatalf("env.Parse(%s) failed: %v", expr, iss.Err())
+	}
+	prg, err := env.Program(ast)
+	if err != nil {
+		t.Fatalf("env.Program() failed: %v", err)
+	}
+	out, _, err := prg.Eval(map[string]interface{}{"err": types.NewErr("error argument"), "unk": types.Unknown{42}})
+	switch want := want.(type) {
+	case types.Unknown:
+		if !reflect.DeepEqual(want, out.(types.Unknown)) {
+			t.Errorf("prg.Eval() got %v, wanted %v", out, want)
+		}
+	case ref.Val:
+		if want.Equal(out) != types.True {
+			t.Errorf("prg.Eval() got %v, wanted %v", out, want)
+		}
+	case error:
+		if err == nil || want.Error() != err.Error() {
+			t.Errorf("prg.Eval() got error '%v', wanted '%v'", err, want)
+		}
+	}
+}
+
+func testCompile(t testing.TB, env *Env, expr string, want interface{}) {
+	t.Helper()
+	ast, iss := env.Compile(expr)
+	if iss.Err() != nil {
+		t.Fatalf("env.Compile(%s) failed: %v", expr, iss.Err())
+	}
+	prg, err := env.Program(ast)
+	if err != nil {
+		t.Fatalf("env.Program() failed: %v", err)
+	}
+	out, _, err := prg.Eval(map[string]interface{}{"err": types.NewErr("error argument"), "unk": types.Unknown{42}})
+	switch want := want.(type) {
+	case types.Unknown:
+		if !reflect.DeepEqual(want, out.(types.Unknown)) {
+			t.Errorf("prg.Eval() got %v, wanted %v", out, want)
+		}
+	case ref.Val:
+		if want.Equal(out) != types.True {
+			t.Errorf("prg.Eval() got %v, wanted %v", out, want)
+		}
+	case error:
+		if err == nil || want.Error() != err.Error() {
+			t.Errorf("prg.Eval() got error '%v', wanted '%v'", err, want)
+		}
+	}
+}

--- a/cel/env.go
+++ b/cel/env.go
@@ -65,7 +65,15 @@ func (ast *Ast) ResultType() *exprpb.Type {
 	if !ast.IsChecked() {
 		return decls.Dyn
 	}
-	return ast.typeMap[ast.expr.Id]
+	return ast.typeMap[ast.expr.GetId()]
+}
+
+func (ast *Ast) OutputType() *Type {
+	t, err := ExprTypeToType(ast.ResultType())
+	if err != nil {
+		return DynType
+	}
+	return t
 }
 
 // Source returns a view of the input used to create the Ast. This source may be complete or
@@ -83,6 +91,7 @@ func FormatType(t *exprpb.Type) string {
 // evaluable programs for different expressions.
 type Env struct {
 	Container    *containers.Container
+	functions    map[string]*functionDecl
 	declarations []*exprpb.Decl
 	macros       []parser.Macro
 	adapter      ref.TypeAdapter
@@ -138,6 +147,7 @@ func NewCustomEnv(opts ...EnvOption) (*Env, error) {
 	}
 	return (&Env{
 		declarations: []*exprpb.Decl{},
+		functions:    map[string]*functionDecl{},
 		macros:       []parser.Macro{},
 		Container:    containers.DefaultContainer,
 		adapter:      registry,
@@ -280,10 +290,16 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 	for k, v := range e.features {
 		featuresCopy[k] = v
 	}
+	funcsCopy := make(map[string]*functionDecl, len(e.functions))
+	for k, v := range e.functions {
+		funcsCopy[k] = v
+	}
 
+	// TODO: functions copy needs to happen here.
 	ext := &Env{
 		Container:    e.Container,
 		declarations: decsCopy,
+		functions:    funcsCopy,
 		macros:       macsCopy,
 		progOpts:     progOptsCopy,
 		adapter:      adapter,
@@ -436,6 +452,14 @@ func (e *Env) configure(opts []EnvOption) (*Env, error) {
 		}
 	}
 
+	// Initialize all of the functions configured within the environment.
+	for _, fn := range e.functions {
+		err = fn.init()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// Configure the parser.
 	prsrOpts := []parser.Option{parser.Macros(e.macros...)}
 	if e.HasFeature(featureEnableMacroCallTracking) {
@@ -446,8 +470,7 @@ func (e *Env) configure(opts []EnvOption) (*Env, error) {
 		return nil, err
 	}
 
-	// The simplest way to eagerly validate declarations on environment creation is to compile
-	// a dummy program and check for the presence of e.chkErr being non-nil.
+	// Ensure that the checker init happens eagerly rather than lazily.
 	if e.HasFeature(featureEagerlyValidateDeclarations) {
 		err := e.initChecker()
 		if err != nil {
@@ -473,11 +496,26 @@ func (e *Env) initChecker() error {
 			e.chkErr = err
 			return
 		}
+		// Add the statically configured declarations.
 		err = ce.Add(e.declarations...)
 		if err != nil {
 			e.chkErr = err
 			return
 		}
+		// Add the function declarations which are derived from the FunctionDecl instances.
+		for _, fn := range e.functions {
+			fnDecl, err := functionDeclToExprDecl(fn)
+			if err != nil {
+				e.chkErr = err
+				return
+			}
+			err = ce.Add(fnDecl)
+			if err != nil {
+				e.chkErr = err
+				return
+			}
+		}
+		// Add function declarations here separately.
 		e.chk = ce
 	})
 	return e.chkErr

--- a/cel/env_test.go
+++ b/cel/env_test.go
@@ -18,12 +18,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/types"
-
-	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 func TestIssuesNil(t *testing.T) {
@@ -167,13 +164,10 @@ func BenchmarkEnvExtendEagerDecls(b *testing.B) {
 	}
 	for i := 0; i < b.N; i++ {
 		ext, err := env.Extend(
-			Declarations(
-				decls.NewVar("test_var", decls.String),
-				decls.NewFunction(
-					operators.In,
-					decls.NewOverload("string_in_string", []*exprpb.Type{
-						decls.String, decls.String,
-					}, decls.Bool)),
+			Variable("test_var", StringType),
+			Function(
+				operators.In,
+				Overload("string_in_string", []*Type{StringType, StringType}, BoolType),
 			),
 		)
 		if err != nil {

--- a/cel/io.go
+++ b/cel/io.go
@@ -241,7 +241,7 @@ func ValueToRefValue(adapter ref.TypeAdapter, v *exprpb.Value) (ref.Val, error) 
 		if err != nil {
 			return nil, err
 		}
-		return adapter.NativeToValue(msg.(proto.Message)), nil
+		return adapter.NativeToValue(msg), nil
 	case *exprpb.Value_MapValue:
 		m := v.GetMapValue()
 		entries := make(map[ref.Val]ref.Val)

--- a/cel/options.go
+++ b/cel/options.go
@@ -99,8 +99,6 @@ func CustomTypeProvider(provider ref.TypeProvider) EnvOption {
 // for the environment. The NewEnv call builds on top of the standard CEL declarations. For a
 // purely custom set of declarations use NewCustomEnv.
 func Declarations(decls ...*exprpb.Decl) EnvOption {
-	// TODO: provide an alternative means of specifying declarations that doesn't refer
-	// to the underlying proto implementations.
 	return func(e *Env) (*Env, error) {
 		e.declarations = append(e.declarations, decls...)
 		return e, nil
@@ -332,6 +330,9 @@ func CustomDecorator(dec interpreter.InterpretableDecorator) ProgramOption {
 }
 
 // Functions adds function overloads that extend or override the set of CEL built-ins.
+//
+// Deprecated: use DeclareFunctions instead to declare the function, its overload signatures,
+// and the overload implementations.
 func Functions(funcs ...*functions.Overload) ProgramOption {
 	return func(p *prog) (*prog, error) {
 		if err := p.dispatcher.Add(funcs...); err != nil {

--- a/cel/program.go
+++ b/cel/program.go
@@ -168,6 +168,18 @@ func newProgram(e *Env, ast *Ast, opts []ProgramOption) (Program, error) {
 		}
 	}
 
+	// Add the function bindings created via Function() options.
+	for _, fn := range e.functions {
+		bindings, err := fn.bindings()
+		if err != nil {
+			return nil, err
+		}
+		err = disp.Add(bindings...)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// Set the attribute factory after the options have been set.
 	var attrFactory interpreter.AttributeFactory
 	if p.evalOpts&OptPartialEval == OptPartialEval {

--- a/common/types/ref/reference.go
+++ b/common/types/ref/reference.go
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package ref contains the reference interfaces used throughout the types
-// components.
+// Package ref contains the reference interfaces used throughout the types components.
 package ref
 
 import (
@@ -29,31 +28,27 @@ type Type interface {
 
 	// TypeName returns the qualified type name of the type.
 	//
-	// The type name is also used as the type's identifier name at type-check
-	// and interpretation time.
+	// The type name is also used as the type's identifier name at type-check and interpretation time.
 	TypeName() string
 }
 
 // Val interface defines the functions supported by all expression values.
-// Val implementations may specialize the behavior of the value through the
-// addition of traits.
+// Val implementations may specialize the behavior of the value through the addition of traits.
 type Val interface {
 	// ConvertToNative converts the Value to a native Go struct according to the
 	// reflected type description, or error if the conversion is not feasible.
 	ConvertToNative(typeDesc reflect.Type) (interface{}, error)
 
-	// ConvertToType supports type conversions between value types supported by
-	// the expression language.
+	// ConvertToType supports type conversions between value types supported by the expression language.
 	ConvertToType(typeValue Type) Val
 
-	// Equal returns true if the `other` value has the same type and content as
-	// the implementing struct.
+	// Equal returns true if the `other` value has the same type and content as the implementing struct.
 	Equal(other Val) Val
 
 	// Type returns the TypeValue of the value.
 	Type() Type
 
-	// Value returns the raw value of the instance which may not be directly
-	// compatible with the expression language types.
+	// Value returns the raw value of the instance which may not be directly compatible with the expression
+	// language types.
 	Value() interface{}
 }

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -445,7 +445,7 @@ func (un *evalUnary) Eval(ctx Activation) ref.Val {
 	}
 	// If the implementation is bound and the argument value has the right traits required to
 	// invoke it, then call the implementation.
-	if un.impl != nil && (un.trait == 0 || argVal.Type().HasTrait(un.trait)) {
+	if un.impl != nil && (un.trait == 0 || (!strict && types.IsUnknownOrError(argVal)) || argVal.Type().HasTrait(un.trait)) {
 		return un.impl(argVal)
 	}
 	// Otherwise, if the argument is a ReceiverType attempt to invoke the receiver method on the
@@ -511,7 +511,7 @@ func (bin *evalBinary) Eval(ctx Activation) ref.Val {
 	}
 	// If the implementation is bound and the argument value has the right traits required to
 	// invoke it, then call the implementation.
-	if bin.impl != nil && (bin.trait == 0 || lVal.Type().HasTrait(bin.trait)) {
+	if bin.impl != nil && (bin.trait == 0 || (!strict && types.IsUnknownOrError(lVal)) || lVal.Type().HasTrait(bin.trait)) {
 		return bin.impl(lVal, rVal)
 	}
 	// Otherwise, if the argument is a ReceiverType attempt to invoke the receiver method on the
@@ -582,7 +582,7 @@ func (fn *evalVarArgs) Eval(ctx Activation) ref.Val {
 	// If the implementation is bound and the argument value has the right traits required to
 	// invoke it, then call the implementation.
 	arg0 := argVals[0]
-	if fn.impl != nil && (fn.trait == 0 || arg0.Type().HasTrait(fn.trait)) {
+	if fn.impl != nil && (fn.trait == 0 || (!strict && types.IsUnknownOrError(arg0)) || arg0.Type().HasTrait(fn.trait)) {
 		return fn.impl(argVals...)
 	}
 	// Otherwise, if the argument is a ReceiverType attempt to invoke the receiver method on the

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -302,8 +302,18 @@ func (p *planner) planCall(expr *exprpb.Expr) (Interpretable, error) {
 	case 0:
 		return p.planCallZero(expr, fnName, oName, fnDef)
 	case 1:
+		// If the FunctionOp has been used, then use it as it may exist for the purposes
+		// of dynamic dispatch within a singleton function implementation.
+		if fnDef != nil && fnDef.Unary == nil && fnDef.Function != nil {
+			return p.planCallVarArgs(expr, fnName, oName, fnDef, args)
+		}
 		return p.planCallUnary(expr, fnName, oName, fnDef, args)
 	case 2:
+		// If the FunctionOp has been used, then use it as it may exist for the purposes
+		// of dynamic dispatch within a singleton function implementation.
+		if fnDef != nil && fnDef.Binary == nil && fnDef.Function != nil {
+			return p.planCallVarArgs(expr, fnName, oName, fnDef, args)
+		}
 		return p.planCallBinary(expr, fnName, oName, fnDef, args)
 	default:
 		return p.planCallVarArgs(expr, fnName, oName, fnDef, args)


### PR DESCRIPTION
This change introduces a top-level `cel.Type` as well as functional options for configuring `cel.Variable` and `cel.Function` definitions using go-native APIs. 

This change is a shift away from the existing protobuf APIs which is also provides the following improvements:
- Automatic generation of function overload type-guards to provide basic invocation protections
- Automatic generation of dynamic dispatch functions for resolving overloads at runtime (for both parse-only expressions and dynamically typed data)
- Ability to declare and define functions within a single context.

The only drawback of this approach is that there is some minimal invocation overhead for functions declared/defined in this manner. Future optimizations may permit users to disable such type-guards if they deem them not to be necessary.

As a follow up PR, the `ext` function libraries and CEL standard operators will be shifted over to this new declaration style to improve the ease of extension of the core library implementations.

This is the basis for the feature requested in #493 