### PR TITLE
Allow creation of custom types.Err structs

### DIFF
--- a/common/types/double.go
+++ b/common/types/double.go
@@ -134,13 +134,13 @@ func (d Double) ConvertToType(typeVal ref.Type) ref.Val {
 	case IntType:
 		i, err := doubleToInt64Checked(float64(d))
 		if err != nil {
-			return wrapErr(err)
+			return WrapErr(err)
 		}
 		return Int(i)
 	case UintType:
 		i, err := doubleToUint64Checked(float64(d))
 		if err != nil {
-			return wrapErr(err)
+			return WrapErr(err)
 		}
 		return Uint(i)
 	case DoubleType:

--- a/common/types/duration.go
+++ b/common/types/duration.go
@@ -57,14 +57,14 @@ func (d Duration) Add(other ref.Val) ref.Val {
 		dur2 := other.(Duration)
 		val, err := addDurationChecked(d.Duration, dur2.Duration)
 		if err != nil {
-			return wrapErr(err)
+			return WrapErr(err)
 		}
 		return durationOf(val)
 	case TimestampType:
 		ts := other.(Timestamp).Time
 		val, err := addTimeDurationChecked(ts, d.Duration)
 		if err != nil {
-			return wrapErr(err)
+			return WrapErr(err)
 		}
 		return timestampOf(val)
 	}
@@ -147,7 +147,7 @@ func (d Duration) IsZeroValue() bool {
 func (d Duration) Negate() ref.Val {
 	val, err := negateDurationChecked(d.Duration)
 	if err != nil {
-		return wrapErr(err)
+		return WrapErr(err)
 	}
 	return durationOf(val)
 }
@@ -170,7 +170,7 @@ func (d Duration) Subtract(subtrahend ref.Val) ref.Val {
 	}
 	val, err := subtractDurationChecked(d.Duration, subtraDur.Duration)
 	if err != nil {
-		return wrapErr(err)
+		return WrapErr(err)
 	}
 	return durationOf(val)
 }

--- a/common/types/err.go
+++ b/common/types/err.go
@@ -22,6 +22,11 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 )
 
+type Error interface {
+	error
+	ref.Val
+}
+
 // Err type which extends the built-in go error and implements ref.Val.
 type Err struct {
 	error
@@ -81,8 +86,8 @@ func ValOrErr(val ref.Val, format string, args ...any) ref.Val {
 	return val
 }
 
-// wrapErr wraps an existing Go error value into a CEL Err value.
-func wrapErr(err error) ref.Val {
+// WrapErr wraps an existing Go error value into a CEL Err value.
+func WrapErr(err error) ref.Val {
 	return &Err{error: err}
 }
 

--- a/common/types/int.go
+++ b/common/types/int.go
@@ -66,7 +66,7 @@ func (i Int) Add(other ref.Val) ref.Val {
 	}
 	val, err := addInt64Checked(int64(i), int64(otherInt))
 	if err != nil {
-		return wrapErr(err)
+		return WrapErr(err)
 	}
 	return Int(val)
 }
@@ -176,7 +176,7 @@ func (i Int) ConvertToType(typeVal ref.Type) ref.Val {
 	case UintType:
 		u, err := int64ToUint64Checked(int64(i))
 		if err != nil {
-			return wrapErr(err)
+			return WrapErr(err)
 		}
 		return Uint(u)
 	case DoubleType:
@@ -204,7 +204,7 @@ func (i Int) Divide(other ref.Val) ref.Val {
 	}
 	val, err := divideInt64Checked(int64(i), int64(otherInt))
 	if err != nil {
-		return wrapErr(err)
+		return WrapErr(err)
 	}
 	return Int(val)
 }
@@ -239,7 +239,7 @@ func (i Int) Modulo(other ref.Val) ref.Val {
 	}
 	val, err := moduloInt64Checked(int64(i), int64(otherInt))
 	if err != nil {
-		return wrapErr(err)
+		return WrapErr(err)
 	}
 	return Int(val)
 }
@@ -252,7 +252,7 @@ func (i Int) Multiply(other ref.Val) ref.Val {
 	}
 	val, err := multiplyInt64Checked(int64(i), int64(otherInt))
 	if err != nil {
-		return wrapErr(err)
+		return WrapErr(err)
 	}
 	return Int(val)
 }
