### PR TITLE
Support context propagation on overloads

### DIFF
--- a/cel/options.go
+++ b/cel/options.go
@@ -332,7 +332,7 @@ func CustomDecorator(dec interpreter.InterpretableDecorator) ProgramOption {
 }
 
 // Functions adds function overloads that extend or override the set of CEL built-ins.
-func Functions(funcs ...*functions.Overload) ProgramOption {
+func Functions(funcs ...functions.Overloader) ProgramOption {
 	return func(p *prog) (*prog, error) {
 		if err := p.dispatcher.Add(funcs...); err != nil {
 			return nil, err

--- a/interpreter/functions/functions.go
+++ b/interpreter/functions/functions.go
@@ -25,9 +25,9 @@ import (
 type Overloader interface {
 	GetOperator() string
 	GetOperandTrait() int
-	GetUnaryOp(ctx context.Context) UnaryOp
-	GetBinaryOp(ctx context.Context) BinaryOp
-	GetFunctionOp(ctx context.Context) FunctionOp
+	GetUnary(ctx context.Context) UnaryOp
+	GetBinary(ctx context.Context) BinaryOp
+	GetFunction(ctx context.Context) FunctionOp
 	IsNonStrict() bool
 }
 
@@ -64,12 +64,12 @@ type Overload struct {
 	NonStrict bool
 }
 
-func (o *Overload) GetOperator() string                          { return o.Operator }
-func (o *Overload) GetOperandTrait() int                         { return o.OperandTrait }
-func (o *Overload) GetUnaryOp(ctx context.Context) UnaryOp       { return o.Unary }
-func (o *Overload) GetBinaryOp(ctx context.Context) BinaryOp     { return o.Binary }
-func (o *Overload) GetFunctionOp(ctx context.Context) FunctionOp { return o.Function }
-func (o *Overload) IsNonStrict() bool                            { return o.NonStrict }
+func (o *Overload) GetOperator() string                        { return o.Operator }
+func (o *Overload) GetOperandTrait() int                       { return o.OperandTrait }
+func (o *Overload) GetUnary(ctx context.Context) UnaryOp       { return o.Unary }
+func (o *Overload) GetBinary(ctx context.Context) BinaryOp     { return o.Binary }
+func (o *Overload) GetFunction(ctx context.Context) FunctionOp { return o.Function }
+func (o *Overload) IsNonStrict() bool                          { return o.NonStrict }
 
 // UnaryOp is a function that takes a single value and produces an output.
 type UnaryOp func(value ref.Val) ref.Val

--- a/interpreter/functions/functions.go
+++ b/interpreter/functions/functions.go
@@ -16,7 +16,20 @@
 // interpreter and as declared within the checker#StandardDeclarations.
 package functions
 
-import "github.com/google/cel-go/common/types/ref"
+import (
+	"context"
+
+	"github.com/google/cel-go/common/types/ref"
+)
+
+type Overloader interface {
+	GetOperator() string
+	GetOperandTrait() int
+	GetUnaryOp(ctx context.Context) UnaryOp
+	GetBinaryOp(ctx context.Context) BinaryOp
+	GetFunctionOp(ctx context.Context) FunctionOp
+	IsNonStrict() bool
+}
 
 // Overload defines a named overload of a function, indicating an operand trait
 // which must be present on the first argument to the overload as well as one
@@ -50,6 +63,13 @@ type Overload struct {
 	// are types.Err or types.Unknown.
 	NonStrict bool
 }
+
+func (o *Overload) GetOperator() string                          { return o.Operator }
+func (o *Overload) GetOperandTrait() int                         { return o.OperandTrait }
+func (o *Overload) GetUnaryOp(ctx context.Context) UnaryOp       { return o.Unary }
+func (o *Overload) GetBinaryOp(ctx context.Context) BinaryOp     { return o.Binary }
+func (o *Overload) GetFunctionOp(ctx context.Context) FunctionOp { return o.Function }
+func (o *Overload) IsNonStrict() bool                            { return o.NonStrict }
 
 // UnaryOp is a function that takes a single value and produces an output.
 type UnaryOp func(value ref.Val) ref.Val

--- a/interpreter/functions/standard.go
+++ b/interpreter/functions/standard.go
@@ -23,10 +23,10 @@ import (
 )
 
 // StandardOverloads returns the definitions of the built-in overloads.
-func StandardOverloads() []*Overload {
-	return []*Overload{
+func StandardOverloads() []Overloader {
+	return []Overloader{
 		// Logical not (!a)
-		{
+		&Overload{
 			Operator:     operators.LogicalNot,
 			OperandTrait: traits.NegatorType,
 			Unary: func(value ref.Val) ref.Val {
@@ -36,16 +36,16 @@ func StandardOverloads() []*Overload {
 				return value.(traits.Negater).Negate()
 			}},
 		// Not strictly false: IsBool(a) ? a : true
-		{
+		&Overload{
 			Operator: operators.NotStrictlyFalse,
 			Unary:    notStrictlyFalse},
 		// Deprecated: not strictly false, may be overridden in the environment.
-		{
+		&Overload{
 			Operator: operators.OldNotStrictlyFalse,
 			Unary:    notStrictlyFalse},
 
 		// Less than operator
-		{Operator: operators.Less,
+		&Overload{Operator: operators.Less,
 			OperandTrait: traits.ComparerType,
 			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
 				cmp := lhs.(traits.Comparer).Compare(rhs)
@@ -59,7 +59,7 @@ func StandardOverloads() []*Overload {
 			}},
 
 		// Less than or equal operator
-		{Operator: operators.LessEquals,
+		&Overload{Operator: operators.LessEquals,
 			OperandTrait: traits.ComparerType,
 			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
 				cmp := lhs.(traits.Comparer).Compare(rhs)
@@ -73,7 +73,7 @@ func StandardOverloads() []*Overload {
 			}},
 
 		// Greater than operator
-		{Operator: operators.Greater,
+		&Overload{Operator: operators.Greater,
 			OperandTrait: traits.ComparerType,
 			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
 				cmp := lhs.(traits.Comparer).Compare(rhs)
@@ -87,7 +87,7 @@ func StandardOverloads() []*Overload {
 			}},
 
 		// Greater than equal operators
-		{Operator: operators.GreaterEquals,
+		&Overload{Operator: operators.GreaterEquals,
 			OperandTrait: traits.ComparerType,
 			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
 				cmp := lhs.(traits.Comparer).Compare(rhs)
@@ -101,42 +101,42 @@ func StandardOverloads() []*Overload {
 			}},
 
 		// Add operator
-		{Operator: operators.Add,
+		&Overload{Operator: operators.Add,
 			OperandTrait: traits.AdderType,
 			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
 				return lhs.(traits.Adder).Add(rhs)
 			}},
 
 		// Subtract operators
-		{Operator: operators.Subtract,
+		&Overload{Operator: operators.Subtract,
 			OperandTrait: traits.SubtractorType,
 			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
 				return lhs.(traits.Subtractor).Subtract(rhs)
 			}},
 
 		// Multiply operator
-		{Operator: operators.Multiply,
+		&Overload{Operator: operators.Multiply,
 			OperandTrait: traits.MultiplierType,
 			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
 				return lhs.(traits.Multiplier).Multiply(rhs)
 			}},
 
 		// Divide operator
-		{Operator: operators.Divide,
+		&Overload{Operator: operators.Divide,
 			OperandTrait: traits.DividerType,
 			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
 				return lhs.(traits.Divider).Divide(rhs)
 			}},
 
 		// Modulo operator
-		{Operator: operators.Modulo,
+		&Overload{Operator: operators.Modulo,
 			OperandTrait: traits.ModderType,
 			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
 				return lhs.(traits.Modder).Modulo(rhs)
 			}},
 
 		// Negate operator
-		{Operator: operators.Negate,
+		&Overload{Operator: operators.Negate,
 			OperandTrait: traits.NegatorType,
 			Unary: func(value ref.Val) ref.Val {
 				if types.IsBool(value) {
@@ -146,26 +146,26 @@ func StandardOverloads() []*Overload {
 			}},
 
 		// Index operator
-		{Operator: operators.Index,
+		&Overload{Operator: operators.Index,
 			OperandTrait: traits.IndexerType,
 			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
 				return lhs.(traits.Indexer).Get(rhs)
 			}},
 
 		// Size function
-		{Operator: overloads.Size,
+		&Overload{Operator: overloads.Size,
 			OperandTrait: traits.SizerType,
 			Unary: func(value ref.Val) ref.Val {
 				return value.(traits.Sizer).Size()
 			}},
 
 		// In operator
-		{Operator: operators.In, Binary: inAggregate},
+		&Overload{Operator: operators.In, Binary: inAggregate},
 		// Deprecated: in operator, may be overridden in the environment.
-		{Operator: operators.OldIn, Binary: inAggregate},
+		&Overload{Operator: operators.OldIn, Binary: inAggregate},
 
 		// Matches function
-		{Operator: overloads.Matches,
+		&Overload{Operator: overloads.Matches,
 			OperandTrait: traits.MatcherType,
 			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
 				return lhs.(traits.Matcher).Match(rhs)
@@ -175,78 +175,78 @@ func StandardOverloads() []*Overload {
 		// TODO: verify type conversion safety of numeric values.
 
 		// Int conversions.
-		{Operator: overloads.TypeConvertInt,
+		&Overload{Operator: overloads.TypeConvertInt,
 			Unary: func(value ref.Val) ref.Val {
 				return value.ConvertToType(types.IntType)
 			}},
 
 		// Uint conversions.
-		{Operator: overloads.TypeConvertUint,
+		&Overload{Operator: overloads.TypeConvertUint,
 			Unary: func(value ref.Val) ref.Val {
 				return value.ConvertToType(types.UintType)
 			}},
 
 		// Double conversions.
-		{Operator: overloads.TypeConvertDouble,
+		&Overload{Operator: overloads.TypeConvertDouble,
 			Unary: func(value ref.Val) ref.Val {
 				return value.ConvertToType(types.DoubleType)
 			}},
 
 		// Bool conversions.
-		{Operator: overloads.TypeConvertBool,
+		&Overload{Operator: overloads.TypeConvertBool,
 			Unary: func(value ref.Val) ref.Val {
 				return value.ConvertToType(types.BoolType)
 			}},
 
 		// Bytes conversions.
-		{Operator: overloads.TypeConvertBytes,
+		&Overload{Operator: overloads.TypeConvertBytes,
 			Unary: func(value ref.Val) ref.Val {
 				return value.ConvertToType(types.BytesType)
 			}},
 
 		// String conversions.
-		{Operator: overloads.TypeConvertString,
+		&Overload{Operator: overloads.TypeConvertString,
 			Unary: func(value ref.Val) ref.Val {
 				return value.ConvertToType(types.StringType)
 			}},
 
 		// Timestamp conversions.
-		{Operator: overloads.TypeConvertTimestamp,
+		&Overload{Operator: overloads.TypeConvertTimestamp,
 			Unary: func(value ref.Val) ref.Val {
 				return value.ConvertToType(types.TimestampType)
 			}},
 
 		// Duration conversions.
-		{Operator: overloads.TypeConvertDuration,
+		&Overload{Operator: overloads.TypeConvertDuration,
 			Unary: func(value ref.Val) ref.Val {
 				return value.ConvertToType(types.DurationType)
 			}},
 
 		// Type operations.
-		{Operator: overloads.TypeConvertType,
+		&Overload{Operator: overloads.TypeConvertType,
 			Unary: func(value ref.Val) ref.Val {
 				return value.ConvertToType(types.TypeType)
 			}},
 
 		// Dyn conversion (identity function).
-		{Operator: overloads.TypeConvertDyn,
+		&Overload{Operator: overloads.TypeConvertDyn,
 			Unary: func(value ref.Val) ref.Val {
 				return value
 			}},
 
-		{Operator: overloads.Iterator,
+		&Overload{Operator: overloads.Iterator,
 			OperandTrait: traits.IterableType,
 			Unary: func(value ref.Val) ref.Val {
 				return value.(traits.Iterable).Iterator()
 			}},
 
-		{Operator: overloads.HasNext,
+		&Overload{Operator: overloads.HasNext,
 			OperandTrait: traits.IteratorType,
 			Unary: func(value ref.Val) ref.Val {
 				return value.(traits.Iterator).HasNext()
 			}},
 
-		{Operator: overloads.Next,
+		&Overload{Operator: overloads.Next,
 			OperandTrait: traits.IteratorType,
 			Unary: func(value ref.Val) ref.Val {
 				return value.(traits.Iterator).Next()

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -15,7 +15,6 @@
 package interpreter
 
 import (
-	"context"
 	"math"
 
 	"github.com/google/cel-go/common/operators"
@@ -398,7 +397,7 @@ func (zero *evalZeroArity) ID() int64 {
 
 // Eval implements the Interpretable interface method.
 func (zero *evalZeroArity) Eval(ctx Activation) ref.Val {
-	return zero.impl(context.TODO())
+	return zero.impl(ctx)
 }
 
 // Cost returns 1 representing the heuristic cost of the function.
@@ -447,7 +446,7 @@ func (un *evalUnary) Eval(ctx Activation) ref.Val {
 	// If the implementation is bound and the argument value has the right traits required to
 	// invoke it, then call the implementation.
 	if un.impl != nil && (un.trait == 0 || argVal.Type().HasTrait(un.trait)) {
-		return un.impl(context.TODO(), argVal)
+		return un.impl(ctx, argVal)
 	}
 	// Otherwise, if the argument is a ReceiverType attempt to invoke the receiver method on the
 	// operand (arg0).
@@ -513,7 +512,7 @@ func (bin *evalBinary) Eval(ctx Activation) ref.Val {
 	// If the implementation is bound and the argument value has the right traits required to
 	// invoke it, then call the implementation.
 	if bin.impl != nil && (bin.trait == 0 || lVal.Type().HasTrait(bin.trait)) {
-		return bin.impl(context.TODO(), lVal, rVal)
+		return bin.impl(ctx, lVal, rVal)
 	}
 	// Otherwise, if the argument is a ReceiverType attempt to invoke the receiver method on the
 	// operand (arg0).
@@ -584,7 +583,7 @@ func (fn *evalVarArgs) Eval(ctx Activation) ref.Val {
 	// invoke it, then call the implementation.
 	arg0 := argVals[0]
 	if fn.impl != nil && (fn.trait == 0 || arg0.Type().HasTrait(fn.trait)) {
-		return fn.impl(context.TODO(), argVals...)
+		return fn.impl(ctx, argVals...)
 	}
 	// Otherwise, if the argument is a ReceiverType attempt to invoke the receiver method on the
 	// operand (arg0).

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -56,7 +56,7 @@ type testCase struct {
 	abbrevs        []string
 	env            []*exprpb.Decl
 	types          []proto.Message
-	funcs          []*functions.Overload
+	funcs          []functions.Overloader
 	attrs          AttributeFactory
 	unchecked      bool
 	extraOpts      []InterpretableDecorator
@@ -121,8 +121,8 @@ var (
 			expr:      `zero()`,
 			cost:      []int64{1, 1},
 			unchecked: true,
-			funcs: []*functions.Overload{
-				{
+			funcs: []functions.Overloader{
+				&functions.Overload{
 					Operator: "zero",
 					Function: func(args ...ref.Val) ref.Val {
 						return types.IntZero
@@ -136,8 +136,8 @@ var (
 			expr:      `neg(1)`,
 			cost:      []int64{1, 1},
 			unchecked: true,
-			funcs: []*functions.Overload{
-				{
+			funcs: []functions.Overloader{
+				&functions.Overload{
 					Operator:     "neg",
 					OperandTrait: traits.NegatorType,
 					Unary: func(arg ref.Val) ref.Val {
@@ -152,8 +152,8 @@ var (
 			expr:      `b'abc'.concat(b'def')`,
 			cost:      []int64{1, 1},
 			unchecked: true,
-			funcs: []*functions.Overload{
-				{
+			funcs: []functions.Overloader{
+				&functions.Overload{
 					Operator:     "concat",
 					OperandTrait: traits.AdderType,
 					Binary: func(lhs, rhs ref.Val) ref.Val {
@@ -168,8 +168,8 @@ var (
 			expr:      `addall(a, b, c, d) == 10`,
 			cost:      []int64{6, 6},
 			unchecked: true,
-			funcs: []*functions.Overload{
-				{
+			funcs: []functions.Overloader{
+				&functions.Overload{
 					Operator:     "addall",
 					OperandTrait: traits.AdderType,
 					Function: func(args ...ref.Val) ref.Val {
@@ -196,12 +196,12 @@ var (
 						decls.String),
 				),
 			},
-			funcs: []*functions.Overload{
-				{
+			funcs: []functions.Overloader{
+				&functions.Overload{
 					Operator: "base64.encode",
 					Unary:    base64Encode,
 				},
-				{
+				&functions.Overload{
 					Operator: "base64_encode_string",
 					Unary:    base64Encode,
 				},
@@ -213,8 +213,8 @@ var (
 			expr:      `base64.encode('hello')`,
 			cost:      []int64{1, 1},
 			unchecked: true,
-			funcs: []*functions.Overload{
-				{
+			funcs: []functions.Overloader{
+				&functions.Overload{
 					Operator: "base64.encode",
 					Unary:    base64Encode,
 				},
@@ -233,12 +233,12 @@ var (
 						decls.String),
 				),
 			},
-			funcs: []*functions.Overload{
-				{
+			funcs: []functions.Overloader{
+				&functions.Overload{
 					Operator: "base64.encode",
 					Unary:    base64Encode,
 				},
-				{
+				&functions.Overload{
 					Operator: "base64_encode_string",
 					Unary:    base64Encode,
 				},
@@ -251,8 +251,8 @@ var (
 			cost:      []int64{1, 1},
 			container: `base64`,
 			unchecked: true,
-			funcs: []*functions.Overload{
-				{
+			funcs: []functions.Overloader{
+				&functions.Overload{
 					Operator: "base64.encode",
 					Unary:    base64Encode,
 				},
@@ -1296,8 +1296,8 @@ var (
 					decls.NewOverload("string_to_json",
 						[]*exprpb.Type{decls.String}, decls.Dyn)),
 			},
-			funcs: []*functions.Overload{
-				{
+			funcs: []functions.Overloader{
+				&functions.Overload{
 					Operator: "json",
 					Unary: func(val ref.Val) ref.Val {
 						str, ok := val.(types.String)
@@ -1342,8 +1342,8 @@ var (
 			name:      "call_with_error_unary",
 			expr:      `try(0/0)`,
 			unchecked: true,
-			funcs: []*functions.Overload{
-				{
+			funcs: []functions.Overloader{
+				&functions.Overload{
 					Operator: "try",
 					Unary: func(arg ref.Val) ref.Val {
 						if types.IsError(arg) {
@@ -1360,8 +1360,8 @@ var (
 			name:      "call_with_error_binary",
 			expr:      `try(0/0, 0)`,
 			unchecked: true,
-			funcs: []*functions.Overload{
-				{
+			funcs: []functions.Overloader{
+				&functions.Overload{
 					Operator: "try",
 					Binary: func(arg0, arg1 ref.Val) ref.Val {
 						if types.IsError(arg0) {
@@ -1378,8 +1378,8 @@ var (
 			name:      "call_with_error_function",
 			expr:      `try(0/0, 0, 0)`,
 			unchecked: true,
-			funcs: []*functions.Overload{
-				{
+			funcs: []functions.Overloader{
+				&functions.Overload{
 					Operator: "try",
 					Function: func(args ...ref.Val) ref.Val {
 						if types.IsError(args[0]) {

--- a/interpreter/optimizations.go
+++ b/interpreter/optimizations.go
@@ -15,6 +15,7 @@
 package interpreter
 
 import (
+	"context"
 	"regexp"
 
 	"github.com/google/cel-go/common/types"
@@ -32,7 +33,7 @@ var MatchesRegexOptimization = &RegexOptimization{
 		if err != nil {
 			return nil, err
 		}
-		return NewCall(call.ID(), call.Function(), call.OverloadID(), call.Args(), func(values ...ref.Val) ref.Val {
+		return NewCall(call.ID(), call.Function(), call.OverloadID(), call.Args(), func(ctx context.Context, values ...ref.Val) ref.Val {
 			if len(values) != 2 {
 				return types.NoSuchOverloadErr()
 			}

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -15,7 +15,6 @@
 package interpreter
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -316,14 +315,14 @@ func (p *planner) planCallZero(expr *exprpb.Expr,
 	function string,
 	overload string,
 	impl functions.Overloader) (Interpretable, error) {
-	if impl == nil || impl.GetFunction(context.Background()) == nil {
+	if impl == nil || impl.GetFunction() == nil {
 		return nil, fmt.Errorf("no such overload: %s()", function)
 	}
 	return &evalZeroArity{
 		id:       expr.Id,
 		function: function,
 		overload: overload,
-		impl:     impl.GetFunction(context.Background()),
+		impl:     impl.GetFunction(),
 	}, nil
 }
 
@@ -333,14 +332,14 @@ func (p *planner) planCallUnary(expr *exprpb.Expr,
 	overload string,
 	impl functions.Overloader,
 	args []Interpretable) (Interpretable, error) {
-	var fn functions.UnaryOp
+	var fn functions.ContextUnaryOp
 	var trait int
 	var nonStrict bool
 	if impl != nil {
-		if impl.GetUnary(context.Background()) == nil {
+		if impl.GetUnary() == nil {
 			return nil, fmt.Errorf("no such overload: %s(arg)", function)
 		}
-		fn = impl.GetUnary(context.Background())
+		fn = impl.GetUnary()
 		trait = impl.GetOperandTrait()
 		nonStrict = impl.IsNonStrict()
 	}
@@ -361,14 +360,14 @@ func (p *planner) planCallBinary(expr *exprpb.Expr,
 	overload string,
 	impl functions.Overloader,
 	args []Interpretable) (Interpretable, error) {
-	var fn functions.BinaryOp
+	var fn functions.ContextBinaryOp
 	var trait int
 	var nonStrict bool
 	if impl != nil {
-		if impl.GetBinary(context.Background()) == nil {
+		if impl.GetBinary() == nil {
 			return nil, fmt.Errorf("no such overload: %s(lhs, rhs)", function)
 		}
-		fn = impl.GetBinary(context.Background())
+		fn = impl.GetBinary()
 		trait = impl.GetOperandTrait()
 		nonStrict = impl.IsNonStrict()
 	}
@@ -390,14 +389,14 @@ func (p *planner) planCallVarArgs(expr *exprpb.Expr,
 	overload string,
 	impl functions.Overloader,
 	args []Interpretable) (Interpretable, error) {
-	var fn functions.FunctionOp
+	var fn functions.ContextFunctionOp
 	var trait int
 	var nonStrict bool
 	if impl != nil {
-		if impl.GetFunction(context.Background()) == nil {
+		if impl.GetFunction() == nil {
 			return nil, fmt.Errorf("no such overload: %s(...)", function)
 		}
-		fn = impl.GetFunction(context.Background())
+		fn = impl.GetFunction()
 		trait = impl.GetOperandTrait()
 		nonStrict = impl.IsNonStrict()
 	}


### PR DESCRIPTION
These changes introduce :
- a new interface `functions.Overloader` for keeping compatiblity with already defined `functions.Overload` structures
- a new structure `functions.ContextOverload` for defining context capable overloads
- the extension of the `interpreter.Activation` interface with `context.Context`
- a small test for checking that context cancellation can be catched with underlying overloads

The idea was to keep API compatibility while propagating the execution context to overload functions.

Resolves #557 