### PR TITLE
Fix some misspelled words

### DIFF
--- a/cel/decls.go
+++ b/cel/decls.go
@@ -413,7 +413,7 @@ func Function(name string, opts ...FunctionOpt) EnvOption {
 // FunctionOpt defines a functional  option for configuring a function declaration.
 type FunctionOpt func(*functionDecl) (*functionDecl, error)
 
-// SingletonUnaryBinding creates a singleton function defintion to be used for all function overloads.
+// SingletonUnaryBinding creates a singleton function definition to be used for all function overloads.
 //
 // Note, this approach works well if operand is expected to have a specific trait which it implements,
 // e.g. traits.ContainerType. Otherwise, prefer per-overload function bindings.

--- a/cel/env.go
+++ b/cel/env.go
@@ -256,7 +256,7 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 	decsCopy := []*exprpb.Decl{}
 	if e.chk != nil {
 		// If the type-checker has already been instantiated, then the e.declarations have been
-		// valdiated within the chk instance.
+		// validated within the chk instance.
 		chkOptsCopy = append(chkOptsCopy, checker.ValidatedDeclarations(e.chk))
 	} else {
 		// If the type-checker has not been instantiated, ensure the unvalidated declarations are

--- a/cel/library.go
+++ b/cel/library.go
@@ -183,7 +183,7 @@ func (optionalLibrary) CompileOptions() []EnvOption {
 			Overload("map_optindex_optional_value", []*Type{mapTypeKV, paramTypeK}, optionalTypeV),
 			Overload("optional_map_optindex_optional_value", []*Type{OptionalType(mapTypeKV), paramTypeK}, optionalTypeV)),
 
-		// Index overloads to accomodate using an optional value as the operand.
+		// Index overloads to accommodate using an optional value as the operand.
 		Function(operators.Index,
 			Overload("optional_list_index_int", []*Type{OptionalType(listTypeV), IntType}, optionalTypeV),
 			Overload("optional_map_index_optional_value", []*Type{OptionalType(mapTypeKV), paramTypeK}, optionalTypeV)),

--- a/checker/types.go
+++ b/checker/types.go
@@ -271,7 +271,7 @@ func internalIsAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) bool {
 // substitution for t1, and whether t2 has a type substitution in mapping m.
 //
 // The type t2 is a valid substitution for t1 if any of the following statements is true
-// - t2 has a type substitition (t2sub) equal to t1
+// - t2 has a type substitution (t2sub) equal to t1
 // - t2 has a type substitution (t2sub) assignable to t1
 // - t2 does not occur within t1.
 func isValidTypeSubstitution(m *mapping, t1, t2 *exprpb.Type) (valid, hasSub bool) {

--- a/ext/native.go
+++ b/ext/native.go
@@ -320,7 +320,7 @@ type nativeObj struct {
 // ConvertToNative implements the ref.Val interface method.
 //
 // CEL does not have a notion of pointers, so whether a field is a pointer or value
-// is handled as part of this converstion step.
+// is handled as part of this conversion step.
 func (o *nativeObj) ConvertToNative(typeDesc reflect.Type) (any, error) {
 	if o.refValue.Type() == typeDesc {
 		return o.val, nil


### PR DESCRIPTION
this pull request just fixes some spelling mistakes. Nothing has changed in the code, so nothing changes in the function, in the tests or anything else.