### PR TITLE
Benchmark harness with some initial reference cases

### DIFF
--- a/test/bench/BUILD.bazel
+++ b/test/bench/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(
+    licenses = ["notice"],  # Apache 2.0
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "bench.go",
+    ],
+    importpath = "github.com/google/cel-go/test/bench",
+    deps = [
+        "//cel:go_default_library",
+        "//ext:go_default_library",
+        "//common/types:go_default_library",
+        "//common/types/ref:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "bench_test.go",
+    ],
+    embed = [
+        ":go_default_library",
+    ],
+    deps = [
+        "//cel:go_default_library",
+    ],
+)

--- a/test/bench/bench.go
+++ b/test/bench/bench.go
@@ -1,0 +1,243 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bench defines a structure for benchmarked tests against custom CEL environments.
+package bench
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/ext"
+)
+
+// Case represents a human-readable expression and an expected output given an input
+type Case struct {
+	// Expr is a human-readable expression which is expected to compile.
+	Expr string
+
+	// Options indicate additional pieces of configuration such as CEL libraries, variables, and functions.
+	Options []cel.EnvOption
+
+	// In is expected to be a map[string]any or interpreter.Activation instance representing the input to the expression.
+	In any
+
+	// Out is the expected CEL valued output.
+	Out ref.Val
+}
+
+var (
+	// ReferenceCases represent canonical CEL expressions for common use cases.
+	ReferenceCases = []*Case{
+		{
+			Expr: `string_value == 'value'`,
+			Options: []cel.EnvOption{
+				cel.Variable("string_value", cel.StringType),
+			},
+			In: map[string]any{
+				"string_value": "value",
+			},
+			Out: types.True,
+		},
+		{
+			Expr: `string_value != 'value'`,
+			Options: []cel.EnvOption{
+				cel.Variable("string_value", cel.StringType),
+			},
+			In: map[string]any{
+				"string_value": "value",
+			},
+			Out: types.False,
+		},
+		{
+			Expr: `'value' in list_value`,
+			Options: []cel.EnvOption{
+				cel.Variable("list_value", cel.ListType(cel.StringType)),
+			},
+			In: map[string]any{
+				"list_value": []string{"a", "b", "c", "value"},
+			},
+			Out: types.True,
+		},
+		{
+			Expr: `!('value' in list_value)`,
+			Options: []cel.EnvOption{
+				cel.Variable("list_value", cel.ListType(cel.StringType)),
+			},
+			In: map[string]any{
+				"list_value": []string{"a", "b", "c", "d"},
+			},
+			Out: types.True,
+		},
+		{
+			Expr: `x in ['a', 'b', 'c', 'd']`,
+			Options: []cel.EnvOption{
+				cel.Variable("x", cel.StringType),
+			},
+			In: map[string]any{
+				"x": "c",
+			},
+			Out: types.True,
+		},
+		{
+			Expr: `!(x in ['a', 'b', 'c', 'd'])`,
+			Options: []cel.EnvOption{
+				cel.Variable("x", cel.StringType),
+			},
+			In: map[string]any{
+				"x": "e",
+			},
+			Out: types.True,
+		},
+		{
+			Expr: `x in list_value`,
+			Options: []cel.EnvOption{
+				cel.Variable("x", cel.StringType),
+				cel.Variable("list_value", cel.ListType(cel.StringType)),
+			},
+			In: map[string]any{
+				"x":          "c",
+				"list_value": []string{"a", "b", "c", "d"},
+			},
+			Out: types.True,
+		},
+		{
+			Expr: `!(x in list_value)`,
+			Options: []cel.EnvOption{
+				cel.Variable("x", cel.StringType),
+				cel.Variable("list_value", cel.ListType(cel.StringType)),
+			},
+			In: map[string]any{
+				"x":          "e",
+				"list_value": []string{"a", "b", "c", "d"},
+			},
+			Out: types.True,
+		},
+		{
+			Expr: `list_value.exists(e, e.contains('cd'))`,
+			Options: []cel.EnvOption{
+				cel.Variable("list_value", cel.ListType(cel.StringType)),
+			},
+			In: map[string]any{
+				"list_value": []string{"abc", "bcd", "cde", "def"},
+			},
+			Out: types.True,
+		},
+		{
+			Expr: `list_value.exists(e, e.startsWith('cd'))`,
+			Options: []cel.EnvOption{
+				cel.Variable("list_value", cel.ListType(cel.StringType)),
+			},
+			In: map[string]any{
+				"list_value": []string{"abc", "bcd", "cde", "def"},
+			},
+			Out: types.True,
+		},
+		{
+			Expr: `list_value.exists(e, e.matches('cd*'))`,
+			Options: []cel.EnvOption{
+				cel.Variable("list_value", cel.ListType(cel.StringType)),
+			},
+			In: map[string]any{
+				"list_value": []string{"abc", "bcd", "cde", "def"},
+			},
+			Out: types.True,
+		},
+		{
+			Expr: `list_value.filter(e, e.matches('^cd+')) == ['cde']`,
+			Options: []cel.EnvOption{
+				cel.Variable("list_value", cel.ListType(cel.StringType)),
+			},
+			In: map[string]any{
+				"list_value": []string{"abc", "bcd", "cde", "def"},
+			},
+			Out: types.True,
+		},
+		{
+			Expr: `'formatted list: %s, size: %d'.format([['abc', 'cde'], 2])`,
+			Options: []cel.EnvOption{
+				ext.Strings(),
+			},
+			In:  map[string]any{},
+			Out: types.String(`formatted list: ["abc", "cde"], size: 2`),
+		},
+	}
+)
+
+// RunReferenceCases evaluates the set of ReferenceCases against a custom CEL environment.
+//
+// See: bench_test.go for an example.
+func RunReferenceCases(b *testing.B, env *cel.Env) {
+	b.Helper()
+	for _, rc := range ReferenceCases {
+		RunCase(b, env, rc)
+	}
+}
+
+// RunCase evaluates a single test case against a custom environment, running three different
+// variants of the expression: optimized, unoptimized, and trace.
+//
+// * `optimized` - applies the cel.EvalOptions(cel.OptOptimize) flag.
+// * `unoptimized` - no optimization flags applied.
+// * `trace` - observes the evaluation state of an expression.
+//
+// In many cases the evaluation times may be similar, but when running comparisons against the
+// baseline CEL environment, it may be useful to characterize the performance of the custom
+// environment against the baseline.
+func RunCase(b *testing.B, env *cel.Env, bc *Case) {
+	b.Helper()
+	var err error
+	if len(bc.Options) > 0 {
+		env, err = env.Extend(bc.Options...)
+		if err != nil {
+			b.Fatalf("env.Extend() failed: %v", err)
+		}
+	}
+	ast, iss := env.Compile(bc.Expr)
+	if iss.Err() != nil {
+		b.Fatalf("env.Compile(%v) failed: %v", bc.Expr, iss.Err())
+	}
+	opts := map[string][]cel.ProgramOption{
+		"optimized":   {cel.EvalOptions(cel.OptOptimize)},
+		"unoptimized": {},
+		"trace":       {cel.EvalOptions(cel.OptTrackState)},
+	}
+	optOrder := []string{"optimized", "unoptimized", "trace"}
+	for _, name := range optOrder {
+		opt := opts[name]
+		b.Run(fmt.Sprintf("%s/%s", bc.Expr, name), func(b *testing.B) {
+			prg, err := env.Program(ast, opt...)
+			if err != nil {
+				b.Fatalf("env.Program(%v) failed: %v", bc.Expr, err)
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var input any = cel.NoVars()
+				if bc.In != nil {
+					input = bc.In
+				}
+				out, _, err := prg.Eval(input)
+				if err != nil {
+					b.Fatalf("prg.Eval(%v) failed: %v", input, err)
+				}
+				if out.Equal(bc.Out) != types.True {
+					b.Fatalf("prg.Eval(%v) got %v, wanted %v", input, out, bc.Out)
+				}
+			}
+		})
+	}
+}