@@ -261,7 +261,7 @@ func (i Int) Multiply(other ref.Val) ref.Val {
 func (i Int) Negate() ref.Val {
 	val, err := negateInt64Checked(int64(i))
 	if err != nil {
-		return wrapErr(err)
+		return WrapErr(err)
 	}
 	return Int(val)
 }
@@ -274,7 +274,7 @@ func (i Int) Subtract(subtrahend ref.Val) ref.Val {
 	}
 	val, err := subtractInt64Checked(int64(i), int64(subtraInt))
 	if err != nil {
-		return wrapErr(err)
+		return WrapErr(err)
 	}
 	return Int(val)
 }

--- a/common/types/timestamp.go
+++ b/common/types/timestamp.go
@@ -165,14 +165,14 @@ func (t Timestamp) Subtract(subtrahend ref.Val) ref.Val {
 		dur := subtrahend.(Duration)
 		val, err := subtractTimeDurationChecked(t.Time, dur.Duration)
 		if err != nil {
-			return wrapErr(err)
+			return WrapErr(err)
 		}
 		return timestampOf(val)
 	case TimestampType:
 		t2 := subtrahend.(Timestamp).Time
 		val, err := subtractTimeChecked(t.Time, t2)
 		if err != nil {
-			return wrapErr(err)
+			return WrapErr(err)
 		}
 		return durationOf(val)
 	}
@@ -293,7 +293,7 @@ func timeZone(tz ref.Val, visitor timestampVisitor) timestampVisitor {
 		if ind == -1 {
 			loc, err := time.LoadLocation(val)
 			if err != nil {
-				return wrapErr(err)
+				return WrapErr(err)
 			}
 			return visitor(t.In(loc))
 		}
@@ -302,11 +302,11 @@ func timeZone(tz ref.Val, visitor timestampVisitor) timestampVisitor {
 		// in the format ^(+|-)(0[0-9]|1[0-4]):[0-5][0-9]$. The numerical input is parsed in terms of hours and minutes.
 		hr, err := strconv.Atoi(string(val[0:ind]))
 		if err != nil {
-			return wrapErr(err)
+			return WrapErr(err)
 		}
 		min, err := strconv.Atoi(string(val[ind+1:]))
 		if err != nil {
-			return wrapErr(err)
+			return WrapErr(err)
 		}
 		var offset int
 		if string(val[0]) == "-" {

--- a/common/types/uint.go
+++ b/common/types/uint.go
@@ -59,7 +59,7 @@ func (i Uint) Add(other ref.Val) ref.Val {
 	}
 	val, err := addUint64Checked(uint64(i), uint64(otherUint))
 	if err != nil {
-		return wrapErr(err)
+		return WrapErr(err)
 	}
 	return Uint(val)
 }
@@ -149,7 +149,7 @@ func (i Uint) ConvertToType(typeVal ref.Type) ref.Val {
 	case IntType:
 		v, err := uint64ToInt64Checked(uint64(i))
 		if err != nil {
-			return wrapErr(err)
+			return WrapErr(err)
 		}
 		return Int(v)
 	case UintType:
@@ -172,7 +172,7 @@ func (i Uint) Divide(other ref.Val) ref.Val {
 	}
 	div, err := divideUint64Checked(uint64(i), uint64(otherUint))
 	if err != nil {
-		return wrapErr(err)
+		return WrapErr(err)
 	}
 	return Uint(div)
 }
@@ -207,7 +207,7 @@ func (i Uint) Modulo(other ref.Val) ref.Val {
 	}
 	mod, err := moduloUint64Checked(uint64(i), uint64(otherUint))
 	if err != nil {
-		return wrapErr(err)
+		return WrapErr(err)
 	}
 	return Uint(mod)
 }
@@ -220,7 +220,7 @@ func (i Uint) Multiply(other ref.Val) ref.Val {
 	}
 	val, err := multiplyUint64Checked(uint64(i), uint64(otherUint))
 	if err != nil {
-		return wrapErr(err)
+		return WrapErr(err)
 	}
 	return Uint(val)
 }
@@ -233,7 +233,7 @@ func (i Uint) Subtract(subtrahend ref.Val) ref.Val {
 	}
 	val, err := subtractUint64Checked(uint64(i), uint64(subtraUint))
 	if err != nil {
-		return wrapErr(err)
+		return WrapErr(err)
 	}
 	return Uint(val)
 }


### PR DESCRIPTION
This change expose the `types.wrapErr(err error) ref.Val` function.

Resolves #629 