### PR TITLE
BUGFIX: accidentally altering 'decorators' slice

### DIFF
--- a/cel/program.go
+++ b/cel/program.go
@@ -213,7 +213,10 @@ func newProgram(e *Env, ast *Ast, opts []ProgramOption) (Program, error) {
 		factory := func(state interpreter.EvalState, costTracker *interpreter.CostTracker) (Program, error) {
 			costTracker.Estimator = p.callCostEstimator
 			costTracker.Limit = p.costLimit
-			decs := decorators
+			// Limit capacity to guarantee a reallocation when calling 'append(decs, ...)' below. This
+			// prevents the underlying memory from being shared between factory function calls causing
+			// undesired mutations.
+			decs := decorators[:len(decorators):len(decorators)]
 			var observers []interpreter.EvalObserver
 
 			if p.evalOpts&(OptExhaustiveEval|OptTrackState) != 0 {


### PR DESCRIPTION
I spent my afternoon trying to find the root cause for https://github.com/kubernetes/kubernetes/issues/114661. And this led me to this bug.

The factory function incorrectly calls `append(decorators, ...)` which alters the original decorators slice.
This can result in the `costTracker` being shared across instances in a concurrent scenario, further causing bugs.

The bug  (https://github.com/kubernetes/kubernetes/issues/114661) originated from calling the `tracker.stack.dropArgs(...)` function from multiple goroutines at the same time (which shouldn't be possible normally), breaking multithreading safety.
