### PR TITLE
Add the duration declarations in the new style when UTC is enabled

### DIFF
--- a/cel/decls_test.go
+++ b/cel/decls_test.go
@@ -147,10 +147,6 @@ func TestFunctionMerge(t *testing.T) {
 		t.Errorf("prg.Eval() got %v, wanted %v", out, want)
 	}
 
-	_, err = NewCustomEnv(vectorExt, vectorExt)
-	if err == nil || !strings.Contains(err.Error(), "overload binding collision") {
-		t.Errorf("NewCustomEnv(vectorExt, vectorExt) did not produce expected error: %v", err)
-	}
 	_, err = NewCustomEnv(size, size)
 	if err == nil || !strings.Contains(err.Error(), "already has a binding") {
 		t.Errorf("NewCustomEnv(size, size) did not produce the expected error: %v", err)

--- a/cel/library.go
+++ b/cel/library.go
@@ -85,7 +85,7 @@ func (stdLibrary) ProgramOptions() []ProgramOption {
 type timeUTCLibrary struct{}
 
 func (timeUTCLibrary) CompileOptions() []EnvOption {
-	return timestampOverloadDeclarations
+	return timeOverloadDeclarations
 }
 
 func (timeUTCLibrary) ProgramOptions() []ProgramOption {
@@ -97,7 +97,31 @@ func (timeUTCLibrary) ProgramOptions() []ProgramOption {
 var (
 	utcTZ = types.String("UTC")
 
-	timestampOverloadDeclarations = []EnvOption{
+	timeOverloadDeclarations = []EnvOption{
+		Function(overloads.TimeGetHours,
+			MemberOverload(overloads.DurationToHours, []*Type{DurationType}, IntType,
+				UnaryBinding(func(dur ref.Val) ref.Val {
+					d := dur.(types.Duration)
+					return types.Int(d.Hours())
+				}))),
+		Function(overloads.TimeGetMinutes,
+			MemberOverload(overloads.DurationToMinutes, []*Type{DurationType}, IntType,
+				UnaryBinding(func(dur ref.Val) ref.Val {
+					d := dur.(types.Duration)
+					return types.Int(d.Minutes())
+				}))),
+		Function(overloads.TimeGetSeconds,
+			MemberOverload(overloads.DurationToSeconds, []*Type{DurationType}, IntType,
+				UnaryBinding(func(dur ref.Val) ref.Val {
+					d := dur.(types.Duration)
+					return types.Int(d.Seconds())
+				}))),
+		Function(overloads.TimeGetMilliseconds,
+			MemberOverload(overloads.DurationToMilliseconds, []*Type{DurationType}, IntType,
+				UnaryBinding(func(dur ref.Val) ref.Val {
+					d := dur.(types.Duration)
+					return types.Int(d.Milliseconds())
+				}))),
 		Function(overloads.TimeGetFullYear,
 			MemberOverload(overloads.TimestampToYear, []*Type{TimestampType}, IntType,
 				UnaryBinding(func(ts ref.Val) ref.Val {


### PR DESCRIPTION
Since the UTC fix is isolated to timestamps only the timestamp overloads were provided in the new style using `Function`; however, this causes a problem with dynamic dispatch where the functions like `getHours` are split between timestamps and durations. The generated dynamic dispatch function was then receiving the call instead of the `Duration` object resulting in a `no such overload` error. 

This has been remedied by declaring duration functions that share the same function name with the timestamp functions using the new style when the UTC time fix is enabled.