### PR TITLE
Use proto safe traversal accessors

### DIFF
--- a/checker/cost.go
+++ b/checker/cost.go
@@ -88,9 +88,9 @@ func (e astNode) ComputedSize() *SizeEstimate {
 		return e.derivedSize
 	}
 	var v uint64
-	switch ek := e.expr.ExprKind.(type) {
+	switch ek := e.expr.GetExprKind().(type) {
 	case *exprpb.Expr_ConstExpr:
-		switch ck := ek.ConstExpr.ConstantKind.(type) {
+		switch ck := ek.ConstExpr.GetConstantKind().(type) {
 		case *exprpb.Constant_StringValue:
 			v = uint64(len(ck.StringValue))
 		case *exprpb.Constant_BytesValue:
@@ -103,10 +103,10 @@ func (e astNode) ComputedSize() *SizeEstimate {
 			return nil
 		}
 	case *exprpb.Expr_ListExpr:
-		v = uint64(len(ek.ListExpr.Elements))
+		v = uint64(len(ek.ListExpr.GetElements()))
 	case *exprpb.Expr_StructExpr:
-		if ek.StructExpr.MessageName == "" {
-			v = uint64(len(ek.StructExpr.Entries))
+		if ek.StructExpr.GetMessageName() == "" {
+			v = uint64(len(ek.StructExpr.GetEntries()))
 		}
 	default:
 		return nil
@@ -297,7 +297,7 @@ func (c *coster) cost(e *exprpb.Expr) CostEstimate {
 		return CostEstimate{}
 	}
 	var cost CostEstimate
-	switch e.ExprKind.(type) {
+	switch e.GetExprKind().(type) {
 	case *exprpb.Expr_ConstExpr:
 		cost = constCost
 	case *exprpb.Expr_IdentExpr:
@@ -323,7 +323,7 @@ func (c *coster) costIdent(e *exprpb.Expr) CostEstimate {
 
 	// build and track the field path
 	if iterRange, ok := c.iterRanges.peek(identExpr.GetName()); ok {
-		switch c.checkedExpr.TypeMap[iterRange].TypeKind.(type) {
+		switch c.checkedExpr.TypeMap[iterRange].GetTypeKind().(type) {
 		case *exprpb.Type_ListType_:
 			c.addPath(e, append(c.exprPath[iterRange], "@items"))
 		case *exprpb.Type_MapType_:
@@ -350,7 +350,7 @@ func (c *coster) costSelect(e *exprpb.Expr) CostEstimate {
 	}
 
 	// build and track the field path
-	c.addPath(e, append(c.getPath(sel.GetOperand()), sel.Field))
+	c.addPath(e, append(c.getPath(sel.GetOperand()), sel.GetField()))
 
 	return sum
 }

--- a/checker/printer.go
+++ b/checker/printer.go
@@ -32,22 +32,22 @@ func (a *semanticAdorner) GetMetadata(elem interface{}) string {
 	if !isExpr {
 		return result
 	}
-	t := a.checks.TypeMap[e.Id]
+	t := a.checks.TypeMap[e.GetId()]
 	if t != nil {
 		result += "~"
 		result += FormatCheckedType(t)
 	}
 
-	switch e.ExprKind.(type) {
+	switch e.GetExprKind().(type) {
 	case *exprpb.Expr_IdentExpr,
 		*exprpb.Expr_CallExpr,
 		*exprpb.Expr_StructExpr,
 		*exprpb.Expr_SelectExpr:
-		if ref, found := a.checks.ReferenceMap[e.Id]; found {
+		if ref, found := a.checks.ReferenceMap[e.GetId()]; found {
 			if len(ref.GetOverloadId()) == 0 {
 				result += "^" + ref.Name
 			} else {
-				for i, overload := range ref.OverloadId {
+				for i, overload := range ref.GetOverloadId() {
 					if i == 0 {
 						result += "^"
 					} else {

--- a/common/containers/container.go
+++ b/common/containers/container.go
@@ -98,12 +98,12 @@ func (c *Container) Name() string {
 //
 // Given a container name a.b.c.M.N and a type name R.s, this will deliver in order:
 //
-//     a.b.c.M.N.R.s
-//     a.b.c.M.R.s
-//     a.b.c.R.s
-//     a.b.R.s
-//     a.R.s
-//     R.s
+//	a.b.c.M.N.R.s
+//	a.b.c.M.R.s
+//	a.b.c.R.s
+//	a.b.R.s
+//	a.R.s
+//	R.s
 //
 // If aliases or abbreviations are configured for the container, then alias names will take
 // precedence over containerized names.
@@ -145,9 +145,9 @@ func (c *Container) aliasSet() map[string]string {
 // If the name is qualified, the first component of the qualified name is checked against known
 // aliases. Any alias that is found in a qualified name is expanded in the result:
 //
-//     alias: R -> my.alias.R
-//     name: R.S.T
-//     output: my.alias.R.S.T
+//	alias: R -> my.alias.R
+//	name: R.S.T
+//	output: my.alias.R.S.T
 //
 // Note, the name must not have a leading dot.
 func (c *Container) findAlias(name string) (string, bool) {
@@ -177,19 +177,19 @@ type ContainerOption func(*Container) (*Container, error)
 // Abbreviations can be useful when working with variables, functions, and especially types from
 // multiple namespaces:
 //
-//    // CEL object construction
-//    qual.pkg.version.ObjTypeName{
-//       field: alt.container.ver.FieldTypeName{value: ...}
-//    }
+//	// CEL object construction
+//	qual.pkg.version.ObjTypeName{
+//	   field: alt.container.ver.FieldTypeName{value: ...}
+//	}
 //
 // Only one the qualified names above may be used as the CEL container, so at least one of these
 // references must be a long qualified name within an otherwise short CEL program. Using the
 // following abbreviations, the program becomes much simpler:
 //
-//    // CEL Go option
-//    Abbrevs("qual.pkg.version.ObjTypeName", "alt.container.ver.FieldTypeName")
-//    // Simplified Object construction
-//    ObjTypeName{field: FieldTypeName{value: ...}}
+//	// CEL Go option
+//	Abbrevs("qual.pkg.version.ObjTypeName", "alt.container.ver.FieldTypeName")
+//	// Simplified Object construction
+//	ObjTypeName{field: FieldTypeName{value: ...}}
 //
 // There are a few rules for the qualified names and the simple abbreviations generated from them:
 // - Qualified names must be dot-delimited, e.g. `package.subpkg.name`.
@@ -198,13 +198,13 @@ type ContainerOption func(*Container) (*Container, error)
 // - The abbreviation must not collide with unqualified names in use.
 //
 // Abbreviations are distinct from container-based references in the following important ways:
-// - Abbreviations must expand to a fully-qualified name.
-// - Expanded abbreviations do not participate in namespace resolution.
-// - Abbreviation expansion is done instead of the container search for a matching identifier.
-// - Containers follow C++ namespace resolution rules with searches from the most qualified name
-//   to the least qualified name.
-// - Container references within the CEL program may be relative, and are resolved to fully
-//   qualified names at either type-check time or program plan time, whichever comes first.
+//   - Abbreviations must expand to a fully-qualified name.
+//   - Expanded abbreviations do not participate in namespace resolution.
+//   - Abbreviation expansion is done instead of the container search for a matching identifier.
+//   - Containers follow C++ namespace resolution rules with searches from the most qualified name
+//     to the least qualified name.
+//   - Container references within the CEL program may be relative, and are resolved to fully
+//     qualified names at either type-check time or program plan time, whichever comes first.
 //
 // If there is ever a case where an identifier could be in both the container and as an
 // abbreviation, the abbreviation wins as this will ensure that the meaning of a program is
@@ -298,18 +298,18 @@ func Name(name string) ContainerOption {
 // ToQualifiedName converts an expression AST into a qualified name if possible, with a boolean
 // 'found' value that indicates if the conversion is successful.
 func ToQualifiedName(e *exprpb.Expr) (string, bool) {
-	switch e.ExprKind.(type) {
+	switch e.GetExprKind().(type) {
 	case *exprpb.Expr_IdentExpr:
 		id := e.GetIdentExpr()
-		return id.Name, true
+		return id.GetName(), true
 	case *exprpb.Expr_SelectExpr:
 		sel := e.GetSelectExpr()
 		// Test only expressions are not valid as qualified names.
 		if sel.GetTestOnly() {
 			return "", false
 		}
-		if qual, found := ToQualifiedName(sel.Operand); found {
-			return qual + "." + sel.Field, true
+		if qual, found := ToQualifiedName(sel.GetOperand()); found {
+			return qual + "." + sel.GetField(), true
 		}
 	}
 	return "", false

--- a/common/debug/debug.go
+++ b/common/debug/debug.go
@@ -102,9 +102,9 @@ func (w *debugWriter) Buffer(e *exprpb.Expr) {
 }
 
 func (w *debugWriter) appendSelect(sel *exprpb.Expr_Select) {
-	w.Buffer(sel.Operand)
+	w.Buffer(sel.GetOperand())
 	w.append(".")
-	w.append(sel.Field)
+	w.append(sel.GetField())
 	if sel.TestOnly {
 		w.append("~test-only~")
 	}
@@ -112,15 +112,15 @@ func (w *debugWriter) appendSelect(sel *exprpb.Expr_Select) {
 
 func (w *debugWriter) appendCall(call *exprpb.Expr_Call) {
 	if call.Target != nil {
-		w.Buffer(call.Target)
+		w.Buffer(call.GetTarget())
 		w.append(".")
 	}
-	w.append(call.Function)
+	w.append(call.GetFunction())
 	w.append("(")
 	if len(call.GetArgs()) > 0 {
 		w.addIndent()
 		w.appendLine()
-		for i, arg := range call.Args {
+		for i, arg := range call.GetArgs() {
 			if i > 0 {
 				w.append(",")
 				w.appendLine()
@@ -138,7 +138,7 @@ func (w *debugWriter) appendList(list *exprpb.Expr_CreateList) {
 	if len(list.GetElements()) > 0 {
 		w.appendLine()
 		w.addIndent()
-		for i, elem := range list.Elements {
+		for i, elem := range list.GetElements() {
 			if i > 0 {
 				w.append(",")
 				w.appendLine()
@@ -160,19 +160,19 @@ func (w *debugWriter) appendStruct(obj *exprpb.Expr_CreateStruct) {
 }
 
 func (w *debugWriter) appendObject(obj *exprpb.Expr_CreateStruct) {
-	w.append(obj.MessageName)
+	w.append(obj.GetMessageName())
 	w.append("{")
-	if len(obj.Entries) > 0 {
+	if len(obj.GetEntries()) > 0 {
 		w.appendLine()
 		w.addIndent()
-		for i, entry := range obj.Entries {
+		for i, entry := range obj.GetEntries() {
 			if i > 0 {
 				w.append(",")
 				w.appendLine()
 			}
 			w.append(entry.GetFieldKey())
 			w.append(":")
-			w.Buffer(entry.Value)
+			w.Buffer(entry.GetValue())
 			w.adorn(entry)
 		}
 		w.removeIndent()
@@ -183,17 +183,17 @@ func (w *debugWriter) appendObject(obj *exprpb.Expr_CreateStruct) {
 
 func (w *debugWriter) appendMap(obj *exprpb.Expr_CreateStruct) {
 	w.append("{")
-	if len(obj.Entries) > 0 {
+	if len(obj.GetEntries()) > 0 {
 		w.appendLine()
 		w.addIndent()
-		for i, entry := range obj.Entries {
+		for i, entry := range obj.GetEntries() {
 			if i > 0 {
 				w.append(",")
 				w.appendLine()
 			}
 			w.Buffer(entry.GetMapKey())
 			w.append(":")
-			w.Buffer(entry.Value)
+			w.Buffer(entry.GetValue())
 			w.adorn(entry)
 		}
 		w.removeIndent()
@@ -208,43 +208,43 @@ func (w *debugWriter) appendComprehension(comprehension *exprpb.Expr_Comprehensi
 	w.appendLine()
 	w.append("// Variable")
 	w.appendLine()
-	w.append(comprehension.IterVar)
+	w.append(comprehension.GetIterVar())
 	w.append(",")
 	w.appendLine()
 	w.append("// Target")
 	w.appendLine()
-	w.Buffer(comprehension.IterRange)
+	w.Buffer(comprehension.GetIterRange())
 	w.append(",")
 	w.appendLine()
 	w.append("// Accumulator")
 	w.appendLine()
-	w.append(comprehension.AccuVar)
+	w.append(comprehension.GetAccuVar())
 	w.append(",")
 	w.appendLine()
 	w.append("// Init")
 	w.appendLine()
-	w.Buffer(comprehension.AccuInit)
+	w.Buffer(comprehension.GetAccuInit())
 	w.append(",")
 	w.appendLine()
 	w.append("// LoopCondition")
 	w.appendLine()
-	w.Buffer(comprehension.LoopCondition)
+	w.Buffer(comprehension.GetLoopCondition())
 	w.append(",")
 	w.appendLine()
 	w.append("// LoopStep")
 	w.appendLine()
-	w.Buffer(comprehension.LoopStep)
+	w.Buffer(comprehension.GetLoopStep())
 	w.append(",")
 	w.appendLine()
 	w.append("// Result")
 	w.appendLine()
-	w.Buffer(comprehension.Result)
+	w.Buffer(comprehension.GetResult())
 	w.append(")")
 	w.removeIndent()
 }
 
 func formatLiteral(c *exprpb.Constant) string {
-	switch c.ConstantKind.(type) {
+	switch c.GetConstantKind().(type) {
 	case *exprpb.Constant_BoolValue:
 		return fmt.Sprintf("%t", c.GetBoolValue())
 	case *exprpb.Constant_BytesValue:

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -95,7 +95,7 @@ type planner struct {
 // such as state-tracking, expression re-write, and possibly efficient thread-safe memoization of
 // repeated expressions.
 func (p *planner) Plan(expr *exprpb.Expr) (Interpretable, error) {
-	switch expr.ExprKind.(type) {
+	switch expr.GetExprKind().(type) {
 	case *exprpb.Expr_CallExpr:
 		return p.decorate(p.planCall(expr))
 	case *exprpb.Expr_IdentExpr:
@@ -146,10 +146,10 @@ func (p *planner) planIdent(expr *exprpb.Expr) (Interpretable, error) {
 
 func (p *planner) planCheckedIdent(id int64, identRef *exprpb.Reference) (Interpretable, error) {
 	// Plan a constant reference if this is the case for this simple identifier.
-	if identRef.Value != nil {
+	if identRef.GetValue() != nil {
 		return p.Plan(&exprpb.Expr{Id: id,
 			ExprKind: &exprpb.Expr_ConstExpr{
-				ConstExpr: identRef.Value,
+				ConstExpr: identRef.GetValue(),
 			}})
 	}
 
@@ -157,9 +157,9 @@ func (p *planner) planCheckedIdent(id int64, identRef *exprpb.Reference) (Interp
 	// registered with the provider.
 	cType := p.typeMap[id]
 	if cType.GetType() != nil {
-		cVal, found := p.provider.FindIdent(identRef.Name)
+		cVal, found := p.provider.FindIdent(identRef.GetName())
 		if !found {
-			return nil, fmt.Errorf("reference to undefined type: %s", identRef.Name)
+			return nil, fmt.Errorf("reference to undefined type: %s", identRef.GetName())
 		}
 		return NewConstValue(id, cVal), nil
 	}
@@ -167,14 +167,15 @@ func (p *planner) planCheckedIdent(id int64, identRef *exprpb.Reference) (Interp
 	// Otherwise, return the attribute for the resolved identifier name.
 	return &evalAttr{
 		adapter: p.adapter,
-		attr:    p.attrFactory.AbsoluteAttribute(id, identRef.Name),
+		attr:    p.attrFactory.AbsoluteAttribute(id, identRef.GetName()),
 	}, nil
 }
 
 // planSelect creates an Interpretable with either:
-//  a) selects a field from a map or proto.
-//  b) creates a field presence test for a select within a has() macro.
-//  c) resolves the select expression to a namespaced identifier.
+//
+//	a) selects a field from a map or proto.
+//	b) creates a field presence test for a select within a has() macro.
+//	c) resolves the select expression to a namespaced identifier.
 func (p *planner) planSelect(expr *exprpb.Expr) (Interpretable, error) {
 	// If the Select id appears in the reference map from the CheckedExpr proto then it is either
 	// a namespaced identifier or enum value.
@@ -193,7 +194,7 @@ func (p *planner) planSelect(expr *exprpb.Expr) (Interpretable, error) {
 	var fieldType *ref.FieldType
 	opType := p.typeMap[sel.GetOperand().GetId()]
 	if opType.GetMessageType() != "" {
-		ft, found := p.provider.FindFieldType(opType.GetMessageType(), sel.Field)
+		ft, found := p.provider.FindFieldType(opType.GetMessageType(), sel.GetField())
 		if found && ft.IsSet != nil && ft.GetFrom != nil {
 			fieldType = ft
 		}
@@ -213,15 +214,15 @@ func (p *planner) planSelect(expr *exprpb.Expr) (Interpretable, error) {
 	if sel.TestOnly {
 		// Return the test only eval expression.
 		return &evalTestOnly{
-			id:        expr.Id,
-			field:     types.String(sel.Field),
+			id:        expr.GetId(),
+			field:     types.String(sel.GetField()),
 			fieldType: fieldType,
 			op:        op,
 		}, nil
 	}
 	// Build a qualifier.
 	qual, err := p.attrFactory.NewQualifier(
-		opType, expr.Id, sel.Field)
+		opType, expr.GetId(), sel.GetField())
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +330,7 @@ func (p *planner) planCallZero(expr *exprpb.Expr,
 		return nil, fmt.Errorf("no such overload: %s()", function)
 	}
 	return &evalZeroArity{
-		id:       expr.Id,
+		id:       expr.GetId(),
 		function: function,
 		overload: overload,
 		impl:     impl.Function,
@@ -354,7 +355,7 @@ func (p *planner) planCallUnary(expr *exprpb.Expr,
 		nonStrict = impl.NonStrict
 	}
 	return &evalUnary{
-		id:        expr.Id,
+		id:        expr.GetId(),
 		function:  function,
 		overload:  overload,
 		arg:       args[0],
@@ -382,7 +383,7 @@ func (p *planner) planCallBinary(expr *exprpb.Expr,
 		nonStrict = impl.NonStrict
 	}
 	return &evalBinary{
-		id:        expr.Id,
+		id:        expr.GetId(),
 		function:  function,
 		overload:  overload,
 		lhs:       args[0],
@@ -411,7 +412,7 @@ func (p *planner) planCallVarArgs(expr *exprpb.Expr,
 		nonStrict = impl.NonStrict
 	}
 	return &evalVarArgs{
-		id:        expr.Id,
+		id:        expr.GetId(),
 		function:  function,
 		overload:  overload,
 		args:      args,
@@ -425,7 +426,7 @@ func (p *planner) planCallVarArgs(expr *exprpb.Expr,
 func (p *planner) planCallEqual(expr *exprpb.Expr,
 	args []Interpretable) (Interpretable, error) {
 	return &evalEq{
-		id:  expr.Id,
+		id:  expr.GetId(),
 		lhs: args[0],
 		rhs: args[1],
 	}, nil
@@ -435,7 +436,7 @@ func (p *planner) planCallEqual(expr *exprpb.Expr,
 func (p *planner) planCallNotEqual(expr *exprpb.Expr,
 	args []Interpretable) (Interpretable, error) {
 	return &evalNe{
-		id:  expr.Id,
+		id:  expr.GetId(),
 		lhs: args[0],
 		rhs: args[1],
 	}, nil
@@ -445,7 +446,7 @@ func (p *planner) planCallNotEqual(expr *exprpb.Expr,
 func (p *planner) planCallLogicalAnd(expr *exprpb.Expr,
 	args []Interpretable) (Interpretable, error) {
 	return &evalAnd{
-		id:  expr.Id,
+		id:  expr.GetId(),
 		lhs: args[0],
 		rhs: args[1],
 	}, nil
@@ -455,7 +456,7 @@ func (p *planner) planCallLogicalAnd(expr *exprpb.Expr,
 func (p *planner) planCallLogicalOr(expr *exprpb.Expr,
 	args []Interpretable) (Interpretable, error) {
 	return &evalOr{
-		id:  expr.Id,
+		id:  expr.GetId(),
 		lhs: args[0],
 		rhs: args[1],
 	}, nil
@@ -486,7 +487,7 @@ func (p *planner) planCallConditional(expr *exprpb.Expr,
 
 	return &evalAttr{
 		adapter: p.adapter,
-		attr:    p.attrFactory.ConditionalAttribute(expr.Id, cond, tAttr, fAttr),
+		attr:    p.attrFactory.ConditionalAttribute(expr.GetId(), cond, tAttr, fAttr),
 	}, nil
 }
 
@@ -541,7 +542,7 @@ func (p *planner) planCreateList(expr *exprpb.Expr) (Interpretable, error) {
 		elems[i] = elemVal
 	}
 	return &evalList{
-		id:      expr.Id,
+		id:      expr.GetId(),
 		elems:   elems,
 		adapter: p.adapter,
 	}, nil
@@ -570,7 +571,7 @@ func (p *planner) planCreateStruct(expr *exprpb.Expr) (Interpretable, error) {
 		vals[i] = valVal
 	}
 	return &evalMap{
-		id:      expr.Id,
+		id:      expr.GetId(),
 		keys:    keys,
 		vals:    vals,
 		adapter: p.adapter,
@@ -596,7 +597,7 @@ func (p *planner) planCreateObj(expr *exprpb.Expr) (Interpretable, error) {
 		vals[i] = val
 	}
 	return &evalObj{
-		id:       expr.Id,
+		id:       expr.GetId(),
 		typeName: typeName,
 		fields:   fields,
 		vals:     vals,
@@ -628,7 +629,7 @@ func (p *planner) planComprehension(expr *exprpb.Expr) (Interpretable, error) {
 		return nil, err
 	}
 	return &evalFold{
-		id:        expr.Id,
+		id:        expr.GetId(),
 		accuVar:   fold.AccuVar,
 		accu:      accu,
 		iterVar:   fold.IterVar,
@@ -646,12 +647,12 @@ func (p *planner) planConst(expr *exprpb.Expr) (Interpretable, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewConstValue(expr.Id, val), nil
+	return NewConstValue(expr.GetId(), val), nil
 }
 
 // constValue converts a proto Constant value to a ref.Val.
 func (p *planner) constValue(c *exprpb.Constant) (ref.Val, error) {
-	switch c.ConstantKind.(type) {
+	switch c.GetConstantKind().(type) {
 	case *exprpb.Constant_BoolValue:
 		return p.adapter.NativeToValue(c.GetBoolValue()), nil
 	case *exprpb.Constant_BytesValue:

--- a/interpreter/prune.go
+++ b/interpreter/prune.go
@@ -41,17 +41,23 @@ type astPruner struct {
 // A)
 // 1) Evaluate expr with some unknowns,
 // 2) If result is unknown:
-//   a) PruneAst
-//   b) Goto 1
+//
+//	a) PruneAst
+//	b) Goto 1
+//
 // Functional call results which are known would be effectively cached across
 // iterations.
 //
 // B)
 // 1) Compile the expression (maybe via a service and maybe after checking a
-//    compiled expression does not exists in local cache)
+//
+//	compiled expression does not exists in local cache)
+//
 // 2) Prepare the environment and the interpreter. Activation might be empty.
 // 3) Eval the expression. This might return unknown or error or a concrete
-//    value.
+//
+//	value.
+//
 // 4) PruneAst
 // 4) Maybe cache the expression
 // This is effectively constant folding the expression. How the environment is
@@ -232,9 +238,9 @@ func (p *astPruner) prune(node *exprpb.Expr) (*exprpb.Expr, bool) {
 	// transform, or expression was not evaluated. If possible, drill down
 	// more.
 
-	switch node.ExprKind.(type) {
+	switch node.GetExprKind().(type) {
 	case *exprpb.Expr_SelectExpr:
-		if operand, pruned := p.prune(node.GetSelectExpr().Operand); pruned {
+		if operand, pruned := p.prune(node.GetSelectExpr().GetOperand()); pruned {
 			return &exprpb.Expr{
 				Id: node.GetId(),
 				ExprKind: &exprpb.Expr_SelectExpr{

--- a/parser/helper.go
+++ b/parser/helper.go
@@ -217,7 +217,7 @@ func (p *parserHelper) buildMacroCallArg(expr *exprpb.Expr) *exprpb.Expr {
 		return &exprpb.Expr{Id: expr.GetId()}
 	}
 
-	switch expr.ExprKind.(type) {
+	switch expr.GetExprKind().(type) {
 	case *exprpb.Expr_CallExpr:
 		// Iterate the AST from `expr` recursively looking for macros. Because we are at most
 		// starting from the top level macro, this recursion is bounded by the size of the AST. This

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -807,13 +807,13 @@ func (p *parser) extractQualifiedName(e *exprpb.Expr) (string, bool) {
 	if e == nil {
 		return "", false
 	}
-	switch e.ExprKind.(type) {
+	switch e.GetExprKind().(type) {
 	case *exprpb.Expr_IdentExpr:
 		return e.GetIdentExpr().GetName(), true
 	case *exprpb.Expr_SelectExpr:
 		s := e.GetSelectExpr()
-		if prefix, found := p.extractQualifiedName(s.Operand); found {
-			return prefix + "." + s.Field, true
+		if prefix, found := p.extractQualifiedName(s.GetOperand()); found {
+			return prefix + "." + s.GetField(), true
 		}
 	}
 	// TODO: Add a method to Source to get location from character offset.

--- a/parser/unparser.go
+++ b/parser/unparser.go
@@ -81,7 +81,7 @@ func (un *unparser) visit(expr *exprpb.Expr) error {
 	if visited || err != nil {
 		return err
 	}
-	switch expr.ExprKind.(type) {
+	switch expr.GetExprKind().(type) {
 	case *exprpb.Expr_CallExpr:
 		return un.visitCall(expr)
 	case *exprpb.Expr_ConstExpr:
@@ -249,7 +249,7 @@ func (un *unparser) visitCallUnary(expr *exprpb.Expr) error {
 
 func (un *unparser) visitConst(expr *exprpb.Expr) error {
 	c := expr.GetConstExpr()
-	switch c.ConstantKind.(type) {
+	switch c.GetConstantKind().(type) {
 	case *exprpb.Constant_BoolValue:
 		un.str.WriteString(strconv.FormatBool(c.GetBoolValue()))
 	case *exprpb.Constant_BytesValue:

--- a/server/server.go
+++ b/server/server.go
@@ -100,7 +100,7 @@ func (s *ConformanceServer) Eval(ctx context.Context, in *confpb.EvalRequest) (*
 	env, _ := evalEnv.Extend(cel.Container(in.Container))
 	var prg cel.Program
 	var err error
-	switch in.ExprKind.(type) {
+	switch in.GetExprKind().(type) {
 	case *confpb.EvalRequest_ParsedExpr:
 		ast := cel.ParsedExprToAst(in.GetParsedExpr())
 		prg, err = env.Program(ast)


### PR DESCRIPTION
It seems that upcoming changes in the codegen for go proto messages seem to change some of the assumptions about safe-traversal. This change ensures that accessor methods are used which preserve the safe traversal promises of proto.