### PR TITLE
Additional string.format() test for message field accesses

### DIFF
--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -942,6 +942,19 @@ func TestStringFormat(t *testing.T) {
 			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
 		},
 		{
+			name:       "message field support",
+			format:     "message field msg.single_int32: %d, msg.single_double: %.1f",
+			formatArgs: `msg.single_int32, msg.single_double`,
+			dynArgs: map[string]any{
+				"msg": &proto3pb.TestAllTypes{
+					SingleInt32:  2,
+					SingleDouble: 1.0,
+				},
+			},
+			locale:         "en_US",
+			expectedOutput: `message field msg.single_int32: 2, msg.single_double: 1.0`,
+		},
+		{
 			name:             "unrecognized formatting clause",
 			format:           "%a",
 			formatArgs:       "1",
@@ -1266,7 +1279,7 @@ func TestStringFormat(t *testing.T) {
 			checkCase(out, tt.expectedOutput, err, tt.err, t)
 			if tt.locale == "" {
 				// if the test has no locale specified, then that means it
-				// should have the same output regardless of lcoale
+				// should have the same output regardless of locale
 				t.Run("no change on locale", func(t *testing.T) {
 					out, err := runCase(tt.format, tt.formatArgs, "da_DK", tt.dynArgs, tt.skipCompileCheck, tt.expectedRuntimeCost, tt.expectedEstimatedCost, t)
 					checkCase(out, tt.expectedOutput, err, tt.err, t)

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -23,10 +23,13 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+
 	proto3pb "github.com/google/cel-go/test/proto3pb"
 )
 
@@ -1222,8 +1225,31 @@ func TestStringFormat(t *testing.T) {
 	buildVariables := func(vars map[string]any) []cel.EnvOption {
 		opts := make([]cel.EnvOption, len(vars))
 		i := 0
-		for name := range vars {
-			opts[i] = cel.Variable(name, cel.DynType)
+		for name, value := range vars {
+			t := cel.DynType
+			switch v := value.(type) {
+			case proto.Message:
+				t = cel.ObjectType(string(v.ProtoReflect().Descriptor().FullName()))
+			case types.Bool:
+				t = cel.BoolType
+			case types.Bytes:
+				t = cel.BytesType
+			case types.Double:
+				t = cel.DoubleType
+			case types.Duration:
+				t = cel.DurationType
+			case types.Int:
+				t = cel.IntType
+			case types.Null:
+				t = cel.NullType
+			case types.String:
+				t = cel.StringType
+			case types.Timestamp:
+				t = cel.TimestampType
+			case types.Uint:
+				t = cel.UintType
+			}
+			opts[i] = cel.Variable(name, t)
 			i++
 		}
 		return opts

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -231,7 +231,11 @@ type absoluteAttribute struct {
 
 // ID implements the Attribute interface method.
 func (a *absoluteAttribute) ID() int64 {
-	return a.id
+	qual_count := len(a.qualifiers)
+	if qual_count == 0 {
+		return a.id
+	}
+	return a.qualifiers[qual_count-1].ID()
 }
 
 // IsOptional returns trivially false for an attribute as the attribute represents a fully
@@ -315,6 +319,11 @@ type conditionalAttribute struct {
 
 // ID is an implementation of the Attribute interface method.
 func (a *conditionalAttribute) ID() int64 {
+	// There's a field access after the conditional.
+	if a.truthy.ID() == a.falsy.ID() {
+		return a.truthy.ID()
+	}
+	// Otherwise return the conditional id as the consistent id being tracked.
 	return a.id
 }
 
@@ -379,7 +388,7 @@ type maybeAttribute struct {
 
 // ID is an implementation of the Attribute interface method.
 func (a *maybeAttribute) ID() int64 {
-	return a.id
+	return a.attrs[0].ID()
 }
 
 // IsOptional returns trivially false for an attribute as the attribute represents a fully
@@ -494,7 +503,11 @@ type relativeAttribute struct {
 
 // ID is an implementation of the Attribute interface method.
 func (a *relativeAttribute) ID() int64 {
-	return a.id
+	qual_count := len(a.qualifiers)
+	if qual_count == 0 {
+		return a.id
+	}
+	return a.qualifiers[qual_count-1].ID()
 }
 
 // IsOptional returns trivially false for an attribute as the attribute represents a fully


### PR DESCRIPTION
Refined the test approach in `ext/strings_test.go` to better cover type-based validation of format args.

Fixed an issue where attribute ids were referring to the variable id rather than the leaf value of the attribute.
This has a minor impact on attribute state tracking which should not affect semantic meaning, but which
does have a real impact on whether or not the attribute expression corresponds to the type identifier in
the `checked.proto` `type_map` field.

Closes #690