### PR TITLE
Presence test cost tracking options

### DIFF
--- a/cel/env.go
+++ b/cel/env.go
@@ -462,12 +462,12 @@ func (e *Env) ResidualAst(a *Ast, details *EvalDetails) (*Ast, error) {
 
 // EstimateCost estimates the cost of a type checked CEL expression using the length estimates of input data and
 // extension functions provided by estimator.
-func (e *Env) EstimateCost(ast *Ast, estimator checker.CostEstimator) (checker.CostEstimate, error) {
+func (e *Env) EstimateCost(ast *Ast, estimator checker.CostEstimator, opts ...checker.CostOption) (checker.CostEstimate, error) {
 	checked, err := AstToCheckedExpr(ast)
 	if err != nil {
 		return checker.CostEstimate{}, fmt.Errorf("EsimateCost could not inspect Ast: %v", err)
 	}
-	return checker.Cost(checked, estimator), nil
+	return checker.Cost(checked, estimator, opts...)
 }
 
 // configure applies a series of EnvOptions to the current environment.

--- a/checker/cost.go
+++ b/checker/cost.go
@@ -261,6 +261,8 @@ type coster struct {
 	computedSizes map[int64]SizeEstimate
 	checkedExpr   *exprpb.CheckedExpr
 	estimator     CostEstimator
+	// presenceTestCost will either be a zero or one based on whether has() macros count against cost computations.
+	presenceTestCost CostEstimate
 }
 
 // Use a stack of iterVar -> iterRange Expr Ids to handle shadowed variable names.
@@ -283,16 +285,39 @@ func (vs iterRangeScopes) peek(varName string) (int64, bool) {
 	return 0, false
 }
 
-// Cost estimates the cost of the parsed and type checked CEL expression.
-func Cost(checker *exprpb.CheckedExpr, estimator CostEstimator) CostEstimate {
-	c := coster{
-		checkedExpr:   checker,
-		estimator:     estimator,
-		exprPath:      map[int64][]string{},
-		iterRanges:    map[string][]int64{},
-		computedSizes: map[int64]SizeEstimate{},
+// CostOption configures flags which affect cost computations.
+type CostOption func(*coster) error
+
+// PresenceTestHasCost determines whether presence testing has a cost of one or zero.
+// Defaults to presence test has a cost of one.
+func PresenceTestHasCost(hasCost bool) CostOption {
+	return func(c *coster) error {
+		if hasCost {
+			c.presenceTestCost = CostEstimate{Min: 1, Max: 1}
+			return nil
+		}
+		c.presenceTestCost = CostEstimate{Min: 0, Max: 0}
+		return nil
 	}
-	return c.cost(checker.GetExpr())
+}
+
+// Cost estimates the cost of the parsed and type checked CEL expression.
+func Cost(checker *exprpb.CheckedExpr, estimator CostEstimator, opts ...CostOption) (CostEstimate, error) {
+	c := &coster{
+		checkedExpr:      checker,
+		estimator:        estimator,
+		exprPath:         map[int64][]string{},
+		iterRanges:       map[string][]int64{},
+		computedSizes:    map[int64]SizeEstimate{},
+		presenceTestCost: CostEstimate{Min: 1, Max: 1},
+	}
+	for _, opt := range opts {
+		err := opt(c)
+		if err != nil {
+			return CostEstimate{}, err
+		}
+	}
+	return c.cost(checker.GetExpr()), nil
 }
 
 func (c *coster) cost(e *exprpb.Expr) CostEstimate {
@@ -347,7 +372,7 @@ func (c *coster) costSelect(e *exprpb.Expr) CostEstimate {
 		// this is equivalent to how evalTestOnly increments the runtime cost counter
 		// but does not add any additional cost for the qualifier, except here we do
 		// the reverse (ident adds cost)
-		sum = sum.Add(selectAndIdentCost)
+		sum = sum.Add(c.presenceTestCost)
 		sum = sum.Add(c.cost(sel.GetOperand()))
 		return sum
 	}

--- a/checker/cost.go
+++ b/checker/cost.go
@@ -293,7 +293,7 @@ type CostOption func(*coster) error
 func PresenceTestHasCost(hasCost bool) CostOption {
 	return func(c *coster) error {
 		if hasCost {
-			c.presenceTestCost = CostEstimate{Min: 1, Max: 1}
+			c.presenceTestCost = selectAndIdentCost
 			return nil
 		}
 		c.presenceTestCost = CostEstimate{Min: 0, Max: 0}

--- a/interpreter/runtimecost.go
+++ b/interpreter/runtimecost.go
@@ -53,6 +53,11 @@ func CostObserver(tracker *CostTracker) EvalObserver {
 				tracker.stack.drop(t.Attr().ID())
 				tracker.cost += common.SelectAndIdentCost
 			}
+			if !tracker.presenceTestHasCost {
+				if _, isTestOnly := programStep.(*evalTestOnly); isTestOnly {
+					tracker.cost -= common.SelectAndIdentCost
+				}
+			}
 		case *evalExhaustiveConditional:
 			// Ternary has no direct cost. All cost is from the conditional and the true/false branch expressions.
 			tracker.stack.drop(t.attr.falsy.ID(), t.attr.truthy.ID(), t.attr.expr.ID())
@@ -95,21 +100,58 @@ func CostObserver(tracker *CostTracker) EvalObserver {
 	return observer
 }
 
-// CostTracker represents the information needed for tacking runtime cost
+// CostTrackerOption configures the behavior of CostTracker objects.
+type CostTrackerOption func(*CostTracker) error
+
+// CostTrackerLimit sets the runtime limit on the evaluation cost during execution and will terminate the expression
+// evaluation if the limit is exceeded.
+func CostTrackerLimit(limit uint64) CostTrackerOption {
+	return func(tracker *CostTracker) error {
+		tracker.Limit = &limit
+		return nil
+	}
+}
+
+// PresenceTestHasCost determines whether presence testing has a cost of one or zero.
+// Defaults to presence test has a cost of one.
+func PresenceTestHasCost(hasCost bool) CostTrackerOption {
+	return func(tracker *CostTracker) error {
+		tracker.presenceTestHasCost = hasCost
+		return nil
+	}
+}
+
+// NewCostTracker creates a new CostTracker with a given estimator and a set of functional CostTrackerOption values.
+func NewCostTracker(estimator ActualCostEstimator, opts ...CostTrackerOption) (*CostTracker, error) {
+	tracker := &CostTracker{
+		Estimator:           estimator,
+		presenceTestHasCost: true,
+	}
+	for _, opt := range opts {
+		err := opt(tracker)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return tracker, nil
+}
+
+// CostTracker represents the information needed for tracking runtime cost.
 type CostTracker struct {
-	Estimator ActualCostEstimator
-	Limit     *uint64
+	Estimator           ActualCostEstimator
+	Limit               *uint64
+	presenceTestHasCost bool
 
 	cost  uint64
 	stack refValStack
 }
 
 // ActualCost returns the runtime cost
-func (c CostTracker) ActualCost() uint64 {
+func (c *CostTracker) ActualCost() uint64 {
 	return c.cost
 }
 
-func (c CostTracker) costCall(call InterpretableCall, argValues []ref.Val, result ref.Val) uint64 {
+func (c *CostTracker) costCall(call InterpretableCall, argValues []ref.Val, result ref.Val) uint64 {
 	var cost uint64
 	if c.Estimator != nil {
 		callCost := c.Estimator.CallCost(call.Function(), call.OverloadID(), argValues, result)
@@ -179,7 +221,7 @@ func (c CostTracker) costCall(call InterpretableCall, argValues []ref.Val, resul
 }
 
 // actualSize returns the size of value
-func (c CostTracker) actualSize(value ref.Val) uint64 {
+func (c *CostTracker) actualSize(value ref.Val) uint64 {
 	if sz, ok := value.(traits.Sizer); ok {
 		return uint64(sz.Size().(types.Int))
 	}


### PR DESCRIPTION
In #711, presence tests began getting tracked with the same cost as a typical select expression, but this may break some users. A new set of functional options have been added to both the `checker` and `interpreter` packages to allow users to opt-out of this change.

Also, note this change breaks the current API contract for `interpreter.CostTracker` and `checker.Cost`. Prefer using `interpreter.NewCostTracker()` which accepts a set of functional arguments for configuring behavior and which may return an error. Likewise, the `checker.Cost` will return `CostEstimate, error` whereas before it did not. Note, the top-level `cel.EstimateCost()` function signature remains unchanged.