### PR TITLE
Allow macros to return an empty Expr to indicate a non-expansion

### DIFF
--- a/cel/macro.go
+++ b/cel/macro.go
@@ -30,7 +30,7 @@ type Macro = parser.Macro
 // MacroExpander converts a call and its associated arguments into a new CEL abstract syntax tree.
 //
 // If the MacroExpander determines within the implementation that an expansion is not needed it may return
-// an empty Expr value to indicate a non-match. However, if an expansion is to be performed, but the arguments
+// a nil Expr value to indicate a non-match. However, if an expansion is to be performed, but the arguments
 // are not well-formed, the result of the expansion will be an error.
 //
 // The MacroExpander accepts as arguments a MacroExprHelper as well as the arguments used in the function call

--- a/cel/macro.go
+++ b/cel/macro.go
@@ -27,8 +27,11 @@ import (
 // a Macro should be created per arg-count or as a var arg macro.
 type Macro = parser.Macro
 
-// MacroExpander converts a call and its associated arguments into a new CEL abstract syntax tree, or an error
-// if the input arguments are not suitable for the expansion requirements for the macro in question.
+// MacroExpander converts a call and its associated arguments into a new CEL abstract syntax tree.
+//
+// If the MacroExpander determines within the implementation that an expansion is not needed it may return
+// an empty Expr value to indicate a non-match. However, if an expansion is to be performed, but the arguments
+// are not well-formed, the result of the expansion will be an error.
 //
 // The MacroExpander accepts as arguments a MacroExprHelper as well as the arguments used in the function call
 // and produces as output an Expr ast node.

--- a/ext/protos.go
+++ b/ext/protos.go
@@ -59,7 +59,6 @@ var (
 	protoNamespace = "proto"
 	hasExtension   = "hasExt"
 	getExtension   = "getExt"
-	defaultExpr    = &exprpb.Expr{}
 )
 
 type protoLib struct{}
@@ -82,7 +81,7 @@ func (protoLib) ProgramOptions() []cel.ProgramOption {
 // hasProtoExt generates a test-only select expression for a fully-qualified extension name on a protobuf message.
 func hasProtoExt(meh cel.MacroExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
 	if !isExtCall(meh, hasExtension, target, args) {
-		return defaultExpr, nil
+		return nil, nil
 	}
 	extensionField, err := getExtFieldName(meh, args[1])
 	if err != nil {
@@ -94,7 +93,7 @@ func hasProtoExt(meh cel.MacroExprHelper, target *exprpb.Expr, args []*exprpb.Ex
 // getProtoExt generates a select expression for a fully-qualified extension name on a protobuf message.
 func getProtoExt(meh cel.MacroExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
 	if !isExtCall(meh, getExtension, target, args) {
-		return defaultExpr, nil
+		return nil, nil
 	}
 	extFieldName, err := getExtFieldName(meh, args[1])
 	if err != nil {

--- a/parser/macro.go
+++ b/parser/macro.go
@@ -132,8 +132,11 @@ func makeVarArgMacroKey(name string, receiverStyle bool) string {
 	return fmt.Sprintf("%s:*:%v", name, receiverStyle)
 }
 
-// MacroExpander converts a call and its associated arguments into a new CEL abstract syntax tree, or an error
-// if the input arguments are not suitable for the expansion requirements for the macro in question.
+// MacroExpander converts a call and its associated arguments into a new CEL abstract syntax tree.
+//
+// If the MacroExpander determines within the implementation that an expansion is not needed it may return
+// an empty Expr value to indicate a non-match. However, if an expansion is to be performed, but the arguments
+// are not well-formed, the result of the expansion will be an error.
 //
 // The MacroExpander accepts as arguments a MacroExprHelper as well as the arguments used in the function call
 // and produces as output an Expr ast node.

--- a/parser/macro.go
+++ b/parser/macro.go
@@ -135,7 +135,7 @@ func makeVarArgMacroKey(name string, receiverStyle bool) string {
 // MacroExpander converts a call and its associated arguments into a new CEL abstract syntax tree.
 //
 // If the MacroExpander determines within the implementation that an expansion is not needed it may return
-// an empty Expr value to indicate a non-match. However, if an expansion is to be performed, but the arguments
+// a nil Expr value to indicate a non-match. However, if an expansion is to be performed, but the arguments
 // are not well-formed, the result of the expansion will be an error.
 //
 // The MacroExpander accepts as arguments a MacroExprHelper as well as the arguments used in the function call

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -31,7 +31,6 @@ import (
 	"github.com/google/cel-go/parser/gen"
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
-	"google.golang.org/protobuf/proto"
 	structpb "google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -881,9 +880,9 @@ func (p *parser) expandMacro(exprID int64, function string, target *exprpb.Expr,
 		}
 		return p.reportError(p.helper.getLocation(exprID), err.Message), true
 	}
-	// An empty Expr value from the macro indicates that the macro implementation decided that
+	// A nil value from the macro indicates that the macro implementation decided that
 	// an expansion should not be performed.
-	if proto.Equal(expr, &exprpb.Expr{}) {
+	if expr == nil {
 		return nil, false
 	}
 	if p.populateMacroCalls {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1650,6 +1650,18 @@ var testCases = []testInfo{
 			)^#7:*expr.Expr_CallExpr#
 		  )^#9:*expr.Expr_CallExpr#`,
 	},
+	{
+		I: `noop_macro(123)`,
+		Opts: []Option{
+			Macros(NewGlobalVarArgMacro("noop_macro",
+				func(eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
+					return &exprpb.Expr{}, nil
+				})),
+		},
+		P: `noop_macro(
+			123^#2:*expr.Constant_Int64Value#
+		  )^#1:*expr.Expr_CallExpr#`,
+	},
 }
 
 type testInfo struct {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1655,7 +1655,7 @@ var testCases = []testInfo{
 		Opts: []Option{
 			Macros(NewGlobalVarArgMacro("noop_macro",
 				func(eh ExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
-					return &exprpb.Expr{}, nil
+					return nil, nil
 				})),
 		},
 		P: `noop_macro(


### PR DESCRIPTION
Allow macro implementations to indicate a non-expansion by returning an empty `Expr` value.

In the cel-cpp project an empty `Expr` return value indicates a non-match, so this change ensures
that the capabilities of cel-go and cel-cpp are at parity.