### PR TITLE
Ensure that optional indices are within the range of elements 

### DIFF
--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -519,8 +519,8 @@ func (p *planner) planCreateList(expr *exprpb.Expr) (Interpretable, error) {
 	elements := list.GetElements()
 	optionals := make([]bool, len(elements))
 	for _, index := range optionalIndices {
-		if index >= int32(len(elements)) {
-			return nil, fmt.Errorf("optional index %d exceeds element count %d", index, len(elements))
+		if index < 0 || index >= int32(len(elements)) {
+			return nil, fmt.Errorf("optional index %d out of element bounds [0, %d]", index, len(elements))
 		}
 		optionals[index] = true
 	}


### PR DESCRIPTION
Ensure that a CEL AST cannot include optional indices which do not correspond to list elements within list literal expressions.