### PR TITLE
Extension to support Golang structs as CEL types

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -1878,7 +1878,7 @@ func TestDynamicDispatch(t *testing.T) {
 
 func TestOptionalValues(t *testing.T) {
 	env, err := NewEnv(
-		OptionalTypes(true),
+		OptionalTypes(),
 		// Container and test message types.
 		Container("google.expr.proto2.test"),
 		Types(&proto2pb.TestAllTypes{}),
@@ -2205,7 +2205,7 @@ func TestOptionalValues(t *testing.T) {
 
 func BenchmarkOptionalValues(b *testing.B) {
 	env, err := NewEnv(
-		OptionalTypes(true),
+		OptionalTypes(),
 		Variable("x", OptionalType(IntType)),
 		Variable("y", OptionalType(IntType)),
 		Variable("z", IntType),

--- a/cel/env.go
+++ b/cel/env.go
@@ -485,11 +485,6 @@ func (e *Env) configure(opts []EnvOption) (*Env, error) {
 	if err != nil {
 		return nil, err
 	}
-	// If optional types have been enabled, then configure the optional library.
-	e, err = e.maybeApplyFeature(featureOptionalTypes, Lib(optionalLibrary{}))
-	if err != nil {
-		return nil, err
-	}
 
 	// Initialize all of the functions configured within the environment.
 	for _, fn := range e.functions {

--- a/cel/library.go
+++ b/cel/library.go
@@ -157,7 +157,7 @@ func (optionalLibrary) CompileOptions() []EnvOption {
 					return opt.GetValue()
 				}))),
 		Function("hasValue",
-			MemberOverload("optional_hasValue", []*Type{optionalTypeV}, paramTypeV,
+			MemberOverload("optional_hasValue", []*Type{optionalTypeV}, BoolType,
 				UnaryBinding(func(value ref.Val) ref.Val {
 					opt := value.(*types.Optional)
 					return types.Bool(opt.HasValue())

--- a/cel/options.go
+++ b/cel/options.go
@@ -542,11 +542,11 @@ func DefaultUTCTimeZone(enabled bool) EnvOption {
 	return features(featureDefaultUTCTimeZone, enabled)
 }
 
-// OptionalTypes determines whether CEL's optional value type is enabled. The optional value type makes it
-// possible to express whether variables have been provided, whether a result has been computed, and
-// in the future whether an object field path, map key value, or list index has a value.
-func OptionalTypes(enabled bool) EnvOption {
-	return features(featureOptionalTypes, enabled)
+// OptionalTypes enable support for optional syntax and types in CEL. The optional value type makes
+// it possible to express whether variables have been provided, whether a result has been computed,
+// and in the future whether an object field path, map key value, or list index has a value.
+func OptionalTypes() EnvOption {
+	return Lib(optionalLibrary{})
 }
 
 // features sets the given feature flags.  See list of Feature constants above.

--- a/common/types/ref/provider.go
+++ b/common/types/ref/provider.go
@@ -39,8 +39,6 @@ type TypeProvider interface {
 
 	// FieldFieldType returns the field type for a checked type value. Returns
 	// false if the field could not be found.
-	//
-	// Used during type-checking only.
 	FindFieldType(messageType string, fieldName string) (*FieldType, bool)
 
 	// NewValue creates a new type value from a qualified name and map of field

--- a/ext/native.go
+++ b/ext/native.go
@@ -51,7 +51,7 @@ var (
 //
 // ```
 //
-// The type `identity.Account` would be expored to CEL using the same qualified name, e.g.
+// The type `identity.Account` would be exported to CEL using the same qualified name, e.g.
 // `identity.Account{ID: 1234}` would create a new `Account` instance with the `ID` field
 // populated.
 //

--- a/ext/native.go
+++ b/ext/native.go
@@ -1,0 +1,141 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ext
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+)
+
+var (
+	nativeObjTraitMask = traits.FieldTesterType | traits.IndexerType
+)
+
+type nativeObj struct {
+	val      any
+	valType  *nativeType
+	refValue reflect.Value
+}
+
+type nativeType struct {
+	refType reflect.Type
+}
+
+func NativeObject(val any) ref.Val {
+	if val == nil {
+		return types.NullValue
+	}
+	refValue := reflect.ValueOf(val)
+	return &nativeObj{
+		val:      val,
+		valType:  &nativeType{refType: refValue.Type()},
+		refValue: refValue,
+	}
+}
+
+func (o *nativeObj) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	if o.valType.refType == typeDesc {
+		return o.val, nil
+	}
+	return nil, fmt.Errorf("type conversion error from '%T' to '%v'", o.val, typeDesc)
+}
+
+func (o *nativeObj) ConvertToType(typeVal ref.Type) ref.Val {
+	switch typeVal {
+	default:
+		if o.Type().TypeName() == typeVal.TypeName() {
+			return o
+		}
+	case types.TypeType:
+		return o.valType
+	}
+	return types.NewErr("type conversion error from '%s' to '%s'", o.Type().TypeName(), typeVal)
+}
+
+func (o *nativeObj) Equal(other ref.Val) ref.Val {
+	otherNtv, ok := other.(*nativeObj)
+	return types.Bool(ok && reflect.DeepEqual(o.val, otherNtv.val))
+}
+
+func (o *nativeObj) IsZeroValue() bool {
+	return o.refValue.IsZero()
+}
+
+func (o *nativeObj) Get(field ref.Val) ref.Val {
+	fieldName, ok := field.(types.String)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(field)
+	}
+	fieldVal := o.refValue.FieldByName(string(fieldName))
+	if !fieldVal.IsValid() {
+		return types.NewErr("no such field: %s", fieldName)
+	}
+	// Convert the field value to a ref.Val
+	return nil
+}
+
+func (o *nativeObj) Type() ref.Type {
+	return o.valType
+}
+
+func (o *nativeObj) Value() any {
+	return o.val
+}
+
+// ConvertToNative implements ref.Val.ConvertToNative.
+func (t *nativeType) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	// TODO: replace the internal type representation with a proto-value.
+	return nil, fmt.Errorf("type conversion not supported for 'type'")
+}
+
+// ConvertToType implements ref.Val.ConvertToType.
+func (t *nativeType) ConvertToType(typeVal ref.Type) ref.Val {
+	switch typeVal {
+	case types.TypeType:
+		return types.TypeType
+	case types.StringType:
+		return types.String(t.TypeName())
+	}
+	return types.NewErr("type conversion error from '%s' to '%s'", types.TypeType, typeVal)
+}
+
+func (t *nativeType) Equal(other ref.Val) ref.Val {
+	otherType, ok := other.(ref.Type)
+	return types.Bool(ok && t.TypeName() == otherType.TypeName())
+}
+
+func (t *nativeType) HasTrait(trait int) bool {
+	return nativeObjTraitMask&trait == trait
+}
+
+func (t *nativeType) String() string {
+	return t.refType.Name()
+}
+
+func (t *nativeType) Type() ref.Type {
+	return types.TypeType
+}
+
+func (t *nativeType) TypeName() string {
+	return t.refType.Name()
+}
+
+func (t *nativeType) Value() any {
+	return t.refType.Name()
+}

--- a/ext/native_test.go
+++ b/ext/native_test.go
@@ -17,20 +17,97 @@ package ext
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
 
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/pb"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/test"
+
+	proto3pb "github.com/google/cel-go/test/proto3pb"
 )
 
 func TestNativeTypes(t *testing.T) {
+	// TODO:
+	// - test numeric overflows on 32-bit fields
 	var nativeTests = []struct {
 		expr string
 		out  any
 	}{
 		{
-			expr: `ext.TestAllTypes{BoolVal: true}`,
-			out:  &TestAllTypes{BoolVal: true},
+			expr: `ext.TestAllTypes{
+				NestedVal: ext.TestNestedType{NestedMapVal: {1: false}},
+				BoolVal: true,
+				BytesVal: b'hello',
+				DurationVal: duration('5s'),
+				DoubleVal: 1.5,
+				FloatVal: 2.5,
+				Int32Val: 10,
+				Int64Val: 20,
+				StringVal: 'hello world',
+				TimestampVal: timestamp('2011-08-06T01:23:45Z'),
+				Uint32Val: 100u,
+				Uint64Val: 200u,
+				ListVal: [
+					ext.TestNestedType{
+						NestedListVal:['goodbye', 'cruel', 'world'],
+						NestedMapVal: {42: true},
+					},
+				],
+				MapVal: {'map-key': ext.TestAllTypes{BoolVal: true}},
+			}`,
+			out: &TestAllTypes{
+				NestedVal:    &TestNestedType{NestedMapVal: map[int64]bool{1: false}},
+				BoolVal:      true,
+				BytesVal:     []byte("hello"),
+				DurationVal:  time.Second * 5,
+				DoubleVal:    1.5,
+				FloatVal:     2.5,
+				Int32Val:     10,
+				Int64Val:     20,
+				StringVal:    "hello world",
+				TimestampVal: mustParseTime(t, "2011-08-06T01:23:45Z"),
+				Uint32Val:    uint32(100),
+				Uint64Val:    uint64(200),
+				ListVal: []*TestNestedType{
+					{
+						NestedListVal: []string{"goodbye", "cruel", "world"},
+						NestedMapVal:  map[int64]bool{42: true},
+					},
+				},
+				MapVal: map[string]TestAllTypes{"map-key": {BoolVal: true}},
+			},
 		},
+		{
+			expr: `ext.TestAllTypes{					
+					PbVal: test.TestAllTypes{single_int32: 123}
+				}.PbVal`,
+			out: &proto3pb.TestAllTypes{SingleInt32: 123},
+		},
+		{
+			expr: `ext.TestAllTypes{PbVal: test.TestAllTypes{}} == 
+			ext.TestAllTypes{PbVal: test.TestAllTypes{single_bool: false}}`,
+		},
+		{expr: `ext.TestNestedType{} == ext.TestNestedType{}`},
+		{expr: `ext.TestAllTypes{}.BoolVal != true`},
+		{expr: `!has(ext.TestAllTypes{}.BoolVal) && !has(ext.TestAllTypes{}.NestedVal)`},
+		{expr: `type(ext.TestAllTypes) == type`},
+		{expr: `type(ext.TestAllTypes{}) == ext.TestAllTypes`},
+		{expr: `type(ext.TestAllTypes{}) == ext.TestAllTypes`},
+		{expr: `ext.TestAllTypes != test.TestAllTypes`},
+		{expr: `ext.TestAllTypes{BoolVal: true} != dyn(test.TestAllTypes{single_bool: true})`},
+		{expr: `ext.TestAllTypes{}.NestedVal == ext.TestNestedType{}`},
+		{expr: `ext.TestNestedType{} == ext.TestAllTypes{}.NestedStructVal`},
+		{expr: `ext.TestAllTypes{}.NestedStructVal == ext.TestNestedType{}`},
+		{expr: `ext.TestAllTypes{}.ListVal.size() == 0`},
+		{expr: `ext.TestAllTypes{}.MapVal.size() == 0`},
+		{expr: `ext.TestAllTypes{}.TimestampVal == timestamp(0)`},
+		{expr: `test.TestAllTypes{}.single_timestamp == timestamp(0)`},
 	}
 	env := testNativeEnv(t)
 	for i, tst := range nativeTests {
@@ -52,12 +129,332 @@ func TestNativeTypes(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				out, _, err := prg.Eval(map[string]any{"msg": msgWithExtensions()})
+				out, _, err := prg.Eval(cel.NoVars())
 				if err != nil {
 					t.Fatal(err)
 				}
-				if !reflect.DeepEqual(out.Value(), tc.out) {
-					t.Errorf("got %v, wanted %v for expr: %s", out.Value(), tc.out, tc.expr)
+				want := tc.out
+				if want == nil {
+					want = true
+				}
+				wantPB, isPB := want.(proto.Message)
+				if isPB && !pb.Equal(wantPB, out.Value().(proto.Message)) {
+					t.Errorf("got %v, wanted %v for expr: %s", out.Value(), want, tc.expr)
+				}
+				if !isPB && !reflect.DeepEqual(out.Value(), want) {
+					t.Errorf("got %v, wanted %v for expr: %s", out.Value(), want, tc.expr)
+				}
+			}
+		})
+	}
+}
+
+func TestNativeTypesStaticErrors(t *testing.T) {
+	var nativeTests = []struct {
+		expr string
+		err  string
+	}{
+		{
+			expr: `TestAllTypes{}`,
+			err: `ERROR: <input>:1:13: undeclared reference to 'TestAllTypes' (in container '')
+			 | TestAllTypes{}
+			 | ............^`,
+		},
+		{
+			expr: `ext.TestAllTypes{bool_val: false}`,
+			err: `ERROR: <input>:1:26: undefined field 'bool_val'
+			| ext.TestAllTypes{bool_val: false}
+			| .........................^`,
+		},
+		{
+			expr: `ext.TestAllTypes{UnsupportedVal: null}`,
+			err: `ERROR: <input>:1:32: undefined field 'UnsupportedVal'
+			| ext.TestAllTypes{UnsupportedVal: null}
+			| ...............................^`,
+		},
+		{
+			expr: `ext.TestAllTypes{UnsupportedListVal: null}`,
+			err: `ERROR: <input>:1:36: undefined field 'UnsupportedListVal'
+			| ext.TestAllTypes{UnsupportedListVal: null}
+			| ...................................^`,
+		},
+		{
+			expr: `ext.TestAllTypes{UnsupportedMapVal: null}`,
+			err: `ERROR: <input>:1:35: undefined field 'UnsupportedMapVal'
+			| ext.TestAllTypes{UnsupportedMapVal: null}
+			| ..................................^`,
+		},
+	}
+	env := testNativeEnv(t)
+	for i, tst := range nativeTests {
+		tc := tst
+		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
+			_, iss := env.Compile(tc.expr)
+			if iss.Err() == nil {
+				t.Fatalf("env.Compile(%v) succeeded, wanted error", tc.expr)
+			}
+			if !test.Compare(iss.Err().Error(), tc.err) {
+				t.Errorf("env.Compile(%v) got %v, wanted error %s", tc.expr, iss.Err(), tc.err)
+			}
+		})
+	}
+}
+
+func TestNativeTypesRuntimeErrors(t *testing.T) {
+	var nativeTests = []struct {
+		expr string
+		err  string
+	}{
+		{
+			expr: `TestAllTypes{}`,
+			err:  `unknown type: TestAllTypes`,
+		},
+		{
+			expr: `ext.TestAllTypes{bool_val: false}`,
+			err:  `no such field: bool_val`,
+		},
+		{
+			expr: `ext.TestAllTypes{UnsupportedVal: null}`,
+			err:  `no such field: UnsupportedVal`,
+		},
+		{
+			expr: `ext.TestAllTypes{UnsupportedListVal: null}`,
+			err:  `no such field: UnsupportedListVal`,
+		},
+		{
+			expr: `ext.TestAllTypes{UnsupportedMapVal: null}`,
+			err:  `no such field: UnsupportedMapVal`,
+		},
+		{
+			expr: `ext.TestAllTypes{privateVal: null}`,
+			err:  `no such field: privateVal`,
+		},
+		{
+			expr: `ext.TestAllTypes{}.UnsupportedMapVal`,
+			err:  `no such field: UnsupportedMapVal`,
+		},
+		{
+			expr: `ext.TestAllTypes{}.privateVal`,
+			err:  `no such field: privateVal`,
+		},
+		{
+			expr: `ext.TestAllTypes{BoolVal: 'false'}`,
+			err:  `unsupported native conversion from string to 'bool'`,
+		},
+	}
+	env := testNativeEnv(t)
+	for i, tst := range nativeTests {
+		tc := tst
+		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
+			ast, iss := env.Parse(tc.expr)
+			if iss.Err() != nil {
+				t.Fatalf("env.Parse(%v) failed: %v", tc.expr, iss.Err())
+			}
+			prg, err := env.Program(ast)
+			if err != nil {
+				if !strings.Contains(err.Error(), tc.err) {
+					t.Fatal(err)
+				}
+				return
+			}
+			out, _, err := prg.Eval(cel.NoVars())
+			if err == nil || !strings.Contains(err.Error(), tc.err) {
+				var got any = err
+				if err == nil {
+					got = out
+				}
+				t.Fatalf("prg.Eval() got %v, wanted error %v", got, tc.err)
+			}
+		})
+	}
+}
+
+func TestNativeTypesErrors(t *testing.T) {
+	envTests := []struct {
+		nativeType any
+		err        string
+	}{
+		{
+			nativeType: reflect.TypeOf(1),
+			err:        "unsupported reflect.Type",
+		},
+		{
+			nativeType: reflect.ValueOf(1),
+			err:        "unsupported reflect.Type",
+		},
+		{
+			nativeType: 1,
+			err:        "must be reflect.Type or reflect.Value",
+		},
+	}
+	for i, tst := range envTests {
+		tc := tst
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			_, err := cel.NewEnv(NativeTypes(tc.nativeType))
+			if err == nil || !strings.Contains(err.Error(), tc.err) {
+				t.Errorf("cel.NewEnv(NativeTypes(%v)) got error %v, wanted %v", tc.nativeType, err, tc.err)
+			}
+		})
+	}
+}
+
+func TestNativeTypesConvertToNative(t *testing.T) {
+	env := testNativeEnv(t, NativeTypes(reflect.TypeOf(TestNestedType{})))
+	adapter := env.TypeAdapter()
+	conversions := []struct {
+		in  any
+		out any
+		err string
+	}{
+		{
+			in:  &TestAllTypes{BoolVal: true},
+			out: &TestAllTypes{BoolVal: true},
+		},
+		{
+			in:  TestAllTypes{BoolVal: true},
+			out: &TestAllTypes{BoolVal: true},
+		},
+		{
+			in:  &TestAllTypes{BoolVal: true},
+			out: TestAllTypes{BoolVal: true},
+		},
+		{
+			in:  nil,
+			out: types.NullValue,
+		},
+		{
+			in:  &TestAllTypes{BoolVal: true},
+			out: &proto3pb.TestAllTypes{},
+			err: "type conversion error",
+		},
+	}
+	for _, c := range conversions {
+		inVal := adapter.NativeToValue(c.in)
+		if types.IsError(inVal) {
+			t.Fatalf("adapter.NativeToValue(%v) failed: %v", c.in, inVal)
+		}
+		out, err := inVal.ConvertToNative(reflect.TypeOf(c.out))
+		if err != nil {
+			if c.err != "" {
+				if !strings.Contains(err.Error(), c.err) {
+					t.Fatalf("%v.ConvertToNative(%T) got %v, wanted error %v", c.in, c.out, err, c.err)
+				}
+				return
+			}
+			t.Fatalf("%v.ConvertToNative(%T) failed: %v", c.in, c.out, err)
+		}
+		if !reflect.DeepEqual(out, c.out) {
+			t.Errorf("%v.ConvertToNative(%T) got %v, wanted %v", c.in, c.out, out, c.out)
+		}
+	}
+}
+
+func TestNativeTypesConvertToExprTypeErrors(t *testing.T) {
+	unsupportedTypes := []reflect.Type{
+		reflect.TypeOf(make(map[string]chan string)),
+		reflect.TypeOf(make([]chan int, 0)),
+		reflect.TypeOf(make(map[chan int]bool, 0)),
+	}
+	for _, ut := range unsupportedTypes {
+		if _, converted := convertToExprType(ut); converted {
+			t.Errorf("convertToExprType(%v) succeeded when it should have failed", ut)
+		}
+	}
+}
+
+func TestConvertToTypeErrors(t *testing.T) {
+	env := testNativeEnv(t, NativeTypes(reflect.TypeOf(TestNestedType{})))
+	adapter := env.TypeAdapter()
+	conversions := []struct {
+		in  any
+		out any
+		err string
+	}{
+		{
+			in:  &TestAllTypes{BoolVal: true},
+			out: &TestAllTypes{BoolVal: true},
+		},
+		{
+			in:  TestAllTypes{BoolVal: true},
+			out: &TestAllTypes{BoolVal: true},
+		},
+		{
+			in:  &TestAllTypes{BoolVal: true},
+			out: TestAllTypes{BoolVal: true},
+		},
+		{
+			in:  &TestAllTypes{BoolVal: true},
+			out: &proto3pb.TestAllTypes{},
+			err: "type conversion error",
+		},
+	}
+	for _, c := range conversions {
+		inVal := adapter.NativeToValue(c.in)
+		outVal := adapter.NativeToValue(c.out)
+		if types.IsError(inVal) {
+			t.Fatalf("adapter.NativeToValue(%v) failed: %v", c.in, inVal)
+		}
+		if types.IsError(outVal) {
+			t.Fatalf("adapter.NativeToValue(%v) failed: %v", c.out, outVal)
+		}
+		conv := inVal.ConvertToType(outVal.Type())
+		if c.err != "" {
+			if !types.IsError(conv) {
+				t.Fatalf("%v.ConvertToType(%v) got %v, wanted error %v", c.in, outVal.Type(), conv, c.err)
+			}
+			convErr := conv.(*types.Err)
+			if !strings.Contains(convErr.Error(), c.err) {
+				t.Fatalf("%v.ConvertToType(%v) got %v, wanted error %v", c.in, outVal.Type(), conv, c.err)
+			}
+			return
+		}
+		if conv != inVal {
+			t.Errorf("%v.ConvertToType(%v) got %v, wanted %v", c.in, outVal.Type(), conv, c.err)
+		}
+		conv = inVal.ConvertToType(types.TypeType)
+		if conv.Type() != types.TypeType || conv.(ref.Type) != inVal.Type() {
+			t.Errorf("%v.ConvertToType(Type) got %v, wanted %v", inVal, conv, inVal.Type())
+		}
+	}
+}
+
+func TestNativeTypesWithOptional(t *testing.T) {
+	var nativeTests = []struct {
+		expr string
+	}{
+		{expr: `!optional.ofNonZeroValue(ext.TestAllTypes{}).hasValue()`},
+		{expr: `!ext.TestAllTypes{}.?BoolVal.orValue(false)`},
+		{expr: `!ext.TestAllTypes{}.?BoolVal.hasValue()`},
+		{expr: `!ext.TestAllTypes{BoolVal: false}.?BoolVal.hasValue()`},
+		{expr: `ext.TestAllTypes{BoolVal: true}.?BoolVal.hasValue()`},
+		{expr: `ext.TestAllTypes{}.NestedVal.?NestedMapVal.orValue({}).size() == 0`},
+	}
+	env := testNativeEnv(t, cel.OptionalTypes())
+	for i, tst := range nativeTests {
+		tc := tst
+		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
+			var asts []*cel.Ast
+			pAst, iss := env.Parse(tc.expr)
+			if iss.Err() != nil {
+				t.Fatalf("env.Parse(%v) failed: %v", tc.expr, iss.Err())
+			}
+			asts = append(asts, pAst)
+			cAst, iss := env.Check(pAst)
+			if iss.Err() != nil {
+				t.Fatalf("env.Check(%v) failed: %v", tc.expr, iss.Err())
+			}
+			asts = append(asts, cAst)
+			for _, ast := range asts {
+				prg, err := env.Program(ast)
+				if err != nil {
+					t.Fatal(err)
+				}
+				out, _, err := prg.Eval(cel.NoVars())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(out.Value(), true) {
+					t.Errorf("got %v, wanted true for expr: %s", out.Value(), tc.expr)
 				}
 			}
 		})
@@ -67,11 +464,14 @@ func TestNativeTypes(t *testing.T) {
 // testEnv initializes the test environment common to all tests.
 func testNativeEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
 	t.Helper()
-	envOpts := []cel.EnvOption{}
+	envOpts := []cel.EnvOption{
+		cel.Abbrevs("google.expr.proto3.test"),
+		cel.Types(&proto3pb.TestAllTypes{}),
+	}
 	envOpts = append(envOpts, opts...)
 	envOpts = append(envOpts,
 		NativeTypes(
-			reflect.ValueOf(&NestedType{}),
+			reflect.TypeOf(&TestNestedType{}),
 			reflect.ValueOf(&TestAllTypes{}),
 		),
 	)
@@ -82,19 +482,43 @@ func testNativeEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
 	return env
 }
 
-type NestedType struct {
+func mustParseTime(t *testing.T, timestamp string) time.Time {
+	t.Helper()
+	out, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		t.Fatalf("time.Parse(%q) failed: %v", timestamp, err)
+	}
+	return out
+}
+
+type TestNestedType struct {
 	NestedListVal []string
 	NestedMapVal  map[int64]bool
 }
 
 type TestAllTypes struct {
-	NestedVal *NestedType
-	BoolVal   bool
-	BytesVal  []byte
-	DoubleVal float64
-	IntVal    int32
-	StringVal string
-	UintVal   uint64
-	ListVal   []*NestedType
-	MapVal    map[string]*TestAllTypes
+	NestedVal       *TestNestedType
+	NestedStructVal TestNestedType
+	BoolVal         bool
+	BytesVal        []byte
+	DurationVal     time.Duration
+	DoubleVal       float64
+	FloatVal        float32
+	Int32Val        int32
+	Int64Val        int32
+	StringVal       string
+	TimestampVal    time.Time
+	Uint32Val       uint32
+	Uint64Val       uint64
+	ListVal         []*TestNestedType
+	MapVal          map[string]TestAllTypes
+	PbVal           *proto3pb.TestAllTypes
+
+	// channel types are not supported
+	UnsupportedVal     chan string
+	UnsupportedListVal []chan string
+	UnsupportedMapVal  map[int]chan string
+
+	// unexported types can be found but not set or accessed
+	privateVal map[string]string
 }

--- a/ext/native_test.go
+++ b/ext/native_test.go
@@ -1,0 +1,100 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ext
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+)
+
+func TestNativeTypes(t *testing.T) {
+	var nativeTests = []struct {
+		expr string
+		out  any
+	}{
+		{
+			expr: `ext.TestAllTypes{BoolVal: true}`,
+			out:  &TestAllTypes{BoolVal: true},
+		},
+	}
+	env := testNativeEnv(t)
+	for i, tst := range nativeTests {
+		tc := tst
+		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
+			var asts []*cel.Ast
+			pAst, iss := env.Parse(tc.expr)
+			if iss.Err() != nil {
+				t.Fatalf("env.Parse(%v) failed: %v", tc.expr, iss.Err())
+			}
+			asts = append(asts, pAst)
+			cAst, iss := env.Check(pAst)
+			if iss.Err() != nil {
+				t.Fatalf("env.Check(%v) failed: %v", tc.expr, iss.Err())
+			}
+			asts = append(asts, cAst)
+			for _, ast := range asts {
+				prg, err := env.Program(ast)
+				if err != nil {
+					t.Fatal(err)
+				}
+				out, _, err := prg.Eval(map[string]any{"msg": msgWithExtensions()})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(out.Value(), tc.out) {
+					t.Errorf("got %v, wanted %v for expr: %s", out.Value(), tc.out, tc.expr)
+				}
+			}
+		})
+	}
+}
+
+// testEnv initializes the test environment common to all tests.
+func testNativeEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
+	t.Helper()
+	envOpts := []cel.EnvOption{}
+	envOpts = append(envOpts, opts...)
+	envOpts = append(envOpts,
+		NativeTypes(
+			reflect.ValueOf(&NestedType{}),
+			reflect.ValueOf(&TestAllTypes{}),
+		),
+	)
+	env, err := cel.NewEnv(envOpts...)
+	if err != nil {
+		t.Fatalf("cel.NewEnv(NativeTypes()) failed: %v", err)
+	}
+	return env
+}
+
+type NestedType struct {
+	NestedListVal []string
+	NestedMapVal  map[int64]bool
+}
+
+type TestAllTypes struct {
+	NestedVal *NestedType
+	BoolVal   bool
+	BytesVal  []byte
+	DoubleVal float64
+	IntVal    int32
+	StringVal string
+	UintVal   uint64
+	ListVal   []*NestedType
+	MapVal    map[string]*TestAllTypes
+}

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -566,9 +566,9 @@ func (p *planner) planCreateStruct(expr *exprpb.Expr) (Interpretable, error) {
 // planCreateObj generates an object construction Interpretable.
 func (p *planner) planCreateObj(expr *exprpb.Expr) (Interpretable, error) {
 	obj := expr.GetStructExpr()
-	typeName, defined := p.resolveTypeName(obj.MessageName)
+	typeName, defined := p.resolveTypeName(obj.GetMessageName())
 	if !defined {
-		return nil, fmt.Errorf("unknown type: %s", typeName)
+		return nil, fmt.Errorf("unknown type: %s", obj.GetMessageName())
 	}
 	entries := obj.GetEntries()
 	optionals := make([]bool, len(entries))


### PR DESCRIPTION
Initial support for Golang struct types within CEL. 

Given a struct defined as follows, you could use the type definition within CEL as follows:

```go
package auth;

type Account struct {
  Name string
  ID int64
}

env, err := cel.NewEnv(
    ext.NativeTypes(reflect.TypeOf(&auth.Account{})),
)
// ... check for errors ... 
ast, iss := env.Compile(`auth.Account{Name: 'test', ID: 1234}`)
// ... check for errors ... 
prg, err := env.Program(ast)
// ... check for errors ... 
out, _, err := prg.Eval(cel.NoVars())
reflect.DeepEqual(out.Value(), &auth.Account{Name: 'test', ID: 1234}) == true
```

The `ext.NativeTypes()` option supports safe traversal over struct types, as well as support for `has()` and the new [CEL optional value](https://github.com/google/cel-spec/wiki/proposal-246) feature introduced with `cel.OptionalTypes()`.

As a future refinement a new `cel` tag may be introduced in order to make it possible to preserve the snake_case field names convention between Golang and protobuf if working with both type systems.

Closes #408 