### PR TITLE
Switch from optimizing single arg min/max 

### DIFF
--- a/ext/math_test.go
+++ b/ext/math_test.go
@@ -416,7 +416,7 @@ func TestMathWithExtension(t *testing.T) {
 
 func testMathEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
 	t.Helper()
-	baseOpts := []cel.EnvOption{Math()}
+	baseOpts := []cel.EnvOption{Math(), cel.EnableMacroCallTracking()}
 	env, err := cel.NewEnv(append(baseOpts, opts...)...)
 	if err != nil {
 		t.Fatalf("cel.NewEnv(Math()) failed: %v", err)


### PR DESCRIPTION
Shift to using single arg overloads which are slightly more robust do different kinds of inputs
to the math.least / math.greatest macros.