### PR TITLE
Update presence test state tracking and pruning

### DIFF
--- a/checker/cost.go
+++ b/checker/cost.go
@@ -347,6 +347,7 @@ func (c *coster) costSelect(e *exprpb.Expr) CostEstimate {
 		// this is equivalent to how evalTestOnly increments the runtime cost counter
 		// but does not add any additional cost for the qualifier, except here we do
 		// the reverse (ident adds cost)
+		sum = sum.Add(selectAndIdentCost)
 		sum = sum.Add(c.cost(sel.GetOperand()))
 		return sum
 	}

--- a/checker/cost_test.go
+++ b/checker/cost_test.go
@@ -75,7 +75,13 @@ func TestCost(t *testing.T) {
 			name:   "select: field test only",
 			expr:   `has(input.single_int32)`,
 			decls:  []*exprpb.Decl{decls.NewVar("input", decls.NewObjectType("google.expr.proto3.test.TestAllTypes"))},
-			wanted: CostEstimate{Min: 1, Max: 1},
+			wanted: CostEstimate{Min: 2, Max: 2},
+		},
+		{
+			name:   "select: non-proto field test",
+			expr:   `has(input.testAttr.nestedAttr)`,
+			decls:  []*exprpb.Decl{decls.NewVar("input", nestedMap)},
+			wanted: CostEstimate{Min: 3, Max: 3},
 		},
 		{
 			name:   "estimated function call",

--- a/ext/sets.go
+++ b/ext/sets.go
@@ -87,13 +87,13 @@ func (setsLib) CompileOptions() []cel.EnvOption {
 	listType := cel.ListType(cel.TypeParamType("T"))
 	return []cel.EnvOption{
 		cel.Function("sets.contains",
-			cel.Overload("sets_contains_list_list", []*cel.Type{listType, listType}, cel.BoolType,
+			cel.Overload("list_sets_contains_list", []*cel.Type{listType, listType}, cel.BoolType,
 				cel.BinaryBinding(setsContains))),
 		cel.Function("sets.equivalent",
-			cel.Overload("sets_equivalent_list_list", []*cel.Type{listType, listType}, cel.BoolType,
+			cel.Overload("list_sets_equivalent_list", []*cel.Type{listType, listType}, cel.BoolType,
 				cel.BinaryBinding(setsEquivalent))),
 		cel.Function("sets.intersects",
-			cel.Overload("sets_intersects_list_list", []*cel.Type{listType, listType}, cel.BoolType,
+			cel.Overload("list_sets_intersects_list", []*cel.Type{listType, listType}, cel.BoolType,
 				cel.BinaryBinding(setsIntersects))),
 	}
 }

--- a/ext/sets.go
+++ b/ext/sets.go
@@ -87,13 +87,13 @@ func (setsLib) CompileOptions() []cel.EnvOption {
 	listType := cel.ListType(cel.TypeParamType("T"))
 	return []cel.EnvOption{
 		cel.Function("sets.contains",
-			cel.Overload("list_sets_contains_list", []*cel.Type{listType, listType}, cel.BoolType,
+			cel.Overload("sets_contains_list_list", []*cel.Type{listType, listType}, cel.BoolType,
 				cel.BinaryBinding(setsContains))),
 		cel.Function("sets.equivalent",
-			cel.Overload("list_sets_equivalent_list", []*cel.Type{listType, listType}, cel.BoolType,
+			cel.Overload("sets_equivalent_list_list", []*cel.Type{listType, listType}, cel.BoolType,
 				cel.BinaryBinding(setsEquivalent))),
 		cel.Function("sets.intersects",
-			cel.Overload("list_sets_intersects_list", []*cel.Type{listType, listType}, cel.BoolType,
+			cel.Overload("sets_intersects_list_list", []*cel.Type{listType, listType}, cel.BoolType,
 				cel.BinaryBinding(setsIntersects))),
 	}
 }

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -110,7 +110,6 @@ type InterpretableConstructor interface {
 type evalTestOnly struct {
 	id    int64
 	attr  InterpretableAttribute
-	qual  Qualifier
 	field types.String
 }
 
@@ -127,20 +126,10 @@ func (test *evalTestOnly) Eval(ctx Activation) ref.Val {
 	}
 	optVal, isOpt := val.(*types.Optional)
 	if isOpt {
-		if !optVal.HasValue() {
-			return types.False
-		}
-		val = optVal.GetValue()
+		return types.Bool(optVal.HasValue())
 	}
-	out, found, err := test.qual.QualifyIfPresent(ctx, val, true)
-	if err != nil {
-		return types.NewErr(err.Error())
-	}
-	if unk, isUnk := out.(types.Unknown); isUnk {
+	if unk, isUnk := val.(types.Unknown); isUnk {
 		return unk
-	}
-	if found {
-		return types.True
 	}
 	return types.False
 }

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/google/cel-go/common/containers"
 	"github.com/google/cel-go/common/operators"
-	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter/functions"
 
@@ -213,22 +212,19 @@ func (p *planner) planSelect(expr *exprpb.Expr) (Interpretable, error) {
 	}
 
 	// Build a qualifier for the attribute.
-	qual, err := p.attrFactory.NewQualifier(opType, expr.GetId(), sel.GetField(), sel.GetTestOnly())
+	qual, err := p.attrFactory.NewQualifier(opType, expr.GetId(), sel.GetField(), false)
 	if err != nil {
 		return nil, err
 	}
-
-	// Otherwise, append the qualifier on the attribute.
-	_, err = attr.AddQualifier(qual)
-	// Return the test only eval expression.
+	// Modify the attribute to be test-only.
 	if sel.GetTestOnly() {
-		return &evalTestOnly{
-			id:    expr.GetId(),
-			field: types.String(sel.GetField()),
-			attr:  attr,
-		}, nil
+		attr = &evalTestOnly{
+			id:                     expr.GetId(),
+			InterpretableAttribute: attr,
+		}
 	}
-
+	// Append the qualifier on the attribute.
+	_, err = attr.AddQualifier(qual)
 	return attr, err
 }
 

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -213,23 +213,22 @@ func (p *planner) planSelect(expr *exprpb.Expr) (Interpretable, error) {
 	}
 
 	// Build a qualifier for the attribute.
-	qual, err := p.attrFactory.NewQualifier(opType, expr.GetId(), sel.GetField(), false)
+	qual, err := p.attrFactory.NewQualifier(opType, expr.GetId(), sel.GetField(), sel.GetTestOnly())
 	if err != nil {
 		return nil, err
 	}
 
+	// Otherwise, append the qualifier on the attribute.
+	_, err = attr.AddQualifier(qual)
 	// Return the test only eval expression.
 	if sel.GetTestOnly() {
 		return &evalTestOnly{
 			id:    expr.GetId(),
 			field: types.String(sel.GetField()),
 			attr:  attr,
-			qual:  qual,
 		}, nil
 	}
 
-	// Otherwise, append the qualifier on the attribute.
-	_, err = attr.AddQualifier(qual)
 	return attr, err
 }
 

--- a/interpreter/runtimecost.go
+++ b/interpreter/runtimecost.go
@@ -69,8 +69,6 @@ func CostObserver(tracker *CostTracker) EvalObserver {
 			tracker.stack.drop(t.rhs.ID(), t.lhs.ID())
 		case *evalFold:
 			tracker.stack.drop(t.iterRange.ID())
-		case *evalTestOnly:
-			tracker.cost += common.SelectAndIdentCost
 		case Qualifier:
 			tracker.cost++
 		case InterpretableCall:

--- a/interpreter/runtimecost_test.go
+++ b/interpreter/runtimecost_test.go
@@ -306,7 +306,7 @@ func TestRuntimeCost(t *testing.T) {
 			name:  "select: field test only",
 			expr:  `has(input.single_int32)`,
 			decls: []*exprpb.Decl{decls.NewVar("input", decls.NewObjectType("google.expr.proto3.test.TestAllTypes"))},
-			want:  1,
+			want:  2,
 			in: map[string]any{
 				"input": &proto3pb.TestAllTypes{
 					RepeatedBool: []bool{false},
@@ -321,7 +321,7 @@ func TestRuntimeCost(t *testing.T) {
 			name:  "select: non-proto field test",
 			expr:  `has(input.testAttr.nestedAttr)`,
 			decls: []*exprpb.Decl{decls.NewVar("input", nestedMap)},
-			want:  2,
+			want:  3,
 			in: map[string]any{
 				"input": map[string]any{
 					"testAttr": map[string]any{
@@ -725,7 +725,6 @@ func TestRuntimeCost(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := constructActivation(t, tc.in)
-
 			var costLimit *uint64
 			if tc.limit > 0 {
 				costLimit = &tc.limit


### PR DESCRIPTION
The has() macro calls were not being adequately captured during
state tracking which led to issues in cost estimation and ast
pruning function. The updated behavior ensures that the has()
macro calls have the same cost as a traditional select expression
and that the state for the presence test is correctly recorded
in a way that works with partial evaluation.