### PR TITLE
Fix nested CallExpr cost estimation

### DIFF
--- a/checker/cost.go
+++ b/checker/cost.go
@@ -480,6 +480,9 @@ func (c *coster) sizeEstimate(t AstNode) SizeEstimate {
 	// lengths, since strings/bytes/more complex objects could be of
 	// variable length
 	if isScalar(t.Type()) {
+		// TODO: since the logic for size estimation is split between
+		// ComputedSize and isScalar, changing one will likely require changing
+		// the other, so they should be merged in the future if possible
 		return SizeEstimate{Min: 1, Max: 1}
 	}
 	return SizeEstimate{Min: 0, Max: math.MaxUint64}

--- a/checker/cost.go
+++ b/checker/cost.go
@@ -606,6 +606,9 @@ func (c *coster) newAstNode(e *exprpb.Expr) *astNode {
 	return &astNode{path: path, t: c.getType(e), expr: e, derivedSize: derivedSize}
 }
 
+// isScalar returns true if the given type is known to be of a constant size at
+// compile time. isScalar will return false for strings (they are variable-width)
+// in addition to protobuf.Any and protobuf.Value (their size is not knowable at compile time).
 func isScalar(t *exprpb.Type) bool {
 	switch kindOf(t) {
 	case kindPrimitive:

--- a/checker/cost.go
+++ b/checker/cost.go
@@ -476,6 +476,11 @@ func (c *coster) sizeEstimate(t AstNode) SizeEstimate {
 	if l := c.estimator.EstimateSize(t); l != nil {
 		return *l
 	}
+	// return a constant size if we're dealing with a CallExpr and EstimateSize
+	// came up empty; this code is reached when a CallExpr is nested inside
+	// another CallExpr and doesn't have an estimator that can handle it, such
+	// as `(1 == 2) == (3 == 4)` - without this block, that expression would
+	// return SizeEstimate{Min: 0, Max: math.MaxUint64}
 	if _, ok := t.Expr().ExprKind.(*exprpb.Expr_CallExpr); ok {
 		return SizeEstimate{Min: 1, Max: 1}
 	}

--- a/checker/cost.go
+++ b/checker/cost.go
@@ -619,19 +619,6 @@ func isScalar(t *exprpb.Type) bool {
 		if t.GetWellKnown() == exprpb.Type_DURATION || t.GetWellKnown() == exprpb.Type_TIMESTAMP {
 			return true
 		}
-	case kindObject:
-		switch t.GetMessageType() {
-		case "google.protobuf.Duration", "google.protobuf.Timestamp",
-			"google.protobuf.BoolValue", "google.protobuf.BytesValue",
-			"google.protobuf.DoubleValue", "google.protobuf.FloatValue",
-			"google.protobuf.Int32Value", "google.protobuf.Int64Value",
-			"google.protobuf.UInt32Value", "google.protobuf.UInt64Value":
-			return true
-		default:
-			return false
-		}
-	default:
-		return false
 	}
 	return false
 }

--- a/checker/cost.go
+++ b/checker/cost.go
@@ -485,10 +485,8 @@ func (c *coster) sizeEstimate(t AstNode) SizeEstimate {
 		// ensure we only return an estimate of 1 for return types of set
 		// lengths, since strings/bytes/more complex objects could be of
 		// variable length
-		if kindOf(t.Type()) == kindPrimitive {
-			if t.Type().GetPrimitive() != exprpb.Type_STRING && t.Type().GetPrimitive() != exprpb.Type_BYTES {
-				return SizeEstimate{Min: 1, Max: 1}
-			}
+		if isScalar(t.Type()) {
+			return SizeEstimate{Min: 1, Max: 1}
 		}
 	}
 	return SizeEstimate{Min: 0, Max: math.MaxUint64}
@@ -613,4 +611,13 @@ func (c *coster) newAstNode(e *exprpb.Expr) *astNode {
 		derivedSize = &size
 	}
 	return &astNode{path: path, t: c.getType(e), expr: e, derivedSize: derivedSize}
+}
+
+func isScalar(t *exprpb.Type) bool {
+	if kindOf(t) == kindPrimitive {
+		if t.GetPrimitive() != exprpb.Type_STRING && t.GetPrimitive() != exprpb.Type_BYTES {
+			return true
+		}
+	}
+	return false
 }

--- a/checker/cost.go
+++ b/checker/cost.go
@@ -476,6 +476,9 @@ func (c *coster) sizeEstimate(t AstNode) SizeEstimate {
 	if l := c.estimator.EstimateSize(t); l != nil {
 		return *l
 	}
+	if _, ok := t.Expr().ExprKind.(*exprpb.Expr_CallExpr); ok {
+		return SizeEstimate{Min: 1, Max: 1}
+	}
 	return SizeEstimate{Min: 0, Max: math.MaxUint64}
 }
 

--- a/checker/cost_test.go
+++ b/checker/cost_test.go
@@ -363,6 +363,31 @@ func TestCost(t *testing.T) {
 			},
 			wanted: CostEstimate{Min: 5, Max: 5},
 		},
+		{
+			name: "list size from ternary",
+			expr: `x > y ? list1.size() : list2.size()`,
+			decls: []*exprpb.Decl{
+				decls.NewVar("x", decls.Int),
+				decls.NewVar("y", decls.Int),
+				decls.NewVar("list1", decls.NewListType(decls.Int)),
+				decls.NewVar("list2", decls.NewListType(decls.Int)),
+			},
+			wanted: CostEstimate{Min: 5, Max: 5},
+		},
+		{
+			name: "str endsWith inequality",
+			expr: `str1.endsWith("abcdefghijklmnopqrstuvwxyz") == str2.endsWith("abcdefghijklmnopqrstuvwxyz")`,
+			decls: []*exprpb.Decl{
+				decls.NewVar("str1", decls.String),
+				decls.NewVar("str2", decls.String),
+			},
+			wanted: CostEstimate{Min: 9, Max: 9},
+		},
+		{
+			name:   "nested subexpression operators",
+			expr:   `((5 != 6) == (1 == 2)) == ((3 <= 4) == (9 != 9))`,
+			wanted: CostEstimate{Min: 7, Max: 7},
+		},
 	}
 
 	for _, tc := range cases {

--- a/checker/cost_test.go
+++ b/checker/cost_test.go
@@ -354,6 +354,15 @@ func TestCost(t *testing.T) {
 			hints:  map[string]int64{"str1": 10, "str2": 10},
 			wanted: CostEstimate{Min: 2, Max: 6},
 		},
+		{
+			name: "list size comparison",
+			expr: `list1.size() == list2.size()`,
+			decls: []*exprpb.Decl{
+				decls.NewVar("list1", decls.NewListType(decls.Int)),
+				decls.NewVar("list2", decls.NewListType(decls.Int)),
+			},
+			wanted: CostEstimate{Min: 5, Max: 5},
+		},
 	}
 
 	for _, tc := range cases {

--- a/checker/cost_test.go
+++ b/checker/cost_test.go
@@ -388,6 +388,15 @@ func TestCost(t *testing.T) {
 			expr:   `((5 != 6) == (1 == 2)) == ((3 <= 4) == (9 != 9))`,
 			wanted: CostEstimate{Min: 7, Max: 7},
 		},
+		{
+			name: "str size estimate",
+			expr: `string(timestamp1) == string(timestamp2)`,
+			decls: []*exprpb.Decl{
+				decls.NewVar("timestamp1", decls.Timestamp),
+				decls.NewVar("timestamp2", decls.Timestamp),
+			},
+			wanted: CostEstimate{Min: 5, Max: 1844674407370955268},
+		},
 	}
 
 	for _, tc := range cases {

--- a/checker/cost_test.go
+++ b/checker/cost_test.go
@@ -397,6 +397,24 @@ func TestCost(t *testing.T) {
 			},
 			wanted: CostEstimate{Min: 5, Max: 1844674407370955268},
 		},
+		{
+			name: "timestamp equality check",
+			expr: `timestamp1 == timestamp2`,
+			decls: []*exprpb.Decl{
+				decls.NewVar("timestamp1", decls.Timestamp),
+				decls.NewVar("timestamp2", decls.Timestamp),
+			},
+			wanted: CostEstimate{Min: 3, Max: 3},
+		},
+		{
+			name: "duration inequality check",
+			expr: `duration1 != duration2`,
+			decls: []*exprpb.Decl{
+				decls.NewVar("duration1", decls.Duration),
+				decls.NewVar("duration2", decls.Duration),
+			},
+			wanted: CostEstimate{Min: 3, Max: 3},
+		},
 	}
 
 	for _, tc := range cases {

--- a/checker/cost_test.go
+++ b/checker/cost_test.go
@@ -375,7 +375,7 @@ func TestCost(t *testing.T) {
 			wanted: CostEstimate{Min: 5, Max: 5},
 		},
 		{
-			name: "str endsWith inequality",
+			name: "str endsWith equality",
 			expr: `str1.endsWith("abcdefghijklmnopqrstuvwxyz") == str2.endsWith("abcdefghijklmnopqrstuvwxyz")`,
 			decls: []*exprpb.Decl{
 				decls.NewVar("str1", decls.String),


### PR DESCRIPTION
This PR fixes instances where cost estimation is used on expressions where a `CallExpr` is nested inside of another `CallExpr` and `math.MaxUint64` is incorrectly returned. The test case included with this PR shows an example of where this can happen; `==` is treated as a function call/`CallExpr`, and will call `sizeEstimate` [on its left and right-hand expressions](https://github.com/google/cel-go/blob/25bb4c6da1759f0104ce8ee935431d32b71977b6/checker/cost.go#L557-L558). sizeEstimate will then try to [call AstNode.ComputedSize before trying EstimateSize and finally returning math.MaxUint64 for an upper limit](https://github.com/google/cel-go/blob/25bb4c6da1759f0104ce8ee935431d32b71977b6/checker/cost.go#L472-L480). 

That constant will get returned for operator-based `CallExpr`s inside `CallExpr`s whenever the inner one lacks an `EstimateSize`, such as with `list.size()`. Instead, this PR checks for `CallExpr` inside `SizeEstimate` and returns a min/max cost of 1.

The original issue was first reported in https://github.com/kubernetes/kubernetes/issues/111769.