### PR TITLE
Math extension library for supporting least and greatest macros

### DIFF
--- a/cel/env.go
+++ b/cel/env.go
@@ -102,6 +102,7 @@ type Env struct {
 	provider        ref.TypeProvider
 	features        map[int]bool
 	appliedFeatures map[int]bool
+	libraries       map[string]bool
 
 	// Internal parser representation
 	prsr     *parser.Parser
@@ -160,6 +161,7 @@ func NewCustomEnv(opts ...EnvOption) (*Env, error) {
 		provider:        registry,
 		features:        map[int]bool{},
 		appliedFeatures: map[int]bool{},
+		libraries:       map[string]bool{},
 		progOpts:        []ProgramOption{},
 	}).configure(opts)
 }
@@ -308,8 +310,11 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 	for k, v := range e.functions {
 		funcsCopy[k] = v
 	}
+	libsCopy := make(map[string]bool, len(e.libraries))
+	for k, v := range e.libraries {
+		libsCopy[k] = v
+	}
 
-	// TODO: functions copy needs to happen here.
 	ext := &Env{
 		Container:       e.Container,
 		declarations:    decsCopy,
@@ -319,6 +324,7 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 		adapter:         adapter,
 		features:        featuresCopy,
 		appliedFeatures: appliedFeaturesCopy,
+		libraries:       libsCopy,
 		provider:        provider,
 		chkOpts:         chkOptsCopy,
 		prsrOpts:        prsrOptsCopy,
@@ -331,6 +337,12 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 func (e *Env) HasFeature(flag int) bool {
 	enabled, has := e.features[flag]
 	return has && enabled
+}
+
+// HasLibrary returns whether a specific SingletonLibrary has been configured in the environment.
+func (e *Env) HasLibrary(libName string) bool {
+	configured, exists := e.libraries[libName]
+	return exists && configured
 }
 
 // Parse parses the input expression value `txt` to a Ast and/or a set of Issues.

--- a/cel/library.go
+++ b/cel/library.go
@@ -88,6 +88,7 @@ func StdLib() EnvOption {
 // features documented in the specification.
 type stdLibrary struct{}
 
+// LibraryName implements the SingletonLibrary interface method.
 func (stdLibrary) LibraryName() string {
 	return "cel.lib.std"
 }

--- a/cel/options.go
+++ b/cel/options.go
@@ -63,6 +63,8 @@ const (
 	// is not already in UTC.
 	featureDefaultUTCTimeZone
 
+	// Enable the use of optional types in the syntax, type-system, type-checking,
+	// and runtime.
 	featureOptionalTypes
 )
 

--- a/ext/BUILD.bazel
+++ b/ext/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     srcs = [
         "encoders.go",
         "guards.go",
+        "math.go",
         "protos.go",
         "strings.go",
     ],
@@ -19,6 +20,7 @@ go_library(
         "//common:go_default_library",
         "//common/types:go_default_library",
         "//common/types/ref:go_default_library",
+        "//common/types/traits:go_default_library",
         "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",
     ],
 )
@@ -28,6 +30,7 @@ go_test(
     size = "small",
     srcs = [
         "encoders_test.go",
+        "math_test.go",
         "protos_test.go",
         "strings_test.go",
     ],

--- a/ext/README.md
+++ b/ext/README.md
@@ -31,6 +31,69 @@ Example:
 
     base64.encode(b'hello') // return 'aGVsbG8='
 
+## Math
+
+Math returns a cel.EnvOption to configure namespaced math helper macros and
+functions.
+
+Note, all macros use the 'math' namespace; however, at the time of macro
+expansion the namespace looks just like any other identifier. If you are
+currently using a variable named 'math', the macro will likely work just as
+intended; however, there is some chance for collision.
+
+### Math.Greatest
+
+Returns the greatest valued number present in the arguments to the macro.
+
+Greatest is a variable argument count macro which must take at least one
+argument. Simple numeric and list literals are supported as valid argument
+types; however, other literals will be flagged as errors during macro
+expansion. If the argument expression does not resolve to a numeric or
+list(numeric) type during type-checking, or during runtime then an error
+will be produced. If a list argument is empty, this too will produce an
+error.
+
+    math.greatest(<arg>, ...) -> <double|int|uint>
+
+Examples:
+
+    math.greatest(1)      // 1
+    math.greatest(1u, 2u) // 2u
+    math.greatest(-42.0, -21.5, -100.0)   // -21.5
+    math.greatest([-42.0, -21.5, -100.0]) // -21.5
+    math.greatest(numbers) // numbers must be list(numeric)
+
+    math.greatest()         // parse error
+    math.greatest('string') // parse error
+    math.greatest(a, b)     // check-time error if a or b is non-numeric
+    math.greatest(dyn('string')) // runtime error
+
+### Math.Least
+
+Returns the least valued number present in the arguments to the macro.
+
+Least is a variable argument count macro which must take at least one
+argument. Simple numeric and list literals are supported as valid argument
+types; however, other literals will be flagged as errors during macro
+expansion. If the argument expression does not resolve to a numeric or
+list(numeric) type during type-checking, or during runtime then an error
+will be produced. If a list argument is empty, this too will produce an error.
+
+    math.least(<arg>, ...) -> <double|int|uint>
+
+Examples:
+
+    math.least(1)      // 1
+    math.least(1u, 2u) // 1u
+    math.least(-42.0, -21.5, -100.0)   // -100.0
+    math.least([-42.0, -21.5, -100.0]) // -100.0
+    math.least(numbers) // numbers must be list(numeric)
+
+    math.least()         // parse error
+    math.least('string') // parse error
+    math.least(a, b)     // check-time error if a or b is non-numeric
+    math.least(dyn('string')) // runtime error
+
 ## Protos
 
 Protos returns a cel.EnvOption to configure extended macros and functions for
@@ -51,18 +114,18 @@ value forthe extension field is returned according to safe-traversal semantics.
 
 Example:
 
-	proto.getExt(msg, google.expr.proto2.test.int32_ext) // returns int value
+    proto.getExt(msg, google.expr.proto2.test.int32_ext) // returns int value
 
 ### Protos.HasExt
 
 Macro which generates a test-only select expression that determines whether
 an extension field is set on a proto2 syntax message.
 
-	proto.hasExt(<msg>, <fully.qualified.extension.name>) -> <bool>
+    proto.hasExt(<msg>, <fully.qualified.extension.name>) -> <bool>
 
 Example:
 
-	proto.hasExt(msg, google.expr.proto2.test.int32_ext) // returns true || false
+    proto.hasExt(msg, google.expr.proto2.test.int32_ext) // returns true || false
 
 ## Strings
 

--- a/ext/encoders.go
+++ b/ext/encoders.go
@@ -54,6 +54,10 @@ func Encoders() cel.EnvOption {
 
 type encoderLib struct{}
 
+func (encoderLib) LibraryName() string {
+	return "cel.lib.ext.encoders"
+}
+
 func (encoderLib) CompileOptions() []cel.EnvOption {
 	return []cel.EnvOption{
 		cel.Function("base64.decode",

--- a/ext/guards.go
+++ b/ext/guards.go
@@ -17,6 +17,7 @@ package ext
 import (
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 // function invocation guards for common call signatures within extension functions.
@@ -47,4 +48,16 @@ func listStringOrError(strs []string, err error) ref.Val {
 		return types.NewErr(err.Error())
 	}
 	return types.DefaultTypeAdapter.NativeToValue(strs)
+}
+
+func macroTargetMatchesNamespace(ns string, target *exprpb.Expr) bool {
+	switch target.GetExprKind().(type) {
+	case *exprpb.Expr_IdentExpr:
+		if target.GetIdentExpr().GetName() != ns {
+			return false
+		}
+		return true
+	default:
+		return false
+	}
 }

--- a/ext/math.go
+++ b/ext/math.go
@@ -1,0 +1,37 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ext
+
+import "github.com/google/cel-go/cel"
+
+func Math() cel.EnvOption {
+	return cel.Lib(mathLib{})
+}
+
+var (
+	mathNamespace = "math"
+	leastMacro    = "least"
+	greatestMacro = "greatest"
+)
+
+type mathLib struct{}
+
+func (mathLib) CompileOptions() []cel.EnvOption {
+	return []cel.EnvOption{}
+}
+
+func (mathLib) ProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{}
+}

--- a/ext/math.go
+++ b/ext/math.go
@@ -14,8 +14,79 @@
 
 package ext
 
-import "github.com/google/cel-go/cel"
+import (
+	"fmt"
+	"strings"
 
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+// Math returns a cel.EnvOption to configure namespaced math helper macros and
+// functions.
+//
+// Note, all macros use the 'math' namespace; however, at the time of macro
+// expansion the namespace looks just like any other identifier. If you are
+// currently using a variable named 'math', the macro will likely work just as
+// intended; however, there is some chance for collision.
+//
+// # Math.Greatest
+//
+// Returns the greatest valued number present in the arguments to the macro.
+//
+// Greatest is a variable argument count macro which must take at least one
+// argument. Simple numeric and list literals are supported as valid argument
+// types; however, other literals will be flagged as errors during macro
+// expansion. If the argument expression does not resolve to a numeric or
+// list(numeric) type during type-checking, or during runtime then an error
+// will be produced. If a list argument is empty, this too will produce an
+// error.
+//
+//	math.greatest(<arg>, ...) -> <double|int|uint>
+//
+// Examples:
+//
+//	math.greatest(1)      // 1
+//	math.greatest(1u, 2u) // 2u
+//	math.greatest(-42.0, -21.5, -100.0)   // -21.5
+//	math.greatest([-42.0, -21.5, -100.0]) // -21.5
+//	math.greatest(numbers) // numbers must be list(numeric)
+//
+//	math.greatest()         // parse error
+//	math.greatest('string') // parse error
+//	math.greatest(a, b)     // check-time error if a or b is non-numeric
+//	math.greatest(dyn('string')) // runtime error
+//
+// # Math.Least
+//
+// Returns the least valued number present in the arguments to the macro.
+//
+// Least is a variable argument count macro which must take at least one
+// argument. Simple numeric and list literals are supported as valid argument
+// types; however, other literals will be flagged as errors during macro
+// expansion. If the argument expression does not resolve to a numeric or
+// list(numeric) type during type-checking, or during runtime then an error
+// will be produced. If a list argument is empty, this too will produce an
+// error.
+//
+//	math.least(<arg>, ...) -> <double|int|uint>
+//
+// Examples:
+//
+//	math.least(1)      // 1
+//	math.least(1u, 2u) // 1u
+//	math.least(-42.0, -21.5, -100.0)   // -100.0
+//	math.least([-42.0, -21.5, -100.0]) // -100.0
+//	math.least(numbers) // numbers must be list(numeric)
+//
+//	math.least()         // parse error
+//	math.least('string') // parse error
+//	math.least(a, b)     // check-time error if a or b is non-numeric
+//	math.least(dyn('string')) // runtime error
 func Math() cel.EnvOption {
 	return cel.Lib(mathLib{})
 }
@@ -24,14 +95,288 @@ var (
 	mathNamespace = "math"
 	leastMacro    = "least"
 	greatestMacro = "greatest"
+	minFunc       = "math.@min"
+	minListFunc   = "math.@minList"
+	maxFunc       = "math.@max"
+	maxListFunc   = "math.@maxList"
 )
 
 type mathLib struct{}
 
-func (mathLib) CompileOptions() []cel.EnvOption {
-	return []cel.EnvOption{}
+// LibraryName implements the SingletonLibrary interface method.
+func (mathLib) LibraryName() string {
+	return "cel.lib.ext.math"
 }
 
+// CompileOptions implements the Library interface method.
+func (mathLib) CompileOptions() []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Macros(
+			// math.least(num, ...)
+			cel.NewReceiverVarArgMacro(leastMacro, mathLeast),
+			// math.greatest(num, ...)
+			cel.NewReceiverVarArgMacro(greatestMacro, mathGreatest),
+		),
+		cel.Function(minFunc,
+			cel.Overload("math_@min_double_double", []*cel.Type{cel.DoubleType, cel.DoubleType}, cel.DoubleType),
+			cel.Overload("math_@min_int_int", []*cel.Type{cel.IntType, cel.IntType}, cel.IntType),
+			cel.Overload("math_@min_uint_uint", []*cel.Type{cel.UintType, cel.UintType}, cel.UintType),
+			cel.Overload("math_@min_int_uint", []*cel.Type{cel.IntType, cel.UintType}, cel.DynType),
+			cel.Overload("math_@min_int_double", []*cel.Type{cel.IntType, cel.DoubleType}, cel.DynType),
+			cel.Overload("math_@min_double_int", []*cel.Type{cel.DoubleType, cel.IntType}, cel.DynType),
+			cel.Overload("math_@min_double_uint", []*cel.Type{cel.DoubleType, cel.UintType}, cel.DynType),
+			cel.Overload("math_@min_uint_int", []*cel.Type{cel.UintType, cel.IntType}, cel.DynType),
+			cel.Overload("math_@min_uint_double", []*cel.Type{cel.UintType, cel.DoubleType}, cel.DynType),
+			cel.SingletonBinaryBinding(minPair, traits.ComparerType),
+		),
+		cel.Function(minListFunc,
+			cel.Overload("math_@minlist_list_double", []*cel.Type{cel.ListType(cel.DoubleType)}, cel.DoubleType),
+			cel.Overload("math_@minlist_list_int", []*cel.Type{cel.ListType(cel.IntType)}, cel.IntType),
+			cel.Overload("math_@minlist_list_uint", []*cel.Type{cel.ListType(cel.UintType)}, cel.UintType),
+			cel.SingletonUnaryBinding(minList),
+		),
+		cel.Function(maxFunc,
+			cel.Overload("math_@max_double_double", []*cel.Type{cel.DoubleType, cel.DoubleType}, cel.DoubleType),
+			cel.Overload("math_@max_int_int", []*cel.Type{cel.IntType, cel.IntType}, cel.IntType),
+			cel.Overload("math_@max_uint_uint", []*cel.Type{cel.UintType, cel.UintType}, cel.UintType),
+			cel.Overload("math_@max_int_uint", []*cel.Type{cel.IntType, cel.UintType}, cel.DynType),
+			cel.Overload("math_@max_int_double", []*cel.Type{cel.IntType, cel.DoubleType}, cel.DynType),
+			cel.Overload("math_@max_double_int", []*cel.Type{cel.DoubleType, cel.IntType}, cel.DynType),
+			cel.Overload("math_@max_double_uint", []*cel.Type{cel.DoubleType, cel.UintType}, cel.DynType),
+			cel.Overload("math_@max_uint_int", []*cel.Type{cel.UintType, cel.IntType}, cel.DynType),
+			cel.Overload("math_@max_uint_double", []*cel.Type{cel.UintType, cel.DoubleType}, cel.DynType),
+			cel.SingletonBinaryBinding(maxPair, traits.ComparerType),
+		),
+		cel.Function(maxListFunc,
+			cel.Overload("math_@maxlist_list_double", []*cel.Type{cel.ListType(cel.DoubleType)}, cel.DoubleType),
+			cel.Overload("math_@maxlist_list_int", []*cel.Type{cel.ListType(cel.IntType)}, cel.IntType),
+			cel.Overload("math_@maxlist_list_uint", []*cel.Type{cel.ListType(cel.UintType)}, cel.UintType),
+			cel.SingletonUnaryBinding(maxList),
+		),
+	}
+}
+
+// ProgramOptions implements the Library interface method.
 func (mathLib) ProgramOptions() []cel.ProgramOption {
 	return []cel.ProgramOption{}
+}
+
+func mathLeast(meh cel.MacroExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
+	if !macroTargetMatchesNamespace(mathNamespace, target) {
+		return nil, nil
+	}
+	switch len(args) {
+	case 0:
+		return nil, &common.Error{
+			Message:  "math.least() requires at least one argument",
+			Location: meh.OffsetLocation(target.GetId()),
+		}
+	case 1:
+		if isNumericConstant(args[0]) {
+			return args[0], nil
+		}
+		if isListLiteralWithValidArgs(args[0]) || isValidArgType(args[0]) {
+			return meh.GlobalCall(minListFunc, args[0]), nil
+		}
+		return nil, &common.Error{
+			Message:  "math.least() invalid single argument value",
+			Location: meh.OffsetLocation(args[0].GetId()),
+		}
+	case 2:
+		err := checkInvalidArgs(meh, "math.least()", args)
+		if err != nil {
+			return nil, err
+		}
+		return meh.GlobalCall(minFunc, args...), nil
+	default:
+		err := checkInvalidArgs(meh, "math.least()", args)
+		if err != nil {
+			return nil, err
+		}
+		return meh.GlobalCall(minListFunc, meh.NewList(args...)), nil
+	}
+}
+
+func mathGreatest(meh cel.MacroExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *common.Error) {
+	if !macroTargetMatchesNamespace(mathNamespace, target) {
+		return nil, nil
+	}
+	switch len(args) {
+	case 0:
+		return nil, &common.Error{
+			Message:  "math.greatest() requires at least one argument",
+			Location: meh.OffsetLocation(target.GetId()),
+		}
+	case 1:
+		if isNumericConstant(args[0]) {
+			return args[0], nil
+		}
+		if isListLiteralWithValidArgs(args[0]) || isValidArgType(args[0]) {
+			return meh.GlobalCall(maxListFunc, args[0]), nil
+		}
+		return nil, &common.Error{
+			Message:  "math.greatest() invalid single argument value",
+			Location: meh.OffsetLocation(args[0].GetId()),
+		}
+	case 2:
+		err := checkInvalidArgs(meh, "math.greatest()", args)
+		if err != nil {
+			return nil, err
+		}
+		return meh.GlobalCall(maxFunc, args...), nil
+	default:
+		err := checkInvalidArgs(meh, "math.greatest()", args)
+		if err != nil {
+			return nil, err
+		}
+		return meh.GlobalCall(maxListFunc, meh.NewList(args...)), nil
+	}
+}
+
+func minPair(first, second ref.Val) ref.Val {
+	cmp, ok := first.(traits.Comparer)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(first)
+	}
+	out := cmp.Compare(second)
+	if types.IsUnknownOrError(out) {
+		return maybeSuffixError(out, "math.@min")
+	}
+	if out == types.IntOne {
+		return second
+	}
+	return first
+}
+
+func minList(numList ref.Val) ref.Val {
+	l, ok := numList.(traits.Lister)
+	if !ok {
+		return types.NewErr("no such overload: math.@minList(%s)", numList.Type().TypeName())
+	}
+	size := l.Size().(types.Int)
+	if size == types.IntZero {
+		return types.NewErr("math.@minList(list) argument must not be empty")
+	}
+	min := l.Get(types.IntZero)
+	for i := types.IntOne; i < size; i++ {
+		min = minPair(min, l.Get(i))
+	}
+	switch min.Type() {
+	case types.IntType, types.DoubleType, types.UintType, types.UnknownType:
+		return min
+	default:
+		return types.NewErr("no such overload: math.@minList")
+	}
+}
+
+func maxPair(first, second ref.Val) ref.Val {
+	cmp, ok := first.(traits.Comparer)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(first)
+	}
+	out := cmp.Compare(second)
+	if types.IsUnknownOrError(out) {
+		return maybeSuffixError(out, "math.@max")
+	}
+	if out == types.IntNegOne {
+		return second
+	}
+	return first
+}
+
+func maxList(numList ref.Val) ref.Val {
+	l, ok := numList.(traits.Lister)
+	if !ok {
+		return types.NewErr("no such overload: math.@maxList(%s)", numList.Type().TypeName())
+	}
+	size := l.Size().(types.Int)
+	if size == types.IntZero {
+		return types.NewErr("math.@maxList(list) argument must not be empty")
+	}
+	max := l.Get(types.IntZero)
+	for i := types.IntOne; i < size; i++ {
+		max = maxPair(max, l.Get(i))
+	}
+	switch max.Type() {
+	case types.IntType, types.DoubleType, types.UintType, types.UnknownType:
+		return max
+	default:
+		return types.NewErr("no such overload: math.@maxList")
+	}
+}
+
+func checkInvalidArgs(meh cel.MacroExprHelper, funcName string, args []*exprpb.Expr) *common.Error {
+	for _, arg := range args {
+		err := checkInvalidArgLiteral(funcName, arg)
+		if err != nil {
+			return &common.Error{
+				Message:  err.Error(),
+				Location: meh.OffsetLocation(arg.GetId()),
+			}
+		}
+	}
+	return nil
+}
+
+func checkInvalidArgLiteral(funcName string, arg *exprpb.Expr) error {
+	if !isValidArgType(arg) {
+		return fmt.Errorf("%s simple literal arguments must be numeric", funcName)
+	}
+	return nil
+}
+
+func isValidArgType(arg *exprpb.Expr) bool {
+	switch arg.GetExprKind().(type) {
+	case *exprpb.Expr_ConstExpr:
+		c := arg.GetConstExpr()
+		switch c.GetConstantKind().(type) {
+		case *exprpb.Constant_DoubleValue, *exprpb.Constant_Int64Value, *exprpb.Constant_Uint64Value:
+			return true
+		default:
+			return false
+		}
+	case *exprpb.Expr_ListExpr, *exprpb.Expr_StructExpr:
+		return false
+	default:
+		return true
+	}
+}
+
+func isNumericConstant(arg *exprpb.Expr) bool {
+	switch arg.GetExprKind().(type) {
+	case *exprpb.Expr_ConstExpr:
+		c := arg.GetConstExpr()
+		switch c.GetConstantKind().(type) {
+		case *exprpb.Constant_DoubleValue, *exprpb.Constant_Int64Value, *exprpb.Constant_Uint64Value:
+			return true
+		}
+	}
+	return false
+}
+
+func isListLiteralWithValidArgs(arg *exprpb.Expr) bool {
+	switch arg.GetExprKind().(type) {
+	case *exprpb.Expr_ListExpr:
+		list := arg.GetListExpr()
+		if len(list.GetElements()) == 0 {
+			return false
+		}
+		for _, e := range list.GetElements() {
+			if !isValidArgType(e) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func maybeSuffixError(val ref.Val, suffix string) ref.Val {
+	if types.IsError(val) {
+		msg := val.(*types.Err).String()
+		if !strings.Contains(msg, suffix) {
+			return types.NewErr("%s: %s", msg, suffix)
+		}
+	}
+	return val
 }

--- a/ext/math.go
+++ b/ext/math.go
@@ -96,9 +96,7 @@ var (
 	leastMacro    = "least"
 	greatestMacro = "greatest"
 	minFunc       = "math.@min"
-	minListFunc   = "math.@minList"
 	maxFunc       = "math.@max"
-	maxListFunc   = "math.@maxList"
 )
 
 type mathLib struct{}
@@ -118,40 +116,56 @@ func (mathLib) CompileOptions() []cel.EnvOption {
 			cel.NewReceiverVarArgMacro(greatestMacro, mathGreatest),
 		),
 		cel.Function(minFunc,
-			cel.Overload("math_@min_double_double", []*cel.Type{cel.DoubleType, cel.DoubleType}, cel.DoubleType),
-			cel.Overload("math_@min_int_int", []*cel.Type{cel.IntType, cel.IntType}, cel.IntType),
-			cel.Overload("math_@min_uint_uint", []*cel.Type{cel.UintType, cel.UintType}, cel.UintType),
-			cel.Overload("math_@min_int_uint", []*cel.Type{cel.IntType, cel.UintType}, cel.DynType),
-			cel.Overload("math_@min_int_double", []*cel.Type{cel.IntType, cel.DoubleType}, cel.DynType),
-			cel.Overload("math_@min_double_int", []*cel.Type{cel.DoubleType, cel.IntType}, cel.DynType),
-			cel.Overload("math_@min_double_uint", []*cel.Type{cel.DoubleType, cel.UintType}, cel.DynType),
-			cel.Overload("math_@min_uint_int", []*cel.Type{cel.UintType, cel.IntType}, cel.DynType),
-			cel.Overload("math_@min_uint_double", []*cel.Type{cel.UintType, cel.DoubleType}, cel.DynType),
-			cel.SingletonBinaryBinding(minPair, traits.ComparerType),
-		),
-		cel.Function(minListFunc,
-			cel.Overload("math_@minlist_list_double", []*cel.Type{cel.ListType(cel.DoubleType)}, cel.DoubleType),
-			cel.Overload("math_@minlist_list_int", []*cel.Type{cel.ListType(cel.IntType)}, cel.IntType),
-			cel.Overload("math_@minlist_list_uint", []*cel.Type{cel.ListType(cel.UintType)}, cel.UintType),
-			cel.SingletonUnaryBinding(minList),
+			cel.Overload("math_@min_double_double", []*cel.Type{cel.DoubleType, cel.DoubleType}, cel.DoubleType,
+				cel.BinaryBinding(minPair)),
+			cel.Overload("math_@min_int_int", []*cel.Type{cel.IntType, cel.IntType}, cel.IntType,
+				cel.BinaryBinding(minPair)),
+			cel.Overload("math_@min_uint_uint", []*cel.Type{cel.UintType, cel.UintType}, cel.UintType,
+				cel.BinaryBinding(minPair)),
+			cel.Overload("math_@min_int_uint", []*cel.Type{cel.IntType, cel.UintType}, cel.DynType,
+				cel.BinaryBinding(minPair)),
+			cel.Overload("math_@min_int_double", []*cel.Type{cel.IntType, cel.DoubleType}, cel.DynType,
+				cel.BinaryBinding(minPair)),
+			cel.Overload("math_@min_double_int", []*cel.Type{cel.DoubleType, cel.IntType}, cel.DynType,
+				cel.BinaryBinding(minPair)),
+			cel.Overload("math_@min_double_uint", []*cel.Type{cel.DoubleType, cel.UintType}, cel.DynType,
+				cel.BinaryBinding(minPair)),
+			cel.Overload("math_@min_uint_int", []*cel.Type{cel.UintType, cel.IntType}, cel.DynType,
+				cel.BinaryBinding(minPair)),
+			cel.Overload("math_@min_uint_double", []*cel.Type{cel.UintType, cel.DoubleType}, cel.DynType,
+				cel.BinaryBinding(minPair)),
+			cel.Overload("math_@min_list_double", []*cel.Type{cel.ListType(cel.DoubleType)}, cel.DoubleType,
+				cel.UnaryBinding(minList)),
+			cel.Overload("math_@min_list_int", []*cel.Type{cel.ListType(cel.IntType)}, cel.IntType,
+				cel.UnaryBinding(minList)),
+			cel.Overload("math_@min_list_uint", []*cel.Type{cel.ListType(cel.UintType)}, cel.UintType,
+				cel.UnaryBinding(minList)),
 		),
 		cel.Function(maxFunc,
-			cel.Overload("math_@max_double_double", []*cel.Type{cel.DoubleType, cel.DoubleType}, cel.DoubleType),
-			cel.Overload("math_@max_int_int", []*cel.Type{cel.IntType, cel.IntType}, cel.IntType),
-			cel.Overload("math_@max_uint_uint", []*cel.Type{cel.UintType, cel.UintType}, cel.UintType),
-			cel.Overload("math_@max_int_uint", []*cel.Type{cel.IntType, cel.UintType}, cel.DynType),
-			cel.Overload("math_@max_int_double", []*cel.Type{cel.IntType, cel.DoubleType}, cel.DynType),
-			cel.Overload("math_@max_double_int", []*cel.Type{cel.DoubleType, cel.IntType}, cel.DynType),
-			cel.Overload("math_@max_double_uint", []*cel.Type{cel.DoubleType, cel.UintType}, cel.DynType),
-			cel.Overload("math_@max_uint_int", []*cel.Type{cel.UintType, cel.IntType}, cel.DynType),
-			cel.Overload("math_@max_uint_double", []*cel.Type{cel.UintType, cel.DoubleType}, cel.DynType),
-			cel.SingletonBinaryBinding(maxPair, traits.ComparerType),
-		),
-		cel.Function(maxListFunc,
-			cel.Overload("math_@maxlist_list_double", []*cel.Type{cel.ListType(cel.DoubleType)}, cel.DoubleType),
-			cel.Overload("math_@maxlist_list_int", []*cel.Type{cel.ListType(cel.IntType)}, cel.IntType),
-			cel.Overload("math_@maxlist_list_uint", []*cel.Type{cel.ListType(cel.UintType)}, cel.UintType),
-			cel.SingletonUnaryBinding(maxList),
+			cel.Overload("math_@max_double_double", []*cel.Type{cel.DoubleType, cel.DoubleType}, cel.DoubleType,
+				cel.BinaryBinding(maxPair)),
+			cel.Overload("math_@max_int_int", []*cel.Type{cel.IntType, cel.IntType}, cel.IntType,
+				cel.BinaryBinding(maxPair)),
+			cel.Overload("math_@max_uint_uint", []*cel.Type{cel.UintType, cel.UintType}, cel.UintType,
+				cel.BinaryBinding(maxPair)),
+			cel.Overload("math_@max_int_uint", []*cel.Type{cel.IntType, cel.UintType}, cel.DynType,
+				cel.BinaryBinding(maxPair)),
+			cel.Overload("math_@max_int_double", []*cel.Type{cel.IntType, cel.DoubleType}, cel.DynType,
+				cel.BinaryBinding(maxPair)),
+			cel.Overload("math_@max_double_int", []*cel.Type{cel.DoubleType, cel.IntType}, cel.DynType,
+				cel.BinaryBinding(maxPair)),
+			cel.Overload("math_@max_double_uint", []*cel.Type{cel.DoubleType, cel.UintType}, cel.DynType,
+				cel.BinaryBinding(maxPair)),
+			cel.Overload("math_@max_uint_int", []*cel.Type{cel.UintType, cel.IntType}, cel.DynType,
+				cel.BinaryBinding(maxPair)),
+			cel.Overload("math_@max_uint_double", []*cel.Type{cel.UintType, cel.DoubleType}, cel.DynType,
+				cel.BinaryBinding(maxPair)),
+			cel.Overload("math_@max_list_double", []*cel.Type{cel.ListType(cel.DoubleType)}, cel.DoubleType,
+				cel.UnaryBinding(maxList)),
+			cel.Overload("math_@max_list_int", []*cel.Type{cel.ListType(cel.IntType)}, cel.IntType,
+				cel.UnaryBinding(maxList)),
+			cel.Overload("math_@max_list_uint", []*cel.Type{cel.ListType(cel.UintType)}, cel.UintType,
+				cel.UnaryBinding(maxList)),
 		),
 	}
 }
@@ -176,7 +190,7 @@ func mathLeast(meh cel.MacroExprHelper, target *exprpb.Expr, args []*exprpb.Expr
 			return args[0], nil
 		}
 		if isListLiteralWithValidArgs(args[0]) || isValidArgType(args[0]) {
-			return meh.GlobalCall(minListFunc, args[0]), nil
+			return meh.GlobalCall(minFunc, args[0]), nil
 		}
 		return nil, &common.Error{
 			Message:  "math.least() invalid single argument value",
@@ -193,7 +207,7 @@ func mathLeast(meh cel.MacroExprHelper, target *exprpb.Expr, args []*exprpb.Expr
 		if err != nil {
 			return nil, err
 		}
-		return meh.GlobalCall(minListFunc, meh.NewList(args...)), nil
+		return meh.GlobalCall(minFunc, meh.NewList(args...)), nil
 	}
 }
 
@@ -212,7 +226,7 @@ func mathGreatest(meh cel.MacroExprHelper, target *exprpb.Expr, args []*exprpb.E
 			return args[0], nil
 		}
 		if isListLiteralWithValidArgs(args[0]) || isValidArgType(args[0]) {
-			return meh.GlobalCall(maxListFunc, args[0]), nil
+			return meh.GlobalCall(maxFunc, args[0]), nil
 		}
 		return nil, &common.Error{
 			Message:  "math.greatest() invalid single argument value",
@@ -229,7 +243,7 @@ func mathGreatest(meh cel.MacroExprHelper, target *exprpb.Expr, args []*exprpb.E
 		if err != nil {
 			return nil, err
 		}
-		return meh.GlobalCall(maxListFunc, meh.NewList(args...)), nil
+		return meh.GlobalCall(maxFunc, meh.NewList(args...)), nil
 	}
 }
 
@@ -249,13 +263,10 @@ func minPair(first, second ref.Val) ref.Val {
 }
 
 func minList(numList ref.Val) ref.Val {
-	l, ok := numList.(traits.Lister)
-	if !ok {
-		return types.NewErr("no such overload: math.@minList(%s)", numList.Type().TypeName())
-	}
+	l := numList.(traits.Lister)
 	size := l.Size().(types.Int)
 	if size == types.IntZero {
-		return types.NewErr("math.@minList(list) argument must not be empty")
+		return types.NewErr("math.@min(list) argument must not be empty")
 	}
 	min := l.Get(types.IntZero)
 	for i := types.IntOne; i < size; i++ {
@@ -265,7 +276,7 @@ func minList(numList ref.Val) ref.Val {
 	case types.IntType, types.DoubleType, types.UintType, types.UnknownType:
 		return min
 	default:
-		return types.NewErr("no such overload: math.@minList")
+		return types.NewErr("no such overload: math.@min")
 	}
 }
 
@@ -285,13 +296,10 @@ func maxPair(first, second ref.Val) ref.Val {
 }
 
 func maxList(numList ref.Val) ref.Val {
-	l, ok := numList.(traits.Lister)
-	if !ok {
-		return types.NewErr("no such overload: math.@maxList(%s)", numList.Type().TypeName())
-	}
+	l := numList.(traits.Lister)
 	size := l.Size().(types.Int)
 	if size == types.IntZero {
-		return types.NewErr("math.@maxList(list) argument must not be empty")
+		return types.NewErr("math.@max(list) argument must not be empty")
 	}
 	max := l.Get(types.IntZero)
 	for i := types.IntOne; i < size; i++ {
@@ -301,7 +309,7 @@ func maxList(numList ref.Val) ref.Val {
 	case types.IntType, types.DoubleType, types.UintType, types.UnknownType:
 		return max
 	default:
-		return types.NewErr("no such overload: math.@maxList")
+		return types.NewErr("no such overload: math.@max")
 	}
 }
 

--- a/ext/math_test.go
+++ b/ext/math_test.go
@@ -1,0 +1,15 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ext

--- a/ext/math_test.go
+++ b/ext/math_test.go
@@ -226,28 +226,35 @@ func TestMathRuntimeErrors(t *testing.T) {
 		},
 		{
 			expr: "math.least(a)",
-			err:  "math.@minList(list) argument must not be empty",
+			err:  "math.@min(list) argument must not be empty",
 			in: map[string]any{
 				"a": []int{},
 			},
 		},
 		{
 			expr: "math.least(a)",
-			err:  "no such overload: math.@minList",
+			err:  "no such overload: math.@min",
 			in: map[string]any{
 				"a": []any{"hello"},
 			},
 		},
 		{
 			expr: "math.least(a)",
-			err:  "no such overload: math.@minList",
+			err:  "no such overload: math.@min",
 			in: map[string]any{
 				"a": []any{[]int{}, []int{}},
 			},
 		},
 		{
+			expr: "math.least(a)",
+			err:  "no such overload: math.@min",
+			in: map[string]any{
+				"a": []any{1, true, 2},
+			},
+		},
+		{
 			expr: "math.least(dyn('string'))",
-			err:  "no such overload: math.@minList",
+			err:  "no such overload: math.@min",
 		},
 
 		// Tests for math.greatest
@@ -269,28 +276,28 @@ func TestMathRuntimeErrors(t *testing.T) {
 		},
 		{
 			expr: "math.greatest(a)",
-			err:  "math.@maxList(list) argument must not be empty",
+			err:  "math.@max(list) argument must not be empty",
 			in: map[string]any{
 				"a": []int{},
 			},
 		},
 		{
 			expr: "math.greatest(a)",
-			err:  "no such overload: math.@maxList",
+			err:  "no such overload: math.@max",
 			in: map[string]any{
 				"a": []any{true},
 			},
 		},
 		{
 			expr: "math.greatest(a)",
-			err:  "no such overload: math.@maxList",
+			err:  "no such overload: math.@max",
 			in: map[string]any{
 				"a": []any{1, true, 2},
 			},
 		},
 		{
 			expr: "math.greatest(dyn('string'))",
-			err:  "no such overload: math.@maxList",
+			err:  "no such overload: math.@max",
 		},
 	}
 

--- a/ext/math_test.go
+++ b/ext/math_test.go
@@ -39,6 +39,16 @@ func TestMath(t *testing.T) {
 		{expr: "math.least(-1, 0, 1) == -1"},
 		{expr: "math.least(-1, -1, -1) == -1"},
 		{expr: "math.least(1u, 42u, 0u) == 0u"},
+		// math.least two arg overloads across type.
+		{expr: "math.least(1, 1.0) == 1"},
+		{expr: "math.least(1, -2.0) == -2.0"},
+		{expr: "math.least(2, 1u) == 1u"},
+		{expr: "math.least(1.5, 2) == 1.5"},
+		{expr: "math.least(1.5, -2) == -2"},
+		{expr: "math.least(2.5, 1u) == 1u"},
+		{expr: "math.least(1u, 2) == 1u"},
+		{expr: "math.least(1u, -2) == -2"},
+		{expr: "math.least(2u, 2.5) == 2u"},
 		// math.least with dynamic values across type.
 		{expr: "math.least(1u, dyn(42)) == 1"},
 		{expr: "math.least(1u, dyn(42), dyn(0.0)) == 0u"},
@@ -72,6 +82,16 @@ func TestMath(t *testing.T) {
 		{expr: "math.greatest(-1, 0, 1) == 1"},
 		{expr: "math.greatest(-1, -1, -1) == -1"},
 		{expr: "math.greatest(1u, 42u, 0u) == 42u"},
+		// math.least two arg overloads across type.
+		{expr: "math.greatest(1, 1.0) == 1"},
+		{expr: "math.greatest(1, -2.0) == 1"},
+		{expr: "math.greatest(2, 1u) == 2"},
+		{expr: "math.greatest(1.5, 2) == 2"},
+		{expr: "math.greatest(1.5, -2) == 1.5"},
+		{expr: "math.greatest(2.5, 1u) == 2.5"},
+		{expr: "math.greatest(1u, 2) == 2"},
+		{expr: "math.greatest(1u, -2) == 1u"},
+		{expr: "math.greatest(2u, 2.5) == 2.5"},
 		// math.greatest with dynamic values across type.
 		{expr: "math.greatest(1u, dyn(42)) == 42.0"},
 		{expr: "math.greatest(1u, dyn(0.0), 0u) == 1"},

--- a/ext/math_test.go
+++ b/ext/math_test.go
@@ -13,3 +13,386 @@
 // limitations under the License.
 
 package ext
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+)
+
+func TestMath(t *testing.T) {
+	mathTests := []struct {
+		expr string
+		in   any
+	}{
+		// Tests for math.least
+		{expr: "math.least(-0.5) == -0.5"},
+		{expr: "math.least(-1) == -1"},
+		{expr: "math.least(1u) == 1u"},
+		{expr: "math.least(42.0, -0.5) == -0.5"},
+		{expr: "math.least(-1, 0) == -1"},
+		{expr: "math.least(-1, -1) == -1"},
+		{expr: "math.least(1u, 42u) == 1u"},
+		{expr: "math.least(42.0, -0.5, -0.25) == -0.5"},
+		{expr: "math.least(-1, 0, 1) == -1"},
+		{expr: "math.least(-1, -1, -1) == -1"},
+		{expr: "math.least(1u, 42u, 0u) == 0u"},
+		// math.least with dynamic values across type.
+		{expr: "math.least(1u, dyn(42)) == 1"},
+		{expr: "math.least(1u, dyn(42), dyn(0.0)) == 0u"},
+		// math.least with a list literal.
+		{expr: "math.least([1u, 42u, 0u]) == 0u"},
+		// math.least with expression arguments.
+		{
+			expr: "math.least(a, b) == a",
+			in: map[string]any{
+				"a": 1,
+				"b": 2,
+			},
+		},
+		{
+			expr: "math.least(numbers) == dyn(a)",
+			in: map[string]any{
+				"a":       -21,
+				"numbers": []float64{-21.0, -10.5, 1.0},
+			},
+		},
+
+		// Tests for math.greatest
+		{expr: "math.greatest(-0.5) == -0.5"},
+		{expr: "math.greatest(-1) == -1"},
+		{expr: "math.greatest(1u) == 1u"},
+		{expr: "math.greatest(42.0, -0.5) == 42.0"},
+		{expr: "math.greatest(-1, 0) == 0"},
+		{expr: "math.greatest(-1, -1) == -1"},
+		{expr: "math.greatest(1u, 42u) == 42u"},
+		{expr: "math.greatest(42.0, -0.5, -0.25) == 42.0"},
+		{expr: "math.greatest(-1, 0, 1) == 1"},
+		{expr: "math.greatest(-1, -1, -1) == -1"},
+		{expr: "math.greatest(1u, 42u, 0u) == 42u"},
+		// math.greatest with dynamic values across type.
+		{expr: "math.greatest(1u, dyn(42)) == 42.0"},
+		{expr: "math.greatest(1u, dyn(0.0), 0u) == 1"},
+		// math.greatest with a list literal
+		{expr: "math.greatest([1u, dyn(0.0), 0u]) == 1"},
+		// math.greatest with expression arguments.
+		{
+			expr: "math.greatest(a, b) == b",
+			in: map[string]any{
+				"a": 1,
+				"b": 2,
+			},
+		},
+		{
+			expr: "math.greatest(numbers) == dyn(a)",
+			in: map[string]any{
+				"a":       1,
+				"numbers": []float64{-21.0, -10.5, 1.0},
+			},
+		},
+	}
+
+	env := testMathEnv(t,
+		cel.Variable("a", cel.IntType),
+		cel.Variable("b", cel.IntType),
+		cel.Variable("numbers", cel.ListType(cel.DoubleType)),
+	)
+	for i, tst := range mathTests {
+		tc := tst
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var asts []*cel.Ast
+			pAst, iss := env.Parse(tc.expr)
+			if iss.Err() != nil {
+				t.Fatalf("env.Parse(%v) failed: %v", tc.expr, iss.Err())
+			}
+			asts = append(asts, pAst)
+			cAst, iss := env.Check(pAst)
+			if iss.Err() != nil {
+				t.Fatalf("env.Check(%v) failed: %v", tc.expr, iss.Err())
+			}
+			asts = append(asts, cAst)
+
+			for _, ast := range asts {
+				prg, err := env.Program(ast)
+				if err != nil {
+					t.Fatalf("env.Program() failed: %v", err)
+				}
+				in := tc.in
+				if in == nil {
+					in = cel.NoVars()
+				}
+				out, _, err := prg.Eval(in)
+				if err != nil {
+					t.Fatalf("prg.Eval() failed: %v", err)
+				}
+				if out.Value() != true {
+					t.Errorf("prg.Eval() got %v, wanted true for expr: %s", out.Value(), tc.expr)
+				}
+			}
+		})
+	}
+}
+
+func TestMathStaticErrors(t *testing.T) {
+	mathTests := []struct {
+		expr string
+		err  string
+	}{
+		// Tests for math.least
+		{
+			expr: "math.least()",
+			err:  "math.least() requires at least one argument",
+		},
+		{
+			expr: "math.least('hello')",
+			err:  "math.least() invalid single argument value",
+		},
+		{
+			expr: "math.least({})",
+			err:  "math.least() invalid single argument value",
+		},
+		{
+			expr: "math.least(1, true)",
+			err:  "math.least() simple literal arguments must be numeric",
+		},
+		{
+			expr: "math.least(1, 2, true)",
+			err:  "math.least() simple literal arguments must be numeric",
+		},
+
+		// Tests for math.greatest
+		{
+			expr: "math.greatest()",
+			err:  "math.greatest() requires at least one argument",
+		},
+		{
+			expr: "math.greatest(true)",
+			err:  "math.greatest() invalid single argument value",
+		},
+		{
+			expr: "math.greatest([])",
+			err:  "math.greatest() invalid single argument value",
+		},
+		{
+			expr: "math.greatest([1, true])",
+			err:  "math.greatest() invalid single argument value",
+		},
+		{
+			expr: "math.greatest(1, true)",
+			err:  "math.greatest() simple literal arguments must be numeric",
+		},
+		{
+			expr: "math.greatest(1, 2, true)",
+			err:  "math.greatest() simple literal arguments must be numeric",
+		},
+	}
+
+	env := testMathEnv(t)
+	for i, tst := range mathTests {
+		tc := tst
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			_, iss := env.Compile(tc.expr)
+			if iss.Err() == nil || !strings.Contains(iss.Err().Error(), tc.err) {
+				t.Errorf("env.Compile(%q) got %v, wanted error %v", tc.expr, iss.Err(), tc.err)
+			}
+		})
+	}
+}
+
+func TestMathRuntimeErrors(t *testing.T) {
+	mathTests := []struct {
+		expr string
+		err  string
+		in   any
+	}{
+		// Tests for math.least
+		{
+			expr: "math.least(a, b)",
+			err:  "no such overload: math.@min",
+			in: map[string]any{
+				"a": []int{},
+				"b": 1,
+			},
+		},
+		{
+			expr: "math.least(b, a)",
+			err:  "no such overload: math.@min",
+			in: map[string]any{
+				"a": []int{},
+				"b": 1,
+			},
+		},
+		{
+			expr: "math.least(a)",
+			err:  "math.@minList(list) argument must not be empty",
+			in: map[string]any{
+				"a": []int{},
+			},
+		},
+		{
+			expr: "math.least(a)",
+			err:  "no such overload: math.@minList",
+			in: map[string]any{
+				"a": []any{"hello"},
+			},
+		},
+		{
+			expr: "math.least(a)",
+			err:  "no such overload: math.@minList",
+			in: map[string]any{
+				"a": []any{[]int{}, []int{}},
+			},
+		},
+		{
+			expr: "math.least(dyn('string'))",
+			err:  "no such overload: math.@minList",
+		},
+
+		// Tests for math.greatest
+		{
+			expr: "math.greatest(a, b)",
+			err:  "no such overload: math.@max",
+			in: map[string]any{
+				"a": []int{},
+				"b": 1,
+			},
+		},
+		{
+			expr: "math.greatest(b, a)",
+			err:  "no such overload: math.@max",
+			in: map[string]any{
+				"a": []int{},
+				"b": 1,
+			},
+		},
+		{
+			expr: "math.greatest(a)",
+			err:  "math.@maxList(list) argument must not be empty",
+			in: map[string]any{
+				"a": []int{},
+			},
+		},
+		{
+			expr: "math.greatest(a)",
+			err:  "no such overload: math.@maxList",
+			in: map[string]any{
+				"a": []any{true},
+			},
+		},
+		{
+			expr: "math.greatest(a)",
+			err:  "no such overload: math.@maxList",
+			in: map[string]any{
+				"a": []any{1, true, 2},
+			},
+		},
+		{
+			expr: "math.greatest(dyn('string'))",
+			err:  "no such overload: math.@maxList",
+		},
+	}
+
+	env := testMathEnv(t,
+		cel.Variable("a", cel.DynType),
+		cel.Variable("b", cel.IntType),
+		cel.Variable("numbers", cel.ListType(cel.DoubleType)),
+	)
+	for i, tst := range mathTests {
+		tc := tst
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			ast, iss := env.Compile(tc.expr)
+			if iss.Err() != nil {
+				t.Fatalf("env.Compile(%q) failed with error %v", tc.expr, iss.Err())
+			}
+			prg, err := env.Program(ast)
+			if err != nil {
+				t.Fatalf("env.Program(ast) failed: %v", err)
+			}
+			in := tc.in
+			if in == nil {
+				in = cel.NoVars()
+			}
+			_, _, err = prg.Eval(in)
+			if err == nil || !strings.Contains(err.Error(), tc.err) {
+				t.Errorf("prg.Eval() got %v, wanted %v", err, tc.err)
+			}
+		})
+	}
+}
+
+func TestMathNonMatch(t *testing.T) {
+	var mathTests = []struct {
+		expr string
+	}{
+		// Even though 'least' is the macro, the call is left unexpanded since the operand is not 'math'.
+		{
+			expr: `100.least(42) == 42`,
+		},
+		// Even though 'greatest' is the macro, the call is left unexpanded since the operand is not 'math'.
+		{
+			expr: `100.greatest(42) == 100`,
+		},
+	}
+	env := testMathEnv(t,
+		cel.Function("greatest",
+			cel.MemberOverload("int_greatest_int", []*cel.Type{cel.IntType, cel.IntType}, cel.IntType,
+				cel.BinaryBinding(maxPair))),
+		cel.Function("least",
+			cel.MemberOverload("int_least_int", []*cel.Type{cel.IntType, cel.IntType}, cel.IntType,
+				cel.BinaryBinding(minPair))),
+	)
+	for i, tst := range mathTests {
+		tc := tst
+		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
+			var asts []*cel.Ast
+			pAst, iss := env.Parse(tc.expr)
+			if iss.Err() != nil {
+				t.Fatalf("env.Parse(%v) failed: %v", tc.expr, iss.Err())
+			}
+			asts = append(asts, pAst)
+			cAst, iss := env.Check(pAst)
+			if iss.Err() != nil {
+				t.Fatalf("env.Check(%v) failed: %v", tc.expr, iss.Err())
+			}
+			asts = append(asts, cAst)
+
+			for _, ast := range asts {
+				prg, err := env.Program(ast)
+				if err != nil {
+					t.Fatalf("env.Program() failed: %v", err)
+				}
+				out, _, err := prg.Eval(cel.NoVars())
+				if err != nil {
+					t.Fatalf("prg.Eval() failed: %v", err)
+				}
+				if out.Value() != true {
+					t.Errorf("prg.Eval() got %v, wanted true for expr: %s", out.Value(), tc.expr)
+				}
+			}
+		})
+	}
+}
+
+func TestMathWithExtension(t *testing.T) {
+	env := testMathEnv(t)
+	_, err := env.Extend(Math())
+	if err != nil {
+		t.Fatalf("env.Extend(Math()) failed: %v", err)
+	}
+	_, iss := env.Compile("math.least(0, 1, 2) == 0")
+	if iss.Err() != nil {
+		t.Errorf("env.Compile() failed: %v", iss.Err())
+	}
+}
+
+func testMathEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
+	t.Helper()
+	baseOpts := []cel.EnvOption{Math()}
+	env, err := cel.NewEnv(append(baseOpts, opts...)...)
+	if err != nil {
+		t.Fatalf("cel.NewEnv(Math()) failed: %v", err)
+	}
+	return env
+}

