### PR TITLE
Fix panic in optimized set membership test for byte values

### DIFF
--- a/interpreter/decorators.go
+++ b/interpreter/decorators.go
@@ -224,8 +224,8 @@ func maybeOptimizeSetMembership(i Interpretable, inlist InterpretableCall) (Inte
 	valueSet := make(map[ref.Val]ref.Val)
 	for it.HasNext() == types.True {
 		elem := it.Next()
-		if !types.IsPrimitiveType(elem) {
-			// Note, non-primitive type are not yet supported.
+		if !types.IsPrimitiveType(elem) || elem.Type() == types.BytesType {
+			// Note, non-primitive type are not yet supported, and []byte isn't hashable.
 			return i, nil
 		}
 		valueSet[elem] = types.True

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -378,6 +378,10 @@ var (
 			optimizedCost: []int64{0, 0},
 		},
 		{
+			name: "bytes_in_constant_list",
+			expr: "b'hello' in [b'world', b'universe', b'hello']",
+		},
+		{
 			name: "list_in_constant_list",
 			expr: `[6] in [2, 12, [6]]`,
 		},


### PR DESCRIPTION
When `cel.OptOptimize()` is enabled, it attempts to convert expressions like the following `a in [1, 2, 3]` into set membership lookups against a map whose keys are the values in the list. Unfortunately, the optimization step did not account for byte values and this resulted in a panic on expressions like `a in [b'hello', b'world']`.

This change turns off optimizations for set membership tests for byte values.