### PR TITLE
Potential index out of bounds fix

### DIFF
--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -519,7 +519,7 @@ func (p *planner) planCreateList(expr *exprpb.Expr) (Interpretable, error) {
 	elements := list.GetElements()
 	optionals := make([]bool, len(elements))
 	for _, index := range optionalIndices {
-		if index > int32(len(elements)) {
+		if index >= int32(len(elements)) {
 			return nil, fmt.Errorf("optional index %d exceeds element count %d", index, len(elements))
 		}
 		optionals[index] = true

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -519,6 +519,9 @@ func (p *planner) planCreateList(expr *exprpb.Expr) (Interpretable, error) {
 	elements := list.GetElements()
 	optionals := make([]bool, len(elements))
 	for _, index := range optionalIndices {
+		if index > int32(len(elements)) {
+			return nil, fmt.Errorf("optional index %d exceeds element count %d", index, len(elements))
+		}
 		optionals[index] = true
 	}
 	elems := make([]Interpretable, len(elements))


### PR DESCRIPTION
For manually constructed `Expr` values, it's possible to provide invalid indices in the optional indices list which can potentially trigger an index out of bounds error.