### PR TITLE
Support assignment of a wrapper field to null

### DIFF
--- a/common/types/json_value.go
+++ b/common/types/json_value.go
@@ -25,4 +25,5 @@ var (
 	jsonValueType     = reflect.TypeOf(&structpb.Value{})
 	jsonListValueType = reflect.TypeOf(&structpb.ListValue{})
 	jsonStructType    = reflect.TypeOf(&structpb.Struct{})
+	jsonNullType      = reflect.TypeOf(structpb.NullValue_NULL_VALUE)
 )

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -480,6 +480,9 @@ func msgSetField(target protoreflect.Message, field *pb.FieldDescription, val re
 	if err != nil {
 		return fieldTypeConversionError(field, err)
 	}
+	if v == nil {
+		return nil
+	}
 	switch pv := v.(type) {
 	case proto.Message:
 		v = pv.ProtoReflect()
@@ -495,6 +498,9 @@ func msgSetListField(target protoreflect.List, listField *pb.FieldDescription, l
 		elemVal, err := elem.ConvertToNative(elemReflectType)
 		if err != nil {
 			return fieldTypeConversionError(listField, err)
+		}
+		if elemVal == nil {
+			continue
 		}
 		switch ev := elemVal.(type) {
 		case proto.Message:
@@ -519,6 +525,9 @@ func msgSetMapField(target protoreflect.Map, mapField *pb.FieldDescription, mapV
 		v, err := val.ConvertToNative(targetValType)
 		if err != nil {
 			return fieldTypeConversionError(mapField, err)
+		}
+		if v == nil {
+			continue
 		}
 		switch pv := v.(type) {
 		case proto.Message:

--- a/common/types/provider_test.go
+++ b/common/types/provider_test.go
@@ -148,6 +148,7 @@ func TestTypeRegistryNewValue_WrapperFields(t *testing.T) {
 		"google.expr.proto3.test.TestAllTypes",
 		map[string]ref.Val{
 			"single_int32_wrapper": Int(123),
+			"single_int64_wrapper": NullValue,
 		})
 	if IsError(exp) {
 		t.Fatalf("reg.NewValue() creation failed: %v", exp)
@@ -156,9 +157,12 @@ func TestTypeRegistryNewValue_WrapperFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ConvertToNative() failed: %v", err)
 	}
-	ce := e.(*proto3pb.TestAllTypes)
-	if ce.GetSingleInt32Wrapper().GetValue() != int32(123) {
-		t.Errorf("single_int32_wrapper value %v not set to 123", ce)
+	out := e.(*proto3pb.TestAllTypes)
+	want := &proto3pb.TestAllTypes{
+		SingleInt32Wrapper: wrapperspb.Int32(123),
+	}
+	if !proto.Equal(out, want) {
+		t.Errorf("reg.NewValue() got %v, wanted %v", out, want)
 	}
 }
 

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -718,6 +718,15 @@ var (
 			},
 		},
 		{
+			name:      "literal_pb_wrapper_assign_roundtrip",
+			container: "google.expr.proto3.test",
+			types:     []proto.Message{&proto3pb.TestAllTypes{}},
+			expr: `TestAllTypes{
+				single_int32_wrapper: TestAllTypes{}.single_int32_wrapper,
+			}.single_int32_wrapper == null`,
+			out: true,
+		},
+		{
 			name:      "literal_pb_list_assign_null_wrapper",
 			container: "google.expr.proto3.test",
 			types:     []proto.Message{&proto3pb.TestAllTypes{}},

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -706,6 +706,46 @@ var (
 			},
 		},
 		{
+			name:      "literal_pb_wrapper_assign",
+			container: "google.expr.proto3.test",
+			types:     []proto.Message{&proto3pb.TestAllTypes{}},
+			expr: `TestAllTypes{
+				single_int64_wrapper: 10,
+				single_int32_wrapper: TestAllTypes{}.single_int32_wrapper,
+			}`,
+			out: &proto3pb.TestAllTypes{
+				SingleInt64Wrapper: wrapperspb.Int64(10),
+			},
+		},
+		{
+			name:      "literal_pb_list_assign_null_wrapper",
+			container: "google.expr.proto3.test",
+			types:     []proto.Message{&proto3pb.TestAllTypes{}},
+			expr: `TestAllTypes{
+				repeated_int32: [123, 456, TestAllTypes{}.single_int32_wrapper],
+			}`,
+			err: "field type conversion error",
+		},
+		{
+			name:      "literal_pb_map_assign_null_entry_value",
+			container: "google.expr.proto3.test",
+			types:     []proto.Message{&proto3pb.TestAllTypes{}},
+			expr: `TestAllTypes{
+				map_string_string: {
+					'hello': 'world',
+					'goodbye': TestAllTypes{}.single_string_wrapper,
+				},
+			}`,
+			err: "field type conversion error",
+		},
+		{
+			name:      "unset_wrapper_access",
+			container: "google.expr.proto3.test",
+			types:     []proto.Message{&proto3pb.TestAllTypes{}},
+			expr:      `TestAllTypes{}.single_string_wrapper`,
+			out:       types.NullValue,
+		},
+		{
 			name:          "timestamp_eq_timestamp",
 			expr:          `timestamp(0) == timestamp(0)`,
 			cost:          []int64{3, 3},


### PR DESCRIPTION
When a protobuf wrapper type field is assigned to null, the wrapper field should
be unset in the containing proto message as `null` indicates that the field was unset
to begin with. Thus, the following expression should roundtrip:

```
TestAllTypes{single_int32_wrapper: TestAllTypes{}.single_int32_wrapper}.single_int32_wrapper == null
```