### PR TITLE
Fix gap in proto to native declaration conversion function

### DIFF
--- a/cel/decls.go
+++ b/cel/decls.go
@@ -325,7 +325,11 @@ func ExprDeclToDeclaration(d *exprpb.Decl) (EnvOption, error) {
 			if err != nil {
 				return nil, err
 			}
-			opts[i] = decls.Overload(o.GetOverloadId(), args, res)
+			if o.IsInstanceFunction {
+				opts[i] = decls.MemberOverload(o.GetOverloadId(), args, res)
+			} else {
+				opts[i] = decls.Overload(o.GetOverloadId(), args, res)
+			}
 		}
 		return Function(d.GetName(), opts...), nil
 	case *exprpb.Decl_Ident:


### PR DESCRIPTION
Previously all proto-based function declarations would always get converted to global overloads, rather than global or member overloads, as appropriate.

Added test to capture the use case.