### PR TITLE
Expose ExpressionSizeCodePointLimit as env option.

### DIFF
--- a/cel/options.go
+++ b/cel/options.go
@@ -568,3 +568,13 @@ func ParserRecursionLimit(limit int) EnvOption {
 		return e, nil
 	}
 }
+
+// ParserExpressionSizeLimit adjusts the max. number of code points the expression parser is allowed
+// to parse.
+// Defaults defined in the parser package.
+func ParserExpressionSizeLimit(limit int) EnvOption {
+	return func(e *Env) (*Env, error) {
+		e.prsrOpts = append(e.prsrOpts, parser.ExpressionSizeCodePointLimit(limit))
+		return e, nil
+	}
+}


### PR DESCRIPTION
Currently, the parser options cannot be customized when creating a new environment. With this change, one can override the max. number of code points the parser accepts via an env option. This is analogous to ParserRecursionLimit.