### PR TITLE
Support formatting options when unparsing ASTs to strings

### DIFF
--- a/common/operators/operators.go
+++ b/common/operators/operators.go
@@ -141,3 +141,13 @@ func Precedence(symbol string) int {
 	}
 	return op.precedence
 }
+
+// Arity returns the number of argument the operator takes
+// -1 is returned if an undefined symbol is provided
+func Arity(symbol string) int {
+	op, found := operatorMap[symbol]
+	if !found {
+		return -1
+	}
+	return op.arity
+}

--- a/parser/unparser.go
+++ b/parser/unparser.go
@@ -41,7 +41,7 @@ import (
 // performing word wrapping on expressions.
 func Unparse(expr *exprpb.Expr, info *exprpb.SourceInfo, opts ...UnparserOption) (string, error) {
 	unparserOpts := &unparserOption{
-		wrapColumn:           defaultWrapColumn,
+		wrapOnColumn:         defaultWrapOnColumn,
 		wrapAfterColumnLimit: defaultWrapAfterColumnLimit,
 		operatorsToWrapOn:    defaultOperatorsToWrapOn,
 	}
@@ -474,7 +474,7 @@ func (un *unparser) writeOperatorWithWrapping(fun string, unmangled string) bool
 	_, wrapOperatorExists := un.options.operatorsToWrapOn[fun]
 	lineLength := un.str.Len() - un.lastWrappedIndex + len(fun)
 
-	if wrapOperatorExists && lineLength >= un.options.wrapColumn {
+	if wrapOperatorExists && lineLength >= un.options.wrapOnColumn {
 		un.lastWrappedIndex = un.str.Len()
 		// wrapAfterColumnLimit flag dictates whether the newline is placed
 		// before or after the operator
@@ -502,7 +502,7 @@ func (un *unparser) writeOperatorWithWrapping(fun string, unmangled string) bool
 
 // Defined defaults for the unparser options
 var (
-	defaultWrapColumn           = 80
+	defaultWrapOnColumn         = 80
 	defaultWrapAfterColumnLimit = true
 	defaultOperatorsToWrapOn    = map[string]bool{
 		operators.LogicalAnd: true,
@@ -516,7 +516,7 @@ type UnparserOption func(*unparserOption) (*unparserOption, error)
 
 // Internal representation of the UnparserOption type
 type unparserOption struct {
-	wrapColumn           int
+	wrapOnColumn         int
 	operatorsToWrapOn    map[string]bool
 	wrapAfterColumnLimit bool
 }
@@ -526,7 +526,7 @@ type unparserOption struct {
 //
 // Example usage:
 //
-//	Unparse(expr, sourceInfo, WrapColumn(40), WrapOnOperators(Operators.LogicalAnd))
+//	Unparse(expr, sourceInfo, WrapOnColumn(40), WrapOnOperators(Operators.LogicalAnd))
 //
 // This will insert a newline immediately after the logical AND operator for the below example input:
 //
@@ -541,7 +541,7 @@ func WrapOnColumn(col int) UnparserOption {
 		if col < 1 {
 			return nil, fmt.Errorf("Invalid unparser option. Wrap column value must be greater than or equal to 1. Got %v instead", col)
 		}
-		opt.wrapColumn = col
+		opt.wrapOnColumn = col
 		return opt, nil
 	}
 }
@@ -577,7 +577,7 @@ func WrapOnOperators(symbols ...string) UnparserOption {
 //
 // Example usage:
 //
-//	Unparse(expr, sourceInfo, WrapColumn(40), WrapOnOperators(Operators.LogicalAnd), WrapAfterColumnLimit(false))
+//	Unparse(expr, sourceInfo, WrapOnColumn(40), WrapOnOperators(Operators.LogicalAnd), WrapAfterColumnLimit(false))
 //
 // This will insert a newline immediately before the logical AND operator for the below example input, ensuring
 // that the length of a line never exceeds the specified column limit:

--- a/parser/unparser_test.go
+++ b/parser/unparser_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/operators"
+
 	"google.golang.org/protobuf/proto"
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
@@ -32,7 +33,7 @@ func TestUnparse(t *testing.T) {
 		in                 string
 		out                interface{}
 		requiresMacroCalls bool
-		formattingOptions  []UnparserFormattingOption
+		formattingOptions  []UnparserOption
 	}{
 		{name: "call_add", in: `a + b - c`},
 		{name: "call_and", in: `a && b && c && d && e`},
@@ -147,16 +148,16 @@ func TestUnparse(t *testing.T) {
 			name: "call_no_wrap_no_operators",
 			in:   "a + b + c + d",
 			out:  "a + b + c + d",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 			},
 		},
 		{
 			name: "call_no_wrap_short_line",
 			in:   "a + b + c + d",
 			out:  "a + b + c + d",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(12),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(12),
 				WrapOnOperators(operators.Add),
 			},
 		},
@@ -166,8 +167,8 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_add",
 			in:   "a + b - d * e",
 			out:  "a +\nb - d * e",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 				WrapOnOperators(operators.Add),
 			},
 		},
@@ -175,8 +176,8 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_add_and_subtract",
 			in:   "a * b + c - d * e",
 			out:  "a * b +\nc -\nd * e",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 				WrapOnOperators(operators.Add, operators.Subtract),
 			},
 		},
@@ -184,8 +185,8 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_and",
 			in:   "a && b && c && d && e",
 			out:  "a &&\nb &&\nc &&\nd &&\ne",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 				WrapOnOperators(operators.LogicalAnd),
 			},
 		},