--- a/ext/strings.go
+++ b/ext/strings.go
@@ -202,6 +202,12 @@ func Strings() cel.EnvOption {
 
 type stringLib struct{}
 
+// LibraryName implements the SingletonLibrary interface method.
+func (stringLib) LibraryName() string {
+	return "cel.lib.ext.strings"
+}
+
+// CompileOptions implements the Library interface method.
 func (stringLib) CompileOptions() []cel.EnvOption {
 	return []cel.EnvOption{
 		cel.Function("charAt",
@@ -324,6 +330,7 @@ func (stringLib) CompileOptions() []cel.EnvOption {
 	}
 }
 
+// ProgramOptions implements the Library interface method.
 func (stringLib) ProgramOptions() []cel.ProgramOption {
 	return []cel.ProgramOption{}
 }

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -318,3 +318,14 @@ func TestStrings(t *testing.T) {
 		})
 	}
 }
+
+func TestStringsWithExtension(t *testing.T) {
+	env, err := cel.NewEnv(Strings())
+	if err != nil {
+		t.Fatalf("cel.NewEnv(Strings()) failed: %v", err)
+	}
+	_, err = env.Extend(Strings())
+	if err != nil {
+		t.Fatalf("env.Extend(Strings()) failed: %v", err)
+	}
+}


### PR DESCRIPTION
The `math` namespaced extension library will become a basis for several other functions, but the initial support only includes the vararg `least` and `greatest` macros.