### PR TITLE
Avoid exception for immutable list from folded expression

### DIFF
--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -835,7 +835,9 @@ func (fold *evalFold) Eval(ctx Activation) ref.Val {
 	varActivationPool.Put(accuCtx)
 	// Convert a mutable list to an immutable one, if the comprehension has generated a list as a result.
 	if !types.IsUnknownOrError(res) && buildingList {
-		res = res.(traits.MutableLister).ToImmutableList()
+		if _, ok := res.(traits.MutableLister); ok {
+			res = res.(traits.MutableLister).ToImmutableList()
+		}
 	}
 	return res
 }


### PR DESCRIPTION
* Added check to avoid error thrown when returning a immutable list from a function called by a comprehension expression

This pull request fixes a regression introduced in commit 8cf150331f8f918625c0c4c83df500e6ce1fb82f. Specifically, an optimization was made which overrides an initial zero size list with a empty mutable list. The optimization makes an assumption that the result from the first step will always be mutable list, which is not always the case. Hopefully the code is self-explanatory, but I can add further details if required.