### PR TITLE
Fix invalid get function assigned to MutableList

### DIFF
--- a/common/types/list.go
+++ b/common/types/list.go
@@ -98,15 +98,18 @@ func NewJSONList(adapter ref.TypeAdapter, l *structpb.ListValue) traits.Lister {
 // NewMutableList creates a new mutable list whose internal state can be modified.
 func NewMutableList(adapter ref.TypeAdapter) traits.MutableLister {
 	var mutableValues []ref.Val
-	return &mutableList{
+	l := &mutableList{
 		baseList: &baseList{
 			TypeAdapter: adapter,
 			value:       mutableValues,
 			size:        0,
-			get:         func(i int) interface{} { return mutableValues[i] },
 		},
 		mutableValues: mutableValues,
 	}
+	l.get = func(i int) interface{} {
+		return l.mutableValues[i]
+	}
+	return l
 }
 
 // baseList points to a list containing elements of any type.

--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -218,6 +218,21 @@ func TestBaseListSize(t *testing.T) {
 	}
 }
 
+func TestMutableListGet(t *testing.T) {
+	reg := newTestRegistry(t)
+	listA := NewMutableList(reg)
+	listB := NewStringList(reg, []string{"item"})
+	listA = listA.Add(listB).(*mutableList)
+
+	itemVal := listA.Get(Int(0))
+
+	if itemVal.Value().(string) != "item" {
+		t.Error("MutableList get returned invalid item.")
+	}
+
+	validateList123(t, NewDynamicList(newTestRegistry(t), []int32{1, 2, 3}).(traits.Lister))
+}
+
 func TestConcatListAdd(t *testing.T) {
 	reg := newTestRegistry(t)
 	listA := NewDynamicList(reg, []float32{1.0, 2.0})

--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -229,8 +229,6 @@ func TestMutableListGet(t *testing.T) {
 	if itemVal.Value().(string) != "item" {
 		t.Error("MutableList get returned invalid item.")
 	}
-
-	validateList123(t, NewDynamicList(newTestRegistry(t), []int32{1, 2, 3}).(traits.Lister))
 }
 
 func TestConcatListAdd(t *testing.T) {

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -835,7 +835,9 @@ func (fold *evalFold) Eval(ctx Activation) ref.Val {
 	varActivationPool.Put(accuCtx)
 	// Convert a mutable list to an immutable one, if the comprehension has generated a list as a result.
 	if !types.IsUnknownOrError(res) && buildingList {
-		res = res.(traits.MutableLister).ToImmutableList()
+		if _, ok := res.(traits.MutableLister); ok {
+			res = res.(traits.MutableLister).ToImmutableList()
+		}
 	}
 	return res
 }


### PR DESCRIPTION
The get function assigned in NewMutableList attempts to index the initiating slice variable which is always an empty list.

Test added to demonstrate.