@@ -193,8 +194,8 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_and_2",
 			in:   "a && b",
 			out:  "a &&\nb",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 				WrapOnOperators(operators.LogicalAnd),
 			},
 		},
@@ -202,8 +203,8 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_conditional",
 			in:   "a ? b : c ? d : e",
 			out:  "a ?\nb : (c ?\nd : e)",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 				WrapOnOperators(operators.Conditional),
 			},
 		},
@@ -211,8 +212,8 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_or",
 			in:   "a || b || c || d || e",
 			out:  "a ||\nb ||\nc ||\nd ||\ne",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 				WrapOnOperators(operators.LogicalOr),
 			},
 		},
@@ -220,8 +221,8 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_equals",
 			in:   "a == b == c == d == e",
 			out:  "a ==\nb ==\nc ==\nd ==\ne",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 				WrapOnOperators(operators.Equals),
 			},
 		},
@@ -229,8 +230,8 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_greater",
 			in:   "a > b > c > d > e",
 			out:  "a >\nb >\nc >\nd >\ne",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 				WrapOnOperators(operators.Greater),
 			},
 		},
@@ -238,8 +239,8 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_greater_equals",
 			in:   "a >= b >= c >= d >= e",
 			out:  "a >=\nb >=\nc >=\nd >=\ne",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 				WrapOnOperators(operators.GreaterEquals),
 			},
 		},
@@ -247,8 +248,8 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_in",
 			in:   "a in b in c in d in e",
 			out:  "a in\nb in\nc in\nd in\ne",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 				WrapOnOperators(operators.In),
 			},
 		},
@@ -256,8 +257,8 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_less",
 			in:   "a < b < c < d < e",
 			out:  "a <\nb <\nc <\nd <\ne",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 				WrapOnOperators(operators.Less),
 			},
 		},
@@ -265,8 +266,8 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_less_equals",
 			in:   "a <= b <= c <= d <= e",
 			out:  "a <=\nb <=\nc <=\nd <=\ne",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 				WrapOnOperators(operators.LessEquals),
 			},
 		},
@@ -274,8 +275,8 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_not_equals",
 			in:   "a != b != c != d != e",
 			out:  "a !=\nb !=\nc !=\nd !=\ne",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 				WrapOnOperators(operators.NotEquals),
 			},
 		},
@@ -283,8 +284,8 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_divide",
 			in:   "a / b / c / d / e",
 			out:  "a /\nb /\nc /\nd /\ne",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 				WrapOnOperators(operators.Divide),
 			},
 		},
@@ -292,8 +293,8 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_modulo",
 			in:   "a % b % c % d % e",
 			out:  "a %\nb %\nc %\nd %\ne",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 				WrapOnOperators(operators.Modulo),
 			},
 		},
@@ -301,8 +302,8 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_multiply",
 			in:   "a * b * c * d * e",
 			out:  "a *\nb *\nc *\nd *\ne",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 				WrapOnOperators(operators.Multiply),
 			},
 		},