--- a/test/bench/bench_test.go
+++ b/test/bench/bench_test.go
@@ -1,0 +1,29 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bench
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+)
+
+func BenchmarkReferenceCases(b *testing.B) {
+	stdenv, err := cel.NewEnv()
+	if err != nil {
+		b.Fatalf("cel.NewEnv() failed: %v", err)
+	}
+	RunReferenceCases(b, stdenv)
+}


### PR DESCRIPTION
Benchmarking harness and input specification for CEL benchmark tests for #729 

Example output:

```
BenchmarkReferenceCases/string_value_==_'value'/optimized-10         	18056289	        59.17 ns/op	      16 B/op	       1 allocs/op
BenchmarkReferenceCases/string_value_==_'value'/unoptimized-10       	20531859	        58.62 ns/op	      16 B/op	       1 allocs/op
BenchmarkReferenceCases/string_value_==_'value'/trace-10             	 1489496	       824.6 ns/op	    1064 B/op	      23 allocs/op
BenchmarkReferenceCases/string_value_!=_'value'/optimized-10         	19404576	        60.92 ns/op	      16 B/op	       1 allocs/op
BenchmarkReferenceCases/string_value_!=_'value'/unoptimized-10       	19588212	        61.08 ns/op	      16 B/op	       1 allocs/op
BenchmarkReferenceCases/string_value_!=_'value'/trace-10             	 1487623	       815.6 ns/op	    1064 B/op	      23 allocs/op
BenchmarkReferenceCases/'value'_in_list_value/optimized-10           	 3781479	       318.8 ns/op	     232 B/op	      11 allocs/op
BenchmarkReferenceCases/'value'_in_list_value/unoptimized-10         	 3786957	       316.6 ns/op	     232 B/op	      11 allocs/op
BenchmarkReferenceCases/'value'_in_list_value/trace-10               	 1000000	      1138 ns/op	    1328 B/op	      33 allocs/op
BenchmarkReferenceCases/!('value'_in_list_value)/optimized-10        	 3770986	       321.1 ns/op	     232 B/op	      11 allocs/op
BenchmarkReferenceCases/!('value'_in_list_value)/unoptimized-10      	 3750060	       319.1 ns/op	     232 B/op	      11 allocs/op
BenchmarkReferenceCases/!('value'_in_list_value)/trace-10            	  830226	      1293 ns/op	    1448 B/op	      36 allocs/op
BenchmarkReferenceCases/x_in_['a',_'b',_'c',_'d']/optimized-10       	17989554	        65.58 ns/op	      16 B/op	       1 allocs/op
BenchmarkReferenceCases/x_in_['a',_'b',_'c',_'d']/unoptimized-10     	 4879408	       247.6 ns/op	     208 B/op	       6 allocs/op
BenchmarkReferenceCases/x_in_['a',_'b',_'c',_'d']/trace-10           	  700068	      1705 ns/op	    1716 B/op	      44 allocs/op
BenchmarkReferenceCases/!(x_in_['a',_'b',_'c',_'d'])/optimized-10    	18499521	        64.24 ns/op	      16 B/op	       1 allocs/op
BenchmarkReferenceCases/!(x_in_['a',_'b',_'c',_'d'])/unoptimized-10  	 4456545	       269.8 ns/op	     208 B/op	       6 allocs/op
BenchmarkReferenceCases/!(x_in_['a',_'b',_'c',_'d'])/trace-10        	  665133	      1842 ns/op	    1836 B/op	      47 allocs/op
BenchmarkReferenceCases/x_in_list_value/optimized-10                 	 3905000	       307.5 ns/op	     216 B/op	      10 allocs/op
BenchmarkReferenceCases/x_in_list_value/unoptimized-10               	 3904173	       306.7 ns/op	     216 B/op	      10 allocs/op
BenchmarkReferenceCases/x_in_list_value/trace-10                     	 1000000	      1138 ns/op	    1432 B/op	      32 allocs/op
BenchmarkReferenceCases/!(x_in_list_value)/optimized-10              	 3395769	       354.1 ns/op	     248 B/op	      12 allocs/op
BenchmarkReferenceCases/!(x_in_list_value)/unoptimized-10            	 3367008	       356.4 ns/op	     248 B/op	      12 allocs/op
BenchmarkReferenceCases/!(x_in_list_value)/trace-10                  	  848238	      1398 ns/op	    1584 B/op	      37 allocs/op
BenchmarkReferenceCases/list_value.exists(e,_e.contains('cd'))/optimized-10         	 2065491	       579.0 ns/op	     248 B/op	      10 allocs/op
BenchmarkReferenceCases/list_value.exists(e,_e.contains('cd'))/unoptimized-10       	 2064439	       579.6 ns/op	     248 B/op	      10 allocs/op
BenchmarkReferenceCases/list_value.exists(e,_e.contains('cd'))/trace-10             	  350517	      3420 ns/op	    3136 B/op	      62 allocs/op
BenchmarkReferenceCases/list_value.exists(e,_e.startsWith('cd'))/optimized-10       	 1686837	       712.8 ns/op	     280 B/op	      12 allocs/op
BenchmarkReferenceCases/list_value.exists(e,_e.startsWith('cd'))/unoptimized-10     	 1654932	       711.4 ns/op	     280 B/op	      12 allocs/op
BenchmarkReferenceCases/list_value.exists(e,_e.startsWith('cd'))/trace-10           	  322887	      3701 ns/op	    3168 B/op	      64 allocs/op
BenchmarkReferenceCases/list_value.exists(e,_e.matches('cd*'))/optimized-10         	 2269831	       529.4 ns/op	     269 B/op	      10 allocs/op
BenchmarkReferenceCases/list_value.exists(e,_e.matches('cd*'))/unoptimized-10       	  814364	      1450 ns/op	    1717 B/op	      25 allocs/op
BenchmarkReferenceCases/list_value.exists(e,_e.matches('cd*'))/trace-10             	  282592	      4261 ns/op	    4673 B/op	      77 allocs/op
BenchmarkReferenceCases/list_value.filter(e,_e.matches('^cd+'))_==_['cde']/optimized-10         	  847449	      1389 ns/op	     849 B/op	      32 allocs/op
BenchmarkReferenceCases/list_value.filter(e,_e.matches('^cd+'))_==_['cde']/unoptimized-10       	  210804	      5616 ns/op	    7583 B/op	     105 allocs/op
BenchmarkReferenceCases/list_value.filter(e,_e.matches('^cd+'))_==_['cde']/trace-10             	  117058	     10430 ns/op	   12348 B/op	     178 allocs/op
BenchmarkReferenceCases/'formatted_list:_%s,_size:_%d'.format([['abc',_'cde'],_2])/optimized-10 	 1256002	       947.9 ns/op	     464 B/op	      21 allocs/op
BenchmarkReferenceCases/'formatted_list:_%s,_size:_%d'.format([['abc',_'cde'],_2])/unoptimized-10         	  961419	      1237 ns/op	     784 B/op	      31 allocs/op
BenchmarkReferenceCases/'formatted_list:_%s,_size:_%d'.format([['abc',_'cde'],_2])/trace-10               	  442335	      2821 ns/op	    2162 B/op	      67 allocs/op
```