### PR TITLE
Add the overload reference for optional field selection

### DIFF
--- a/cel/BUILD.bazel
+++ b/cel/BUILD.bazel
@@ -72,6 +72,7 @@ go_test(
         "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
         "@org_golang_google_genproto_googleapis_api//expr/v1alpha1:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//encoding/prototext:go_default_library",
         "@org_golang_google_protobuf//types/known/structpb:go_default_library",
     ],
 )

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -1972,7 +1973,122 @@ func TestDynamicDispatch(t *testing.T) {
 	}
 }
 
-func TestOptionalValues(t *testing.T) {
+func TestOptionalValuesCompile(t *testing.T) {
+	env, err := NewEnv(
+		OptionalTypes(),
+		// Test variables.
+		Variable("m", MapType(StringType, MapType(StringType, StringType))),
+		Variable("optm", OptionalType(MapType(StringType, MapType(StringType, StringType)))),
+		Variable("l", ListType(StringType)),
+		Variable("optl", OptionalType(ListType(StringType))),
+		Variable("x", OptionalType(IntType)),
+		Variable("y", IntType),
+	)
+	if err != nil {
+		t.Fatalf("NewEnv() failed: %v", err)
+	}
+	tests := []struct {
+		expr       string
+		references map[int64]*exprpb.Reference
+	}{
+		{
+			expr: `x.or(optional.of(y)).orValue(42)`,
+			references: map[int64]*exprpb.Reference{
+				1: {Name: "x"},
+				2: {OverloadId: []string{"optional_or_optional"}},
+				4: {OverloadId: []string{"optional_of"}},
+				5: {Name: "y"},
+				6: {OverloadId: []string{"optional_orValue_value"}},
+			},
+		},
+		{
+			expr: `m.?x.hasValue()`,
+			references: map[int64]*exprpb.Reference{
+				1: {Name: "m"},
+				3: {OverloadId: []string{"select_optional_field"}},
+				4: {OverloadId: []string{"optional_hasValue"}},
+			},
+		},
+		{
+			expr: `has(m.?x.y)`,
+			references: map[int64]*exprpb.Reference{
+				2: {Name: "m"},
+				4: {OverloadId: []string{"select_optional_field"}},
+			},
+		},
+		{
+			// Optional index selection in map.
+			expr: `m.k[?'dashed-index'].orValue('default value')`,
+			references: map[int64]*exprpb.Reference{
+				1: {Name: "m"},
+				3: {OverloadId: []string{"map_optindex_optional_value"}},
+				5: {OverloadId: []string{"optional_orValue_value"}},
+			},
+		},
+		{
+			// Optional index selection in list.
+			expr: `l[?y]`,
+			references: map[int64]*exprpb.Reference{
+				1: {Name: "l"},
+				2: {OverloadId: []string{"list_optindex_optional_int"}},
+				3: {Name: "y"},
+			},
+		},
+		{
+			// Index selection against a value in an optional map.
+			expr: `optm.c['index'].orValue('default value')`,
+			references: map[int64]*exprpb.Reference{
+				1: {Name: "optm"},
+				3: {OverloadId: []string{"optional_map_index_value"}},
+				5: {OverloadId: []string{"optional_orValue_value"}},
+			},
+		},
+		{
+			// Index selection against a value in an optional map.
+			expr: `optm.c[?'index']`,
+			references: map[int64]*exprpb.Reference{
+				1: {Name: "optm"},
+				3: {OverloadId: []string{"optional_map_optindex_optional_value"}},
+			},
+		},
+		{
+			// Index selection against an value in an optional list.
+			expr: `optl[0]`,
+			references: map[int64]*exprpb.Reference{
+				1: {Name: "optl"},
+				2: {OverloadId: []string{"optional_list_index_int"}},
+			},
+		},
+		{
+			// Index selection against an value in an optional list.
+			expr: `optl[?0]`,
+			references: map[int64]*exprpb.Reference{
+				1: {Name: "optl"},
+				2: {OverloadId: []string{"optional_list_optindex_optional_int"}},
+			},
+		},
+	}
+
+	for i, tst := range tests {
+		tc := tst
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			ast, iss := env.Compile(tc.expr)
+			if iss.Err() != nil {
+				t.Fatalf("%v failed: %v", tc.expr, iss.Err())
+			}
+			for id, reference := range ast.refMap {
+				other, found := tc.references[id]
+				if !found {
+					t.Errorf("Compile(%v) expected reference %d: %v", tc.expr, id, prototext.Format(reference))
+				} else if !proto.Equal(reference, other) {
+					t.Errorf("Compile(%v) got reference %d: %v, wanted %v", tc.expr, id, prototext.Format(reference), prototext.Format(other))
+				}
+			}
+		})
+	}
+}
+
+func TestOptionalValuesEval(t *testing.T) {
 	env, err := NewEnv(
 		OptionalTypes(),
 		// Container and test message types.

--- a/cel/library.go
+++ b/cel/library.go
@@ -201,7 +201,7 @@ func (optionalLibrary) CompileOptions() []EnvOption {
 		// Index overloads to accommodate using an optional value as the operand.
 		Function(operators.Index,
 			Overload("optional_list_index_int", []*Type{OptionalType(listTypeV), IntType}, optionalTypeV),
-			Overload("optional_map_index_optional_value", []*Type{OptionalType(mapTypeKV), paramTypeK}, optionalTypeV)),
+			Overload("optional_map_index_value", []*Type{OptionalType(mapTypeKV), paramTypeK}, optionalTypeV)),
 	}
 }
 

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -205,6 +205,7 @@ func (c *checker) checkOptSelect(e *exprpb.Expr) {
 	// Perform type-checking using the field selection logic.
 	resultType := c.checkSelectField(e, operand, fieldName, true)
 	c.setType(e, substitute(c.mappings, resultType, false))
+	c.setReference(e, newFunctionReference("select_optional_field"))
 }
 
 func (c *checker) checkSelectField(e, operand *exprpb.Expr, field string, optional bool) *exprpb.Type {

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -2048,7 +2048,7 @@ _&&_(_==_(list~type(list(dyn))^list,
 		out: `_?._(
 			a~map(string, string)^a,
 			"b"
-		  )~optional(string)`,
+		  )~optional(string)^select_optional_field`,
 	},
 	{
 		in: `a.b`,
@@ -2091,7 +2091,7 @@ _&&_(_==_(list~type(list(dyn))^list,
 		out: `_?._(
 			a~optional(map(string, dyn))^a,
 			"b"
-		  )~optional(dyn).c~test-only~~bool`,
+		  )~optional(dyn)^select_optional_field.c~test-only~~bool`,
 	},
 	{
 		in:      `{?'key': {'a': 'b'}.?value}`,
@@ -2102,7 +2102,7 @@ _&&_(_==_(list~type(list(dyn))^list,
 				"a"~string:"b"~string
 			  }~map(string, string),
 			  "value"
-			)~optional(string)
+			)~optional(string)^select_optional_field
 		  }~map(string, string)`,
 	},
 	{
@@ -2114,7 +2114,7 @@ _&&_(_==_(list~type(list(dyn))^list,
 				"a"~string:"b"~string
 			  }~map(string, string),
 			  "value"
-			)~optional(string)
+			)~optional(string)^select_optional_field
 		  }~map(string, string).key~string`,
 	},
 	{
@@ -2163,7 +2163,7 @@ _&&_(_==_(list~type(list(dyn))^list,
 			?single_int32:_?._(
 			  {}~map(dyn, int),
 			  "i"
-			)~optional(int)
+			)~optional(int)^select_optional_field
 		  }~google.expr.proto2.test.TestAllTypes^google.expr.proto2.test.TestAllTypes`,
 		outType: decls.NewObjectType(
 			"google.expr.proto2.test.TestAllTypes",


### PR DESCRIPTION
Ensure that the overload id is set on the optional field selection call, e.g. `a.?b`.

Additionally, update the overload id to more accurately reflect the argument types.
This overload id change is backwards compatible since the interpreter special cases
handling based on the function name in these situations, and none of the other
runtimes currently support the new overloads yet.