@@ -310,8 +311,17 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_and_long_variables",
 			in:   "longVariableA && longVariableB && longVariableC",
 			out:  "longVariableA &&\nlongVariableB &&\nlongVariableC",
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
+				WrapOnOperators(operators.LogicalAnd),
+			},
+		},
+		{
+			name: "call_wrap_and_long_input",
+			in:   `"my-principal-group" in request.auth.claims && request.auth.claims.iat > now - duration("5m")`,
+			out:  `"my-principal-group" in request.auth.claims &&` + "\n" + `request.auth.claims.iat > now - duration("5m")`,
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(40),
 				WrapOnOperators(operators.LogicalAnd),
 			},
 		},
@@ -320,8 +330,8 @@ func TestUnparse(t *testing.T) {
 			in:                 "[1, 2, 3].map(x, x >= 2, x * 4).filter(x, x <= 10)",
 			out:                "[1, 2, 3].map(x, x >=\n2, x * 4).filter(x, x <=\n10)",
 			requiresMacroCalls: true,
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(3),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
 				WrapOnOperators(operators.GreaterEquals, operators.LessEquals),
 			},
 		},
@@ -378,7 +388,7 @@ func TestUnparseErrors(t *testing.T) {
 		name              string
 		in                *exprpb.Expr
 		err               error
-		formattingOptions []UnparserFormattingOption
+		formattingOptions []UnparserOption
 	}{
 		{name: "empty_expr", in: &exprpb.Expr{}, err: errors.New("unsupported expression")},
 		{
@@ -442,18 +452,26 @@ func TestUnparseErrors(t *testing.T) {
 			err: errors.New("unsupported expression"),
 		},
 		{
-			name: "bad_formatting_option_wrap_column",
+			name: "bad_formatting_option_wrap_column_zero",
 			in:   validConstantExpression,
 			err:  errors.New("Invalid formatting option. Wrap column value must be greater than or equal to 1. Got 0 instead"),
-			formattingOptions: []UnparserFormattingOption{
-				WrapColumn(0),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(0),
+			},
+		},
+		{
+			name: "bad_formatting_option_wrap_column_negative",
+			in:   validConstantExpression,
+			err:  errors.New("Invalid formatting option. Wrap column value must be greater than or equal to 1. Got -1 instead"),
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(-1),
 			},
 		},
 		{
 			name: "bad_formatting_option_unsupported_operator",
 			in:   validConstantExpression,
 			err:  errors.New("Invalid formatting option. Unsupported operator: bogus"),
-			formattingOptions: []UnparserFormattingOption{
+			formattingOptions: []UnparserOption{
 				WrapOnOperators("bogus"),
 			},
 		},
@@ -461,7 +479,7 @@ func TestUnparseErrors(t *testing.T) {
 			name: "bad_formatting_option_unary_operator",
 			in:   validConstantExpression,
 			err:  errors.New("Invalid formatting option. Unary operators are unsupported: " + operators.Negate),
-			formattingOptions: []UnparserFormattingOption{
+			formattingOptions: []UnparserOption{
 				WrapOnOperators(operators.Negate),
 			},
 		},

--- a/parser/unparser_test.go
+++ b/parser/unparser_test.go
@@ -182,7 +182,7 @@ func TestUnparse(t *testing.T) {
 			},
 		},
 		{
-			name: "call_wrap_add_and_subtract",
+			name: "call_wrap_add_subtract",
 			in:   "a * b + c - d * e",
 			out:  "a * b +\nc -\nd * e",
 			formattingOptions: []UnparserOption{
@@ -191,7 +191,16 @@ func TestUnparse(t *testing.T) {
 			},
 		},
 		{
-			name: "call_wrap_and",
+			name: "call_wrap_add_subtract",
+			in:   "a * b + c - d * e",
+			out:  "a * b +\nc -\nd * e",
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
+				WrapOnOperators(operators.Add, operators.Subtract),
+			},
+		},
+		{
+			name: "call_wrap_logical_and",
 			in:   "a && b && c && d && e",
 			out:  "a &&\nb &&\nc &&\nd &&\ne",
 			formattingOptions: []UnparserOption{
@@ -200,7 +209,7 @@ func TestUnparse(t *testing.T) {
 			},
 		},
 		{
-			name: "call_wrap_and_2",
+			name: "call_wrap_logical_and_2",
 			in:   "a && b",
 			out:  "a &&\nb",
 			formattingOptions: []UnparserOption{
@@ -317,20 +326,11 @@ func TestUnparse(t *testing.T) {
 			},
 		},
 		{
-			name: "call_wrap_and_long_variables",
+			name: "call_wrap_logical_and_long_variables",
 			in:   "longVariableA && longVariableB && longVariableC",
 			out:  "longVariableA &&\nlongVariableB &&\nlongVariableC",
 			formattingOptions: []UnparserOption{
 				WrapOnColumn(3),
-				WrapOnOperators(operators.LogicalAnd),
-			},
-		},
-		{
-			name: "call_wrap_and_long_input",
-			in:   `"my-principal-group" in request.auth.claims && request.auth.claims.iat > now - duration("5m")`,
-			out:  `"my-principal-group" in request.auth.claims &&` + "\n" + `request.auth.claims.iat > now - duration("5m")`,
-			formattingOptions: []UnparserOption{
-				WrapOnColumn(40),
 				WrapOnOperators(operators.LogicalAnd),
 			},
 		},
@@ -342,6 +342,55 @@ func TestUnparse(t *testing.T) {
 			formattingOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.GreaterEquals, operators.LessEquals),
+			},
+		},
+		{
+			name: "call_wrap_before_add",
+			in:   "a + b - d * e",
+			out:  "a\n+ b - d * e",
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
+				WrapOnOperators(operators.Add),
+				WrapAfterColumnLimit(false),
+			},
+		},
+		{
+			name: "call_wrap_before_add_subtract",
+			in:   "a * b + c - d * e",
+			out:  "a * b\n+ c\n- d * e",
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
+				WrapOnOperators(operators.Add, operators.Subtract),
+				WrapAfterColumnLimit(false),
+			},
+		},
+		{
+			name: "call_wrap_logical_and_long_variables",
+			in:   "longVariableA && longVariableB && longVariableC",
+			out:  "longVariableA\n&& longVariableB\n&& longVariableC",
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
+				WrapOnOperators(operators.LogicalAnd),
+				WrapAfterColumnLimit(false),
+			},
+		},
+		{
+			name: "call_wrap_logical_and_long_input",
+			in:   `"my-principal-group" in request.auth.claims && request.auth.claims.iat > now - duration("5m")`,
+			out:  `"my-principal-group" in request.auth.claims &&` + "\n" + `request.auth.claims.iat > now - duration("5m")`,
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(40),
+				WrapOnOperators(operators.LogicalAnd),
+			},
+		},
+		{
+			name: "call_wrap_before_logical_and_long_input",
+			in:   `"my-principal-group" in request.auth.claims && request.auth.claims.iat > now - duration("5m")`,
+			out:  `"my-principal-group" in request.auth.claims` + "\n" + `&& request.auth.claims.iat > now - duration("5m")`,
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(40),
+				WrapOnOperators(operators.LogicalAnd),
+				WrapAfterColumnLimit(false),
 			},
 		},
 	}

