### PR TITLE
Introduce a stdlib containing common function declarations and bindings

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -460,7 +460,7 @@ func TestCustomTypes(t *testing.T) {
 		Variable("expr", ObjectType("google.api.expr.v1alpha1.Expr")),
 	)
 
-	ast, _ := e.Compile(`
+	ast, iss := e.Compile(`
 		expr == Expr{id: 2,
 			call_expr: Expr.Call{
 				function: "_==_",
@@ -468,6 +468,9 @@ func TestCustomTypes(t *testing.T) {
 					Expr{id: 1, ident_expr: Expr.Ident{ name: "a" }},
 					Expr{id: 3, ident_expr: Expr.Ident{ name: "b" }}]
 			}}`)
+	if iss.Err() != nil {
+		t.Fatalf("Compile() failed: %v", iss.Err())
+	}
 	if ast.OutputType() != BoolType {
 		t.Fatalf("got %v, wanted type bool", ast.OutputType())
 	}
@@ -1977,8 +1980,7 @@ func TestDynamicDispatch(t *testing.T) {
 		t.Fatalf("NewEnv() failed: %v", err)
 	}
 	out, err := interpret(t, env, `
-		[].first() == 0
-		&& [1, 2].first() == 1
+		[1, 2].first() == 1
 		&& [1.0, 2.0].first() == 1.0
 		&& ["hello", "world"].first() == "hello"
 		&& [["hello"], ["world", "!"]].first().first() == "hello"

--- a/cel/decls.go
+++ b/cel/decls.go
@@ -187,7 +187,7 @@ func Function(name string, opts ...FunctionOpt) EnvOption {
 				return nil, err
 			}
 		}
-		e.functions[name] = fn
+		e.functions[fn.Name] = fn
 		return e, nil
 	}
 }
@@ -348,34 +348,7 @@ func TypeToExprType(t *Type) (*exprpb.Type, error) {
 	case StringKind:
 		return maybeWrapper(t, chkdecls.String), nil
 	case StructKind:
-		switch t.RuntimeTypeName() {
-		case "google.protobuf.Any":
-			return chkdecls.Any, nil
-		case "google.protobuf.Duration":
-			return chkdecls.Duration, nil
-		case "google.protobuf.Timestamp":
-			return chkdecls.Timestamp, nil
-		case "google.protobuf.Value":
-			return chkdecls.Dyn, nil
-		case "google.protobuf.ListValue":
-			return chkdecls.NewListType(chkdecls.Dyn), nil
-		case "google.protobuf.Struct":
-			return chkdecls.NewMapType(chkdecls.String, chkdecls.Dyn), nil
-		case "google.protobuf.BoolValue":
-			return chkdecls.NewWrapperType(chkdecls.Bool), nil
-		case "google.protobuf.BytesValue":
-			return chkdecls.NewWrapperType(chkdecls.Bytes), nil
-		case "google.protobuf.DoubleValue", "google.protobuf.FloatValue":
-			return chkdecls.NewWrapperType(chkdecls.Double), nil
-		case "google.protobuf.Int32Value", "google.protobuf.Int64Value":
-			return chkdecls.NewWrapperType(chkdecls.Int), nil
-		case "google.protobuf.StringValue":
-			return chkdecls.NewWrapperType(chkdecls.String), nil
-		case "google.protobuf.UInt32Value", "google.protobuf.UInt64Value":
-			return chkdecls.NewWrapperType(chkdecls.Uint), nil
-		default:
-			return chkdecls.NewObjectType(t.RuntimeTypeName()), nil
-		}
+		return chkdecls.NewObjectType(t.RuntimeTypeName()), nil
 	case TimestampKind:
 		return chkdecls.Timestamp, nil
 	case TypeParamKind:
@@ -420,34 +393,7 @@ func ExprTypeToType(t *exprpb.Type) (*Type, error) {
 		}
 		return MapType(kt, vt), nil
 	case *exprpb.Type_MessageType:
-		switch t.GetMessageType() {
-		case "google.protobuf.Any":
-			return AnyType, nil
-		case "google.protobuf.Duration":
-			return DurationType, nil
-		case "google.protobuf.Timestamp":
-			return TimestampType, nil
-		case "google.protobuf.Value":
-			return DynType, nil
-		case "google.protobuf.ListValue":
-			return ListType(DynType), nil
-		case "google.protobuf.Struct":
-			return MapType(StringType, DynType), nil
-		case "google.protobuf.BoolValue":
-			return NullableType(BoolType), nil
-		case "google.protobuf.BytesValue":
-			return NullableType(BytesType), nil
-		case "google.protobuf.DoubleValue", "google.protobuf.FloatValue":
-			return NullableType(DoubleType), nil
-		case "google.protobuf.Int32Value", "google.protobuf.Int64Value":
-			return NullableType(IntType), nil
-		case "google.protobuf.StringValue":
-			return NullableType(StringType), nil
-		case "google.protobuf.UInt32Value", "google.protobuf.UInt64Value":
-			return NullableType(UintType), nil
-		default:
-			return ObjectType(t.GetMessageType()), nil
-		}
+		return ObjectType(t.GetMessageType()), nil
 	case *exprpb.Type_Null:
 		return NullType, nil
 	case *exprpb.Type_Primitive:

--- a/cel/decls.go
+++ b/cel/decls.go
@@ -239,6 +239,12 @@ func SingletonFunctionBinding(fn functions.FunctionOp, traits ...int) FunctionOp
 	return decls.SingletonFunctionBinding(fn, traits...)
 }
 
+// DisableDeclaration disables the function signatures, effectively removing them from the type-check
+// environment while preserving the runtime bindings.
+func DisableDeclaration(value bool) FunctionOpt {
+	return decls.DisableDeclaration(value)
+}
+
 // Overload defines a new global overload with an overload id, argument types, and result type. Through the
 // use of OverloadOpt options, the overload may also be configured with a binding, an operand trait, and to
 // be non-strict.
@@ -354,6 +360,13 @@ func TypeToExprType(t *Type) (*exprpb.Type, error) {
 	case TypeParamKind:
 		return chkdecls.NewTypeParamType(t.RuntimeTypeName()), nil
 	case TypeKind:
+		if len(t.Parameters) == 1 {
+			p, err := TypeToExprType(t.Parameters[0])
+			if err != nil {
+				return nil, err
+			}
+			return chkdecls.NewTypeType(p), nil
+		}
 		return chkdecls.NewTypeType(chkdecls.Dyn), nil
 	case UintKind:
 		return maybeWrapper(t, chkdecls.Uint), nil

--- a/cel/library.go
+++ b/cel/library.go
@@ -111,13 +111,11 @@ func (stdLibrary) CompileOptions() []EnvOption {
 		Declarations(checker.StandardTypes()...),
 		Macros(StandardMacros...),
 		func(e *Env) (*Env, error) {
-			for _, fn := range stdlib.Functions() {
-				ed, err := functionDeclToExprDecl(fn)
-				if err != nil {
-					return nil, err
-				}
-				e.declarations = append(e.declarations, ed)
+			stdDecls, err := stdlibFuncDecls()
+			if err != nil {
+				return nil, err
 			}
+			e.declarations = append(e.declarations, stdDecls...)
 			return e, nil
 		},
 	}
@@ -140,6 +138,21 @@ func (stdLibrary) ProgramOptions() []ProgramOption {
 			return p, nil
 		},
 	}
+}
+
+func stdlibFuncDecls() ([]*exprpb.Decl, error) {
+	stdDecls := make([]*exprpb.Decl, 0, len(stdlib.Functions()))
+	for _, fn := range stdlib.Functions() {
+		if fn.IsDeclarationDisabled() {
+			continue
+		}
+		ed, err := functionDeclToExprDecl(fn)
+		if err != nil {
+			return nil, err
+		}
+		stdDecls = append(stdDecls, ed)
+	}
+	return stdDecls, nil
 }
 
 type optionalLibrary struct{}

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -2461,7 +2461,7 @@ func TestAddEquivalentDeclarations(t *testing.T) {
 	}
 }
 
