### PR TITLE
Support for protobuf JSON serialization of native object types

### DIFF
--- a/ext/native.go
+++ b/ext/native.go
@@ -31,10 +31,13 @@ import (
 	"github.com/google/cel-go/common/types/traits"
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 )
 
 var (
 	nativeObjTraitMask = traits.FieldTesterType | traits.IndexerType
+	jsonValueType      = reflect.TypeOf(&structpb.Value{})
+	jsonStructType     = reflect.TypeOf(&structpb.Struct{})
 )
 
 // NativeTypes creates a type provider which uses reflect.Type and reflect.Value instances
@@ -207,6 +210,9 @@ func (tp *nativeTypeProvider) NativeToValue(val any) ref.Val {
 	if val == nil {
 		return types.NullValue
 	}
+	if v, ok := val.(ref.Val); ok {
+		return v
+	}
 	rawVal := reflect.ValueOf(val)
 	refVal := rawVal
 	if refVal.Kind() == reflect.Ptr {
@@ -216,7 +222,7 @@ func (tp *nativeTypeProvider) NativeToValue(val any) ref.Val {
 	// but maybe an acceptable limitation.
 	switch refVal.Kind() {
 	case reflect.Array, reflect.Slice:
-		switch val.(type) {
+		switch val := val.(type) {
 		case []byte:
 			return tp.baseAdapter.NativeToValue(val)
 		default:
@@ -226,8 +232,6 @@ func (tp *nativeTypeProvider) NativeToValue(val any) ref.Val {
 		return types.NewDynamicMap(tp, val)
 	case reflect.Struct:
 		switch val := val.(type) {
-		case ref.Val:
-			return val
 		case proto.Message, *pb.Map, protoreflect.List, protoreflect.Message, protoreflect.Value,
 			time.Time:
 			return tp.baseAdapter.NativeToValue(val)
@@ -328,6 +332,32 @@ func (o *nativeObj) ConvertToNative(typeDesc reflect.Type) (any, error) {
 		ptr := reflect.New(typeDesc.Elem())
 		ptr.Elem().Set(o.refValue)
 		return ptr.Interface(), nil
+	}
+	switch typeDesc {
+	case jsonValueType:
+		jsonStruct, err := o.ConvertToNative(jsonStructType)
+		if err != nil {
+			return nil, err
+		}
+		return structpb.NewStructValue(jsonStruct.(*structpb.Struct)), nil
+	case jsonStructType:
+		refVal := reflect.Indirect(o.refValue)
+		refType := refVal.Type()
+		fields := make(map[string]*structpb.Value, refVal.NumField())
+		for i := 0; i < refVal.NumField(); i++ {
+			fieldType := refType.Field(i)
+			fieldValue := refVal.Field(i)
+			if !fieldValue.IsValid() || fieldValue.IsZero() {
+				continue
+			}
+			fieldCelVal := o.NativeToValue(fieldValue.Interface())
+			fieldJsonVal, err := fieldCelVal.ConvertToNative(jsonValueType)
+			if err != nil {
+				return nil, err
+			}
+			fields[fieldType.Name] = fieldJsonVal.(*structpb.Value)
+		}
+		return &structpb.Struct{Fields: fields}, nil
 	}
 	return nil, fmt.Errorf("type conversion error from '%v' to '%v'", o.Type(), typeDesc)
 }

--- a/ext/native_test.go
+++ b/ext/native_test.go
@@ -224,16 +224,21 @@ func TestNativeTypesJsonSerialization(t *testing.T) {
 		},
 		{
 			expr: `TestAllTypes{
-				NestedVal: TestNestedType{
-					NestedListVal: ["first", "second"],
-				},
 				BoolVal: true,
 				DurationVal: duration('5s'),
 				DoubleVal: 1.5,
 				FloatVal: 2.0,
 				Int32Val: 23,
 				Int64Val: 64,
-				StringVal: "string",
+				MapVal: {
+					'map-key': ext.TestAllTypes{
+						BoolVal: true
+					}
+				},
+				NestedVal: TestNestedType{
+					NestedListVal: ["first", "second"],
+				},
+				StringVal: "string"
 			}`,
 			out: `{
 				"BoolVal":  true,
@@ -242,6 +247,11 @@ func TestNativeTypesJsonSerialization(t *testing.T) {
 				"FloatVal":  2,
 				"Int32Val":  23,
 				"Int64Val":  64,
+				"MapVal": {
+	              "map-key": {
+    	            "BoolVal": true
+        	      }
+            	},
 				"NestedVal": {
 					"NestedListVal": [
 					  "first",


### PR DESCRIPTION
Support conversion of native object types to `google.protobuf.Value` instances.

Closes #614 