--- a/parser/unparser_test.go
+++ b/parser/unparser_test.go
@@ -393,6 +393,29 @@ func TestUnparse(t *testing.T) {
 				WrapAfterColumnLimit(false),
 			},
 		},
+		{
+			// By default:
+			// - Column limit is at 80
+			// - && and || are wrapped
+			// - Wrapping occurs after the symbol
+			name: "call_wrap_default",
+			in:   `jwt.extra_claims.filter(c, c.startsWith("group")).all(c, jwt.extra_claims[c].all(g, g.endsWith("@acme.co"))) && jwt.extra_claims.exists(c, c.startsWith("group")) || request.auth.claims.group == "admin" || request.auth.principal == "user:me@acme.co"`,
+			out: `jwt.extra_claims.filter(c, c.startsWith("group")).all(c, jwt.extra_claims[c].all(g, g.endsWith("@acme.co"))) &&` +
+				"\n" +
+				`jwt.extra_claims.exists(c, c.startsWith("group")) || request.auth.claims.group == "admin" ||` +
+				"\n" +
+				`request.auth.principal == "user:me@acme.co"`,
+			requiresMacroCalls: true,
+		},
+		{
+			// && and || are wrapped by default if only the column limit is specified
+			name: "call_wrap_default_operators",
+			in:   "longVariableA && longVariableB || longVariableC + longVariableD - longVariableE",
+			out:  "longVariableA &&\nlongVariableB ||\nlongVariableC + longVariableD - longVariableE",
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(3),
+			},
+		},
 	}
 
 	for _, tst := range tests {

--- a/parser/unparser_test.go
+++ b/parser/unparser_test.go
@@ -153,11 +153,20 @@ func TestUnparse(t *testing.T) {
 			},
 		},
 		{
-			name: "call_no_wrap_short_line",
+			name: "call_no_wrap_column_limit_large_val",
 			in:   "a + b + c + d",
 			out:  "a + b + c + d",
 			formattingOptions: []UnparserOption{
-				WrapOnColumn(12),
+				WrapOnColumn(1000),
+				WrapOnOperators(operators.Add),
+			},
+		},
+		{
+			name: "call_no_wrap_column_limit_equal_length_to_input",
+			in:   "a + b + c + d",
+			out:  "a + b + c + d",
+			formattingOptions: []UnparserOption{
+				WrapOnColumn(13),
 				WrapOnOperators(operators.Add),
 			},
 		},

