### PR TITLE
Thread-safety fix for unprotected mutation of decorator set.

### DIFF
--- a/cel/program.go
+++ b/cel/program.go
@@ -201,7 +201,10 @@ func newProgram(e *Env, ast *Ast, opts []ProgramOption) (Program, error) {
 		factory := func(state interpreter.EvalState, costTracker *interpreter.CostTracker) (Program, error) {
 			costTracker.Estimator = p.callCostEstimator
 			costTracker.Limit = p.costLimit
-			decs := decorators
+			// Limit capacity to guarantee a reallocation when calling 'append(decs, ...)' below. This
+			// prevents the underlying memory from being shared between factory function calls causing
+			// undesired mutations.
+			decs := decorators[:len(decorators):len(decorators)]
 			var observers []interpreter.EvalObserver
 
 			if p.evalOpts&(OptExhaustiveEval|OptTrackState) != 0 {


### PR DESCRIPTION
Signed-off-by: Tim Ramlot <42113979+inteon@users.noreply.github.com>

Cherry-pick of thread-safety fix into release-v0.11 branch