### PR TITLE
Clear iteration variable data during expression pruning

### DIFF
--- a/interpreter/evalstate.go
+++ b/interpreter/evalstate.go
@@ -66,7 +66,11 @@ func (s *evalState) Value(exprID int64) (ref.Val, bool) {
 
 // SetValue is an implementation of the EvalState interface method.
 func (s *evalState) SetValue(exprID int64, val ref.Val) {
-	s.values[exprID] = val
+	if val == nil {
+		delete(s.values, exprID)
+	} else {
+		s.values[exprID] = val
+	}
 }
 
 // Reset implements the EvalState interface method.

--- a/interpreter/prune.go
+++ b/interpreter/prune.go
@@ -341,6 +341,12 @@ func (p *astPruner) prune(node *exprpb.Expr) (*exprpb.Expr, bool) {
 		}
 	}
 	if macro, found := p.macroCalls[node.GetId()]; found {
+		// Ensure that intermediate values for the comprehension are cleared during pruning
+		compre := node.GetComprehensionExpr()
+		if compre != nil {
+			visit(macro, clearIterVarVisitor(compre.IterVar, p.state))
+			visit(macro, clearIterVarVisitor(compre.AccuVar, p.state))
+		}
 		// prune the expression in terms of the macro call instead of the expanded form.
 		if newMacro, pruned := p.prune(macro); pruned {
 			p.macroCalls[node.GetId()] = newMacro
@@ -524,6 +530,17 @@ func getMaxID(expr *exprpb.Expr) int64 {
 	return maxID
 }
 
+func clearIterVarVisitor(varName string, state EvalState) astVisitor {
+	return astVisitor{
+		visitExpr: func(e *exprpb.Expr) {
+			ident := e.GetIdentExpr()
+			if ident != nil && ident.GetName() == varName {
+				state.SetValue(e.GetId(), nil)
+			}
+		},
+	}
+}
+
 func maxIDVisitor(maxID *int64) astVisitor {
 	return astVisitor{
 		visitExpr: func(e *exprpb.Expr) {
@@ -543,7 +560,9 @@ func visit(expr *exprpb.Expr, visitor astVisitor) {
 	exprs := []*exprpb.Expr{expr}
 	for len(exprs) != 0 {
 		e := exprs[0]
-		visitor.visitExpr(e)
+		if visitor.visitExpr != nil {
+			visitor.visitExpr(e)
+		}
 		exprs = exprs[1:]
 		switch e.GetExprKind().(type) {
 		case *exprpb.Expr_SelectExpr:
@@ -567,7 +586,9 @@ func visit(expr *exprpb.Expr, visitor astVisitor) {
 			exprs = append(exprs, list.GetElements()...)
 		case *exprpb.Expr_StructExpr:
 			for _, entry := range e.GetStructExpr().GetEntries() {
-				visitor.visitEntry(entry)
+				if visitor.visitEntry != nil {
+					visitor.visitEntry(entry)
+				}
 				if entry.GetMapKey() != nil {
 					exprs = append(exprs, entry.GetMapKey())
 				}

--- a/interpreter/prune.go
+++ b/interpreter/prune.go
@@ -345,7 +345,6 @@ func (p *astPruner) prune(node *exprpb.Expr) (*exprpb.Expr, bool) {
 		compre := node.GetComprehensionExpr()
 		if compre != nil {
 			visit(macro, clearIterVarVisitor(compre.IterVar, p.state))
-			visit(macro, clearIterVarVisitor(compre.AccuVar, p.state))
 		}
 		// prune the expression in terms of the macro call instead of the expanded form.
 		if newMacro, pruned := p.prune(macro); pruned {

--- a/interpreter/prune_test.go
+++ b/interpreter/prune_test.go
@@ -371,6 +371,20 @@ var testCases = []testInfo{
 		out:  `["bob"] == r.attr.authorized["managers"]`,
 	},
 	{
+		in: partialActivation(map[string]any{
+			"users": []string{"alice", "bob"},
+		}, NewAttributePattern("r").QualString("attr").Wildcard()),
+		expr: `users.filter(u, u.startsWith(r.attr.prefix))`,
+		out:  `["alice", "bob"].filter(u, u.startsWith(r.attr.prefix))`,
+	},
+	{
+		in: partialActivation(map[string]any{
+			"users": []string{"alice", "bob"},
+		}, NewAttributePattern("r").QualString("attr").Wildcard()),
+		expr: `users.filter(u, r.attr.prefix.endsWith(u))`,
+		out:  `["alice", "bob"].filter(u, r.attr.prefix.endsWith(u))`,
+	},
+	{
 		in:   unknownActivation("four"),
 		expr: `[1+3, 2+2, 3+1, four]`,
 		out:  `[4, 4, 4, four]`,


### PR DESCRIPTION
This PR clears iteration variable data from expression tracking state during macro pruning.
The clearing of the iteration variable is based on the iteration variable name which could
potentially shadow an existing, but in the worst case, this would just cause a duplicate name
to be cleared more than once in a nested macro scope.

Closes #735 