### PR TITLE
Update ext/README.md with missing string 'join' documentation

### DIFF
--- a/ext/README.md
+++ b/ext/README.md
@@ -166,6 +166,23 @@ Examples:
     'hello mellow'.indexOf('ello', 2)  // returns 7
     'hello mellow'.indexOf('ello', 20) // error
 
+### Join
+
+Returns a new string where the elements of string list are concatenated.
+
+The function also accepts an optional separator which is placed between
+elements in the resulting string.
+
+    <list<string>>.join() -> <string>
+    <list<string>>.join(<string>) -> <string>
+
+Examples:
+
+	['hello', 'mellow'].join() // returns 'hellomellow'
+	['hello', 'mellow'].join(' ') // returns 'hello mellow'
+	[].join() // returns ''
+	[].join('/') // returns ''
+
 ### LastIndexOf
 
 Returns the integer index of the last occurrence of the search string. If the


### PR DESCRIPTION
The string extension `join` has been implemented for quite some time, but its documentation was not present in the README.md