### PR TITLE
Stringer functions for list and map values

### DIFF
--- a/common/types/list.go
+++ b/common/types/list.go
@@ -17,6 +17,7 @@ package types
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
@@ -273,6 +274,20 @@ func (l *baseList) Value() interface{} {
 	return l.value
 }
 
+// String converts the list to a human readable string form.
+func (l *baseList) String() string {
+	var sb strings.Builder
+	sb.WriteString("[")
+	for i := 0; i < l.size; i++ {
+		sb.WriteString(fmt.Sprintf("%v", l.get(i)))
+		if i != l.size-1 {
+			sb.WriteString(", ")
+		}
+	}
+	sb.WriteString("]")
+	return sb.String()
+}
+
 // mutableList aggregates values into its internal storage. For use with internal CEL variables only.
 type mutableList struct {
 	*baseList
@@ -419,6 +434,20 @@ func (l *concatList) Iterator() traits.Iterator {
 // Size implements the traits.Sizer interface method.
 func (l *concatList) Size() ref.Val {
 	return l.prevList.Size().(Int).Add(l.nextList.Size())
+}
+
+// String converts the concatenated list to a human-readable string.
+func (l *concatList) String() string {
+	var sb strings.Builder
+	sb.WriteString("[")
+	for i := Int(0); i < l.Size().(Int); i++ {
+		sb.WriteString(fmt.Sprintf("%v", l.Get(i)))
+		if i != l.Size().(Int)-1 {
+			sb.WriteString(", ")
+		}
+	}
+	sb.WriteString("]")
+	return sb.String()
 }
 
 // Type implements the ref.Val interface method.

--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 	"math"
 	"reflect"
 	"testing"
@@ -177,6 +178,14 @@ func TestBaseListEqual(t *testing.T) {
 
 func TestBaseListGet(t *testing.T) {
 	validateList123(t, NewDynamicList(newTestRegistry(t), []int32{1, 2, 3}).(traits.Lister))
+}
+
+func TestBaseListString(t *testing.T) {
+	l := NewDynamicList(newTestRegistry(t), []interface{}{1, "hello", 2.1, true, []string{"world"}})
+	want := `[1, hello, 2.1, true, [world]]`
+	if fmt.Sprintf("%v", l) != want {
+		t.Errorf("l.String() got %v, wanted %v", l, want)
+	}
 }
 
 func TestValueListGet(t *testing.T) {

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -17,6 +17,7 @@ package types
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/google/cel-go/common/types/pb"
 	"github.com/google/cel-go/common/types/ref"
@@ -278,6 +279,25 @@ func (m *baseMap) Get(key ref.Val) ref.Val {
 // Size implements the traits.Sizer interface method.
 func (m *baseMap) Size() ref.Val {
 	return Int(m.size)
+}
+
+// String converts the map into a human-readable string.
+func (m *baseMap) String() string {
+	var sb strings.Builder
+	sb.WriteString("{")
+	it := m.Iterator()
+	i := 0
+	for it.HasNext() == True {
+		k := it.Next()
+		v, _ := m.Find(k)
+		sb.WriteString(fmt.Sprintf("%v: %v", k, v))
+		if i != m.size-1 {
+			sb.WriteString(", ")
+		}
+		i++
+	}
+	sb.WriteString("}")
+	return sb.String()
 }
 
 // Type implements the ref.Val interface method.

--- a/common/types/map_test.go
+++ b/common/types/map_test.go
@@ -752,7 +752,18 @@ func TestProtoMapGet(t *testing.T) {
 	if !IsError(badKey) || !strings.Contains(badKey.(*Err).Error(), "no such key: 42") {
 		t.Errorf("mapVal.Get(42) got %v, wanted no such key: 42", badKey)
 	}
+}
 
+func TestProtoMapString(t *testing.T) {
+	strMap := map[string]string{
+		"hello": "world",
+	}
+	reg := newTestRegistry(t)
+	m := reg.NativeToValue(strMap)
+	want := `{hello: world}`
+	if fmt.Sprintf("%v", m) != want {
+		t.Errorf("map.String() got %v, wanted %v", m, want)
+	}
 }
 
 func TestProtoMapConvertToNative(t *testing.T) {


### PR DESCRIPTION
Stringer implementations for list and map values. 

The stringers make the evaluation output in the cel-repl more readable for list and map values.