### PR TITLE
Add the missing global matches() declaration

### DIFF
--- a/checker/standard.go
+++ b/checker/standard.go
@@ -287,6 +287,8 @@ func init() {
 			decls.NewInstanceOverload(overloads.EndsWithString,
 				[]*exprpb.Type{decls.String, decls.String}, decls.Bool)),
 		decls.NewFunction(overloads.Matches,
+			decls.NewOverload(overloads.Matches,
+				[]*exprpb.Type{decls.String, decls.String}, decls.Bool),
 			decls.NewInstanceOverload(overloads.MatchesString,
 				[]*exprpb.Type{decls.String, decls.String}, decls.Bool)),
 		decls.NewFunction(overloads.StartsWith,

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -656,7 +656,7 @@ var (
 			expr:          `string(b"""Kim\t""")`,
 			cost:          []int64{1, 1},
 			optimizedCost: []int64{0, 0},
-			out: `Kim	`,
+			out:           `Kim	`,
 		},
 		{
 			name:      "literal_pb3_msg",
@@ -861,7 +861,17 @@ var (
 			exhaustiveCost: []int64{14, 14},
 		},
 		{
-			name: "matches",
+			name: "matches_global",
+			expr: `matches(input, 'k.*')`,
+			env: []*exprpb.Decl{
+				decls.NewVar("input", decls.String),
+			},
+			in: map[string]interface{}{
+				"input": "kathmandu",
+			},
+		},
+		{
+			name: "matches_member",
 			expr: `input.matches('k.*')
 				&& !'foo'.matches('k.*')
 				&& !'bar'.matches('k.*')


### PR DESCRIPTION
Addresses support discussion here: https://github.com/google/cel-spec/discussions/247

The global matches operator was deprecated in favor of the member syntax, but is still officially supported in the spec.