--- a/parser/unparser_test.go
+++ b/parser/unparser_test.go
@@ -33,7 +33,7 @@ func TestUnparse(t *testing.T) {
 		in                 string
 		out                interface{}
 		requiresMacroCalls bool
-		formattingOptions  []UnparserOption
+		unparserOptions    []UnparserOption
 	}{
 		{name: "call_add", in: `a + b - c`},
 		{name: "call_and", in: `a && b && c && d && e`},
@@ -143,12 +143,12 @@ func TestUnparse(t *testing.T) {
 		},
 
 		// These expressions will not be wrapped because they haven't met the
-		// conditions required by the provided formatting options
+		// conditions required by the provided unparser options
 		{
 			name: "call_no_wrap_no_operators",
 			in:   "a + b + c + d",
 			out:  "a + b + c + d",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 			},
 		},
@@ -156,7 +156,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_no_wrap_column_limit_large_val",
 			in:   "a + b + c + d",
 			out:  "a + b + c + d",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(1000),
 				WrapOnOperators(operators.Add),
 			},
@@ -165,18 +165,18 @@ func TestUnparse(t *testing.T) {
 			name: "call_no_wrap_column_limit_equal_length_to_input",
 			in:   "a + b + c + d",
 			out:  "a + b + c + d",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(13),
 				WrapOnOperators(operators.Add),
 			},
 		},
 
-		// These expressions will be formatted based on the formatting options provided
+		// These expressions will be formatted based on the unparser options provided
 		{
 			name: "call_wrap_add",
 			in:   "a + b - d * e",
 			out:  "a +\nb - d * e",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.Add),
 			},
@@ -185,7 +185,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_add_subtract",
 			in:   "a * b + c - d * e",
 			out:  "a * b +\nc -\nd * e",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.Add, operators.Subtract),
 			},
@@ -194,7 +194,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_add_subtract",
 			in:   "a * b + c - d * e",
 			out:  "a * b +\nc -\nd * e",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.Add, operators.Subtract),
 			},
@@ -203,7 +203,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_logical_and",
 			in:   "a && b && c && d && e",
 			out:  "a &&\nb &&\nc &&\nd &&\ne",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.LogicalAnd),
 			},
@@ -212,7 +212,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_logical_and_2",
 			in:   "a && b",
 			out:  "a &&\nb",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.LogicalAnd),
 			},
@@ -221,7 +221,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_conditional",
 			in:   "a ? b : c ? d : e",
 			out:  "a ?\nb : (c ?\nd : e)",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.Conditional),
 			},
@@ -230,7 +230,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_or",
 			in:   "a || b || c || d || e",
 			out:  "a ||\nb ||\nc ||\nd ||\ne",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.LogicalOr),
 			},
