### PR TITLE
Harden field visiting parser paths

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -633,8 +633,14 @@ func (p *parser) VisitIFieldInitializerList(ctx gen.IFieldInitializerListContext
 		optional := optField.GetOpt() != nil
 		if !p.enableOptionalSyntax && optional {
 			p.reportError(optField, "unsupported syntax '?'")
+			continue
 		}
-		fieldName := optField.IDENTIFIER().GetText()
+		// The field may be empty due to a prior error.
+		id := optField.IDENTIFIER()
+		if id == nil {
+			return []*exprpb.Expr_CreateStruct_Entry{}
+		}
+		fieldName := id.GetText()
 		value := p.Visit(vals[i]).(*exprpb.Expr)
 		field := p.helper.newObjectField(initID, fieldName, value, optional)
 		result[i] = field
@@ -701,6 +707,7 @@ func (p *parser) VisitMapInitializerList(ctx *gen.MapInitializerListContext) any
 		optional := optKey.GetOpt() != nil
 		if !p.enableOptionalSyntax && optional {
 			p.reportError(optKey, "unsupported syntax '?'")
+			continue
 		}
 		key := p.Visit(optKey.Expr()).(*exprpb.Expr)
 		value := p.Visit(vals[i]).(*exprpb.Expr)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1686,6 +1686,27 @@ var testCases = []testInfo{
 			123^#2:*expr.Constant_Int64Value#
 		  )^#1:*expr.Expr_CallExpr#`,
 	},
+	{
+		I: `x{?.`,
+		Opts: []Option{
+			ErrorRecoveryLookaheadTokenLimit(10),
+			ErrorRecoveryLimit(10),
+		},
+		E: `
+		ERROR: <input>:1:3: unsupported syntax '?'
+		 | x{?.
+		 | ..^
+	    ERROR: <input>:1:4: Syntax error: mismatched input '.' expecting IDENTIFIER
+		 | x{?.
+		 | ...^`,
+	},
+	{
+		I: `x{.`,
+		E: `
+		ERROR: <input>:1:3: Syntax error: mismatched input '.' expecting {'}', ',', '?', IDENTIFIER}
+		 | x{.
+		 | ..^`,
+	},
 }
 
 type testInfo struct {


### PR DESCRIPTION
Harden the error checking paths for visiting fields to ensure there is not a `nil` dereference

See #610 