### PR TITLE
Introduce optFlatMap and OptionalTypes documentation

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -2157,6 +2157,13 @@ func TestOptionalValuesEval(t *testing.T) {
 		{
 			expr: `m.?key.optFlatMap(k, k.?subkey)`,
 			in: map[string]any{
+				"m": map[string]any{},
+			},
+			out: types.OptionalNone,
+		},
+		{
+			expr: `m.?key.optFlatMap(k, k.?subkey)`,
+			in: map[string]any{
 				"m": map[string]any{
 					"key": map[string]string{},
 				},
@@ -2173,6 +2180,28 @@ func TestOptionalValuesEval(t *testing.T) {
 				},
 			},
 			out: types.OptionalOf(types.String("subvalue")),
+		},
+		{
+			expr: `m.?key.optFlatMap(k, k.?subkey)`,
+			in: map[string]any{
+				"m": map[string]any{
+					"key": map[string]string{
+						"subkey": "",
+					},
+				},
+			},
+			out: types.OptionalOf(types.String("")),
+		},
+		{
+			expr: `m.?key.optFlatMap(k, optional.ofNonZeroValue(k.subkey))`,
+			in: map[string]any{
+				"m": map[string]any{
+					"key": map[string]string{
+						"subkey": "",
+					},
+				},
+			},
+			out: types.OptionalNone,
 		},
 		{
 			expr: `x.optMap(y, y + 1)`,

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -2155,6 +2155,26 @@ func TestOptionalValuesEval(t *testing.T) {
 			out: types.OptionalNone,
 		},
 		{
+			expr: `m.?key.optFlatMap(k, k.?subkey)`,
+			in: map[string]any{
+				"m": map[string]any{
+					"key": map[string]string{},
+				},
+			},
+			out: types.OptionalNone,
+		},
+		{
+			expr: `m.?key.optFlatMap(k, k.?subkey)`,
+			in: map[string]any{
+				"m": map[string]any{
+					"key": map[string]string{
+						"subkey": "subvalue",
+					},
+				},
+			},
+			out: types.OptionalOf(types.String("subvalue")),
+		},
+		{
 			expr: `x.optMap(y, y + 1)`,
 			in: map[string]any{
 				"x": types.OptionalOf(types.Int(42)),
@@ -2503,6 +2523,22 @@ func TestOptionalMacroError(t *testing.T) {
 	_, iss := env.Compile("x.optMap(y.z, y.z + 1)")
 	if iss.Err() == nil || !strings.Contains(iss.Err().Error(), "variable name must be a simple identifier") {
 		t.Errorf("optMap() got an unexpected result: %v", iss.Err())
+	}
+	_, iss = env.Compile("x.optFlatMap(y.z, y.z + 1)")
+	if iss.Err() == nil || !strings.Contains(iss.Err().Error(), "variable name must be a simple identifier") {
+		t.Errorf("optFlatMap() got an unexpected result: %v", iss.Err())
+	}
+	env, err = NewEnv(
+		OptionalTypes(OptionalTypesVersion(0)),
+		// Test variables.
+		Variable("x", OptionalType(IntType)),
+	)
+	if err != nil {
+		t.Fatalf("NewEnv() failed: %v", err)
+	}
+	_, iss = env.Compile("x.optFlatMap(y, y.z + 1)")
+	if iss.Err() == nil || !strings.Contains(iss.Err().Error(), "undeclared reference to 'optFlatMap'") {
+		t.Errorf("optFlatMap() got an unexpected result: %v", iss.Err())
 	}
 }
 

--- a/cel/library.go
+++ b/cel/library.go
@@ -172,9 +172,10 @@ func (stdLibrary) ProgramOptions() []ProgramOption {
 // will ensure the type on the right-hand side must be optional(T) where T
 // is the type of the field or key-value.
 //
-//		// returns a map with the key expression set only if the subfield is
-//	 // present otherwise an empty map is created.
-//		{?key: obj.?field.subfield}
+// The following returns a map with the key expression set only if the
+// subfield is present, otherwise an empty map is created:
+//
+//	{?key: obj.?field.subfield}
 //
 // ## Optional Element Setting
 //

--- a/cel/library.go
+++ b/cel/library.go
@@ -15,6 +15,7 @@
 package cel
 
 import (
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -33,6 +34,7 @@ import (
 
 const (
 	optMapMacro                = "optMap"
+	optFlatMapMacro            = "optFlatMap"
 	hasValueFunc               = "hasValue"
 	optionalNoneFunc           = "optional.none"
 	optionalOfFunc             = "optional.of"
@@ -132,29 +134,182 @@ func (stdLibrary) ProgramOptions() []ProgramOption {
 	}
 }
 
-type optionalLibrary struct{}
+// OptionalTypes enable support for optional syntax and types in CEL.
+//
+// The optional value type makes it possible to express whether variables have
+// been provided, whether a result has been computed, and in the future whether
+// an object field path, map key value, or list index has a value.
+//
+// # Syntax Changes
+//
+// OptionalTypes are unlike other CEL extensions because they modify the CEL
+// syntax itself, notably through the use of a `?` preceding a field name or
+// index value.
+//
+// ## Field Selection
+//
+// The optional syntax in field selection is denoted as `obj.?field`. In other
+// words, if a field is set, return `optional.of(obj.field)“, else
+// `optional.none()`. The optional field selection is viral in the sense that
+// after the first optional selection all subsequent selections or indices
+// are treated as optional, i.e. the following expressions are equivalent:
+//
+//	obj.?field.subfield
+//	obj.?field.?subfield
+//
+// ## Indexing
+//
+// Similar to field selection, the optional syntax can be used in index
+// expressions on maps and lists:
+//
+//	list[?0]
+//	map[?key]
+//
+// ## Optional Field Setting
+//
+// When creating map or message literals, if a field may be optionally set
+// based on its presence, then placing a `?` before the field name or key
+// will ensure the type on the right-hand side must be optional(T) where T
+// is the type of the field or key-value.
+//
+//		// returns a map with the key expression set only if the subfield is
+//	 // present otherwise an empty map is created.
+//		{?key: obj.?field.subfield}
+//
+// ## Optional Element Setting
+//
+// When creating list literals, an element in the list may be optionally added
+// when the element expression is preceded by a `?`:
+//
+//	[a, ?b, ?c] // return a list with either [a], [a, b], [a, b, c], or [a, c]
+//
+// # Optional.Of
+//
+// Create an optional(T) value of a given value with type T.
+//
+//	optional.of(10)
+//
+// # Optional.OfNonZeroValue
+//
+// Create an optional(T) value of a given value with type T if it is not a
+// zero-value. A zero-value the default empty value for any given CEL type,
+// including empty protobuf message types. If the value is empty, the result
+// of this call will be optional.none().
+//
+//	optional.ofNonZeroValue([1, 2, 3]) // optional(list(int))
+//	optional.ofNonZeroValue([]) // optional.none()
+//	optional.ofNonZeroValue(0)  // optional.none()
+//	optional.ofNonZeroValue("") // optional.none()
+//
+// # Optional.None
+//
+// Create an empty optional value.
+//
+// # HasValue
+//
+// Determine whether the optional contains a value.
+//
+//	optional.of(b'hello').hasValue() // true
+//	optional.ofNonZeroValue({}).hasValue() // false
+//
+// # Value
+//
+// Get the value contained by the optional. If the optional does not have a
+// value, the result will be a CEL error.
+//
+//	optional.of(b'hello').value() // b'hello'
+//	optional.ofNonZeroValue({}).value() // error
+//
+// # Or
+//
+// If the value on the left-hand side is optional.none(), the optional value
+// on the right hand side is returned. If the value on the left-hand set is
+// valued, then it is returned. This operation is short-circuiting and will
+// only evaluate as many links in the `or` chain as are needed to return a
+// non-empty optional value.
+//
+//	obj.?field.or(m[?key])
+//	l[?index].or(obj.?field.subfield).or(obj.?other)
+//
+// # OrValue
+//
+// Either return the value contained within the optional on the left-hand side
+// or return the alternative value on the right hand side.
+//
+//	m[?key].orValue("none")
+//
+// # OptMap
+//
+// Apply a transformation to the optional's underlying value if it is not empty
+// and return an optional typed result based on the transformation. The
+// transformation expression type must return a type T which is wrapped into
+// an optional.
+//
+//	msg.?elements.optMap(e, e.size()).orValue(0)
+//
+// # OptFlatMap
+//
+// Introduced in version: 1
+//
+// Apply a transformation to the optional's underlying value if it is not empty
+// and return the result. The transform expression must return an optional(T)
+// rather than type T. This can be useful when dealing with zero values and
+// conditionally generating an empty or non-empty result in ways which cannot
+// be expressed with `optMap`.
+//
+//	msg.?elements.optFlatMap(e, e[?0]) // return the first element if present.
+func OptionalTypes(opts ...OptionalTypesOption) EnvOption {
+	lib := &optionalLib{version: math.MaxUint32}
+	for _, opt := range opts {
+		lib = opt(lib)
+	}
+	return Lib(lib)
+}
+
+type optionalLib struct {
+	version uint32
+}
+
+// OptionalTypesOption is a functional interface for configuring the strings library.
+type OptionalTypesOption func(*optionalLib) *optionalLib
+
+// OptionalTypesVersion configures the version of the optional type library.
+//
+// The version limits which functions are available. Only functions introduced
+// below or equal to the given version included in the library. If this option
+// is not set, all functions are available.
+//
+// See the library documentation to determine which version a function was introduced.
+// If the documentation does not state which version a function was introduced, it can
+// be assumed to be introduced at version 0, when the library was first created.
+func OptionalTypesVersion(version uint32) OptionalTypesOption {
+	return func(lib *optionalLib) *optionalLib {
+		lib.version = version
+		return lib
+	}
+}
 
 // LibraryName implements the SingletonLibrary interface method.
-func (optionalLibrary) LibraryName() string {
+func (lib *optionalLib) LibraryName() string {
 	return "cel.lib.optional"
 }
 
 // CompileOptions implements the Library interface method.
-func (optionalLibrary) CompileOptions() []EnvOption {
+func (lib *optionalLib) CompileOptions() []EnvOption {
 	paramTypeK := TypeParamType("K")
 	paramTypeV := TypeParamType("V")
 	optionalTypeV := OptionalType(paramTypeV)
 	listTypeV := ListType(paramTypeV)
 	mapTypeKV := MapType(paramTypeK, paramTypeV)
 
-	return []EnvOption{
+	opts := []EnvOption{
 		// Enable the optional syntax in the parser.
 		enableOptionalSyntax(),
 
 		// Introduce the optional type.
 		Types(types.OptionalType),
 
-		// Configure the optMap macro.
+		// Configure the optMap and optFlatMap macros.
 		Macros(NewReceiverMacro(optMapMacro, 2, optMap)),
 
 		// Global and member functions for working with optional values.
@@ -215,6 +370,17 @@ func (optionalLibrary) CompileOptions() []EnvOption {
 			Overload("optional_list_index_int", []*Type{OptionalType(listTypeV), IntType}, optionalTypeV),
 			Overload("optional_map_index_value", []*Type{OptionalType(mapTypeKV), paramTypeK}, optionalTypeV)),
 	}
+	if lib.version >= 1 {
+		opts = append(opts, Macros(NewReceiverMacro(optFlatMapMacro, 2, optFlatMap)))
+	}
+	return opts
+}
+
+// ProgramOptions implements the Library interface method.
+func (lib *optionalLib) ProgramOptions() []ProgramOption {
+	return []ProgramOption{
+		CustomDecorator(decorateOptionalOr),
+	}
 }
 
 func optMap(meh MacroExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *Error) {
@@ -245,11 +411,30 @@ func optMap(meh MacroExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exp
 	), nil
 }
 
-// ProgramOptions implements the Library interface method.
-func (optionalLibrary) ProgramOptions() []ProgramOption {
-	return []ProgramOption{
-		CustomDecorator(decorateOptionalOr),
+func optFlatMap(meh MacroExprHelper, target *exprpb.Expr, args []*exprpb.Expr) (*exprpb.Expr, *Error) {
+	varIdent := args[0]
+	varName := ""
+	switch varIdent.GetExprKind().(type) {
+	case *exprpb.Expr_IdentExpr:
+		varName = varIdent.GetIdentExpr().GetName()
+	default:
+		return nil, meh.NewError(varIdent.GetId(), "optFlatMap() variable name must be a simple identifier")
 	}
+	mapExpr := args[1]
+	return meh.GlobalCall(
+		operators.Conditional,
+		meh.ReceiverCall(hasValueFunc, target),
+		meh.Fold(
+			unusedIterVar,
+			meh.NewList(),
+			varName,
+			meh.ReceiverCall(valueFunc, target),
+			meh.LiteralBool(false),
+			meh.Ident(varName),
+			mapExpr,
+		),
+		meh.GlobalCall(optionalNoneFunc),
+	), nil
 }
 
 func enableOptionalSyntax() EnvOption {

--- a/cel/options.go
+++ b/cel/options.go
@@ -561,13 +561,6 @@ func DefaultUTCTimeZone(enabled bool) EnvOption {
 	return features(featureDefaultUTCTimeZone, enabled)
 }
 
-// OptionalTypes enable support for optional syntax and types in CEL. The optional value type makes
-// it possible to express whether variables have been provided, whether a result has been computed,
-// and in the future whether an object field path, map key value, or list index has a value.
-func OptionalTypes() EnvOption {
-	return Lib(optionalLibrary{})
-}
-
 // features sets the given feature flags.  See list of Feature constants above.
 func features(flag int, enabled bool) EnvOption {
 	return func(e *Env) (*Env, error) {

--- a/ext/strings.go
+++ b/ext/strings.go
@@ -57,7 +57,7 @@ const (
 //	'hello'.charAt(5)  // return ''
 //	'hello'.charAt(-1) // error
 //
-// # Strings.Format
+// # Format
 //
 // Introduced at version: 1
 //

--- a/ext/strings.go
+++ b/ext/strings.go
@@ -57,7 +57,7 @@ const (
 //	'hello'.charAt(5)  // return ''
 //	'hello'.charAt(-1) // error
 //
-// # Format
+// # Strings.Format
 //
 // Introduced at version: 1
 //
@@ -173,7 +173,7 @@ const (
 //	'TacoCat'.lowerAscii()      // returns 'tacocat'
 //	'TacoCÆt Xii'.lowerAscii()  // returns 'tacocÆt xii'
 //
-// # Quote
+// # Strings.Quote
 //
 // Introduced in version: 1
 //
@@ -301,26 +301,28 @@ func StringsLocale(locale string) StringsOption {
 	}
 }
 
-// StringsVersion configures the version of the string library. The version limits which
-// functions are available. Only functions introduced below or equal to the given
-// version included in the library. See the library documentation to determine
-// which version a function was introduced at. If the documentation does not
-// state which version a function was introduced at, it can be assumed to be
-// introduced at version 0, when the library was first created.
-// If this option is not set, all functions are available.
-func StringsVersion(version uint32) func(lib *stringLib) *stringLib {
-	return func(sl *stringLib) *stringLib {
-		sl.version = version
-		return sl
+// StringsVersion configures the version of the string library.
+//
+// The version limits which functions are available. Only functions introduced
+// below or equal to the given version included in the library. If this option
+// is not set, all functions are available.
+//
+// See the library documentation to determine which version a function was introduced.
+// If the documentation does not state which version a function was introduced, it can
+// be assumed to be introduced at version 0, when the library was first created.
+func StringsVersion(version uint32) StringsOption {
+	return func(lib *stringLib) *stringLib {
+		lib.version = version
+		return lib
 	}
 }
 
 // CompileOptions implements the Library interface method.
-func (sl *stringLib) CompileOptions() []cel.EnvOption {
+func (lib *stringLib) CompileOptions() []cel.EnvOption {
 	formatLocale := "en_US"
-	if sl.locale != "" {
+	if lib.locale != "" {
 		// ensure locale is properly-formed if set
-		_, err := language.Parse(sl.locale)
+		_, err := language.Parse(lib.locale)
 		if err != nil {
 			return []cel.EnvOption{
 				func(e *cel.Env) (*cel.Env, error) {
@@ -328,7 +330,7 @@ func (sl *stringLib) CompileOptions() []cel.EnvOption {
 				},
 			}
 		}
-		formatLocale = sl.locale
+		formatLocale = lib.locale
 	}
 
 	opts := []cel.EnvOption{
@@ -432,7 +434,7 @@ func (sl *stringLib) CompileOptions() []cel.EnvOption {
 					return stringOrError(upperASCII(string(s)))
 				}))),
 	}
-	if sl.version >= 1 {
+	if lib.version >= 1 {
 		opts = append(opts, cel.Function("format",
 			cel.MemberOverload("string_format", []*cel.Type{cel.StringType, cel.ListType(cel.DynType)}, cel.StringType,
 				cel.FunctionBinding(func(args ...ref.Val) ref.Val {
@@ -447,7 +449,7 @@ func (sl *stringLib) CompileOptions() []cel.EnvOption {
 				}))))
 
 	}
-	if sl.version >= 2 {
+	if lib.version >= 2 {
 		opts = append(opts,
 			cel.Function("join",
 				cel.MemberOverload("list_join", []*cel.Type{cel.ListType(cel.StringType)}, cel.StringType,


### PR DESCRIPTION
The `optFlatMap` macro allows for the use of optional syntax within mapping
expressions which are applied if a value exists. 

This feature exists at `OptionalTypesVersion(1)` and above.