### PR TITLE
Support for conditional attribute qualification

### DIFF
--- a/common/types/list.go
+++ b/common/types/list.go
@@ -245,7 +245,7 @@ func (l *baseList) Equal(other ref.Val) ref.Val {
 
 // Get implements the traits.Indexer interface method.
 func (l *baseList) Get(index ref.Val) ref.Val {
-	ind, err := indexOrError(index)
+	ind, err := IndexOrError(index)
 	if err != nil {
 		return ValOrErr(index, err.Error())
 	}
@@ -420,7 +420,7 @@ func (l *concatList) Equal(other ref.Val) ref.Val {
 
 // Get implements the traits.Indexer interface method.
 func (l *concatList) Get(index ref.Val) ref.Val {
-	ind, err := indexOrError(index)
+	ind, err := IndexOrError(index)
 	if err != nil {
 		return ValOrErr(index, err.Error())
 	}
@@ -512,7 +512,8 @@ func (it *listIterator) Next() ref.Val {
 	return nil
 }
 
-func indexOrError(index ref.Val) (int, error) {
+// IndexOrError converts an input index value into either a lossless integer index or an error.
+func IndexOrError(index ref.Val) (int, error) {
 	switch iv := index.(type) {
 	case Int:
 		return int(iv), nil

--- a/interpreter/attribute_patterns.go
+++ b/interpreter/attribute_patterns.go
@@ -360,6 +360,7 @@ func (m *attributeMatcher) Qualify(vars Activation, obj any) (any, error) {
 	return attrQualify(m.fac, vars, obj, m)
 }
 
+// QualifyIfPresent is an implementation of the Qualifier interface method.
 func (m *attributeMatcher) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	return attrQualifyIfPresent(m.fac, vars, obj, m, presenceOnly)
 }

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -103,8 +103,8 @@ type Attribute interface {
 	// For objects which support safe traversal, the value may be non-nil and the presence flag be false.
 	//
 	// If an error is encountered during attribute resolution, it will be returned immediately.
-	// If the attribute cannot be resolved within the Activation, the result must be: `nil`,
-	// `false`, `nil`.
+	// If the attribute cannot be resolved within the Activation, the result must be: `nil`, `error`
+	// with the error indicating which variable was missing.
 	Resolve(Activation) (any, error)
 }
 
@@ -274,7 +274,8 @@ func (a *absoluteAttribute) String() string {
 // variable is not found, or if its Qualifiers cannot be applied successfully.
 //
 // If the variable name cannot be found as an Activation variable or in the TypeProvider as
-// a type, then the result is `nil`, `false`, `nil` per the interface requirement.
+// a type, then the result is `nil`, `error` with the error indicating the name of the first
+// variable searched as missing.
 func (a *absoluteAttribute) Resolve(vars Activation) (any, error) {
 	for _, nm := range a.namespaceNames {
 		// If the variable is found, process it. Otherwise, wait until the checks to

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -260,6 +260,7 @@ func (a *absoluteAttribute) Qualify(vars Activation, obj any) (any, error) {
 	return attrQualify(a.fac, vars, obj, a)
 }
 
+// QualifyIfPresent is an implementation of the Qualifier interface method.
 func (a *absoluteAttribute) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	return attrQualifyIfPresent(a.fac, vars, obj, a, presenceOnly)
 }
@@ -349,6 +350,7 @@ func (a *conditionalAttribute) Qualify(vars Activation, obj any) (any, error) {
 	return attrQualify(a.fac, vars, obj, a)
 }
 
+// QualifyIfPresent is an implementation of the Qualifier interface method.
 func (a *conditionalAttribute) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	return attrQualifyIfPresent(a.fac, vars, obj, a, presenceOnly)
 }
@@ -471,6 +473,7 @@ func (a *maybeAttribute) Qualify(vars Activation, obj any) (any, error) {
 	return attrQualify(a.fac, vars, obj, a)
 }
 
+// QualifyIfPresent is an implementation of the Qualifier interface method.
 func (a *maybeAttribute) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	return attrQualifyIfPresent(a.fac, vars, obj, a, presenceOnly)
 }
@@ -544,6 +547,7 @@ func (a *relativeAttribute) Qualify(vars Activation, obj any) (any, error) {
 	return attrQualify(a.fac, vars, obj, a)
 }
 
+// QualifyIfPresent is an implementation of the Qualifier interface method.
 func (a *relativeAttribute) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	return attrQualifyIfPresent(a.fac, vars, obj, a, presenceOnly)
 }
@@ -650,6 +654,7 @@ func (q *stringQualifier) Qualify(vars Activation, obj any) (any, error) {
 	return val, err
 }
 
+// QualifyIfPresent is an implementation of the Qualifier interface method.
 func (q *stringQualifier) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	return q.qualifyInternal(vars, obj, true, presenceOnly)
 }
@@ -749,6 +754,7 @@ func (q *intQualifier) Qualify(vars Activation, obj any) (any, error) {
 	return val, err
 }
 
+// QualifyIfPresent is an implementation of the Qualifier interface method.
 func (q *intQualifier) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	return q.qualifyInternal(vars, obj, true, presenceOnly)
 }
@@ -874,6 +880,7 @@ func (q *uintQualifier) Qualify(vars Activation, obj any) (any, error) {
 	return val, err
 }
 
+// QualifyIfPresent is an implementation of the Qualifier interface method.
 func (q *uintQualifier) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	return q.qualifyInternal(vars, obj, true, presenceOnly)
 }
@@ -937,6 +944,7 @@ func (q *boolQualifier) Qualify(vars Activation, obj any) (any, error) {
 	return val, err
 }
 
+// QualifyIfPresent is an implementation of the Qualifier interface method.
 func (q *boolQualifier) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	return q.qualifyInternal(vars, obj, true, presenceOnly)
 }
@@ -995,6 +1003,7 @@ func (q *fieldQualifier) Qualify(vars Activation, obj any) (any, error) {
 	return val, nil
 }
 
+// QualifyIfPresent is an implementation of the Qualifier interface method.
 func (q *fieldQualifier) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	if rv, ok := obj.(ref.Val); ok {
 		obj = rv.Value()
@@ -1075,6 +1084,7 @@ func (q *unknownQualifier) Qualify(vars Activation, obj any) (any, error) {
 	return q.value, nil
 }
 
+// QualifyIfPresent is an implementation of the Qualifier interface method.
 func (q *unknownQualifier) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	return q.value, true, nil
 }
@@ -1084,6 +1094,7 @@ func (q *unknownQualifier) Value() ref.Val {
 	return q.value
 }
 
+// attrQualify performs a qualification using the result of an attribute evaluation.
 func attrQualify(fac AttributeFactory, vars Activation, obj any, qualAttr Attribute) (any, error) {
 	val, err := qualAttr.Resolve(vars)
 	if err != nil {
@@ -1096,6 +1107,8 @@ func attrQualify(fac AttributeFactory, vars Activation, obj any, qualAttr Attrib
 	return qual.Qualify(vars, obj)
 }
 
+// attrQualifyIfPresent conditionally performs the qualification of the result of attribute is present
+// on the target object.
 func attrQualifyIfPresent(fac AttributeFactory, vars Activation, obj any, qualAttr Attribute,
 	presenceOnly bool) (any, bool, error) {
 	val, err := qualAttr.Resolve(vars)
@@ -1168,6 +1181,8 @@ func refQualify(adapter ref.TypeAdapter, obj any, idx ref.Val, presenceTest, pre
 	}
 }
 
+// resolutionError is a custom error type which encodes the different error states which may
+// occur during attribute resolution.
 type resolutionError struct {
 	missingVariable string
 	missingIndex    ref.Val
@@ -1176,10 +1191,6 @@ type resolutionError struct {
 
 func (e *resolutionError) isMissingVariable() bool {
 	return e.missingVariable != ""
-}
-
-func (e *resolutionError) isMissingQualifier() bool {
-	return e.missingIndex != nil || e.missingKey != nil
 }
 
 func missingIndex(missing ref.Val) *resolutionError {
@@ -1200,6 +1211,7 @@ func missingVariable(variable string) *resolutionError {
 	}
 }
 
+// Error implements the error interface method.
 func (e *resolutionError) Error() string {
 	if e.missingKey != nil {
 		return fmt.Sprintf("no such key: %v", e.missingKey)
@@ -1211,4 +1223,9 @@ func (e *resolutionError) Error() string {
 		return fmt.Sprintf("no such variable: %s", e.missingVariable)
 	}
 	return "invalid attribute"
+}
+
+// Is implements the errors.Is() method used by more recent versions of Go.
+func (e *resolutionError) Is(err error) bool {
+	return err.Error() == e.Error()
 }

--- a/interpreter/attributes_test.go
+++ b/interpreter/attributes_test.go
@@ -765,6 +765,14 @@ func (q *nestedMsgQualifier) Qualify(vars Activation, obj any) (any, error) {
 	return pb.GetBb(), nil
 }
 
+func (q *nestedMsgQualifier) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
+	pb := obj.(*proto3pb.TestAllTypes_NestedMessage)
+	if pb.GetBb() == 0 {
+		return nil, false, nil
+	}
+	return pb.GetBb(), true, nil
+}
+
 // Cost implements the Coster interface method. It returns zero for testing purposes.
 func (q *nestedMsgQualifier) Cost() (min, max int64) {
 	return 0, 0

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -66,6 +66,8 @@ type InterpretableAttribute interface {
 	// of object qualification.
 	Qualify(vars Activation, obj any) (any, error)
 
+	QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error)
+
 	// Resolve returns the value of the Attribute given the current Activation.
 	Resolve(Activation) (any, error)
 }
@@ -103,10 +105,10 @@ type InterpretableConstructor interface {
 // Core Interpretable implementations used during the program planning phase.
 
 type evalTestOnly struct {
-	id        int64
-	op        Interpretable
-	field     types.String
-	fieldType *ref.FieldType
+	id    int64
+	attr  InterpretableAttribute
+	qual  Qualifier
+	field types.String
 }
 
 // ID implements the Interpretable interface method.
@@ -116,41 +118,27 @@ func (test *evalTestOnly) ID() int64 {
 
 // Eval implements the Interpretable interface method.
 func (test *evalTestOnly) Eval(ctx Activation) ref.Val {
-	// Handle field selection on a proto in the most efficient way possible.
-	if test.fieldType != nil {
-		opAttr, ok := test.op.(InterpretableAttribute)
-		if ok {
-			opVal, err := opAttr.Resolve(ctx)
-			if err != nil {
-				return types.NewErr(err.Error())
-			}
-			refVal, ok := opVal.(ref.Val)
-			if ok {
-				opVal = refVal.Value()
-			}
-			if test.fieldType.IsSet(opVal) {
-				return types.True
-			}
-			return types.False
-		}
+	val, err := test.attr.Resolve(ctx)
+	if err != nil {
+		return types.NewErr(err.Error())
 	}
-
-	obj := test.op.Eval(ctx)
-	tester, ok := obj.(traits.FieldTester)
-	if ok {
-		return tester.IsSet(test.field)
+	out, found, err := test.qual.QualifyIfPresent(ctx, val, true)
+	if err != nil {
+		return types.NewErr(err.Error())
 	}
-	container, ok := obj.(traits.Container)
-	if ok {
-		return container.Contains(test.field)
+	if unk, isUnk := out.(types.Unknown); isUnk {
+		return unk
 	}
-	return types.ValOrErr(obj, "invalid type for field selection.")
+	if found {
+		return types.True
+	}
+	return types.False
 }
 
 // Cost provides the heuristic cost of a `has(field)` macro. The cost has at least 1 for determining
 // if the field exists, apart from the cost of accessing the field.
 func (test *evalTestOnly) Cost() (min, max int64) {
-	min, max = estimateCost(test.op)
+	min, max = estimateCost(test.attr)
 	min++
 	max++
 	return
@@ -923,10 +911,10 @@ func (e *evalWatch) Cost() (min, max int64) {
 	return estimateCost(e.Interpretable)
 }
 
-// evalWatchAttr describes a watcher of an instAttr Interpretable.
+// evalWatchAttr describes a watcher of an InterpretableAttribute Interpretable.
 //
 // Since the watcher may be selected against at a later stage in program planning, the watcher
-// must implement the instAttr interface by proxy.
+// must implement the InterpretableAttribute interface by proxy.
 type evalWatchAttr struct {
 	InterpretableAttribute
 	observer EvalObserver
@@ -1154,13 +1142,13 @@ func (cond *evalExhaustiveConditional) ID() int64 {
 // Eval implements the Interpretable interface method.
 func (cond *evalExhaustiveConditional) Eval(ctx Activation) ref.Val {
 	cVal := cond.attr.expr.Eval(ctx)
-	tVal, err := cond.attr.truthy.Resolve(ctx)
-	if err != nil {
-		return types.NewErr(err.Error())
+	tVal, tErr := cond.attr.truthy.Resolve(ctx)
+	fVal, fErr := cond.attr.falsy.Resolve(ctx)
+	if tErr != nil {
+		return types.NewErr(tErr.Error())
 	}
-	fVal, err := cond.attr.falsy.Resolve(ctx)
-	if err != nil {
-		return types.NewErr(err.Error())
+	if fErr != nil {
+		return types.NewErr(fErr.Error())
 	}
 	cBool, ok := cVal.(types.Bool)
 	if !ok {
@@ -1188,19 +1176,19 @@ func (a *evalAttr) ID() int64 {
 	return a.attr.ID()
 }
 
-// AddQualifier implements the instAttr interface method.
+// AddQualifier implements the InterpretableAttribute interface method.
 func (a *evalAttr) AddQualifier(qual Qualifier) (Attribute, error) {
 	attr, err := a.attr.AddQualifier(qual)
 	a.attr = attr
 	return attr, err
 }
 
-// Attr implements the instAttr interface method.
+// Attr implements the InterpretableAttribute interface method.
 func (a *evalAttr) Attr() Attribute {
 	return a.attr
 }
 
-// Adapter implements the instAttr interface method.
+// Adapter implements the InterpretableAttribute interface method.
 func (a *evalAttr) Adapter() ref.TypeAdapter {
 	return a.adapter
 }
@@ -1222,6 +1210,10 @@ func (a *evalAttr) Eval(ctx Activation) ref.Val {
 // Qualify proxies to the Attribute's Qualify method.
 func (a *evalAttr) Qualify(ctx Activation, obj any) (any, error) {
 	return a.attr.Qualify(ctx, obj)
+}
+
+func (a *evalAttr) QualifyIfPresent(ctx Activation, obj any, presenceOnly bool) (any, bool, error) {
+	return a.attr.QualifyIfPresent(ctx, obj, presenceOnly)
 }
 
 // Resolve proxies to the Attribute's Resolve method.

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -66,6 +66,9 @@ type InterpretableAttribute interface {
 	// of object qualification.
 	Qualify(vars Activation, obj any) (any, error)
 
+	// QualifyIfPresent qualifies the object if the qualifier is declared or defined on the object.
+	// The 'presenceOnly' flag indicates that the value is not necessary, just a boolean status as
+	// to whether the qualifier is present.
 	QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error)
 
 	// Resolve returns the value of the Attribute given the current Activation.
@@ -1212,6 +1215,7 @@ func (a *evalAttr) Qualify(ctx Activation, obj any) (any, error) {
 	return a.attr.Qualify(ctx, obj)
 }
 
+// QualifyIfPresent proxies to the Attribute's QualifyIfPresent method.
 func (a *evalAttr) QualifyIfPresent(ctx Activation, obj any, presenceOnly bool) (any, bool, error) {
 	return a.attr.QualifyIfPresent(ctx, obj, presenceOnly)
 }

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -580,6 +580,14 @@ var (
 			err: "invalid qualifier type",
 		},
 		{
+			name: "index_list_int_double_type_index",
+			expr: `[7, 8, 9][dyn(0.0)] == 7`,
+		},
+		{
+			name: "index_list_int_uint_type_index",
+			expr: `[7, 8, 9][dyn(0u)] == 7`,
+		},
+		{
 			name: "index_relative",
 			expr: `([[[1]], [[2]], [[3]]][0][0] + [2, 3, {'four': {'five': 'six'}}])[3].four.five == 'six'`,
 			cost: []int64{2, 2},
@@ -793,6 +801,14 @@ var (
 			expr:           `has({'a':1}.a) && !has({}.a)`,
 			cost:           []int64{1, 4},
 			exhaustiveCost: []int64{4, 4},
+		},
+		{
+			name:      "macro_has_pb2_field_undefined",
+			container: "google.expr.proto2.test",
+			types:     []proto.Message{&proto2pb.TestAllTypes{}},
+			unchecked: true,
+			expr:      `has(TestAllTypes{}.invalid_field)`,
+			err:       "no such field 'invalid_field'",
 		},
 		{
 			name:      "macro_has_pb2_field",


### PR DESCRIPTION
The logic for testing whether a field is set overlapped significantly with the logic for qualifying an attribute, and the code in question needed an overhaul to support CEL optional values. 

The  introduction of the `Qualifier.QualifyIfPresent` method is a breaking change on the `Qualifier` interface. In subsequent PRs the `Qualifier` will also be updated to indicate whether it is optional, and the `AttributeFactory` will likewise require an update to support the creation of optional `Qualifier` values.

While development on cel-go tries to avoid any breaking API changes, it is possible some users may be affected by this and forthcoming changes.