### PR TITLE
Fix ID collision between partial eval and AST pruner

### DIFF
--- a/interpreter/prune.go
+++ b/interpreter/prune.go
@@ -68,15 +68,19 @@ type astPruner struct {
 // the overloads accordingly.
 func PruneAst(expr *exprpb.Expr, macroCalls map[int64]*exprpb.Expr, state EvalState) *exprpb.ParsedExpr {
 	pruneState := NewEvalState()
+	maxID := int64(1)
 	for _, id := range state.IDs() {
 		v, _ := state.Value(id)
 		pruneState.SetValue(id, v)
+		if id > maxID {
+			maxID = id + 1
+		}
 	}
 	pruner := &astPruner{
 		expr:       expr,
 		macroCalls: macroCalls,
 		state:      pruneState,
-		nextExprID: 1}
+		nextExprID: maxID}
 	newExpr, _ := pruner.maybePrune(expr)
 	return &exprpb.ParsedExpr{
 		Expr:       newExpr,

--- a/interpreter/prune_test.go
+++ b/interpreter/prune_test.go
@@ -152,6 +152,11 @@ var testCases = []testInfo{
 		expr: `test in {'a': 1, 'field': [test, 3]}.field`,
 		out:  `test in {"a": 1, "field": [test, 3]}.field`,
 	},
+	{
+		in:   partialActivation(map[string]any{"foo": "bar"}, "r.attr"),
+		expr: `foo == "bar" && r.attr.loc in ["GB", "US"]`,
+		out:  `r.attr.loc in ["GB", "US"]`,
+	},
 	// TODO: the output of an expression like this relies on either
 	// a) doing replacements on the original macro call, or
 	// b) mutating the macro call tracking data rather than the core


### PR DESCRIPTION
Partial state used to be tracked for every id, even when the id-value pairs
weren't accurate reflections the observed evaluation. The tracking was
fixed in #690, but this resulted in evaluation state which had 'holes' in the
id space that caused a collision between the AST pruner and partial eval
output.

Thanks @charithe for the report and suggested fix.

Closes #699 