-func TestCheckErrorExprID(t *testing.T) {
+func TestCheckErrorData(t *testing.T) {
 	p, err := parser.NewParser(
 		parser.EnableOptionalSyntax(true),
 		parser.Macros(parser.AllMacros...),

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -2367,7 +2367,8 @@ func TestCheck(t *testing.T) {
 				t.Fatalf("NewEnv(cont, reg) failed: %v", err)
 			}
 			if !tc.disableStdEnv {
-				env.Add(StandardDeclarations()...)
+				env.Add(StandardTypes()...)
+				env.Add(StandardFunctions()...)
 			}
 			if tc.env.idents != nil {
 				for _, ident := range tc.env.idents {
@@ -2420,11 +2421,11 @@ func TestAddDuplicateDeclarations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEnv() failed: %v", err)
 	}
-	err = env.Add(StandardDeclarations()...)
+	err = env.Add(StandardFunctions()...)
 	if err != nil {
 		t.Fatalf("env.Add() failed: %v", err)
 	}
-	err = env.Add(StandardDeclarations()...)
+	err = env.Add(StandardFunctions()...)
 	if err != nil {
 		t.Errorf("env.Add() failed with duplicate declarations: %v", err)
 	}
@@ -2480,7 +2481,8 @@ func TestCheckErrorData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEnv(cont, reg) failed: %v", err)
 	}
-	env.Add(StandardDeclarations()...)
+	env.Add(StandardTypes()...)
+	env.Add(StandardFunctions()...)
 	_, iss = Check(ast, src, env)
 	if len(iss.GetErrors()) != 1 {
 		t.Fatalf("Check() of a bad expression did produce a single error: %v", iss.ToDisplayString())

--- a/checker/cost_test.go
+++ b/checker/cost_test.go
@@ -490,7 +490,7 @@ func TestCost(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewEnv() failed: %v", err)
 			}
-			err = e.Add(StandardDeclarations()...)
+			err = e.Add(StandardFunctions()...)
 			if err != nil {
 				t.Fatalf("environment creation error: %v", err)
 			}

--- a/checker/env_test.go
+++ b/checker/env_test.go
@@ -120,7 +120,7 @@ func BenchmarkNewStdEnv(b *testing.B) {
 		decls = append(decls, StandardFunctions()...)
 		err = env.Add(decls...)
 		if err != nil {
-			b.Fatalf("env.Add(StandardDeclarations()) failed: %v", err)
+			b.Fatalf("env.Add(StandardFunctions()) failed: %v", err)
 		}
 	}
 }
@@ -135,7 +135,7 @@ func BenchmarkCopyDeclarations(b *testing.B) {
 	decls = append(decls, StandardFunctions()...)
 	err = env.Add(decls...)
 	if err != nil {
-		b.Fatalf("env.Add(StandardDeclarations()) failed: %v", err)
+		b.Fatalf("env.Add(StandardFunctions()) failed: %v", err)
 	}
 	for i := 0; i < b.N; i++ {
 		env.validatedDeclarations().Copy()

--- a/checker/env_test.go
+++ b/checker/env_test.go
@@ -117,7 +117,7 @@ func BenchmarkNewStdEnv(b *testing.B) {
 			b.Fatalf("NewEnv() failed: %v", err)
 		}
 		decls := []*exprpb.Decl{}
-		decls = append(decls, StandardDeclarations()...)
+		decls = append(decls, StandardFunctions()...)
 		err = env.Add(decls...)
 		if err != nil {
 			b.Fatalf("env.Add(StandardDeclarations()) failed: %v", err)
@@ -131,7 +131,8 @@ func BenchmarkCopyDeclarations(b *testing.B) {
 		b.Fatalf("NewEnv() failed: %v", err)
 	}
 	decls := []*exprpb.Decl{}
-	decls = append(decls, StandardDeclarations()...)
+	decls = append(decls, StandardTypes()...)
+	decls = append(decls, StandardFunctions()...)
 	err = env.Add(decls...)
 	if err != nil {
 		b.Fatalf("env.Add(StandardDeclarations()) failed: %v", err)
@@ -147,9 +148,13 @@ func newStdEnv(t *testing.T) *Env {
 	if err != nil {
 		t.Fatalf("NewEnv() failed: %v", err)
 	}
-	err = env.Add(StandardDeclarations()...)
+	err = env.Add(StandardTypes()...)
 	if err != nil {
-		t.Fatalf("env.Add(StandardDeclarations()) failed: %v", err)
+		t.Fatalf("env.Add(StandardTypes()...) failed: %v", err)
+	}
+	err = env.Add(StandardFunctions()...)
+	if err != nil {
+		t.Fatalf("env.Add(StandardFunctions()...) failed: %v", err)
 	}
 	return env
 }

--- a/checker/standard.go
+++ b/checker/standard.go
@@ -23,7 +23,8 @@ import (
 )
 
 var (
-	standardDeclarations []*exprpb.Decl
+	standardTypes     []*exprpb.Decl
+	standardFunctions []*exprpb.Decl
 )
 
 func init() {
@@ -35,21 +36,19 @@ func init() {
 	typeParamABList := []string{"A", "B"}
 	mapOfAB := decls.NewMapType(paramA, paramB)
 
-	var idents []*exprpb.Decl
 	for _, t := range []*exprpb.Type{
 		decls.Int, decls.Uint, decls.Bool,
 		decls.Double, decls.Bytes, decls.String} {
-		idents = append(idents,
+		standardTypes = append(standardTypes,
 			decls.NewVar(FormatCheckedType(t), decls.NewTypeType(t)))
 	}
-	idents = append(idents,
+	standardTypes = append(standardTypes,
 		decls.NewVar("list", decls.NewTypeType(listOfA)),
 		decls.NewVar("map", decls.NewTypeType(mapOfAB)),
 		decls.NewVar("null_type", decls.NewTypeType(decls.Null)),
 		decls.NewVar("type", decls.NewTypeType(decls.NewTypeType(nil))))
 
-	standardDeclarations = append(standardDeclarations, idents...)
-	standardDeclarations = append(standardDeclarations, []*exprpb.Decl{
+	standardFunctions = append(standardFunctions, []*exprpb.Decl{
 		// Booleans
 		decls.NewFunction(operators.Conditional,
 			decls.NewParameterizedOverload(overloads.Conditional,
@@ -488,7 +487,12 @@ func init() {
 	}...)
 }
 
-// StandardDeclarations returns the Decls for all functions and constants in the evaluator.
-func StandardDeclarations() []*exprpb.Decl {
-	return standardDeclarations
+// StandardFunctions returns the Decls for all functions in the evaluator.
+func StandardFunctions() []*exprpb.Decl {
+	return standardFunctions
+}
+
+// StandardTypes returns the set of type identifiers for standard library types.
+func StandardTypes() []*exprpb.Decl {
+	return standardTypes
 }

--- a/checker/standard.go
+++ b/checker/standard.go
@@ -184,16 +184,6 @@ func init() {
 				[]*exprpb.Type{paramA, mapOfAB}, decls.Bool,
 				typeParamABList)),
 
-		// Deprecated 'in()' function.
-
-		decls.NewFunction(overloads.DeprecatedIn,
-			decls.NewParameterizedOverload(overloads.InList,
-				[]*exprpb.Type{paramA, listOfA}, decls.Bool,
-				typeParamAList),
-			decls.NewParameterizedOverload(overloads.InMap,
-				[]*exprpb.Type{paramA, mapOfAB}, decls.Bool,
-				typeParamABList)),
-
 		// Conversions to type.
 
 		decls.NewFunction(overloads.TypeConvertType,

--- a/common/decls/decls.go
+++ b/common/decls/decls.go
@@ -402,6 +402,16 @@ type FunctionDecl struct {
 	// add overhead on common operations. Setting this option true leaves error checks and argument checks
 	// intact.
 	disableTypeGuards bool
+
+	// declarationDisabled indicates that the binding should be provided on the runtime, but the method should
+	// not be exposed as a declaration available for use.
+	declarationDisabled bool
+}
+
+// IsDeclarationDisabled indicates that the function implementation should be added to the dispatcher, but the
+// declaration should not be exposed for use in expressions.
+func (f *FunctionDecl) IsDeclarationDisabled() bool {
+	return f.declarationDisabled
 }
 
 // Merge combines an existing function declaration with another.
@@ -571,6 +581,16 @@ type FunctionOpt func(*FunctionDecl) (*FunctionDecl, error)
 func DisableTypeGuards(value bool) FunctionOpt {
 	return func(fn *FunctionDecl) (*FunctionDecl, error) {
 		fn.disableTypeGuards = value
+		return fn, nil
+	}
+}
+
+// DisableDeclaration indicates that the function declaration should be disabled, but the runtime function
+// binding should be provided. Marking a function as runtime-only is a safe way to manage deprecations
+// of function declarations while still preserving the runtime behavior for previously compiled expressions.
+func DisableDeclaration(value bool) FunctionOpt {
+	return func(fn *FunctionDecl) (*FunctionDecl, error) {
+		fn.declarationDisabled = value
 		return fn, nil
 	}
 }

--- a/common/stdlib/standard.go
+++ b/common/stdlib/standard.go
@@ -15,6 +15,7 @@
 package stdlib
 
 import (
+	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/functions"
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/overloads"
@@ -23,237 +24,529 @@ import (
 	"github.com/google/cel-go/common/types/traits"
 )
 
-// StandardOverloads returns the definitions of the built-in overloads.
-func StandardOverloads() []*functions.Overload {
-	return []*functions.Overload{
-		// Logical not (!a)
-		{
-			Operator:     operators.LogicalNot,
-			OperandTrait: traits.NegatorType,
-			Unary: func(value ref.Val) ref.Val {
-				if !types.IsBool(value) {
-					return types.ValOrErr(value, "no such overload")
-				}
-				return value.(traits.Negater).Negate()
-			}},
-		// Not strictly false: IsBool(a) ? a : true
-		{
-			Operator: operators.NotStrictlyFalse,
-			Unary:    notStrictlyFalse},
-		// Deprecated: not strictly false, may be overridden in the environment.
-		{
-			Operator: operators.OldNotStrictlyFalse,
-			Unary:    notStrictlyFalse},
+var (
+	stdFunctions []*decls.FunctionDecl
+)
 
-		// Less than operator
-		{Operator: operators.Less,
-			OperandTrait: traits.ComparerType,
-			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
-				cmp := lhs.(traits.Comparer).Compare(rhs)
-				if cmp == types.IntNegOne {
-					return types.True
-				}
-				if cmp == types.IntOne || cmp == types.IntZero {
-					return types.False
-				}
-				return cmp
-			}},
+func init() {
+	paramA := decls.TypeParamType("A")
+	paramB := decls.TypeParamType("B")
+	listOfA := decls.ListType(paramA)
+	mapOfAB := decls.MapType(paramA, paramB)
 
-		// Less than or equal operator
-		{Operator: operators.LessEquals,
-			OperandTrait: traits.ComparerType,
-			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
-				cmp := lhs.(traits.Comparer).Compare(rhs)
-				if cmp == types.IntNegOne || cmp == types.IntZero {
-					return types.True
+	stdFunctions = []*decls.FunctionDecl{
+		// Logical operators. Special-cased within the interpreter.
+		// Note, the singleton binding prevents extensions from overriding the operator behavior.
+		function(operators.Conditional,
+			decls.Overload(overloads.Conditional, argTypes(decls.BoolType, paramA, paramA), paramA,
+				decls.OverloadIsNonStrict()),
+			decls.SingletonFunctionBinding(noFunctionOverrides)),
+		function(operators.LogicalAnd,
+			decls.Overload(overloads.LogicalAnd, argTypes(decls.BoolType, decls.BoolType), decls.BoolType,
+				decls.OverloadIsNonStrict()),
+			decls.SingletonBinaryBinding(noBinaryOverrides)),
+		function(operators.LogicalOr,
+			decls.Overload(overloads.LogicalOr, argTypes(decls.BoolType, decls.BoolType), decls.BoolType,
+				decls.OverloadIsNonStrict()),
+			decls.SingletonBinaryBinding(noBinaryOverrides)),
+		function(operators.LogicalNot,
+			decls.Overload(overloads.LogicalNot, argTypes(decls.BoolType), decls.BoolType),
+			decls.SingletonUnaryBinding(func(val ref.Val) ref.Val {
+				b, ok := val.(types.Bool)
+				if !ok {
+					return types.MaybeNoSuchOverloadErr(val)
 				}
-				if cmp == types.IntOne {
-					return types.False
-				}
-				return cmp
-			}},
+				return b.Negate()
+			})),
 
-		// Greater than operator
-		{Operator: operators.Greater,
-			OperandTrait: traits.ComparerType,
-			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
-				cmp := lhs.(traits.Comparer).Compare(rhs)
-				if cmp == types.IntOne {
-					return types.True
-				}
-				if cmp == types.IntNegOne || cmp == types.IntZero {
-					return types.False
-				}
-				return cmp
-			}},
+		// Comprehension short-circuiting related function
+		function(operators.NotStrictlyFalse,
+			decls.Overload(overloads.NotStrictlyFalse, argTypes(decls.BoolType), decls.BoolType,
+				decls.OverloadIsNonStrict(),
+				decls.UnaryBinding(notStrictlyFalse))),
+		// Deprecated: __not_strictly_false__
+		function(operators.OldNotStrictlyFalse,
+			decls.Overload(operators.OldNotStrictlyFalse, argTypes(decls.BoolType), decls.BoolType,
+				decls.OverloadIsNonStrict(),
+				decls.UnaryBinding(notStrictlyFalse))),
 
-		// Greater than equal operators
-		{Operator: operators.GreaterEquals,
-			OperandTrait: traits.ComparerType,
-			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
-				cmp := lhs.(traits.Comparer).Compare(rhs)
-				if cmp == types.IntOne || cmp == types.IntZero {
-					return types.True
-				}
-				if cmp == types.IntNegOne {
-					return types.False
-				}
-				return cmp
-			}},
+		// Equality / inequality. Special-cased in the interpreter
+		function(operators.Equals,
+			decls.Overload(overloads.Equals, argTypes(paramA, paramA), decls.BoolType),
+			decls.SingletonBinaryBinding(noBinaryOverrides)),
+		function(operators.NotEquals,
+			decls.Overload(overloads.NotEquals, argTypes(paramA, paramA), decls.BoolType),
+			decls.SingletonBinaryBinding(noBinaryOverrides)),
 
-		// Add operator
-		{Operator: operators.Add,
-			OperandTrait: traits.AdderType,
-			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
+		// Mathematical operators
+		function(operators.Add,
+			decls.Overload(overloads.AddBytes,
+				argTypes(decls.BytesType, decls.BytesType), decls.BytesType),
+			decls.Overload(overloads.AddDouble,
+				argTypes(decls.DoubleType, decls.DoubleType), decls.DoubleType),
+			decls.Overload(overloads.AddDurationDuration,
+				argTypes(decls.DurationType, decls.DurationType), decls.DurationType),
+			decls.Overload(overloads.AddDurationTimestamp,
+				argTypes(decls.DurationType, decls.TimestampType), decls.TimestampType),
+			decls.Overload(overloads.AddTimestampDuration,
+				argTypes(decls.TimestampType, decls.DurationType), decls.TimestampType),
+			decls.Overload(overloads.AddInt64,
+				argTypes(decls.IntType, decls.IntType), decls.IntType),
+			decls.Overload(overloads.AddList,
+				argTypes(listOfA, listOfA), listOfA),
+			decls.Overload(overloads.AddString,
+				argTypes(decls.StringType, decls.StringType), decls.StringType),
+			decls.Overload(overloads.AddUint64,
+				argTypes(decls.UintType, decls.UintType), decls.UintType),
+			decls.SingletonBinaryBinding(func(lhs, rhs ref.Val) ref.Val {
 				return lhs.(traits.Adder).Add(rhs)
-			}},
-
-		// Subtract operators
-		{Operator: operators.Subtract,
-			OperandTrait: traits.SubtractorType,
-			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
-				return lhs.(traits.Subtractor).Subtract(rhs)
-			}},
-
-		// Multiply operator
-		{Operator: operators.Multiply,
-			OperandTrait: traits.MultiplierType,
-			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
-				return lhs.(traits.Multiplier).Multiply(rhs)
-			}},
-
-		// Divide operator
-		{Operator: operators.Divide,
-			OperandTrait: traits.DividerType,
-			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
+			}, traits.AdderType)),
+		function(operators.Divide,
+			decls.Overload(overloads.DivideDouble,
+				argTypes(decls.DoubleType, decls.DoubleType), decls.DoubleType),
+			decls.Overload(overloads.DivideInt64,
+				argTypes(decls.IntType, decls.IntType), decls.IntType),
+			decls.Overload(overloads.DivideUint64,
+				argTypes(decls.UintType, decls.UintType), decls.UintType),
+			decls.SingletonBinaryBinding(func(lhs, rhs ref.Val) ref.Val {
 				return lhs.(traits.Divider).Divide(rhs)
-			}},
-
-		// Modulo operator
-		{Operator: operators.Modulo,
-			OperandTrait: traits.ModderType,
-			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
+			}, traits.DividerType)),
+		function(operators.Modulo,
+			decls.Overload(overloads.ModuloInt64,
+				argTypes(decls.IntType, decls.IntType), decls.IntType),
+			decls.Overload(overloads.ModuloUint64,
+				argTypes(decls.UintType, decls.UintType), decls.UintType),
+			decls.SingletonBinaryBinding(func(lhs, rhs ref.Val) ref.Val {
 				return lhs.(traits.Modder).Modulo(rhs)
-			}},
-
-		// Negate operator
-		{Operator: operators.Negate,
-			OperandTrait: traits.NegatorType,
-			Unary: func(value ref.Val) ref.Val {
-				if types.IsBool(value) {
-					return types.ValOrErr(value, "no such overload")
+			}, traits.ModderType)),
+		function(operators.Multiply,
+			decls.Overload(overloads.MultiplyDouble,
+				argTypes(decls.DoubleType, decls.DoubleType), decls.DoubleType),
+			decls.Overload(overloads.MultiplyInt64,
+				argTypes(decls.IntType, decls.IntType), decls.IntType),
+			decls.Overload(overloads.MultiplyUint64,
+				argTypes(decls.UintType, decls.UintType), decls.UintType),
+			decls.SingletonBinaryBinding(func(lhs, rhs ref.Val) ref.Val {
+				return lhs.(traits.Multiplier).Multiply(rhs)
+			}, traits.MultiplierType)),
+		function(operators.Negate,
+			decls.Overload(overloads.NegateDouble, argTypes(decls.DoubleType), decls.DoubleType),
+			decls.Overload(overloads.NegateInt64, argTypes(decls.IntType), decls.IntType),
+			decls.SingletonUnaryBinding(func(val ref.Val) ref.Val {
+				if types.IsBool(val) {
+					return types.MaybeNoSuchOverloadErr(val)
 				}
-				return value.(traits.Negater).Negate()
-			}},
+				return val.(traits.Negater).Negate()
+			}, traits.NegatorType)),
+		function(operators.Subtract,
+			decls.Overload(overloads.SubtractDouble,
+				argTypes(decls.DoubleType, decls.DoubleType), decls.DoubleType),
+			decls.Overload(overloads.SubtractDurationDuration,
+				argTypes(decls.DurationType, decls.DurationType), decls.DurationType),
+			decls.Overload(overloads.SubtractInt64,
+				argTypes(decls.IntType, decls.IntType), decls.IntType),
+			decls.Overload(overloads.SubtractTimestampDuration,
+				argTypes(decls.TimestampType, decls.DurationType), decls.TimestampType),
+			decls.Overload(overloads.SubtractTimestampTimestamp,
+				argTypes(decls.TimestampType, decls.TimestampType), decls.DurationType),
+			decls.Overload(overloads.SubtractUint64,
+				argTypes(decls.UintType, decls.UintType), decls.UintType),
+			decls.SingletonBinaryBinding(func(lhs, rhs ref.Val) ref.Val {
+				return lhs.(traits.Subtractor).Subtract(rhs)
+			}, traits.SubtractorType)),
 
-		// Index operator
-		{Operator: operators.Index,
-			OperandTrait: traits.IndexerType,
-			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
+		// Relations operators
+
+		function(operators.Less,
+			decls.Overload(overloads.LessBool,
+				argTypes(decls.BoolType, decls.BoolType), decls.BoolType),
+			decls.Overload(overloads.LessInt64,
+				argTypes(decls.IntType, decls.IntType), decls.BoolType),
+			decls.Overload(overloads.LessInt64Double,
+				argTypes(decls.IntType, decls.DoubleType), decls.BoolType),
+			decls.Overload(overloads.LessInt64Uint64,
+				argTypes(decls.IntType, decls.UintType), decls.BoolType),
+			decls.Overload(overloads.LessUint64,
+				argTypes(decls.UintType, decls.UintType), decls.BoolType),
+			decls.Overload(overloads.LessUint64Double,
+				argTypes(decls.UintType, decls.DoubleType), decls.BoolType),
+			decls.Overload(overloads.LessUint64Int64,
+				argTypes(decls.UintType, decls.IntType), decls.BoolType),
+			decls.Overload(overloads.LessDouble,
+				argTypes(decls.DoubleType, decls.DoubleType), decls.BoolType),
+			decls.Overload(overloads.LessDoubleInt64,
+				argTypes(decls.DoubleType, decls.IntType), decls.BoolType),
+			decls.Overload(overloads.LessDoubleUint64,
+				argTypes(decls.DoubleType, decls.UintType), decls.BoolType),
+			decls.Overload(overloads.LessString,
+				argTypes(decls.StringType, decls.StringType), decls.BoolType),
+			decls.Overload(overloads.LessBytes,
+				argTypes(decls.BytesType, decls.BytesType), decls.BoolType),
+			decls.Overload(overloads.LessTimestamp,
+				argTypes(decls.TimestampType, decls.TimestampType), decls.BoolType),
+			decls.Overload(overloads.LessDuration,
+				argTypes(decls.DurationType, decls.DurationType), decls.BoolType),
+			decls.SingletonBinaryBinding(func(lhs, rhs ref.Val) ref.Val {
+				cmp := lhs.(traits.Comparer).Compare(rhs)
+				if cmp == types.IntNegOne {
+					return types.True
+				}
+				if cmp == types.IntOne || cmp == types.IntZero {
+					return types.False
+				}
+				return cmp
+			}, traits.ComparerType)),
+
+		function(operators.LessEquals,
+			decls.Overload(overloads.LessEqualsBool,
+				argTypes(decls.BoolType, decls.BoolType), decls.BoolType),
+			decls.Overload(overloads.LessEqualsInt64,
+				argTypes(decls.IntType, decls.IntType), decls.BoolType),
+			decls.Overload(overloads.LessEqualsInt64Double,
+				argTypes(decls.IntType, decls.DoubleType), decls.BoolType),
+			decls.Overload(overloads.LessEqualsInt64Uint64,
+				argTypes(decls.IntType, decls.UintType), decls.BoolType),
+			decls.Overload(overloads.LessEqualsUint64,
+				argTypes(decls.UintType, decls.UintType), decls.BoolType),
+			decls.Overload(overloads.LessEqualsUint64Double,
+				argTypes(decls.UintType, decls.DoubleType), decls.BoolType),
+			decls.Overload(overloads.LessEqualsUint64Int64,
+				argTypes(decls.UintType, decls.IntType), decls.BoolType),
+			decls.Overload(overloads.LessEqualsDouble,
+				argTypes(decls.DoubleType, decls.DoubleType), decls.BoolType),
+			decls.Overload(overloads.LessEqualsDoubleInt64,
+				argTypes(decls.DoubleType, decls.IntType), decls.BoolType),
+			decls.Overload(overloads.LessEqualsDoubleUint64,
+				argTypes(decls.DoubleType, decls.UintType), decls.BoolType),
+			decls.Overload(overloads.LessEqualsString,
+				argTypes(decls.StringType, decls.StringType), decls.BoolType),
+			decls.Overload(overloads.LessEqualsBytes,
+				argTypes(decls.BytesType, decls.BytesType), decls.BoolType),
+			decls.Overload(overloads.LessEqualsTimestamp,
+				argTypes(decls.TimestampType, decls.TimestampType), decls.BoolType),
+			decls.Overload(overloads.LessEqualsDuration,
+				argTypes(decls.DurationType, decls.DurationType), decls.BoolType),
+			decls.SingletonBinaryBinding(func(lhs, rhs ref.Val) ref.Val {
+				cmp := lhs.(traits.Comparer).Compare(rhs)
+				if cmp == types.IntNegOne || cmp == types.IntZero {
+					return types.True
+				}
+				if cmp == types.IntOne {
+					return types.False
+				}
+				return cmp
+			}, traits.ComparerType)),
+
+		function(operators.Greater,
+			decls.Overload(overloads.GreaterBool,
+				argTypes(decls.BoolType, decls.BoolType), decls.BoolType),
+			decls.Overload(overloads.GreaterInt64,
+				argTypes(decls.IntType, decls.IntType), decls.BoolType),
+			decls.Overload(overloads.GreaterInt64Double,
+				argTypes(decls.IntType, decls.DoubleType), decls.BoolType),
+			decls.Overload(overloads.GreaterInt64Uint64,
+				argTypes(decls.IntType, decls.UintType), decls.BoolType),
+			decls.Overload(overloads.GreaterUint64,
+				argTypes(decls.UintType, decls.UintType), decls.BoolType),
+			decls.Overload(overloads.GreaterUint64Double,
+				argTypes(decls.UintType, decls.DoubleType), decls.BoolType),
+			decls.Overload(overloads.GreaterUint64Int64,
+				argTypes(decls.UintType, decls.IntType), decls.BoolType),
+			decls.Overload(overloads.GreaterDouble,
+				argTypes(decls.DoubleType, decls.DoubleType), decls.BoolType),
+			decls.Overload(overloads.GreaterDoubleInt64,
+				argTypes(decls.DoubleType, decls.IntType), decls.BoolType),
+			decls.Overload(overloads.GreaterDoubleUint64,
+				argTypes(decls.DoubleType, decls.UintType), decls.BoolType),
+			decls.Overload(overloads.GreaterString,
+				argTypes(decls.StringType, decls.StringType), decls.BoolType),
+			decls.Overload(overloads.GreaterBytes,
+				argTypes(decls.BytesType, decls.BytesType), decls.BoolType),
+			decls.Overload(overloads.GreaterTimestamp,
+				argTypes(decls.TimestampType, decls.TimestampType), decls.BoolType),
+			decls.Overload(overloads.GreaterDuration,
+				argTypes(decls.DurationType, decls.DurationType), decls.BoolType),
+			decls.SingletonBinaryBinding(func(lhs, rhs ref.Val) ref.Val {
+				cmp := lhs.(traits.Comparer).Compare(rhs)
+				if cmp == types.IntOne {
+					return types.True
+				}
+				if cmp == types.IntNegOne || cmp == types.IntZero {
+					return types.False
+				}
+				return cmp
+			}, traits.ComparerType)),
+
+		function(operators.GreaterEquals,
+			decls.Overload(overloads.GreaterEqualsBool,
+				argTypes(decls.BoolType, decls.BoolType), decls.BoolType),
+			decls.Overload(overloads.GreaterEqualsInt64,
+				argTypes(decls.IntType, decls.IntType), decls.BoolType),
+			decls.Overload(overloads.GreaterEqualsInt64Double,
+				argTypes(decls.IntType, decls.DoubleType), decls.BoolType),
+			decls.Overload(overloads.GreaterEqualsInt64Uint64,
+				argTypes(decls.IntType, decls.UintType), decls.BoolType),
+			decls.Overload(overloads.GreaterEqualsUint64,
+				argTypes(decls.UintType, decls.UintType), decls.BoolType),
+			decls.Overload(overloads.GreaterEqualsUint64Double,
+				argTypes(decls.UintType, decls.DoubleType), decls.BoolType),
+			decls.Overload(overloads.GreaterEqualsUint64Int64,
+				argTypes(decls.UintType, decls.IntType), decls.BoolType),
+			decls.Overload(overloads.GreaterEqualsDouble,
+				argTypes(decls.DoubleType, decls.DoubleType), decls.BoolType),
+			decls.Overload(overloads.GreaterEqualsDoubleInt64,
+				argTypes(decls.DoubleType, decls.IntType), decls.BoolType),
+			decls.Overload(overloads.GreaterEqualsDoubleUint64,
+				argTypes(decls.DoubleType, decls.UintType), decls.BoolType),
+			decls.Overload(overloads.GreaterEqualsString,
+				argTypes(decls.StringType, decls.StringType), decls.BoolType),
+			decls.Overload(overloads.GreaterEqualsBytes,
+				argTypes(decls.BytesType, decls.BytesType), decls.BoolType),
+			decls.Overload(overloads.GreaterEqualsTimestamp,
+				argTypes(decls.TimestampType, decls.TimestampType), decls.BoolType),
+			decls.Overload(overloads.GreaterEqualsDuration,
+				argTypes(decls.DurationType, decls.DurationType), decls.BoolType),
+			decls.SingletonBinaryBinding(func(lhs, rhs ref.Val) ref.Val {
+				cmp := lhs.(traits.Comparer).Compare(rhs)
+				if cmp == types.IntOne || cmp == types.IntZero {
+					return types.True
+				}
+				if cmp == types.IntNegOne {
+					return types.False
+				}
+				return cmp
+			}, traits.ComparerType)),
+
+		// Indexing
+		function(operators.Index,
+			decls.Overload(overloads.IndexList, argTypes(listOfA, decls.IntType), paramA),
+			decls.Overload(overloads.IndexMap, argTypes(mapOfAB, paramA), paramB),
+			decls.SingletonBinaryBinding(func(lhs, rhs ref.Val) ref.Val {
 				return lhs.(traits.Indexer).Get(rhs)
-			}},
+			}, traits.IndexerType)),
 
-		// Size function
-		{Operator: overloads.Size,
-			OperandTrait: traits.SizerType,
-			Unary: func(value ref.Val) ref.Val {
-				return value.(traits.Sizer).Size()
-			}},
+		// Collections operators
+		function(operators.In,
+			decls.Overload(overloads.InList, argTypes(paramA, listOfA), decls.BoolType),
+			decls.Overload(overloads.InMap, argTypes(paramA, mapOfAB), decls.BoolType),
+			decls.SingletonBinaryBinding(inAggregate)),
+		function(operators.OldIn,
+			decls.Overload(overloads.InList, argTypes(paramA, listOfA), decls.BoolType),
+			decls.Overload(overloads.InMap, argTypes(paramA, mapOfAB), decls.BoolType),
+			decls.SingletonBinaryBinding(inAggregate)),
+		function(overloads.DeprecatedIn,
+			decls.Overload(overloads.InList, argTypes(paramA, listOfA), decls.BoolType),
+			decls.Overload(overloads.InMap, argTypes(paramA, mapOfAB), decls.BoolType),
+			decls.SingletonBinaryBinding(inAggregate)),
+		function(overloads.Size,
+			decls.Overload(overloads.SizeBytes, argTypes(decls.BytesType), decls.IntType),
+			decls.MemberOverload(overloads.SizeBytesInst, argTypes(decls.BytesType), decls.IntType),
+			decls.Overload(overloads.SizeList, argTypes(listOfA), decls.IntType),
+			decls.MemberOverload(overloads.SizeListInst, argTypes(listOfA), decls.IntType),
+			decls.Overload(overloads.SizeMap, argTypes(mapOfAB), decls.IntType),
+			decls.MemberOverload(overloads.SizeMapInst, argTypes(mapOfAB), decls.IntType),
+			decls.Overload(overloads.SizeString, argTypes(decls.StringType), decls.IntType),
+			decls.MemberOverload(overloads.SizeStringInst, argTypes(decls.StringType), decls.IntType),
+			decls.SingletonUnaryBinding(func(val ref.Val) ref.Val {
+				return val.(traits.Sizer).Size()
+			}, traits.SizerType)),
 
-		// In operator
-		{Operator: operators.In, Binary: inAggregate},
-		// Deprecated: in operator, may be overridden in the environment.
-		{Operator: operators.OldIn, Binary: inAggregate},
+		// Type conversions
+		function(overloads.TypeConvertType,
+			decls.Overload(overloads.TypeConvertType, argTypes(paramA), decls.TypeTypeWithParam(paramA)),
+			decls.SingletonUnaryBinding(convertToType(types.TypeType))),
 
-		// Matches function
-		{Operator: overloads.Matches,
-			OperandTrait: traits.MatcherType,
-			Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
-				return lhs.(traits.Matcher).Match(rhs)
-			}},
+		// Bool conversions
+		function(overloads.TypeConvertBool,
+			decls.Overload(overloads.BoolToBool, argTypes(decls.BoolType), decls.BoolType,
+				decls.UnaryBinding(identity)),
+			decls.Overload(overloads.StringToBool, argTypes(decls.StringType), decls.BoolType,
+				decls.UnaryBinding(convertToType(types.BoolType)))),
 
-		// Type conversion functions
-		// TODO: verify type conversion safety of numeric values.
+		// Bytes conversions
+		function(overloads.TypeConvertBytes,
+			decls.Overload(overloads.BytesToBytes, argTypes(decls.BytesType), decls.BytesType,
+				decls.UnaryBinding(identity)),
+			decls.Overload(overloads.StringToBytes, argTypes(decls.StringType), decls.BytesType,
+				decls.UnaryBinding(convertToType(types.BytesType)))),
 
-		// Int conversions.
-		{Operator: overloads.TypeConvertInt,
-			Unary: func(value ref.Val) ref.Val {
-				return value.ConvertToType(types.IntType)
-			}},
+		// Double conversions
+		function(overloads.TypeConvertDouble,
+			decls.Overload(overloads.DoubleToDouble, argTypes(decls.DoubleType), decls.DoubleType,
+				decls.UnaryBinding(identity)),
+			decls.Overload(overloads.IntToDouble, argTypes(decls.IntType), decls.DoubleType,
+				decls.UnaryBinding(convertToType(types.DoubleType))),
+			decls.Overload(overloads.StringToDouble, argTypes(decls.StringType), decls.DoubleType,
+				decls.UnaryBinding(convertToType(types.DoubleType))),
+			decls.Overload(overloads.UintToDouble, argTypes(decls.UintType), decls.DoubleType,
+				decls.UnaryBinding(convertToType(types.DoubleType)))),
 
-		// Uint conversions.
-		{Operator: overloads.TypeConvertUint,
-			Unary: func(value ref.Val) ref.Val {
-				return value.ConvertToType(types.UintType)
-			}},
+		// Duration conversions
+		function(overloads.TypeConvertDuration,
+			decls.Overload(overloads.DurationToDuration, argTypes(decls.DurationType), decls.DurationType,
+				decls.UnaryBinding(identity)),
+			decls.Overload(overloads.IntToDuration, argTypes(decls.IntType), decls.DurationType,
+				decls.UnaryBinding(convertToType(types.DurationType))),
+			decls.Overload(overloads.StringToDuration, argTypes(decls.StringType), decls.DurationType,
+				decls.UnaryBinding(convertToType(types.DurationType)))),
 
-		// Double conversions.
-		{Operator: overloads.TypeConvertDouble,
-			Unary: func(value ref.Val) ref.Val {
-				return value.ConvertToType(types.DoubleType)
-			}},
+		// Dyn conversions
+		function(overloads.TypeConvertDyn,
+			decls.Overload(overloads.TypeConvertDyn, argTypes(paramA), decls.DynType),
+			decls.SingletonUnaryBinding(identity)),
 
-		// Bool conversions.
-		{Operator: overloads.TypeConvertBool,
-			Unary: func(value ref.Val) ref.Val {
-				return value.ConvertToType(types.BoolType)
-			}},
+		// Int conversions
+		function(overloads.TypeConvertInt,
+			decls.Overload(overloads.IntToInt, argTypes(decls.IntType), decls.IntType,
+				decls.UnaryBinding(identity)),
+			decls.Overload(overloads.DoubleToInt, argTypes(decls.DoubleType), decls.IntType,
+				decls.UnaryBinding(convertToType(types.IntType))),
+			decls.Overload(overloads.DurationToInt, argTypes(decls.DurationType), decls.IntType,
+				decls.UnaryBinding(convertToType(types.IntType))),
+			decls.Overload(overloads.StringToInt, argTypes(decls.StringType), decls.IntType,
+				decls.UnaryBinding(convertToType(types.IntType))),
+			decls.Overload(overloads.TimestampToInt, argTypes(decls.TimestampType), decls.IntType,
+				decls.UnaryBinding(convertToType(types.IntType))),
+			decls.Overload(overloads.UintToInt, argTypes(decls.UintType), decls.IntType,
+				decls.UnaryBinding(convertToType(types.IntType))),
+		),
 
-		// Bytes conversions.
-		{Operator: overloads.TypeConvertBytes,
-			Unary: func(value ref.Val) ref.Val {
-				return value.ConvertToType(types.BytesType)
-			}},
+		// String conversions
+		function(overloads.TypeConvertString,
+			decls.Overload(overloads.StringToString, argTypes(decls.StringType), decls.StringType,
+				decls.UnaryBinding(identity)),
+			decls.Overload(overloads.BoolToString, argTypes(decls.BoolType), decls.StringType,
+				decls.UnaryBinding(convertToType(types.StringType))),
+			decls.Overload(overloads.BytesToString, argTypes(decls.BytesType), decls.StringType,
+				decls.UnaryBinding(convertToType(types.StringType))),
+			decls.Overload(overloads.DoubleToString, argTypes(decls.DoubleType), decls.StringType,
+				decls.UnaryBinding(convertToType(types.StringType))),
+			decls.Overload(overloads.DurationToString, argTypes(decls.DurationType), decls.StringType,
+				decls.UnaryBinding(convertToType(types.StringType))),
+			decls.Overload(overloads.IntToString, argTypes(decls.IntType), decls.StringType,
+				decls.UnaryBinding(convertToType(types.StringType))),
+			decls.Overload(overloads.TimestampToString, argTypes(decls.TimestampType), decls.StringType,
+				decls.UnaryBinding(convertToType(types.StringType))),
+			decls.Overload(overloads.UintToString, argTypes(decls.UintType), decls.StringType,
+				decls.UnaryBinding(convertToType(types.StringType)))),
 
-		// String conversions.
-		{Operator: overloads.TypeConvertString,
-			Unary: func(value ref.Val) ref.Val {
-				return value.ConvertToType(types.StringType)
-			}},
+		// Timestamp conversions
+		function(overloads.TypeConvertTimestamp,
+			decls.Overload(overloads.TimestampToTimestamp, argTypes(decls.TimestampType), decls.TimestampType,
+				decls.UnaryBinding(identity)),
+			decls.Overload(overloads.IntToTimestamp, argTypes(decls.IntType), decls.TimestampType,
+				decls.UnaryBinding(convertToType(types.TimestampType))),
+			decls.Overload(overloads.StringToTimestamp, argTypes(decls.StringType), decls.TimestampType,
+				decls.UnaryBinding(convertToType(types.TimestampType)))),
 
-		// Timestamp conversions.
-		{Operator: overloads.TypeConvertTimestamp,
-			Unary: func(value ref.Val) ref.Val {
-				return value.ConvertToType(types.TimestampType)
-			}},
+		// Uint conversions
+		function(overloads.TypeConvertUint,
+			decls.Overload(overloads.UintToUint, argTypes(decls.UintType), decls.UintType,
+				decls.UnaryBinding(identity)),
+			decls.Overload(overloads.DoubleToUint, argTypes(decls.DoubleType), decls.UintType,
+				decls.UnaryBinding(convertToType(types.UintType))),
+			decls.Overload(overloads.IntToUint, argTypes(decls.IntType), decls.UintType,
+				decls.UnaryBinding(convertToType(types.UintType))),
+			decls.Overload(overloads.StringToUint, argTypes(decls.StringType), decls.UintType,
+				decls.UnaryBinding(convertToType(types.UintType)))),
 
-		// Duration conversions.
-		{Operator: overloads.TypeConvertDuration,
-			Unary: func(value ref.Val) ref.Val {
-				return value.ConvertToType(types.DurationType)
-			}},
+		// String functions
+		function(overloads.Contains,
+			decls.MemberOverload(overloads.ContainsString,
+				argTypes(decls.StringType, decls.StringType), decls.BoolType,
+				decls.BinaryBinding(types.StringContains)),
+			decls.DisableTypeGuards(true)),
+		function(overloads.EndsWith,
+			decls.MemberOverload(overloads.EndsWithString,
+				argTypes(decls.StringType, decls.StringType), decls.BoolType,
+				decls.BinaryBinding(types.StringEndsWith)),
+			decls.DisableTypeGuards(true)),
+		function(overloads.StartsWith,
+			decls.MemberOverload(overloads.StartsWithString,
+				argTypes(decls.StringType, decls.StringType), decls.BoolType,
+				decls.BinaryBinding(types.StringStartsWith)),
+			decls.DisableTypeGuards(true)),
+		function(overloads.Matches,
+			decls.Overload(overloads.Matches, argTypes(decls.StringType, decls.StringType), decls.BoolType),
+			decls.MemberOverload(overloads.MatchesString,
+				argTypes(decls.StringType, decls.StringType), decls.BoolType),
+			decls.SingletonBinaryBinding(func(str, pat ref.Val) ref.Val {
+				return str.(traits.Matcher).Match(pat)
+			}, traits.MatcherType)),
 
-		// Type operations.
-		{Operator: overloads.TypeConvertType,
-			Unary: func(value ref.Val) ref.Val {
-				return value.ConvertToType(types.TypeType)
-			}},
+		// Timestamp / duration functions
+		function(overloads.TimeGetFullYear,
+			decls.MemberOverload(overloads.TimestampToYear,
+				argTypes(decls.TimestampType), decls.IntType),
+			decls.MemberOverload(overloads.TimestampToYearWithTz,
+				argTypes(decls.TimestampType, decls.StringType), decls.IntType)),
 
-		// Dyn conversion (identity function).
-		{Operator: overloads.TypeConvertDyn,
-			Unary: func(value ref.Val) ref.Val {
-				return value
-			}},
+		function(overloads.TimeGetMonth,
+			decls.MemberOverload(overloads.TimestampToMonth,
+				argTypes(decls.TimestampType), decls.IntType),
+			decls.MemberOverload(overloads.TimestampToMonthWithTz,
+				argTypes(decls.TimestampType, decls.StringType), decls.IntType)),
 
-		{Operator: overloads.Iterator,
-			OperandTrait: traits.IterableType,
-			Unary: func(value ref.Val) ref.Val {
-				return value.(traits.Iterable).Iterator()
-			}},
+		function(overloads.TimeGetDayOfYear,
+			decls.MemberOverload(overloads.TimestampToDayOfYear,
+				argTypes(decls.TimestampType), decls.IntType),
+			decls.MemberOverload(overloads.TimestampToDayOfYearWithTz,
+				argTypes(decls.TimestampType, decls.StringType), decls.IntType)),
 
-		{Operator: overloads.HasNext,
-			OperandTrait: traits.IteratorType,
-			Unary: func(value ref.Val) ref.Val {
-				return value.(traits.Iterator).HasNext()
-			}},
+		function(overloads.TimeGetDayOfMonth,
+			decls.MemberOverload(overloads.TimestampToDayOfMonthZeroBased,
+				argTypes(decls.TimestampType), decls.IntType),
+			decls.MemberOverload(overloads.TimestampToDayOfMonthZeroBasedWithTz,
+				argTypes(decls.TimestampType, decls.StringType), decls.IntType)),
 
-		{Operator: overloads.Next,
-			OperandTrait: traits.IteratorType,
-			Unary: func(value ref.Val) ref.Val {
-				return value.(traits.Iterator).Next()
-			}},
+		function(overloads.TimeGetDate,
+			decls.MemberOverload(overloads.TimestampToDayOfMonthOneBased,
+				argTypes(decls.TimestampType), decls.IntType),
+			decls.MemberOverload(overloads.TimestampToDayOfMonthOneBasedWithTz,
+				argTypes(decls.TimestampType, decls.StringType), decls.IntType)),
+
+		function(overloads.TimeGetDayOfWeek,
+			decls.MemberOverload(overloads.TimestampToDayOfWeek,
+				argTypes(decls.TimestampType), decls.IntType),
+			decls.MemberOverload(overloads.TimestampToDayOfWeekWithTz,
+				argTypes(decls.TimestampType, decls.StringType), decls.IntType)),
+
+		function(overloads.TimeGetHours,
+			decls.MemberOverload(overloads.TimestampToHours,
+				argTypes(decls.TimestampType), decls.IntType),
+			decls.MemberOverload(overloads.TimestampToHoursWithTz,
+				argTypes(decls.TimestampType, decls.StringType), decls.IntType),
+			decls.MemberOverload(overloads.DurationToHours,
+				argTypes(decls.DurationType), decls.IntType)),
+
+		function(overloads.TimeGetMinutes,
+			decls.MemberOverload(overloads.TimestampToMinutes,
+				argTypes(decls.TimestampType), decls.IntType),
+			decls.MemberOverload(overloads.TimestampToMinutesWithTz,
+				argTypes(decls.TimestampType, decls.StringType), decls.IntType),
+			decls.MemberOverload(overloads.DurationToMinutes,
+				argTypes(decls.DurationType), decls.IntType)),
+
+		function(overloads.TimeGetSeconds,
+			decls.MemberOverload(overloads.TimestampToSeconds,
+				argTypes(decls.TimestampType), decls.IntType),
+			decls.MemberOverload(overloads.TimestampToSecondsWithTz,
+				argTypes(decls.TimestampType, decls.StringType), decls.IntType),
+			decls.MemberOverload(overloads.DurationToSeconds,
+				argTypes(decls.DurationType), decls.IntType)),
+
+		function(overloads.TimeGetMilliseconds,
+			decls.MemberOverload(overloads.TimestampToMilliseconds,
+				argTypes(decls.TimestampType), decls.IntType),
+			decls.MemberOverload(overloads.TimestampToMillisecondsWithTz,
+				argTypes(decls.TimestampType, decls.StringType), decls.IntType),
+			decls.MemberOverload(overloads.DurationToMilliseconds,
+				argTypes(decls.DurationType), decls.IntType)),
 	}
+}
 
+func Functions() []*decls.FunctionDecl {
+	return stdFunctions
 }
 
 func notStrictlyFalse(value ref.Val) ref.Val {
@@ -268,4 +561,34 @@ func inAggregate(lhs ref.Val, rhs ref.Val) ref.Val {
 		return rhs.(traits.Container).Contains(lhs)
 	}
 	return types.ValOrErr(rhs, "no such overload")
+}
+
+func function(name string, opts ...decls.FunctionOpt) *decls.FunctionDecl {
+	fn, err := decls.NewFunction(name, opts...)
+	if err != nil {
+		panic(err)
+	}
+	return fn
+}
+
+func argTypes(args ...*decls.Type) []*decls.Type {
+	return args
+}
+
+func noBinaryOverrides(rhs, lhs ref.Val) ref.Val {
+	return types.NoSuchOverloadErr()
+}
+
+func noFunctionOverrides(args ...ref.Val) ref.Val {
+	return types.NoSuchOverloadErr()
+}
+
+func identity(val ref.Val) ref.Val {
+	return val
+}
+
+func convertToType(t ref.Type) functions.UnaryOp {
+	return func(val ref.Val) ref.Val {
+		return val.ConvertToType(t)
+	}
 }

--- a/common/stdlib/standard.go
+++ b/common/stdlib/standard.go
@@ -66,6 +66,7 @@ func init() {
 				decls.UnaryBinding(notStrictlyFalse))),
 		// Deprecated: __not_strictly_false__
 		function(operators.OldNotStrictlyFalse,
+			decls.DisableDeclaration(true), // safe deprecation
 			decls.Overload(operators.OldNotStrictlyFalse, argTypes(decls.BoolType), decls.BoolType,
 				decls.OverloadIsNonStrict(),
 				decls.UnaryBinding(notStrictlyFalse))),
@@ -331,10 +332,12 @@ func init() {
 			decls.Overload(overloads.InMap, argTypes(paramA, mapOfAB), decls.BoolType),
 			decls.SingletonBinaryBinding(inAggregate)),
 		function(operators.OldIn,
+			decls.DisableDeclaration(true), // safe deprecation
 			decls.Overload(overloads.InList, argTypes(paramA, listOfA), decls.BoolType),
 			decls.Overload(overloads.InMap, argTypes(paramA, mapOfAB), decls.BoolType),
 			decls.SingletonBinaryBinding(inAggregate)),
 		function(overloads.DeprecatedIn,
+			decls.DisableDeclaration(true), // safe deprecation
 			decls.Overload(overloads.InList, argTypes(paramA, listOfA), decls.BoolType),
 			decls.Overload(overloads.InMap, argTypes(paramA, mapOfAB), decls.BoolType),
 			decls.SingletonBinaryBinding(inAggregate)),
@@ -392,7 +395,7 @@ func init() {
 
 		// Dyn conversions
 		function(overloads.TypeConvertDyn,
-			decls.Overload(overloads.TypeConvertDyn, argTypes(paramA), decls.DynType),
+			decls.Overload(overloads.ToDyn, argTypes(paramA), decls.DynType),
 			decls.SingletonUnaryBinding(identity)),
 
 		// Int conversions

--- a/common/types/BUILD.bazel
+++ b/common/types/BUILD.bazel
@@ -40,7 +40,6 @@ go_library(
         "//common/types/traits:go_default_library",
         "@com_github_stoewer_go_strcase//:go_default_library",
         "@org_golang_google_genproto_googleapis_api//expr/v1alpha1:go_default_library",
-        "@org_golang_google_genproto_googleapis_rpc//status:go_default_library",
         "@org_golang_google_protobuf//encoding/protojson:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
         "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",

--- a/common/types/duration.go
+++ b/common/types/duration.go
@@ -48,6 +48,15 @@ var (
 		traits.NegatorType,
 		traits.ReceiverType,
 		traits.SubtractorType)
+
+	durationValueType = reflect.TypeOf(&dpb.Duration{})
+
+	durationZeroArgOverloads = map[string]func(ref.Val) ref.Val{
+		overloads.TimeGetHours:        DurationGetHours,
+		overloads.TimeGetMinutes:      DurationGetMinutes,
+		overloads.TimeGetSeconds:      DurationGetSeconds,
+		overloads.TimeGetMilliseconds: DurationGetMilliseconds,
+	}
 )
 
 // Add implements traits.Adder.Add.
@@ -156,7 +165,7 @@ func (d Duration) Negate() ref.Val {
 func (d Duration) Receive(function string, overload string, args []ref.Val) ref.Val {
 	if len(args) == 0 {
 		if f, found := durationZeroArgOverloads[function]; found {
-			return f(d.Duration)
+			return f(d)
 		}
 	}
 	return NoSuchOverloadErr()
@@ -185,20 +194,38 @@ func (d Duration) Value() any {
 	return d.Duration
 }
 
-var (
-	durationValueType = reflect.TypeOf(&dpb.Duration{})
+// DurationGetHours returns the duration in hours.
+func DurationGetHours(val ref.Val) ref.Val {
+	dur, ok := val.(Duration)
+	if !ok {
+		return MaybeNoSuchOverloadErr(val)
+	}
+	return Int(dur.Hours())
+}
 
-	durationZeroArgOverloads = map[string]func(time.Duration) ref.Val{
-		overloads.TimeGetHours: func(dur time.Duration) ref.Val {
-			return Int(dur.Hours())
-		},
-		overloads.TimeGetMinutes: func(dur time.Duration) ref.Val {
-			return Int(dur.Minutes())
-		},
-		overloads.TimeGetSeconds: func(dur time.Duration) ref.Val {
-			return Int(dur.Seconds())
-		},
-		overloads.TimeGetMilliseconds: func(dur time.Duration) ref.Val {
-			return Int(dur.Milliseconds())
-		}}
-)
+// DurationGetMinutes returns duration in minutes.
+func DurationGetMinutes(val ref.Val) ref.Val {
+	dur, ok := val.(Duration)
+	if !ok {
+		return MaybeNoSuchOverloadErr(val)
+	}
+	return Int(dur.Minutes())
+}
+
+// DurationGetSeconds returns duration in seconds.
+func DurationGetSeconds(val ref.Val) ref.Val {
+	dur, ok := val.(Duration)
+	if !ok {
+		return MaybeNoSuchOverloadErr(val)
+	}
+	return Int(dur.Seconds())
+}
+
+// DurationGetMilliseconds returns duration in milliseconds.
+func DurationGetMilliseconds(val ref.Val) ref.Val {
+	dur, ok := val.(Duration)
+	if !ok {
+		return MaybeNoSuchOverloadErr(val)
+	}
+	return Int(dur.Milliseconds())
+}

--- a/common/types/string.go
+++ b/common/types/string.go
@@ -44,10 +44,10 @@ var (
 		traits.ReceiverType,
 		traits.SizerType)
 
-	stringOneArgOverloads = map[string]func(String, ref.Val) ref.Val{
-		overloads.Contains:   stringContains,
-		overloads.EndsWith:   stringEndsWith,
-		overloads.StartsWith: stringStartsWith,
+	stringOneArgOverloads = map[string]func(ref.Val, ref.Val) ref.Val{
+		overloads.Contains:   StringContains,
+		overloads.EndsWith:   StringEndsWith,
+		overloads.StartsWith: StringStartsWith,
 	}
 
 	stringWrapperType = reflect.TypeOf(&wrapperspb.StringValue{})
@@ -198,26 +198,41 @@ func (s String) Value() any {
 	return string(s)
 }
 
-func stringContains(s String, sub ref.Val) ref.Val {
+// StringContains returns whether the string contains a substring.
+func StringContains(s, sub ref.Val) ref.Val {
+	str, ok := s.(String)
+	if !ok {
+		return MaybeNoSuchOverloadErr(s)
+	}
 	subStr, ok := sub.(String)
 	if !ok {
 		return MaybeNoSuchOverloadErr(sub)
 	}
-	return Bool(strings.Contains(string(s), string(subStr)))
+	return Bool(strings.Contains(string(str), string(subStr)))
 }
 
-func stringEndsWith(s String, suf ref.Val) ref.Val {
+// StringEndsWith returns whether the target string contains the input suffix.
+func StringEndsWith(s, suf ref.Val) ref.Val {
+	str, ok := s.(String)
+	if !ok {
+		return MaybeNoSuchOverloadErr(s)
+	}
 	sufStr, ok := suf.(String)
 	if !ok {
 		return MaybeNoSuchOverloadErr(suf)
 	}
-	return Bool(strings.HasSuffix(string(s), string(sufStr)))
+	return Bool(strings.HasSuffix(string(str), string(sufStr)))
 }
 
-func stringStartsWith(s String, pre ref.Val) ref.Val {
+// StringStartsWith returns whether the target string contains the input prefix.
+func StringStartsWith(s, pre ref.Val) ref.Val {
+	str, ok := s.(String)
+	if !ok {
+		return MaybeNoSuchOverloadErr(s)
+	}
 	preStr, ok := pre.(String)
 	if !ok {
 		return MaybeNoSuchOverloadErr(pre)
 	}
-	return Bool(strings.HasPrefix(string(s), string(preStr)))
+	return Bool(strings.HasPrefix(string(str), string(preStr)))
 }

--- a/interpreter/attributes_test.go
+++ b/interpreter/attributes_test.go
@@ -1112,7 +1112,7 @@ func TestAttributeStateTracking(t *testing.T) {
 			if err != nil {
 				t.Fatalf("checker.NewEnv() failed: %v", err)
 			}
-			env.Add(checker.StandardDeclarations()...)
+			env.Add(checker.StandardFunctions()...)
 			env.Add(optionalSignatures()...)
 			if tc.env != nil {
 				env.Add(tc.env...)

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -2104,7 +2104,7 @@ func newTestEnv(t *testing.T, cont *containers.Container, reg ref.TypeRegistry) 
 	return env
 }
 
-// NewStandardInterpreter builds a Dispatcher and TypeProvider with support for all of the CEL
+// newStandardInterpreter builds a Dispatcher and TypeProvider with support for all of the CEL
 // builtins defined in the language definition.
 func newStandardInterpreter(t *testing.T,
 	container *containers.Container,

--- a/interpreter/prune_test.go
+++ b/interpreter/prune_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/google/cel-go/common/containers"
 	"github.com/google/cel-go/common/functions"
 	"github.com/google/cel-go/common/operators"
-	"github.com/google/cel-go/common/stdlib"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/parser"
@@ -448,7 +447,7 @@ func TestPrune(t *testing.T) {
 		reg := newTestRegistry(t, &proto3pb.TestAllTypes{})
 		attrs := NewPartialAttributeFactory(containers.DefaultContainer, reg, reg)
 		dispatcher := NewDispatcher()
-		dispatcher.Add(stdlib.StandardOverloads()...)
+		addFunctionBindings(t, dispatcher)
 		dispatcher.Add(optionalFunctions()...)
 		interp := NewInterpreter(dispatcher, containers.DefaultContainer, reg, reg, attrs)
 


### PR DESCRIPTION
The new stdlib unifies the declarations and bindings using the new common/decl package. 

The legacy `checker.StandardFunctions()` still exists, but the `interpreter.StandardFunctions()`
has been migrated away. This PR ensures that the declaration signatures are identical between
the old and new style. Subsequent PRs will remove `checker.StandardFunctions()` 

Prerequisite for #493 and #568