@@ -239,7 +239,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_equals",
 			in:   "a == b == c == d == e",
 			out:  "a ==\nb ==\nc ==\nd ==\ne",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.Equals),
 			},
@@ -248,7 +248,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_greater",
 			in:   "a > b > c > d > e",
 			out:  "a >\nb >\nc >\nd >\ne",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.Greater),
 			},
@@ -257,7 +257,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_greater_equals",
 			in:   "a >= b >= c >= d >= e",
 			out:  "a >=\nb >=\nc >=\nd >=\ne",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.GreaterEquals),
 			},
@@ -266,7 +266,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_in",
 			in:   "a in b in c in d in e",
 			out:  "a in\nb in\nc in\nd in\ne",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.In),
 			},
@@ -275,7 +275,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_less",
 			in:   "a < b < c < d < e",
 			out:  "a <\nb <\nc <\nd <\ne",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.Less),
 			},
@@ -284,7 +284,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_less_equals",
 			in:   "a <= b <= c <= d <= e",
 			out:  "a <=\nb <=\nc <=\nd <=\ne",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.LessEquals),
 			},
@@ -293,7 +293,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_not_equals",
 			in:   "a != b != c != d != e",
 			out:  "a !=\nb !=\nc !=\nd !=\ne",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.NotEquals),
 			},
@@ -302,7 +302,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_divide",
 			in:   "a / b / c / d / e",
 			out:  "a /\nb /\nc /\nd /\ne",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.Divide),
 			},
@@ -311,7 +311,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_modulo",
 			in:   "a % b % c % d % e",
 			out:  "a %\nb %\nc %\nd %\ne",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.Modulo),
 			},
@@ -320,7 +320,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_multiply",
 			in:   "a * b * c * d * e",
 			out:  "a *\nb *\nc *\nd *\ne",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.Multiply),
 			},
@@ -329,7 +329,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_logical_and_long_variables",
 			in:   "longVariableA && longVariableB && longVariableC",
 			out:  "longVariableA &&\nlongVariableB &&\nlongVariableC",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.LogicalAnd),
 			},
@@ -339,7 +339,7 @@ func TestUnparse(t *testing.T) {
 			in:                 "[1, 2, 3].map(x, x >= 2, x * 4).filter(x, x <= 10)",
 			out:                "[1, 2, 3].map(x, x >=\n2, x * 4).filter(x, x <=\n10)",
 			requiresMacroCalls: true,
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.GreaterEquals, operators.LessEquals),
 			},
@@ -348,7 +348,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_before_add",
 			in:   "a + b - d * e",
 			out:  "a\n+ b - d * e",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.Add),
 				WrapAfterColumnLimit(false),
@@ -358,7 +358,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_before_add_subtract",
 			in:   "a * b + c - d * e",
 			out:  "a * b\n+ c\n- d * e",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.Add, operators.Subtract),
 				WrapAfterColumnLimit(false),
@@ -368,7 +368,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_logical_and_long_variables",
 			in:   "longVariableA && longVariableB && longVariableC",
 			out:  "longVariableA\n&& longVariableB\n&& longVariableC",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 				WrapOnOperators(operators.LogicalAnd),
 				WrapAfterColumnLimit(false),
@@ -378,7 +378,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_logical_and_long_input",
 			in:   `"my-principal-group" in request.auth.claims && request.auth.claims.iat > now - duration("5m")`,
 			out:  `"my-principal-group" in request.auth.claims &&` + "\n" + `request.auth.claims.iat > now - duration("5m")`,
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(40),
 				WrapOnOperators(operators.LogicalAnd),
 			},
@@ -387,7 +387,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_before_logical_and_long_input",
 			in:   `"my-principal-group" in request.auth.claims && request.auth.claims.iat > now - duration("5m")`,
 			out:  `"my-principal-group" in request.auth.claims` + "\n" + `&& request.auth.claims.iat > now - duration("5m")`,
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(40),
 				WrapOnOperators(operators.LogicalAnd),
 				WrapAfterColumnLimit(false),
@@ -412,7 +412,7 @@ func TestUnparse(t *testing.T) {
 			name: "call_wrap_default_operators",
 			in:   "longVariableA && longVariableB || longVariableC + longVariableD - longVariableE",
 			out:  "longVariableA &&\nlongVariableB ||\nlongVariableC + longVariableD - longVariableE",
-			formattingOptions: []UnparserOption{
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(3),
 			},
 		},
