### PR TITLE
Variadic logical operator AST support

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -1299,7 +1299,7 @@ func TestEnvExtensionIsolation(t *testing.T) {
 }
 
 func TestVariadicLogicalOperators(t *testing.T) {
-	e, err := NewEnv(VariadicLogicalOperatorASTs())
+	e, err := NewEnv(variadicLogicalOperatorASTs())
 	if err != nil {
 		t.Fatalf("NewEnv() failed: %v", err)
 	}

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -1298,6 +1298,30 @@ func TestEnvExtensionIsolation(t *testing.T) {
 	}
 }
 
+func TestVariadicLogicalOperators(t *testing.T) {
+	e, err := NewEnv(VariadicLogicalOperatorASTs())
+	if err != nil {
+		t.Fatalf("NewEnv() failed: %v", err)
+	}
+	ast, iss := e.Compile(
+		`(false || false || false || false || true) && 
+		 (true && true && true && true && false)`)
+	if iss.Err() != nil {
+		t.Fatalf("Compile() failed: %v", iss.Err())
+	}
+	prg, err := e.Program(ast)
+	if err != nil {
+		t.Fatalf("Program(ast) failed: %v", err)
+	}
+	out, _, err := prg.Eval(NoVars())
+	if err != nil {
+		t.Errorf("Eval() got error %v, wanted false", err)
+	}
+	if out != types.False {
+		t.Errorf("Eval() got %v, wanted false", out)
+	}
+}
+
 func TestParseError(t *testing.T) {
 	e, err := NewEnv()
 	if err != nil {

--- a/cel/env.go
+++ b/cel/env.go
@@ -504,6 +504,9 @@ func (e *Env) configure(opts []EnvOption) (*Env, error) {
 	if e.HasFeature(featureEnableMacroCallTracking) {
 		prsrOpts = append(prsrOpts, parser.PopulateMacroCalls(true))
 	}
+	if e.HasFeature(featureVariadicLogicalASTs) {
+		prsrOpts = append(prsrOpts, parser.EnableVariadicOperatorASTs(true))
+	}
 	e.prsr, err = parser.NewParser(prsrOpts...)
 	if err != nil {
 		return nil, err

--- a/cel/options.go
+++ b/cel/options.go
@@ -140,7 +140,7 @@ func HomogeneousAggregateLiterals() EnvOption {
 	return features(featureDisableDynamicAggregateLiterals, true)
 }
 
-// VariadicLogicalOperatorASTs flatten like-operator chained logical expressions into a single
+// variadicLogicalOperatorASTs flatten like-operator chained logical expressions into a single
 // variadic call with N-terms. This behavior is useful when serializing to a protocol buffer as
 // it will reduce the number of recursive calls needed to deserialize the AST later.
 //
@@ -148,7 +148,7 @@ func HomogeneousAggregateLiterals() EnvOption {
 //
 //	expression: a && b && c && (d || e)
 //	ast: call(_&&_, [a, b, c, call(_||_, [d, e])])
-func VariadicLogicalOperatorASTs() EnvOption {
+func variadicLogicalOperatorASTs() EnvOption {
 	return features(featureVariadicLogicalASTs, true)
 }
 

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -366,7 +366,11 @@ func (c *checker) resolveOverload(
 			checkedRef = newFunctionReference(overload.GetOverloadId())
 			for i, argType := range argTypes {
 				if !c.isAssignable(argType, decls.Bool) {
-					c.errors.typeMismatch(c.locationByID(args[i].GetId()), decls.Bool, argType)
+					c.errors.typeMismatch(
+						args[i].GetId(),
+						c.locationByID(args[i].GetId()),
+						decls.Bool,
+						argType)
 					resultType = decls.Error
 				}
 			}

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -360,6 +360,22 @@ func (c *checker) resolveOverload(
 			continue
 		}
 
+		// Alternative type-checking behavior when the logical operators are compacted into
+		// variadic AST representations.
+		if fn.GetName() == operators.LogicalAnd || fn.GetName() == operators.LogicalOr {
+			checkedRef = newFunctionReference(overload.GetOverloadId())
+			for i, argType := range argTypes {
+				if !c.isAssignable(argType, decls.Bool) {
+					c.errors.typeMismatch(c.locationByID(args[i].GetId()), decls.Bool, argType)
+					resultType = decls.Error
+				}
+			}
+			if isError(resultType) {
+				return nil
+			}
+			return newResolution(checkedRef, decls.Bool)
+		}
+
 		overloadType := decls.NewFunctionType(overload.ResultType, overload.Params...)
 		if len(overload.GetTypeParams()) > 0 {
 			// Instantiate overload's type with fresh type variables.
@@ -389,8 +405,8 @@ func (c *checker) resolveOverload(
 	}
 
 	if resultType == nil {
-		for i, arg := range argTypes {
-			argTypes[i] = substitute(c.mappings, arg, true)
+		for i, argType := range argTypes {
+			argTypes[i] = substitute(c.mappings, argType, true)
 		}
 		c.errors.noMatchingOverload(call.GetId(), c.location(call), fn.GetName(), argTypes, target != nil)
 		return nil

--- a/common/types/BUILD.bazel
+++ b/common/types/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
         "timestamp_test.go",
         "type_test.go",
         "uint_test.go",
+        "unknown_test.go",
         "util_test.go",
     ],
     embed = [":go_default_library"],

--- a/common/types/unknown.go
+++ b/common/types/unknown.go
@@ -65,7 +65,12 @@ func IsUnknown(val ref.Val) bool {
 	}
 }
 
-// MaybeMergeUnknowns determines whether a value can be merged with another, possibly nil, unknown.
+// MaybeMergeUnknowns determines whether an input value and another, possibly nil, unknown will produce
+// an unknown result.
+//
+// If the input `val` is another Unknown, then the result will be the merge of the `val` and the input
+// `unk`. If the `val` is not unknown, then the result will depend on whether the input `unk` is nil.
+// If both values are non-nil and unknown, then the return value will be a merge of both unknowns.
 func MaybeMergeUnknowns(val ref.Val, unk Unknown) (Unknown, bool) {
 	src, isUnk := val.(Unknown)
 	if !isUnk {

--- a/common/types/unknown.go
+++ b/common/types/unknown.go
@@ -64,3 +64,18 @@ func IsUnknown(val ref.Val) bool {
 		return false
 	}
 }
+
+// MaybeMergeUnknowns determines whether a value can be merged with another, possibly nil, unknown.
+func MaybeMergeUnknowns(val ref.Val, unk Unknown) (Unknown, bool) {
+	src, isUnk := val.(Unknown)
+	if !isUnk {
+		if unk != nil {
+			return unk, true
+		}
+		return nil, false
+	}
+	if unk == nil {
+		return src, true
+	}
+	return append(unk, src...), true
+}

--- a/common/types/unknown_test.go
+++ b/common/types/unknown_test.go
@@ -1,0 +1,75 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/cel-go/common/types/ref"
+)
+
+func TestIsUnknown(t *testing.T) {
+	if IsUnknown(Unknown{}) != true {
+		t.Error("IsUnknown(Unknown{}) returned false, wanted true")
+	}
+	if IsUnknown(Bool(true)) != false {
+		t.Error("IsUnknown(true) returned true, wanted false")
+	}
+}
+
+func TestMaybeMergeUnknowns(t *testing.T) {
+	tests := []struct {
+		in    ref.Val
+		unk   Unknown
+		want  Unknown
+		isUnk bool
+	}{
+		{
+			in:    String(""),
+			unk:   nil,
+			want:  nil,
+			isUnk: false,
+		},
+		{
+			in:    String(""),
+			unk:   Unknown{},
+			want:  Unknown{},
+			isUnk: true,
+		},
+		{
+			in:    Unknown{2},
+			unk:   Unknown{1},
+			want:  Unknown{1, 2},
+			isUnk: true,
+		},
+		{
+			in:    Unknown{2},
+			unk:   nil,
+			want:  Unknown{2},
+			isUnk: true,
+		},
+	}
+
+	for i, tst := range tests {
+		tc := tst
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			got, isUnk := MaybeMergeUnknowns(tc.in, tc.unk)
+			if isUnk != tc.isUnk {
+				t.Errorf("MaybeMergeUnknowns(%v, %v) got %v, wanted %v", tc.in, tc.unk, got, tc.want)
+			}
+		})
+	}
+}

--- a/interpreter/decorators.go
+++ b/interpreter/decorators.go
@@ -75,15 +75,13 @@ func decDisableShortcircuits() InterpretableDecorator {
 		switch expr := i.(type) {
 		case *evalOr:
 			return &evalExhaustiveOr{
-				id:  expr.id,
-				lhs: expr.lhs,
-				rhs: expr.rhs,
+				id:    expr.id,
+				terms: expr.terms,
 			}, nil
 		case *evalAnd:
 			return &evalExhaustiveAnd{
-				id:  expr.id,
-				lhs: expr.lhs,
-				rhs: expr.rhs,
+				id:    expr.id,
+				terms: expr.terms,
 			}, nil
 		case *evalFold:
 			expr.exhaustive = true

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -223,21 +223,14 @@ func (or *evalOr) Eval(ctx Activation) ref.Val {
 			return types.True
 		}
 		if !ok {
-			if types.IsUnknown(val) {
-				if unk == nil {
-					unk = types.Unknown{}
-				}
-				unk = append(unk, val.(types.Unknown)...)
-				continue
-			}
-			if types.IsError(val) {
-				if unk == nil && err == nil {
+			isUnk := false
+			unk, isUnk = types.MaybeMergeUnknowns(val, unk)
+			if !isUnk && err == nil {
+				if types.IsError(val) {
 					err = val
+				} else {
+					err = types.MaybeNoSuchOverloadErr(val)
 				}
-				continue
-			}
-			if unk == nil {
-				err = types.MaybeNoSuchOverloadErr(val)
 			}
 		}
 	}
@@ -272,21 +265,14 @@ func (and *evalAnd) Eval(ctx Activation) ref.Val {
 			return types.False
 		}
 		if !ok {
-			if types.IsUnknown(val) {
-				if unk == nil {
-					unk = types.Unknown{}
-				}
-				unk = append(unk, val.(types.Unknown)...)
-				continue
-			}
-			if types.IsError(val) {
-				if unk == nil && err == nil {
+			isUnk := false
+			unk, isUnk = types.MaybeMergeUnknowns(val, unk)
+			if !isUnk && err == nil {
+				if types.IsError(val) {
 					err = val
+				} else {
+					err = types.MaybeNoSuchOverloadErr(val)
 				}
-				continue
-			}
-			if unk == nil {
-				err = types.MaybeNoSuchOverloadErr(val)
 			}
 		}
 	}

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -2004,6 +2004,7 @@ func program(ctx any, tst *testCase, opts ...InterpretableDecorator) (Interpreta
 	p, err := parser.NewParser(
 		parser.Macros(parser.AllMacros...),
 		parser.EnableOptionalSyntax(true),
+		parser.EnableVariadicOperatorASTs(true),
 	)
 	if err != nil {
 		return nil, nil, err

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -429,18 +429,16 @@ func (p *planner) planCallNotEqual(expr *exprpb.Expr, args []Interpretable) (Int
 // planCallLogicalAnd generates a logical and (&&) Interpretable.
 func (p *planner) planCallLogicalAnd(expr *exprpb.Expr, args []Interpretable) (Interpretable, error) {
 	return &evalAnd{
-		id:  expr.GetId(),
-		lhs: args[0],
-		rhs: args[1],
+		id:    expr.GetId(),
+		terms: args,
 	}, nil
 }
 
 // planCallLogicalOr generates a logical or (||) Interpretable.
 func (p *planner) planCallLogicalOr(expr *exprpb.Expr, args []Interpretable) (Interpretable, error) {
 	return &evalOr{
-		id:  expr.GetId(),
-		lhs: args[0],
-		rhs: args[1],
+		id:    expr.GetId(),
+		terms: args,
 	}, nil
 }
 

--- a/interpreter/runtimecost.go
+++ b/interpreter/runtimecost.go
@@ -65,13 +65,21 @@ func CostObserver(tracker *CostTracker) EvalObserver {
 		// While the field names are identical, the boolean operation eval structs do not share an interface and so
 		// must be handled individually.
 		case *evalOr:
-			tracker.stack.drop(t.rhs.ID(), t.lhs.ID())
+			for _, term := range t.terms {
+				tracker.stack.drop(term.ID())
+			}
 		case *evalAnd:
-			tracker.stack.drop(t.rhs.ID(), t.lhs.ID())
+			for _, term := range t.terms {
+				tracker.stack.drop(term.ID())
+			}
 		case *evalExhaustiveOr:
-			tracker.stack.drop(t.rhs.ID(), t.lhs.ID())
+			for _, term := range t.terms {
+				tracker.stack.drop(term.ID())
+			}
 		case *evalExhaustiveAnd:
-			tracker.stack.drop(t.rhs.ID(), t.lhs.ID())
+			for _, term := range t.terms {
+				tracker.stack.drop(term.ID())
+			}
 		case *evalFold:
 			tracker.stack.drop(t.iterRange.ID())
 		case Qualifier:

--- a/parser/helper.go
+++ b/parser/helper.go
@@ -297,18 +297,17 @@ func (p *parserHelper) addMacroCall(exprID int64, function string, target *exprp
 	}
 }
 
-// logicManager performs tree balancing on operators whose arguments are of equal precedence.
+// logicManager compacts logical trees into a more efficient structure which is semantically
+// equivalent with how the logic graph is constructed by the ANTLR parser.
 //
 // The purpose of the logicManager is to ensure a compact serialization format for the logical &&, ||
 // operators which have a tendency to create long DAGs which are skewed in one direction. Since the
 // operators are commutative re-ordering the terms *must not* affect the evaluation result.
 //
-// Re-balancing the terms is a safe, if somewhat controversial choice. A better solution would be
-// to make these functions variadic and update both the checker and interpreter to understand this;
-// however, this is a more complex change.
-//
-// TODO: Consider replacing tree-balancing with variadic logical &&, || within the parser, checker,
-// and interpreter.
+// The logic manager will either render the terms to N-chained && / || operators as a single logical
+// call with N-terms, or will rebalance the tree. Rebalancing the terms is a safe, if somewhat
+// controversial choice as it alters the traditional order of execution assumptions present in most
+// expressions.
 type logicManager struct {
 	helper       *parserHelper
 	function     string

--- a/parser/helper.go
+++ b/parser/helper.go
@@ -297,9 +297,9 @@ func (p *parserHelper) addMacroCall(exprID int64, function string, target *exprp
 	}
 }
 
-// balancer performs tree balancing on operators whose arguments are of equal precedence.
+// logicManager performs tree balancing on operators whose arguments are of equal precedence.
 //
-// The purpose of the balancer is to ensure a compact serialization format for the logical &&, ||
+// The purpose of the logicManager is to ensure a compact serialization format for the logical &&, ||
 // operators which have a tendency to create long DAGs which are skewed in one direction. Since the
 // operators are commutative re-ordering the terms *must not* affect the evaluation result.
 //
@@ -309,55 +309,72 @@ func (p *parserHelper) addMacroCall(exprID int64, function string, target *exprp
 //
 // TODO: Consider replacing tree-balancing with variadic logical &&, || within the parser, checker,
 // and interpreter.
-type balancer struct {
-	helper   *parserHelper
-	function string
-	terms    []*exprpb.Expr
-	ops      []int64
+type logicManager struct {
+	helper       *parserHelper
+	function     string
+	terms        []*exprpb.Expr
+	ops          []int64
+	variadicASTs bool
 }
 
-// newBalancer creates a balancer instance bound to a specific function and its first term.
-func newBalancer(h *parserHelper, function string, term *exprpb.Expr) *balancer {
-	return &balancer{
-		helper:   h,
-		function: function,
-		terms:    []*exprpb.Expr{term},
-		ops:      []int64{},
+// newVariadicLogicManager creates a logic manager instance bound to a specific function and its first term.
+func newVariadicLogicManager(h *parserHelper, function string, term *exprpb.Expr) *logicManager {
+	return &logicManager{
+		helper:       h,
+		function:     function,
+		terms:        []*exprpb.Expr{term},
+		ops:          []int64{},
+		variadicASTs: true,
+	}
+}
+
+// newBalancingLogicManager creates a logic manager instance bound to a specific function and its first term.
+func newBalancingLogicManager(h *parserHelper, function string, term *exprpb.Expr) *logicManager {
+	return &logicManager{
+		helper:       h,
+		function:     function,
+		terms:        []*exprpb.Expr{term},
+		ops:          []int64{},
+		variadicASTs: false,
 	}
 }
 
 // addTerm adds an operation identifier and term to the set of terms to be balanced.
-func (b *balancer) addTerm(op int64, term *exprpb.Expr) {
-	b.terms = append(b.terms, term)
-	b.ops = append(b.ops, op)
+func (l *logicManager) addTerm(op int64, term *exprpb.Expr) {
+	l.terms = append(l.terms, term)
+	l.ops = append(l.ops, op)
 }
 
-// balance creates a balanced tree from the sub-terms and returns the final Expr value.
-func (b *balancer) balance() *exprpb.Expr {
-	if len(b.terms) == 1 {
-		return b.terms[0]
+// toExpr renders the logic graph into an Expr value, either balancing a tree of logical
+// operations or creating a variadic representation of the logical operator.
+func (l *logicManager) toExpr() *exprpb.Expr {
+	if len(l.terms) == 1 {
+		return l.terms[0]
 	}
-	return b.balancedTree(0, len(b.ops)-1)
+	if l.variadicASTs {
+		return l.helper.newGlobalCall(l.ops[0], l.function, l.terms...)
+	}
+	return l.balancedTree(0, len(l.ops)-1)
 }
 
 // balancedTree recursively balances the terms provided to a commutative operator.
-func (b *balancer) balancedTree(lo, hi int) *exprpb.Expr {
+func (l *logicManager) balancedTree(lo, hi int) *exprpb.Expr {
 	mid := (lo + hi + 1) / 2
 
 	var left *exprpb.Expr
 	if mid == lo {
-		left = b.terms[mid]
+		left = l.terms[mid]
 	} else {
-		left = b.balancedTree(lo, mid-1)
+		left = l.balancedTree(lo, mid-1)
 	}
 
 	var right *exprpb.Expr
 	if mid == hi {
-		right = b.terms[mid+1]
+		right = l.terms[mid+1]
 	} else {
-		right = b.balancedTree(mid+1, hi)
+		right = l.balancedTree(mid+1, hi)
 	}
-	return b.helper.newGlobalCall(b.ops[mid], b.function, left, right)
+	return l.helper.newGlobalCall(l.ops[mid], l.function, left, right)
 }
 
 type exprHelper struct {

--- a/parser/options.go
+++ b/parser/options.go
@@ -25,6 +25,7 @@ type options struct {
 	macros                           map[string]Macro
 	populateMacroCalls               bool
 	enableOptionalSyntax             bool
+	enableVariadicOperatorASTs       bool
 }
 
 // Option configures the behavior of the parser.
@@ -122,6 +123,18 @@ func PopulateMacroCalls(populateMacroCalls bool) Option {
 func EnableOptionalSyntax(optionalSyntax bool) Option {
 	return func(opts *options) error {
 		opts.enableOptionalSyntax = optionalSyntax
+		return nil
+	}
+}
+
+// EnableVariadicOperatorASTs enables a compact representation of chained like-kind commutative
+// operators. e.g. `a || b || c || d` -> `call(op='||', args=[a, b, c, d])`
+//
+// The benefit of enabling variadic operators ASTs is a more compact representation deeply nested
+// logic graphs.
+func EnableVariadicOperatorASTs(varArgASTs bool) Option {
+	return func(opts *options) error {
+		opts.enableVariadicOperatorASTs = varArgASTs
 		return nil
 	}
 }


### PR DESCRIPTION
Support for variadic logical operators to assist with reducing expression recursion depth.

Note, this change is not yet compatible with the cel-cpp or cel-java runtimes, so enable it carefully.