### PR TITLE
Ensure that macro call tracking is updated during AST pruning

### DIFF
--- a/cel/env.go
+++ b/cel/env.go
@@ -439,8 +439,8 @@ func (e *Env) UnknownVars() interpreter.PartialActivation {
 // TODO: Consider adding an option to generate a Program.Residual to avoid round-tripping to an
 // Ast format and then Program again.
 func (e *Env) ResidualAst(a *Ast, details *EvalDetails) (*Ast, error) {
-	pruned := interpreter.PruneAst(a.Expr(), details.State())
-	expr, err := AstToString(ParsedExprToAst(&exprpb.ParsedExpr{Expr: pruned}))
+	pruned := interpreter.PruneAst(a.Expr(), a.SourceInfo().GetMacroCalls(), details.State())
+	expr, err := AstToString(ParsedExprToAst(pruned))
 	if err != nil {
 		return nil, err
 	}

--- a/interpreter/prune_test.go
+++ b/interpreter/prune_test.go
@@ -145,8 +145,8 @@ func TestPrune(t *testing.T) {
 			ast.Expr,
 			ExhaustiveEval(), Observe(EvalStateObserver(state)))
 		interpretable.Eval(testActivation(t, tst.in))
-		newExpr := PruneAst(ast.Expr, state)
-		actual, err := parser.Unparse(newExpr, nil)
+		newExpr := PruneAst(ast.Expr, ast.SourceInfo.GetMacroCalls(), state)
+		actual, err := parser.Unparse(newExpr.GetExpr(), newExpr.GetSourceInfo())
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
Ensure that macro call tracking is updated during AST pruning as otherwise the pruned expression cannot be successfully rendered back into a human-readable string.