### PR TITLE
enable comparison of wrapped errors via errors.Is

### DIFF
--- a/common/types/err.go
+++ b/common/types/err.go
@@ -118,6 +118,11 @@ func (e *Err) Value() interface{} {
 	return e.error
 }
 
+// Is implements errors.Is.
+func (e *Err) Is(target error) bool {
+	return e.error.Error() == target.Error()
+}
+
 // IsError returns whether the input element ref.Type or ref.Val is equal to
 // the ErrType singleton.
 func IsError(val ref.Val) bool {


### PR DESCRIPTION
This change adds type.Err.Is, which enables comparisons of wrapped errors via errors.Is in the standard library.
Although this is of limited use within cel-go itself, it can help users of this library compare sentinel errors wrapped by types.NewErr