### PR TITLE
Hack to massage certain error messages into a previous format

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1618,6 +1618,12 @@ var testCases = []testInfo{
 		a[1][2][3][4][5][6][7][8][9][10][11][12][13][14][15][16][17][18][19][20]`,
 		E: `ERROR: <input>:-1:0: max recursion depth exceeded`,
 	},
+	{
+		I: `self.true == 1`,
+		E: `ERROR: <input>:1:6: Syntax error: mismatched input 'true' expecting IDENTIFIER
+		| self.true == 1
+		| .....^`,
+	},
 }
 
 type testInfo struct {


### PR DESCRIPTION
During a recent refactor of the CEL grammar, a handful of error messages were shifted. The following change restores the error messages to their previous format for the limited number of cases which caused upstream tests to break.