### PR TITLE
Fix the sets overload IDs to mirror best practices.

### DIFF
--- a/ext/sets.go
+++ b/ext/sets.go
@@ -87,13 +87,13 @@ func (setsLib) CompileOptions() []cel.EnvOption {
 	listType := cel.ListType(cel.TypeParamType("T"))
 	return []cel.EnvOption{
 		cel.Function("sets.contains",
-			cel.Overload("list_sets_contains_list", []*cel.Type{listType, listType}, cel.BoolType,
+			cel.Overload("sets_contains_list_list", []*cel.Type{listType, listType}, cel.BoolType,
 				cel.BinaryBinding(setsContains))),
 		cel.Function("sets.equivalent",
-			cel.Overload("list_sets_equivalent_list", []*cel.Type{listType, listType}, cel.BoolType,
+			cel.Overload("sets_equivalent_list_list", []*cel.Type{listType, listType}, cel.BoolType,
 				cel.BinaryBinding(setsEquivalent))),
 		cel.Function("sets.intersects",
-			cel.Overload("list_sets_intersects_list", []*cel.Type{listType, listType}, cel.BoolType,
+			cel.Overload("sets_intersects_list_list", []*cel.Type{listType, listType}, cel.BoolType,
 				cel.BinaryBinding(setsIntersects))),
 	}
 }


### PR DESCRIPTION
This change updates set overload ids to match the best practice for naming overloads.

This is a breaking change for those depending on v0.15.0+ who are already using `ext.Sets()`