### PR TITLE
Provide an option to ensure time operations are in UTC by default

### DIFF
--- a/cel/BUILD.bazel
+++ b/cel/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//checker/decls:go_default_library",
         "//common:go_default_library",
         "//common/containers:go_default_library",
+        "//common/overloads:go_default_library",
         "//common/types:go_default_library",
         "//common/types/pb:go_default_library",
         "//common/types/ref:go_default_library",

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -1666,26 +1666,26 @@ func TestDefaultUTCTimeZone(t *testing.T) {
 		&& x.getMinutes() == 5
 		&& x.getSeconds() == 6
 		&& x.getMilliseconds() == 1
-		&& x.getFullYear('-07:00') == 1969
-		&& x.getDayOfYear('-07:00') == 364
-		&& x.getMonth('-07:00') == 11
-		&& x.getDayOfMonth('-07:00') == 30
-		&& x.getDate('-07:00') == 31
-		&& x.getDayOfWeek('-07:00') == 3
-		&& x.getHours('-07:00') == 19
-		&& x.getMinutes('-07:00') == 5
-		&& x.getSeconds('-07:00') == 6
-		&& x.getMilliseconds('-07:00') == 1
-		&& x.getFullYear('23:00') == 1970
-		&& x.getDayOfYear('23:00') == 1
-		&& x.getMonth('23:00') == 0
-		&& x.getDayOfMonth('23:00') == 1
-		&& x.getDate('23:00') == 2
-		&& x.getDayOfWeek('23:00') == 5
-		&& x.getHours('23:00') == 1
-		&& x.getMinutes('23:00') == 5
-		&& x.getSeconds('23:00') == 6
-		&& x.getMilliseconds('23:00') == 1
+		&& x.getFullYear('-07:30') == 1969
+		&& x.getDayOfYear('-07:30') == 364
+		&& x.getMonth('-07:30') == 11
+		&& x.getDayOfMonth('-07:30') == 30
+		&& x.getDate('-07:30') == 31
+		&& x.getDayOfWeek('-07:30') == 3
+		&& x.getHours('-07:30') == 18
+		&& x.getMinutes('-07:30') == 35
+		&& x.getSeconds('-07:30') == 6
+		&& x.getMilliseconds('-07:30') == 1
+		&& x.getFullYear('23:15') == 1970
+		&& x.getDayOfYear('23:15') == 1
+		&& x.getMonth('23:15') == 0
+		&& x.getDayOfMonth('23:15') == 1
+		&& x.getDate('23:15') == 2
+		&& x.getDayOfWeek('23:15') == 5
+		&& x.getHours('23:15') == 1
+		&& x.getMinutes('23:15') == 20
+		&& x.getSeconds('23:15') == 6
+		&& x.getMilliseconds('23:15') == 1
 	`)
 	if iss.Err() != nil {
 		t.Fatalf("env.Compile() failed: %v", iss.Err())

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -1650,8 +1650,8 @@ func TestRegexOptimizer(t *testing.T) {
 	}
 }
 
-func TestUseUTCTimeZone(t *testing.T) {
-	env, err := NewEnv(Variable("x", TimestampType), EnableDefaultUTCTimeZone())
+func TestDefaultUTCTimeZone(t *testing.T) {
+	env, err := NewEnv(Variable("x", TimestampType), DefaultUTCTimeZone(true))
 	if err != nil {
 		t.Fatalf("NewEnv() failed: %v", err)
 	}
@@ -1703,8 +1703,8 @@ func TestUseUTCTimeZone(t *testing.T) {
 	}
 }
 
-func TestUseUTCTimeZoneError(t *testing.T) {
-	env, err := NewEnv(Variable("x", TimestampType), EnableDefaultUTCTimeZone())
+func TestDefaultUTCTimeZoneError(t *testing.T) {
+	env, err := NewEnv(Variable("x", TimestampType), DefaultUTCTimeZone(true))
 	if err != nil {
 		t.Fatalf("NewEnv() failed: %v", err)
 	}

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -144,7 +144,7 @@ func TestAbbrevsParsed(t *testing.T) {
 	}
 }
 
-func TestAbbrevs_Disambiguation(t *testing.T) {
+func TestAbbrevsDisambiguation(t *testing.T) {
 	env, err := NewEnv(
 		Abbrevs("external.Expr"),
 		Container("google.api.expr.v1alpha1"),
@@ -1085,7 +1085,7 @@ func TestResidualAstComplex(t *testing.T) {
 	}
 }
 
-func Benchmark_EvalOptions(b *testing.B) {
+func BenchmarkEvalOptions(b *testing.B) {
 	e, _ := NewEnv(
 		Variable("ai", IntType),
 		Variable("ar", MapType(StringType, StringType)),
@@ -1647,6 +1647,89 @@ func TestRegexOptimizer(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestUseUTCTimeZone(t *testing.T) {
+	env, err := NewEnv(Variable("x", TimestampType), EnableDefaultUTCTimeZone())
+	if err != nil {
+		t.Fatalf("NewEnv() failed: %v", err)
+	}
+	ast, iss := env.Compile(`
+		x.getFullYear() == 1970
+		&& x.getMonth() == 0
+		&& x.getDayOfYear() == 0
+		&& x.getDayOfMonth() == 0
+		&& x.getDate() == 1
+		&& x.getDayOfWeek() == 4
+		&& x.getHours() == 2
+		&& x.getMinutes() == 5
+		&& x.getSeconds() == 6
+		&& x.getMilliseconds() == 1
+		&& x.getFullYear('-07:00') == 1969
+		&& x.getDayOfYear('-07:00') == 364
+		&& x.getMonth('-07:00') == 11
+		&& x.getDayOfMonth('-07:00') == 30
+		&& x.getDate('-07:00') == 31
+		&& x.getDayOfWeek('-07:00') == 3
+		&& x.getHours('-07:00') == 19
+		&& x.getMinutes('-07:00') == 5
+		&& x.getSeconds('-07:00') == 6
+		&& x.getMilliseconds('-07:00') == 1
+		&& x.getFullYear('23:00') == 1970
+		&& x.getDayOfYear('23:00') == 1
+		&& x.getMonth('23:00') == 0
+		&& x.getDayOfMonth('23:00') == 1
+		&& x.getDate('23:00') == 2
+		&& x.getDayOfWeek('23:00') == 5
+		&& x.getHours('23:00') == 1
+		&& x.getMinutes('23:00') == 5
+		&& x.getSeconds('23:00') == 6
+		&& x.getMilliseconds('23:00') == 1
+	`)
+	if iss.Err() != nil {
+		t.Fatalf("env.Compile() failed: %v", iss.Err())
+	}
+	prg, err := env.Program(ast)
+	if err != nil {
+		t.Fatalf("env.Program() failed: %v", err)
+	}
+	out, _, err := prg.Eval(map[string]interface{}{"x": time.Unix(7506, 1000000).Local()})
+	if err != nil {
+		t.Fatalf("prg.Eval() failed: %v", err)
+	}
+	if out != types.True {
+		t.Errorf("Eval() got %v, wanted true", out)
+	}
+}
+
+func TestUseUTCTimeZoneError(t *testing.T) {
+	env, err := NewEnv(Variable("x", TimestampType), EnableDefaultUTCTimeZone())
+	if err != nil {
+		t.Fatalf("NewEnv() failed: %v", err)
+	}
+	ast, iss := env.Compile(`
+		x.getFullYear(':xx') == 1969
+		|| x.getDayOfYear('xx:') == 364
+		|| x.getMonth('Am/Ph') == 11
+		|| x.getDayOfMonth('Am/Ph') == 30
+		|| x.getDate('Am/Ph') == 31
+		|| x.getDayOfWeek('Am/Ph') == 3
+		|| x.getHours('Am/Ph') == 19
+		|| x.getMinutes('Am/Ph') == 5
+		|| x.getSeconds('Am/Ph') == 6
+		|| x.getMilliseconds('Am/Ph') == 1
+	`)
+	if iss.Err() != nil {
+		t.Fatalf("env.Compile() failed: %v", iss.Err())
+	}
+	prg, err := env.Program(ast)
+	if err != nil {
+		t.Fatalf("env.Program() failed: %v", err)
+	}
+	out, _, err := prg.Eval(map[string]interface{}{"x": time.Unix(7506, 1000000).Local()})
+	if err == nil {
+		t.Fatalf("prg.Eval() got %v wanted error", out)
 	}
 }
 

--- a/cel/env.go
+++ b/cel/env.go
@@ -452,6 +452,14 @@ func (e *Env) configure(opts []EnvOption) (*Env, error) {
 		}
 	}
 
+	// If the default UTC timezone fix has been enabled, make sure the library is configured
+	if e.HasFeature(featureDefaultUTCTimeZone) {
+		e, err = Lib(timeUTCLibrary{})(e)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// Initialize all of the functions configured within the environment.
 	for _, fn := range e.functions {
 		err = fn.init()

--- a/cel/library.go
+++ b/cel/library.go
@@ -69,11 +69,10 @@ type stdLibrary struct{}
 
 // EnvOptions returns options for the standard CEL function declarations and macros.
 func (stdLibrary) CompileOptions() []EnvOption {
-	opts := []EnvOption{
+	return []EnvOption{
 		Declarations(checker.StandardDeclarations()...),
 		Macros(StandardMacros...),
 	}
-	return opts
 }
 
 // ProgramOptions returns function implementations for the standard CEL functions.

--- a/cel/library.go
+++ b/cel/library.go
@@ -303,7 +303,7 @@ func inTimeZone(ts, tz ref.Val) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, err
 	}
-	min, err := strconv.Atoi(string(val[ind+1]))
+	min, err := strconv.Atoi(string(val[ind+1:]))
 	if err != nil {
 		return time.Time{}, err
 	}

--- a/cel/library.go
+++ b/cel/library.go
@@ -15,7 +15,14 @@
 package cel
 
 import (
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/google/cel-go/checker"
+	"github.com/google/cel-go/common/overloads"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter/functions"
 )
 
@@ -62,10 +69,11 @@ type stdLibrary struct{}
 
 // EnvOptions returns options for the standard CEL function declarations and macros.
 func (stdLibrary) CompileOptions() []EnvOption {
-	return []EnvOption{
+	opts := []EnvOption{
 		Declarations(checker.StandardDeclarations()...),
 		Macros(StandardMacros...),
 	}
+	return opts
 }
 
 // ProgramOptions returns function implementations for the standard CEL functions.
@@ -73,4 +81,240 @@ func (stdLibrary) ProgramOptions() []ProgramOption {
 	return []ProgramOption{
 		Functions(functions.StandardOverloads()...),
 	}
+}
+
+type timeUTCLibrary struct{}
+
+func (timeUTCLibrary) CompileOptions() []EnvOption {
+	return timestampOverloadDeclarations
+}
+
+func (timeUTCLibrary) ProgramOptions() []ProgramOption {
+	return []ProgramOption{}
+}
+
+// Declarations and functions which enable using UTC on time.Time inputs when the timezone is unspecified
+// in the CEL expression.
+var (
+	utcTZ = types.String("UTC")
+
+	timestampOverloadDeclarations = []EnvOption{
+		Function(overloads.TimeGetFullYear,
+			MemberOverload(overloads.TimestampToYear, []*Type{TimestampType}, IntType,
+				UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetFullYear(ts, utcTZ)
+				}),
+			),
+			MemberOverload(overloads.TimestampToYearWithTz, []*Type{TimestampType, StringType}, IntType,
+				BinaryBinding(timestampGetFullYear),
+			),
+		),
+		Function(overloads.TimeGetMonth,
+			MemberOverload(overloads.TimestampToMonth, []*Type{TimestampType}, IntType,
+				UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetMonth(ts, utcTZ)
+				}),
+			),
+			MemberOverload(overloads.TimestampToMonthWithTz, []*Type{TimestampType, StringType}, IntType,
+				BinaryBinding(timestampGetMonth),
+			),
+		),
+		Function(overloads.TimeGetDayOfYear,
+			MemberOverload(overloads.TimestampToDayOfYear, []*Type{TimestampType}, IntType,
+				UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetDayOfYear(ts, utcTZ)
+				}),
+			),
+			MemberOverload(overloads.TimestampToDayOfYearWithTz, []*Type{TimestampType, StringType}, IntType,
+				BinaryBinding(func(ts, tz ref.Val) ref.Val {
+					return timestampGetDayOfYear(ts, tz)
+				}),
+			),
+		),
+		Function(overloads.TimeGetDayOfMonth,
+			MemberOverload(overloads.TimestampToDayOfMonthZeroBased, []*Type{TimestampType}, IntType,
+				UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetDayOfMonthZeroBased(ts, utcTZ)
+				}),
+			),
+			MemberOverload(overloads.TimestampToDayOfMonthZeroBasedWithTz, []*Type{TimestampType, StringType}, IntType,
+				BinaryBinding(timestampGetDayOfMonthZeroBased),
+			),
+		),
+		Function(overloads.TimeGetDate,
+			MemberOverload(overloads.TimestampToDayOfMonthOneBased, []*Type{TimestampType}, IntType,
+				UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetDayOfMonthOneBased(ts, utcTZ)
+				}),
+			),
+			MemberOverload(overloads.TimestampToDayOfMonthOneBasedWithTz, []*Type{TimestampType, StringType}, IntType,
+				BinaryBinding(timestampGetDayOfMonthOneBased),
+			),
+		),
+		Function(overloads.TimeGetDayOfWeek,
+			MemberOverload(overloads.TimestampToDayOfWeek, []*Type{TimestampType}, IntType,
+				UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetDayOfWeek(ts, utcTZ)
+				}),
+			),
+			MemberOverload(overloads.TimestampToDayOfWeekWithTz, []*Type{TimestampType, StringType}, IntType,
+				BinaryBinding(timestampGetDayOfWeek),
+			),
+		),
+		Function(overloads.TimeGetHours,
+			MemberOverload(overloads.TimestampToHours, []*Type{TimestampType}, IntType,
+				UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetHours(ts, utcTZ)
+				}),
+			),
+			MemberOverload(overloads.TimestampToHoursWithTz, []*Type{TimestampType, StringType}, IntType,
+				BinaryBinding(timestampGetHours),
+			),
+		),
+		Function(overloads.TimeGetMinutes,
+			MemberOverload(overloads.TimestampToMinutes, []*Type{TimestampType}, IntType,
+				UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetMinutes(ts, utcTZ)
+				}),
+			),
+			MemberOverload(overloads.TimestampToMinutesWithTz, []*Type{TimestampType, StringType}, IntType,
+				BinaryBinding(timestampGetMinutes),
+			),
+		),
+		Function(overloads.TimeGetSeconds,
+			MemberOverload(overloads.TimestampToSeconds, []*Type{TimestampType}, IntType,
+				UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetSeconds(ts, utcTZ)
+				}),
+			),
+			MemberOverload(overloads.TimestampToSecondsWithTz, []*Type{TimestampType, StringType}, IntType,
+				BinaryBinding(timestampGetSeconds),
+			),
+		),
+		Function(overloads.TimeGetMilliseconds,
+			MemberOverload(overloads.TimestampToMilliseconds, []*Type{TimestampType}, IntType,
+				UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetMilliseconds(ts, utcTZ)
+				}),
+			),
+			MemberOverload(overloads.TimestampToMillisecondsWithTz, []*Type{TimestampType, StringType}, IntType,
+				BinaryBinding(timestampGetMilliseconds),
+			),
+		),
+	}
+)
+
+func timestampGetFullYear(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErr(err.Error())
+	}
+	return types.Int(t.Year())
+}
+
+func timestampGetMonth(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErr(err.Error())
+	}
+	// CEL spec indicates that the month should be 0-based, but the Time value
+	// for Month() is 1-based.
+	return types.Int(t.Month() - 1)
+}
+
+func timestampGetDayOfYear(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErr(err.Error())
+	}
+	return types.Int(t.YearDay() - 1)
+}
+
+func timestampGetDayOfMonthZeroBased(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErr(err.Error())
+	}
+	return types.Int(t.Day() - 1)
+}
+
+func timestampGetDayOfMonthOneBased(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErr(err.Error())
+	}
+	return types.Int(t.Day())
+}
+
+func timestampGetDayOfWeek(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErr(err.Error())
+	}
+	return types.Int(t.Weekday())
+}
+
+func timestampGetHours(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErr(err.Error())
+	}
+	return types.Int(t.Hour())
+}
+
+func timestampGetMinutes(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErr(err.Error())
+	}
+	return types.Int(t.Minute())
+}
+
+func timestampGetSeconds(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErr(err.Error())
+	}
+	return types.Int(t.Second())
+}
+
+func timestampGetMilliseconds(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErr(err.Error())
+	}
+	return types.Int(t.Nanosecond() / 1000000)
+}
+
+func inTimeZone(ts, tz ref.Val) (time.Time, error) {
+	t := ts.(types.Timestamp)
+	val := string(tz.(types.String))
+	ind := strings.Index(val, ":")
+	if ind == -1 {
+		loc, err := time.LoadLocation(val)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return t.In(loc), nil
+	}
+
+	// If the input is not the name of a timezone (for example, 'US/Central'), it should be a numerical offset from UTC
+	// in the format ^(+|-)(0[0-9]|1[0-4]):[0-5][0-9]$. The numerical input is parsed in terms of hours and minutes.
+	hr, err := strconv.Atoi(string(val[0:ind]))
+	if err != nil {
+		return time.Time{}, err
+	}
+	min, err := strconv.Atoi(string(val[ind+1]))
+	if err != nil {
+		return time.Time{}, err
+	}
+	var offset int
+	if string(val[0]) == "-" {
+		offset = hr*60 - min
+	} else {
+		offset = hr*60 + min
+	}
+	secondsEastOfUTC := int((time.Duration(offset) * time.Minute).Seconds())
+	timezone := time.FixedZone("", secondsEastOfUTC)
+	return t.In(timezone), nil
 }

--- a/cel/options.go
+++ b/cel/options.go
@@ -56,6 +56,11 @@ const (
 	// Enable eager validation of declarations to ensure that Env values created
 	// with `Extend` inherit a validated list of declarations from the parent Env.
 	featureEagerlyValidateDeclarations
+
+	// Enable the use of the default UTC timezone when a timezone is not specified
+	// on a CEL timestamp operation. This fixes the scenario where the input time
+	// is not already in UTC.
+	featureDefaultUTCTimeZone
 )
 
 // EnvOption is a functional interface for configuring the environment.
@@ -523,10 +528,10 @@ func CrossTypeNumericComparisons(enabled bool) EnvOption {
 	return features(featureCrossTypeNumericComparisons, enabled)
 }
 
-// EnableDefaultUTCTimeZone ensures that time-based operations use the UTC timezone rather than the
+// DefaultUTCTimeZone ensures that time-based operations use the UTC timezone rather than the
 // input time's local timezone.
-func EnableDefaultUTCTimeZone() EnvOption {
-	return Lib(timeUTCLibrary{})
+func DefaultUTCTimeZone(enabled bool) EnvOption {
+	return features(featureDefaultUTCTimeZone, enabled)
 }
 
 // features sets the given feature flags.  See list of Feature constants above.

--- a/cel/options.go
+++ b/cel/options.go
@@ -523,6 +523,12 @@ func CrossTypeNumericComparisons(enabled bool) EnvOption {
 	return features(featureCrossTypeNumericComparisons, enabled)
 }
 
+// EnableDefaultUTCTimeZone ensures that time-based operations use the UTC timezone rather than the
+// input time's local timezone.
+func EnableDefaultUTCTimeZone() EnvOption {
+	return Lib(timeUTCLibrary{})
+}
+
 // features sets the given feature flags.  See list of Feature constants above.
 func features(flag int, enabled bool) EnvOption {
 	return func(e *Env) (*Env, error) {

--- a/checker/env_test.go
+++ b/checker/env_test.go
@@ -54,12 +54,8 @@ func TestOverlappingMacro(t *testing.T) {
 
 func TestOverlappingOverload(t *testing.T) {
 	env := newStdEnv(t)
-	paramA := decls.NewTypeParamType("A")
-	typeParamAList := []string{"A"}
 	err := env.Add(decls.NewFunction(overloads.TypeConvertDyn,
-		decls.NewParameterizedOverload(overloads.ToDyn,
-			[]*exprpb.Type{paramA}, decls.Dyn,
-			typeParamAList)))
+		decls.NewOverload(overloads.ToDyn, []*exprpb.Type{decls.String}, decls.Dyn)))
 	if err == nil {
 		t.Error("Got nil, wanted error")
 	} else if !strings.Contains(err.Error(), "overlapping overload") {

--- a/common/types/timestamp.go
+++ b/common/types/timestamp.go
@@ -299,7 +299,7 @@ func timeZone(tz ref.Val, visitor timestampVisitor) timestampVisitor {
 		if err != nil {
 			return wrapErr(err)
 		}
-		min, err := strconv.Atoi(string(val[ind+1]))
+		min, err := strconv.Atoi(string(val[ind+1:]))
 		if err != nil {
 			return wrapErr(err)
 		}


### PR DESCRIPTION
Currently, unary member functions on `timestamp` values in cel-go will use whatever the timezone is of the input object. However, this is not what is specified in the spec and can result in differences in evaluation behavior depending on where the call takes place. This fixes an issue with spec-conformance and should be enabled by default in future releases. To opt-in or opt-out see the usage below.

Usage: `cel.NewEnv(cel.DefaultUTCTimeZone(true))`

Closes #468 by ensuring that all time operations are in UTC by default.