@@ -432,7 +432,7 @@ func TestUnparse(t *testing.T) {
 			if len(iss.GetErrors()) > 0 {
 				t.Fatalf("parser.Parse(%s) failed: %v", tc.in, iss.ToDisplayString())
 			}
-			out, err := Unparse(p.GetExpr(), p.GetSourceInfo(), tc.formattingOptions...)
+			out, err := Unparse(p.GetExpr(), p.GetSourceInfo(), tc.unparserOptions...)
 
 			if err != nil {
 				t.Fatalf("Unparse(%s) failed: %v", tc.in, err)
@@ -466,10 +466,10 @@ func TestUnparseErrors(t *testing.T) {
 		},
 	}
 	tests := []struct {
-		name              string
-		in                *exprpb.Expr
-		err               error
-		formattingOptions []UnparserOption
+		name            string
+		in              *exprpb.Expr
+		err             error
+		unparserOptions []UnparserOption
 	}{
 		{name: "empty_expr", in: &exprpb.Expr{}, err: errors.New("unsupported expression")},
 		{
@@ -533,34 +533,34 @@ func TestUnparseErrors(t *testing.T) {
 			err: errors.New("unsupported expression"),
 		},
 		{
-			name: "bad_formatting_option_wrap_column_zero",
+			name: "bad_unparser_option_wrap_column_zero",
 			in:   validConstantExpression,
-			err:  errors.New("Invalid formatting option. Wrap column value must be greater than or equal to 1. Got 0 instead"),
-			formattingOptions: []UnparserOption{
+			err:  errors.New("Invalid unparser option. Wrap column value must be greater than or equal to 1. Got 0 instead"),
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(0),
 			},
 		},
 		{
-			name: "bad_formatting_option_wrap_column_negative",
+			name: "bad_unparser_option_wrap_column_negative",
 			in:   validConstantExpression,
-			err:  errors.New("Invalid formatting option. Wrap column value must be greater than or equal to 1. Got -1 instead"),
-			formattingOptions: []UnparserOption{
+			err:  errors.New("Invalid unparser option. Wrap column value must be greater than or equal to 1. Got -1 instead"),
+			unparserOptions: []UnparserOption{
 				WrapOnColumn(-1),
 			},
 		},
 		{
-			name: "bad_formatting_option_unsupported_operator",
+			name: "bad_unparser_option_unsupported_operator",
 			in:   validConstantExpression,
-			err:  errors.New("Invalid formatting option. Unsupported operator: bogus"),
-			formattingOptions: []UnparserOption{
+			err:  errors.New("Invalid unparser option. Unsupported operator: bogus"),
+			unparserOptions: []UnparserOption{
 				WrapOnOperators("bogus"),
 			},
 		},
 		{
-			name: "bad_formatting_option_unary_operator",
+			name: "bad_unparser_option_unary_operator",
 			in:   validConstantExpression,
-			err:  errors.New("Invalid formatting option. Unary operators are unsupported: " + operators.Negate),
-			formattingOptions: []UnparserOption{
+			err:  errors.New("Invalid unparser option. Unary operators are unsupported: " + operators.Negate),
+			unparserOptions: []UnparserOption{
 				WrapOnOperators(operators.Negate),
 			},
 		},
@@ -569,7 +569,7 @@ func TestUnparseErrors(t *testing.T) {
 	for _, tst := range tests {
 		tc := tst
 		t.Run(tc.name, func(t *testing.T) {
-			out, err := Unparse(tc.in, &exprpb.SourceInfo{}, tc.formattingOptions...)
+			out, err := Unparse(tc.in, &exprpb.SourceInfo{}, tc.unparserOptions...)
 			if err == nil {
 				t.Fatalf("Unparse(%v) got %v, wanted error %v", tc.in, out, tc.err)
 			}


### PR DESCRIPTION
This change adds formatting capability to unparser by introducing new functional option`UnparseOption`. `Unparse` function will accept any number of `UnparseOption` augment the behavior of unparsing an AST.

This will allow support adding new lines for any desired non-unary operators when the length of a string exceeds the defined column limit.

Resolves #293 