### PR TITLE
Additional coverage for static and runtime cost computations

### DIFF
--- a/checker/cost_test.go
+++ b/checker/cost_test.go
@@ -135,9 +135,31 @@ func TestCost(t *testing.T) {
 			wanted: zeroCost,
 		},
 		{
+			name: "or accumulated branch cost",
+			expr: `a || b || c || d`,
+			decls: []*exprpb.Decl{
+				decls.NewVar("a", decls.Bool),
+				decls.NewVar("b", decls.Bool),
+				decls.NewVar("c", decls.Bool),
+				decls.NewVar("d", decls.Bool),
+			},
+			wanted: CostEstimate{Min: 1, Max: 4},
+		},
+		{
 			name:   "and",
 			expr:   `true && false`,
 			wanted: zeroCost,
+		},
+		{
+			name: "and accumulated branch cost",
+			expr: `a && b && c && d`,
+			decls: []*exprpb.Decl{
+				decls.NewVar("a", decls.Bool),
+				decls.NewVar("b", decls.Bool),
+				decls.NewVar("c", decls.Bool),
+				decls.NewVar("d", decls.Bool),
+			},
+			wanted: CostEstimate{Min: 1, Max: 4},
 		},
 		{
 			name:   "lt",

--- a/interpreter/runtimecost_test.go
+++ b/interpreter/runtimecost_test.go
@@ -398,6 +398,24 @@ func TestRuntimeCost(t *testing.T) {
 			expr: `true || false`,
 			want: 0,
 		},
+
+		{
+			name: "or accumulated branch cost",
+			expr: `a || b || c || d`,
+			decls: []*exprpb.Decl{
+				decls.NewVar("a", decls.Bool),
+				decls.NewVar("b", decls.Bool),
+				decls.NewVar("c", decls.Bool),
+				decls.NewVar("d", decls.Bool),
+			},
+			in: map[string]any{
+				"a": false,
+				"b": false,
+				"c": false,
+				"d": false,
+			},
+			want: 4,
+		},
 		{
 			name: "and",
 			expr: `true && false`,
@@ -407,6 +425,23 @@ func TestRuntimeCost(t *testing.T) {
 			name: "and short-circuit",
 			expr: `false && true`,
 			want: 0,
+		},
+		{
+			name: "and accumulated branch cost",
+			expr: `a && b && c && d`,
+			decls: []*exprpb.Decl{
+				decls.NewVar("a", decls.Bool),
+				decls.NewVar("b", decls.Bool),
+				decls.NewVar("c", decls.Bool),
+				decls.NewVar("d", decls.Bool),
+			},
+			in: map[string]any{
+				"a": true,
+				"b": true,
+				"c": true,
+				"d": true,
+			},
+			want: 4,
 		},
 		{
 			name: "lt",


### PR DESCRIPTION
With the possibility of variadic logical operator ASTs, improve coverage for and/or branches which have an associated cost.