### PR TITLE
Fix long build times by upgrading gazelle.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,10 +13,10 @@ http_archive(
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
+    sha256 = "ecba0f04f96b4960a5b250c8e8eeec42281035970aa8852dda73098274d14a1d",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.29.0/bazel-gazelle-v0.29.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.29.0/bazel-gazelle-v0.29.0.tar.gz",
     ],
 )
 


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel-gazelle/pull/1201

results:

```
 % time bazel build ...
 INFO: Analyzed 49 targets (0 packages loaded, 0 targets configured).
 INFO: Found 49 targets...
 INFO: Elapsed time: 20.776s, Critical Path: 20.33s
 INFO: 138 processes: 3 internal, 135 linux-sandbox.
 INFO: Build completed successfully, 138 total actions
 bazel build ...  0.01s user 0.01s system 0% cpu 20.797 total
```