### PR TITLE
Fix for type guard on optimized set membership step

### DIFF
--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -802,6 +802,9 @@ func (e *evalSetMembership) ID() int64 {
 // Eval implements the Interpretable interface method.
 func (e *evalSetMembership) Eval(ctx Activation) ref.Val {
 	val := e.arg.Eval(ctx)
+	if types.IsUnknownOrError(val) {
+		return val
+	}
 	if ret, found := e.valueSet[val]; found {
 		return ret
 	}

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -1395,6 +1395,11 @@ var (
 			unchecked: true,
 			err:       `cannot initialize optional list element from non-optional value 123`,
 		},
+		{
+			name: "bad_argument_in_optimized_list",
+			expr: `1/0 in [1, 2, 3]`,
+			err:  `division by zero`,
+		},
 	}
 )
 


### PR DESCRIPTION
There's a missing check for error / unknown before accessing the pre-computed value map