### PR TITLE
Add version option to Strings extension library

### DIFF
--- a/ext/strings.go
+++ b/ext/strings.go
@@ -268,7 +268,7 @@ type stringLib struct {
 }
 
 // LibraryName implements the SingletonLibrary interface method.
-func (stringLib) LibraryName() string {
+func (*stringLib) LibraryName() string {
 	return "cel.lib.ext.strings"
 }
 
@@ -300,7 +300,7 @@ func Version(version uint32) func(lib *stringLib) *stringLib {
 }
 
 // CompileOptions implements the Library interface method.
-func (sl stringLib) CompileOptions() []cel.EnvOption {
+func (sl *stringLib) CompileOptions() []cel.EnvOption {
 	formatLocale := "en_US"
 	if sl.locale != "" {
 		// ensure locale is properly-formed if set
@@ -447,7 +447,7 @@ func (sl stringLib) CompileOptions() []cel.EnvOption {
 }
 
 // ProgramOptions implements the Library interface method.
-func (stringLib) ProgramOptions() []cel.ProgramOption {
+func (*stringLib) ProgramOptions() []cel.ProgramOption {
 	return []cel.ProgramOption{}
 }
 

--- a/ext/strings.go
+++ b/ext/strings.go
@@ -285,14 +285,14 @@ func StringsLocale(locale string) StringsOption {
 	}
 }
 
-// Version configures the version of the string library. The version limits which
+// StringsVersion configures the version of the string library. The version limits which
 // functions are available. Only functions introduced below or equal to the given
 // version included in the library. See the library documentation to determine
 // which version a function was introduced at. If the documentation does not
 // state which version a function was introduced at, it can be assumed to be
 // introduced at version 0, when the library was first created.
 // If this option is not set, all functions are available.
-func Version(version uint32) func(lib *stringLib) *stringLib {
+func StringsVersion(version uint32) func(lib *stringLib) *stringLib {
 	return func(sl *stringLib) *stringLib {
 		sl.version = version
 		return sl

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -31,6 +31,7 @@ import (
 // TODO: move these tests to a conformance test.
 var stringTests = []struct {
 	expr      string
+	version   *uint32
 	err       string
 	parseOnly bool
 }{
@@ -323,6 +324,71 @@ func TestStrings(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVersions(t *testing.T) {
+	versionCases := []struct {
+		version            uint32
+		supportedFunctions map[string]string
+	}{
+		{
+			version: 0,
+			supportedFunctions: map[string]string{
+				"chatAt":      "''.charAt(0)",
+				"indexOf":     "'a'.indexOf('a')",
+				"lastIndexOf": "'a'.lastIndexOf('a')",
+				"join":        "['a', 'b'].join()",
+				"lowerAscii":  "'a'.lowerAscii()",
+				"replace":     "'hello hello'.replace('he', 'we')",
+				"split":       "'hello hello hello'.split(' ')",
+				"substring":   "'tacocat'.substring(4)",
+				"trim":        "'  \\ttrim\\n    '.trim()",
+				"upperAscii":  "'TacoCat'.upperAscii()",
+			},
+		},
+		{
+			version: 1,
+			supportedFunctions: map[string]string{
+				"format": "'a %d'.format([1])",
+			},
+		},
+	}
+	for _, lib := range versionCases {
+		env, err := cel.NewEnv(Strings(Version(lib.version)))
+		if err != nil {
+			t.Fatalf("cel.NewEnv(Strings(Version(%d))) failed: %v", lib.version, err)
+		}
+		t.Run(fmt.Sprintf("version=%d", lib.version), func(t *testing.T) {
+			for _, tc := range versionCases {
+				for name, expr := range tc.supportedFunctions {
+					supported := lib.version >= tc.version
+					t.Run(fmt.Sprintf("%s-supported=%t", name, supported), func(t *testing.T) {
+						var asts []*cel.Ast
+						pAst, iss := env.Parse(expr)
+						if iss.Err() != nil {
+							t.Fatalf("env.Parse(%v) failed: %v", expr, iss.Err())
+						}
+						asts = append(asts, pAst)
+						_, iss = env.Check(pAst)
+
+						if supported {
+							if iss.Err() != nil {
+								t.Errorf("unexpected error: %v", iss.Err())
+							}
+						} else {
+							if iss.Err() == nil || !strings.Contains(iss.Err().Error(), "undeclared reference") {
+								t.Errorf("got error %v, wanted error %s for expr: %s, version: %d", iss.Err(), "undeclared reference", expr, tc.version)
+							}
+						}
+					})
+				}
+			}
+		})
+	}
+}
+
+func version(v uint32) *uint32 {
+	return &v
 }
 
 func TestStringsWithExtension(t *testing.T) {

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -31,7 +31,6 @@ import (
 // TODO: move these tests to a conformance test.
 var stringTests = []struct {
 	expr      string
-	version   *uint32
 	err       string
 	parseOnly bool
 }{

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -353,9 +353,9 @@ func TestVersions(t *testing.T) {
 		},
 	}
 	for _, lib := range versionCases {
-		env, err := cel.NewEnv(Strings(Version(lib.version)))
+		env, err := cel.NewEnv(Strings(StringsVersion(lib.version)))
 		if err != nil {
-			t.Fatalf("cel.NewEnv(Strings(Version(%d))) failed: %v", lib.version, err)
+			t.Fatalf("cel.NewEnv(Strings(StringsVersion(%d))) failed: %v", lib.version, err)
 		}
 		t.Run(fmt.Sprintf("version=%d", lib.version), func(t *testing.T) {
 			for _, tc := range versionCases {


### PR DESCRIPTION
Adds a `StringsVersion()` option for the string extension library, a convention for declaring which version new functions are introduced at, and a way for exhaustively testing the versions of a library for function support.