### PR TITLE
Update the ConvertToNative API documentation and strings.join

### DIFF
--- a/common/types/ref/reference.go
+++ b/common/types/ref/reference.go
@@ -37,9 +37,18 @@ type Type interface {
 type Val interface {
 	// ConvertToNative converts the Value to a native Go struct according to the
 	// reflected type description, or error if the conversion is not feasible.
+	//
+	// The ConvertToNative method is intended to be used to support conversion between CEL types
+	// and native types during object creation expressions or by clients who need to adapt the,
+	// returned CEL value into an equivalent Go value instance.
+	//
+	// When implementing or using ConvertToNative, the following guidelines apply:
+	// - Use ConvertToNative when marshalling CEL evaluation results to native types.
+	// - Do not use ConvertToNative within CEL extension functions.
+	// - Document whether your implementation supports non-CEL field types, such as Go or Protobuf.
 	ConvertToNative(typeDesc reflect.Type) (any, error)
 
-	// ConvertToType supports type conversions between value types supported by the expression language.
+	// ConvertToType supports type conversions between CEL value types supported by the expression language.
 	ConvertToType(typeValue Type) Val
 
 	// Equal returns true if the `other` value has the same type and content as the implementing struct.


### PR DESCRIPTION
Update the `ConvertToNative` API docs to clarify the call contract. 

The change also introduces a refactor of the `strings.join` method which
does not rely on `ConvertToNative`, but rather uses the `traits.Lister` with
an expectation that all contained elements will be `types.String` values.

This change can be taken advantage of using `ext.StringsVersion(2)` if
you are using extension versioning. If you are not using extension versioning,
the change will be default enabled.

The functionality should be equivalent with the prior behavior, though there
are some limited cases where a `ConvertToNative` might succeed when
the new approach might fail.

Closes #688 