### PR TITLE
Enable extensions for REPL

### DIFF
--- a/repl/BUILD.bazel
+++ b/repl/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cel:go_default_library",
+        "//test/proto2pb:go_default_library",
         "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
     ],

--- a/repl/evaluator.go
+++ b/repl/evaluator.go
@@ -720,23 +720,20 @@ func (e *Evaluator) setOption(args []string) error {
 	for idx := 0; idx < len(args); {
 		arg := args[idx]
 		idx++
-		if arg == "--container" {
-			if idx >= len(args) {
-				issues = append(issues, "not enough args for container")
-			}
-			container := args[idx]
+		switch arg {
+		case "--container":
+			err := e.loadContainerOption(idx, args)
 			idx++
-			err := e.AddOption(&containerOption{container: container})
 			if err != nil {
 				issues = append(issues, fmt.Sprintf("container: %v", err))
 			}
-		} else if arg == "--extension" {
+		case "--extension":
 			err := e.loadExtensionOption(idx, args)
 			idx++
 			if err != nil {
 				issues = append(issues, fmt.Sprintf("extension: %v", err))
 			}
-		} else {
+		default:
 			issues = append(issues, fmt.Sprintf("unsupported option '%s'", arg))
 		}
 	}
@@ -746,9 +743,32 @@ func (e *Evaluator) setOption(args []string) error {
 	return nil
 }
 
-func (e *Evaluator) loadExtensionOption(idx int, args []string) error {
+func checkOptionArgs(idx int, args []string) error {
 	if idx >= len(args) {
-		return fmt.Errorf("not enough args for extension")
+		return fmt.Errorf("not enough arguments")
+	}
+	return nil
+}
+
+func (e *Evaluator) loadContainerOption(idx int, args []string) error {
+	err := checkOptionArgs(idx, args)
+	if err != nil {
+		return err
+	}
+
+	container := args[idx]
+	idx++
+	err = e.AddOption(&containerOption{container: container})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *Evaluator) loadExtensionOption(idx int, args []string) error {
+	err := checkOptionArgs(idx, args)
+	if err != nil {
+		return err
 	}
 
 	argExtType := args[idx]

--- a/repl/evaluator.go
+++ b/repl/evaluator.go
@@ -707,7 +707,7 @@ func newExtensionOption(extType string) (*extensionOption, error) {
 	case "encoders":
 		extOption = ext.Encoders()
 	default:
-		return nil, fmt.Errorf("Unknown option: %s. Available options are: ['strings', 'protos', 'math', 'encoders']", op)
+		return nil, fmt.Errorf("Unknown option: %s. Available options are: ['strings', 'protos', 'math', 'encoders', 'all']", op)
 	}
 
 	return &extensionOption{extensionType: extType, option: extOption}, nil
@@ -751,7 +751,22 @@ func (e *Evaluator) loadExtensionOption(idx int, args []string) error {
 		return fmt.Errorf("not enough args for extension")
 	}
 
-	extType := args[idx]
+	argExtType := args[idx]
+	if argExtType == "all" {
+		// Load all extension types as a convenience
+		var extensionTypes = []string{"strings", "protos", "math", "encoders"}
+		for _, val := range extensionTypes {
+			err := e.loadExtensionOptionType(val)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return e.loadExtensionOptionType(argExtType)
+}
+
+func (e *Evaluator) loadExtensionOptionType(extType string) error {
 	extensionOption, err := newExtensionOption(extType)
 	if err != nil {
 		return err
@@ -763,6 +778,7 @@ func (e *Evaluator) loadExtensionOption(idx int, args []string) error {
 	}
 
 	return nil
+
 }
 
 func loadFileDescriptorSet(path string, textfmt bool) (*descpb.FileDescriptorSet, error) {

--- a/repl/evaluator_test.go
+++ b/repl/evaluator_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/cel-go/cel"
 
+	proto2pb "github.com/google/cel-go/test/proto2pb"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
@@ -572,6 +573,78 @@ func TestProcess(t *testing.T) {
 			wantError: false,
 		},
 		{
+			name: "OptionExtensionStrings",
+			commands: []Cmder{
+				&simpleCmd{
+					cmd: "option",
+					args: []string{
+						"--extension",
+						"strings",
+					},
+				},
+				&evalCmd{
+					expr: "'test'.substring(2)",
+				},
+			},
+			wantText:  "st : string",
+			wantExit:  false,
+			wantError: false,
+		},
+		{
+			name: "OptionExtensionProtos",
+			commands: []Cmder{
+				&simpleCmd{
+					cmd: "option",
+					args: []string{
+						"--extension",
+						"protos",
+					},
+				},
+				&evalCmd{
+					expr: "proto.getExt(google.expr.proto2.test.ExampleType{}, google.expr.proto2.test.int32_ext) == 0",
+				},
+			},
+			wantText:  "true : bool",
+			wantExit:  false,
+			wantError: false,
+		},
+		{
+			name: "OptionExtensionMath",
+			commands: []Cmder{
+				&simpleCmd{
+					cmd: "option",
+					args: []string{
+						"--extension",
+						"math",
+					},
+				},
+				&evalCmd{
+					expr: "math.greatest(1,2)",
+				},
+			},
+			wantText:  "2 : int",
+			wantExit:  false,
+			wantError: false,
+		},
+		{
+			name: "OptionExtensionEncoders",
+			commands: []Cmder{
+				&simpleCmd{
+					cmd: "option",
+					args: []string{
+						"--extension",
+						"encoders",
+					},
+				},
+				&evalCmd{
+					expr: "base64.encode(b'hello')",
+				},
+			},
+			wantText:  "aGVsbG8= : string",
+			wantExit:  false,
+			wantError: false,
+		},
+		{
 			name: "LoadDescriptorsError",
 			commands: []Cmder{
 				&simpleCmd{
@@ -695,6 +768,7 @@ func TestProcess(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewEvaluator returned error: %v, wanted nil", err)
 			}
+			eval.env, _ = eval.env.Extend(cel.Types(&proto2pb.ExampleType{}, &proto2pb.ExternalMessageType{}))
 			n := len(tc.commands)
 			for _, cmd := range tc.commands[:n-1] {
 				// only need output of last command

--- a/repl/evaluator_test.go
+++ b/repl/evaluator_test.go
@@ -810,3 +810,63 @@ func TestProcess(t *testing.T) {
 		})
 	}
 }
+
+func TestProcessOptionError(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		command  Cmder
+		errorMsg string
+	}{
+		{
+			name: "OptionContainerNotEnoughArgs",
+			command: &simpleCmd{
+				cmd: "option",
+				args: []string{
+					"--container",
+				},
+			},
+			errorMsg: "container: not enough arguments",
+		},
+		{
+			name: "OptionExtensionNotEnoughArgs",
+			command: &simpleCmd{
+				cmd: "option",
+				args: []string{
+					"--extension",
+				},
+			},
+			errorMsg: "extension: not enough arguments",
+		},
+		{
+			name: "OptionExtensionInvalid",
+			command: &simpleCmd{
+				cmd: "option",
+				args: []string{
+					"--extension",
+					"'bogus'",
+				},
+			},
+			errorMsg: "extension: Unknown option: 'bogus'. Available options are: ['strings', 'protos', 'math', 'encoders', 'all']",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			eval, err := NewEvaluator()
+			if err != nil {
+				t.Fatalf("NewEvaluator returned error: %v, wanted nil", err)
+			}
+			_, _, err = eval.Process(tc.command)
+
+			if err == nil {
+				t.Fatalf("Expected an error processing command: %s", tc.command)
+			}
+
+			if err.Error() != tc.errorMsg {
+				t.Errorf("For command %s got (error: '%s') wanted (error: '%s')",
+					tc.command, err.Error(), tc.errorMsg)
+			}
+		})
+	}
+}

--- a/repl/evaluator_test.go
+++ b/repl/evaluator_test.go
@@ -645,6 +645,28 @@ func TestProcess(t *testing.T) {
 			wantError: false,
 		},
 		{
+			name: "OptionExtensionAll",
+			commands: []Cmder{
+				&simpleCmd{
+					cmd: "option",
+					args: []string{
+						"--extension",
+						"all",
+					},
+				},
+				&evalCmd{
+					expr: "'test'.substring(2) == 'st' && " +
+						"proto.getExt(google.expr.proto2.test.ExampleType{}, google.expr.proto2.test.int32_ext) == 0 && " +
+						"math.greatest(1,2) == 2 && " +
+						"base64.encode(b'hello') == 'aGVsbG8='",
+				},
+			},
+			wantText:  "true : bool",
+			wantExit:  false,
+			wantError: false,
+		},
+
+		{
 			name: "LoadDescriptorsError",
 			commands: []Cmder{
 				&simpleCmd{

--- a/repl/main/README.md
+++ b/repl/main/README.md
@@ -118,13 +118,15 @@ may take string arguments.
 
 `--container <string>` sets the expression container for name resolution.
 
-`--extension <extensionType>` enables CEL extensions. Valid options are: `strings`, `protos`, `math`, `encoders`.
+`--extension <extensionType>` enables CEL extensions. Valid options are: `strings`, `protos`, `math`, `encoders`, `all`.
 
 example:
 
 `%option --container 'google.protobuf'` 
 
 `%option --extension 'strings'`
+
+`%option --extension 'all'` (Loads all 4 extensions)
 
 #### reset
 

--- a/repl/main/README.md
+++ b/repl/main/README.md
@@ -118,9 +118,13 @@ may take string arguments.
 
 `--container <string>` sets the expression container for name resolution.
 
+`--extension <extensionType>` enables CEL extensions. Valid options are: `strings`, `protos`, `math`, `encoders`.
+
 example:
 
 `%option --container 'google.protobuf'` 
+
+`%option --extension 'strings'`
 
 #### reset
 

--- a/test/proto2pb/BUILD.bazel
+++ b/test/proto2pb/BUILD.bazel
@@ -9,6 +9,7 @@ package(
         "//ext:__subpackages__",
         "//interpreter:__subpackages__",
         "//parser:__subpackages__",
+        "//repl:__subpackages__",
         "//server:__subpackages__",
         "//test:__subpackages__",
     ],
@@ -24,13 +25,13 @@ go_library(
     importpath = "github.com/google/cel-go/test/proto2pb",
     deps = [
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
         "@org_golang_google_protobuf//types/known/anypb:go_default_library",
         "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
         "@org_golang_google_protobuf//types/known/structpb:go_default_library",
         "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
         "@org_golang_google_protobuf//types/known/wrapperspb:go_default_library",
-        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
     ],
 )
 


### PR DESCRIPTION
This allows the usage of [all extensions in REPL](https://github.com/google/cel-go/blob/master/ext/README.md).

Example:

```
cel-repl> %option --extension 'strings'
cel-repl> 'hello world'.substring(6)
world : string
```

Available extension options:

```
%option --extension 'strings'
%option --extension 'math'
%option --extension 'protos'
%option --extension 'encoders'
%option --extension 'all' (adds all 4 above)
```