### PR TITLE
Type-check benchmarks and parameterized test inputs

### DIFF
--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -37,156 +37,158 @@ import (
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
-var testCases = []testInfo{
-	// Const types
-	{
-		in:      `"A"`,
-		out:     `"A"~string`,
-		outType: decls.String,
-	},
-	{
-		in:      `12`,
-		out:     `12~int`,
-		outType: decls.Int,
-	},
-	{
-		in:      `12u`,
-		out:     `12u~uint`,
-		outType: decls.Uint,
-	},
-	{
-		in:      `true`,
-		out:     `true~bool`,
-		outType: decls.Bool,
-	},
-	{
-		in:      `false`,
-		out:     `false~bool`,
-		outType: decls.Bool,
-	},
-	{
-		in:      `12.23`,
-		out:     `12.23~double`,
-		outType: decls.Double,
-	},
-	{
-		in:      `null`,
-		out:     `null~null`,
-		outType: decls.Null,
-	},
-	{
-		in:      `b"ABC"`,
-		out:     `b"ABC"~bytes`,
-		outType: decls.Bytes,
-	},
-	// Ident types
-	{
-		in:      `is`,
-		out:     `is~string^is`,
-		outType: decls.String,
-		env:     testEnvs["default"],
-	},
-	{
-		in:      `ii`,
-		out:     `ii~int^ii`,
-		outType: decls.Int,
-		env:     testEnvs["default"],
-	},
-	{
-		in:      `iu`,
-		out:     `iu~uint^iu`,
-		outType: decls.Uint,
-		env:     testEnvs["default"],
-	},
-	{
-		in:      `iz`,
-		out:     `iz~bool^iz`,
-		outType: decls.Bool,
-		env:     testEnvs["default"],
-	},
-	{
-		in:      `id`,
-		out:     `id~double^id`,
-		outType: decls.Double,
-		env:     testEnvs["default"],
-	},
-	{
-		in:      `ix`,
-		out:     `ix~null^ix`,
-		outType: decls.Null,
-		env:     testEnvs["default"],
-	},
-	{
-		in:      `ib`,
-		out:     `ib~bytes^ib`,
-		outType: decls.Bytes,
-		env:     testEnvs["default"],
-	},
-	{
-		in:      `id`,
-		out:     `id~double^id`,
-		outType: decls.Double,
-		env:     testEnvs["default"],
-	},
-	{
-		in:      `[]`,
-		out:     `[]~list(dyn)`,
-		outType: decls.NewListType(decls.Dyn),
-	},
-	{
-		in:      `[1]`,
-		out:     `[1~int]~list(int)`,
-		outType: decls.NewListType(decls.Int),
-	},
-	{
-		in:      `[1, "A"]`,
-		out:     `[1~int, "A"~string]~list(dyn)`,
-		outType: decls.NewListType(decls.Dyn),
-	},
-	{
-		in:      `foo`,
-		out:     `foo~!error!`,
-		outType: decls.Error,
-		err: `
+func testCases(t testing.TB) []testInfo {
+	t.Helper()
+	return []testInfo{
+		// Const types
+		{
+			in:      `"A"`,
+			out:     `"A"~string`,
+			outType: decls.String,
+		},
+		{
+			in:      `12`,
+			out:     `12~int`,
+			outType: decls.Int,
+		},
+		{
+			in:      `12u`,
+			out:     `12u~uint`,
+			outType: decls.Uint,
+		},
+		{
+			in:      `true`,
+			out:     `true~bool`,
+			outType: decls.Bool,
+		},
+		{
+			in:      `false`,
+			out:     `false~bool`,
+			outType: decls.Bool,
+		},
+		{
+			in:      `12.23`,
+			out:     `12.23~double`,
+			outType: decls.Double,
+		},
+		{
+			in:      `null`,
+			out:     `null~null`,
+			outType: decls.Null,
+		},
+		{
+			in:      `b"ABC"`,
+			out:     `b"ABC"~bytes`,
+			outType: decls.Bytes,
+		},
+		// Ident types
+		{
+			in:      `is`,
+			out:     `is~string^is`,
+			outType: decls.String,
+			env:     testEnvs["default"],
+		},
+		{
+			in:      `ii`,
+			out:     `ii~int^ii`,
+			outType: decls.Int,
+			env:     testEnvs["default"],
+		},
+		{
+			in:      `iu`,
+			out:     `iu~uint^iu`,
+			outType: decls.Uint,
+			env:     testEnvs["default"],
+		},
+		{
+			in:      `iz`,
+			out:     `iz~bool^iz`,
+			outType: decls.Bool,
+			env:     testEnvs["default"],
+		},
+		{
+			in:      `id`,
+			out:     `id~double^id`,
+			outType: decls.Double,
+			env:     testEnvs["default"],
+		},
+		{
+			in:      `ix`,
+			out:     `ix~null^ix`,
+			outType: decls.Null,
+			env:     testEnvs["default"],
+		},
+		{
+			in:      `ib`,
+			out:     `ib~bytes^ib`,
+			outType: decls.Bytes,
+			env:     testEnvs["default"],
+		},
+		{
+			in:      `id`,
+			out:     `id~double^id`,
+			outType: decls.Double,
+			env:     testEnvs["default"],
+		},
+		{
+			in:      `[]`,
+			out:     `[]~list(dyn)`,
+			outType: decls.NewListType(decls.Dyn),
+		},
+		{
+			in:      `[1]`,
+			out:     `[1~int]~list(int)`,
+			outType: decls.NewListType(decls.Int),
+		},
+		{
+			in:      `[1, "A"]`,
+			out:     `[1~int, "A"~string]~list(dyn)`,
+			outType: decls.NewListType(decls.Dyn),
+		},
+		{
+			in:      `foo`,
+			out:     `foo~!error!`,
+			outType: decls.Error,
+			err: `
 ERROR: <input>:1:1: undeclared reference to 'foo' (in container '')
 | foo
 | ^`,
-	},
-	// Call resolution
-	{
-		in:      `fg_s()`,
-		out:     `fg_s()~string^fg_s_0`,
-		outType: decls.String,
-		env:     testEnvs["default"],
-	},
-	{
-		in:      `is.fi_s_s()`,
-		out:     `is~string^is.fi_s_s()~string^fi_s_s_0`,
-		outType: decls.String,
-		env:     testEnvs["default"],
-	},
-	{
-		in:      `1 + 2`,
-		out:     `_+_(1~int, 2~int)~int^add_int64`,
-		outType: decls.Int,
-		env:     testEnvs["default"],
-	},
-	{
-		in:      `1 + ii`,
-		out:     `_+_(1~int, ii~int^ii)~int^add_int64`,
-		outType: decls.Int,
-		env:     testEnvs["default"],
-	},
-	{
-		in:      `[1] + [2]`,
-		out:     `_+_([1~int]~list(int), [2~int]~list(int))~list(int)^add_list`,
-		outType: decls.NewListType(decls.Int),
-		env:     testEnvs["default"],
-	},
-	{
-		in:      `[] + [1,2,3,] + [4]`,
-		outType: decls.NewListType(decls.Int),
-		out: `
+		},
+		// Call resolution
+		{
+			in:      `fg_s()`,
+			out:     `fg_s()~string^fg_s_0`,
+			outType: decls.String,
+			env:     testEnvs["default"],
+		},
+		{
+			in:      `is.fi_s_s()`,
+			out:     `is~string^is.fi_s_s()~string^fi_s_s_0`,
+			outType: decls.String,
+			env:     testEnvs["default"],
+		},
+		{
+			in:      `1 + 2`,
+			out:     `_+_(1~int, 2~int)~int^add_int64`,
+			outType: decls.Int,
+			env:     testEnvs["default"],
+		},
+		{
+			in:      `1 + ii`,
+			out:     `_+_(1~int, ii~int^ii)~int^add_int64`,
+			outType: decls.Int,
+			env:     testEnvs["default"],
+		},
+		{
+			in:      `[1] + [2]`,
+			out:     `_+_([1~int]~list(int), [2~int]~list(int))~list(int)^add_list`,
+			outType: decls.NewListType(decls.Int),
+			env:     testEnvs["default"],
+		},
+		{
+			in:      `[] + [1,2,3,] + [4]`,
+			outType: decls.NewListType(decls.Int),
+			out: `
 	_+_(
 		_+_(
 			[]~list(int),
@@ -194,82 +196,82 @@ ERROR: <input>:1:1: undeclared reference to 'foo' (in container '')
 			[4~int]~list(int))
 	~list(int)^add_list
 	`,
-	},
-	{
-		in: `[1, 2u] + []`,
-		out: `_+_(
+		},
+		{
+			in: `[1, 2u] + []`,
+			out: `_+_(
 			[
 				1~int,
 				2u~uint
 			]~list(dyn),
 			[]~list(dyn)
 		)~list(dyn)^add_list`,
-		outType: decls.NewListType(decls.Dyn),
-	},
-	{
-		in:      `{1:2u, 2:3u}`,
-		outType: decls.NewMapType(decls.Int, decls.Uint),
-		out:     `{1~int : 2u~uint, 2~int : 3u~uint}~map(int, uint)`,
-	},
-	{
-		in:      `{"a":1, "b":2}.a`,
-		outType: decls.Int,
-		out:     `{"a"~string : 1~int, "b"~string : 2~int}~map(string, int).a~int`,
-	},
-	{
-		in:      `{1:2u, 2u:3}`,
-		outType: decls.NewMapType(decls.Dyn, decls.Dyn),
-		out:     `{1~int : 2u~uint, 2u~uint : 3~int}~map(dyn, dyn)`,
-	},
-	{
-		in:        `TestAllTypes{single_int32: 1, single_int64: 2}`,
-		container: "google.expr.proto3.test",
-		out: `
+			outType: decls.NewListType(decls.Dyn),
+		},
+		{
+			in:      `{1:2u, 2:3u}`,
+			outType: decls.NewMapType(decls.Int, decls.Uint),
+			out:     `{1~int : 2u~uint, 2~int : 3u~uint}~map(int, uint)`,
+		},
+		{
+			in:      `{"a":1, "b":2}.a`,
+			outType: decls.Int,
+			out:     `{"a"~string : 1~int, "b"~string : 2~int}~map(string, int).a~int`,
+		},
+		{
+			in:      `{1:2u, 2u:3}`,
+			outType: decls.NewMapType(decls.Dyn, decls.Dyn),
+			out:     `{1~int : 2u~uint, 2u~uint : 3~int}~map(dyn, dyn)`,
+		},
+		{
+			in:        `TestAllTypes{single_int32: 1, single_int64: 2}`,
+			container: "google.expr.proto3.test",
+			out: `
 		google.expr.proto3.test.TestAllTypes{
 			single_int32 : 1~int,
 			single_int64 : 2~int
 		}~google.expr.proto3.test.TestAllTypes^google.expr.proto3.test.TestAllTypes`,
-		outType: decls.NewObjectType("google.expr.proto3.test.TestAllTypes"),
-	},
-	{
-		in:        `TestAllTypes{single_int32: 1u}`,
-		container: "google.expr.proto3.test",
-		err: `
+			outType: decls.NewObjectType("google.expr.proto3.test.TestAllTypes"),
+		},
+		{
+			in:        `TestAllTypes{single_int32: 1u}`,
+			container: "google.expr.proto3.test",
+			err: `
 	ERROR: <input>:1:26: expected type of field 'single_int32' is 'int' but provided type is 'uint'
 	  | TestAllTypes{single_int32: 1u}
 	  | .........................^`,
-	},
-	{
-		in:        `TestAllTypes{single_int32: 1, undefined: 2}`,
-		container: "google.expr.proto3.test",
-		err: `
+		},
+		{
+			in:        `TestAllTypes{single_int32: 1, undefined: 2}`,
+			container: "google.expr.proto3.test",
+			err: `
 	ERROR: <input>:1:40: undefined field 'undefined'
 	  | TestAllTypes{single_int32: 1, undefined: 2}
 	  | .......................................^`,
-	},
-	{
-		in: `size(x) == x.size()`,
-		out: `
+		},
+		{
+			in: `size(x) == x.size()`,
+			out: `
 _==_(size(x~list(int)^x)~int^size_list, x~list(int)^x.size()~int^list_size)
   ~bool^equals`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewListType(decls.Int)),
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewListType(decls.Int)),
+				},
 			},
+			outType: decls.Bool,
 		},
-		outType: decls.Bool,
-	},
-	{
-		in: `int(1u) + int(uint("1"))`,
-		out: `
+		{
+			in: `int(1u) + int(uint("1"))`,
+			out: `
 _+_(int(1u~uint)~int^uint64_to_int64,
       int(uint("1"~string)~uint^string_to_uint64)~int^uint64_to_int64)
   ~int^add_int64`,
-		outType: decls.Int,
-	},
-	{
-		in: `false && !true || false ? 2 : 3`,
-		out: `
+			outType: decls.Int,
+		},
+		{
+			in: `false && !true || false ? 2 : 3`,
+			out: `
 _?_:_(_||_(_&&_(false~bool, !_(true~bool)~bool^logical_not)~bool^logical_and,
             false~bool)
         ~bool^logical_or,
@@ -277,27 +279,27 @@ _?_:_(_||_(_&&_(false~bool, !_(true~bool)~bool^logical_not)~bool^logical_and,
       3~int)
   ~int^conditional
 `,
-		outType: decls.Int,
-	},
-	{
-		in:      `b"abc" + b"def"`,
-		out:     `_+_(b"abc"~bytes, b"def"~bytes)~bytes^add_bytes`,
-		outType: decls.Bytes,
-	},
-	{
-		in: `1.0 + 2.0 * 3.0 - 1.0 / 2.20202 != 66.6`,
-		out: `
+			outType: decls.Int,
+		},
+		{
+			in:      `b"abc" + b"def"`,
+			out:     `_+_(b"abc"~bytes, b"def"~bytes)~bytes^add_bytes`,
+			outType: decls.Bytes,
+		},
+		{
+			in: `1.0 + 2.0 * 3.0 - 1.0 / 2.20202 != 66.6`,
+			out: `
 _!=_(_-_(_+_(1~double, _*_(2~double, 3~double)~double^multiply_double)
            ~double^add_double,
            _/_(1~double, 2.20202~double)~double^divide_double)
        ~double^subtract_double,
       66.6~double)
   ~bool^not_equals`,
-		outType: decls.Bool,
-	},
-	{
-		in: `null == null && null != null`,
-		out: `
+			outType: decls.Bool,
+		},
+		{
+			in: `null == null && null != null`,
+			out: `
 		_&&_(
 			_==_(
 				null~null,
@@ -308,11 +310,11 @@ _!=_(_-_(_+_(1~double, _*_(2~double, 3~double)~double^multiply_double)
 				null~null
 			)~bool^not_equals
 		)~bool^logical_and`,
-		outType: decls.Bool,
-	},
-	{
-		in: `1 == 1 && 2 != 1`,
-		out: `
+			outType: decls.Bool,
+		},
+		{
+			in: `1 == 1 && 2 != 1`,
+			out: `
 		_&&_(
 			_==_(
 				1~int,
@@ -323,49 +325,49 @@ _!=_(_-_(_+_(1~double, _*_(2~double, 3~double)~double^multiply_double)
 				1~int
 			)~bool^not_equals
 		)~bool^logical_and`,
-		outType: decls.Bool,
-	},
-	{
-		in:      `1 + 2 * 3 - 1 / 2 == 6 % 1`,
-		out:     ` _==_(_-_(_+_(1~int, _*_(2~int, 3~int)~int^multiply_int64)~int^add_int64, _/_(1~int, 2~int)~int^divide_int64)~int^subtract_int64, _%_(6~int, 1~int)~int^modulo_int64)~bool^equals`,
-		outType: decls.Bool,
-	},
-	{
-		in:      `"abc" + "def"`,
-		out:     `_+_("abc"~string, "def"~string)~string^add_string`,
-		outType: decls.String,
-	},
-	{
-		in: `1u + 2u * 3u - 1u / 2u == 6u % 1u`,
-		out: `_==_(_-_(_+_(1u~uint, _*_(2u~uint, 3u~uint)~uint^multiply_uint64)
+			outType: decls.Bool,
+		},
+		{
+			in:      `1 + 2 * 3 - 1 / 2 == 6 % 1`,
+			out:     ` _==_(_-_(_+_(1~int, _*_(2~int, 3~int)~int^multiply_int64)~int^add_int64, _/_(1~int, 2~int)~int^divide_int64)~int^subtract_int64, _%_(6~int, 1~int)~int^modulo_int64)~bool^equals`,
+			outType: decls.Bool,
+		},
+		{
+			in:      `"abc" + "def"`,
+			out:     `_+_("abc"~string, "def"~string)~string^add_string`,
+			outType: decls.String,
+		},
+		{
+			in: `1u + 2u * 3u - 1u / 2u == 6u % 1u`,
+			out: `_==_(_-_(_+_(1u~uint, _*_(2u~uint, 3u~uint)~uint^multiply_uint64)
 	         ~uint^add_uint64,
 	         _/_(1u~uint, 2u~uint)~uint^divide_uint64)
 	     ~uint^subtract_uint64,
 	    _%_(6u~uint, 1u~uint)~uint^modulo_uint64)
 	~bool^equals`,
-		outType: decls.Bool,
-	},
-	{
-		in: `x.single_int32 != null`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.Proto2Message")),
-			},
+			outType: decls.Bool,
 		},
-		err: `
+		{
+			in: `x.single_int32 != null`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.Proto2Message")),
+				},
+			},
+			err: `
 	ERROR: <input>:1:2: unexpected failed resolution of 'google.expr.proto3.test.Proto2Message'
 	  | x.single_int32 != null
 	  | .^
 	`,
-	},
-	{
-		in: `x.single_value + 1 / x.single_struct.y == 23`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-			},
 		},
-		out: `_==_(
+		{
+			in: `x.single_value + 1 / x.single_struct.y == 23`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
+			},
+			out: `_==_(
 			_+_(
 			  x~google.expr.proto3.test.TestAllTypes^x.single_value~dyn,
 			  _/_(
@@ -375,16 +377,16 @@ _!=_(_-_(_+_(1~double, _*_(2~double, 3~double)~double^multiply_double)
 			)~int^add_int64,
 			23~int
 		  )~bool^equals`,
-		outType: decls.Bool,
-	},
-	{
-		in: `x.single_value[23] + x.single_struct['y']`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-			},
+			outType: decls.Bool,
 		},
-		out: `_+_(
+		{
+			in: `x.single_value[23] + x.single_struct['y']`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
+			},
+			out: `_+_(
 			_[_](
 			  x~google.expr.proto3.test.TestAllTypes^x.single_value~dyn,
 			  23~int
@@ -395,33 +397,33 @@ _!=_(_-_(_+_(1~double, _*_(2~double, 3~double)~double^multiply_double)
 			)~dyn^index_map
 		  )~dyn^add_bytes|add_double|add_duration_duration|add_duration_timestamp|add_int64|add_list|add_string|add_timestamp_duration|add_uint64
 		  `,
-		outType: decls.Dyn,
-	},
-	{
-		in:        `TestAllTypes.NestedEnum.BAR != 99`,
-		container: "google.expr.proto3.test",
-		out: `_!=_(google.expr.proto3.test.TestAllTypes.NestedEnum.BAR
+			outType: decls.Dyn,
+		},
+		{
+			in:        `TestAllTypes.NestedEnum.BAR != 99`,
+			container: "google.expr.proto3.test",
+			out: `_!=_(google.expr.proto3.test.TestAllTypes.NestedEnum.BAR
 	     ~int^google.expr.proto3.test.TestAllTypes.NestedEnum.BAR,
 	    99~int)
 	~bool^not_equals`,
-		outType: decls.Bool,
-	},
-	{
-		in:      `size([] + [1])`,
-		out:     `size(_+_([]~list(int), [1~int]~list(int))~list(int)^add_list)~int^size_list`,
-		outType: decls.Int,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+			outType: decls.Bool,
+		},
+		{
+			in:      `size([] + [1])`,
+			out:     `size(_+_([]~list(int), [1~int]~list(int))~list(int)^add_list)~int^size_list`,
+			outType: decls.Int,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
 			},
 		},
-	},
-	{
-		in: `x["claims"]["groups"][0].name == "dummy"
+		{
+			in: `x["claims"]["groups"][0].name == "dummy"
 		&& x.claims["exp"] == y[1].time
 		&& x.claims.structured == {'key': z}
 		&& z == 1.0`,
-		out: `_&&_(
+			out: `_&&_(
 			_&&_(
 				_==_(
 					_[_](
@@ -460,51 +462,51 @@ _!=_(_-_(_+_(1~double, _*_(2~double, 3~double)~double^multiply_double)
 				)~bool^equals
 			)~bool^logical_and
 		)~bool^logical_and`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.protobuf.Struct")),
-				decls.NewVar("y", decls.NewObjectType("google.protobuf.ListValue")),
-				decls.NewVar("z", decls.NewObjectType("google.protobuf.Value")),
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.protobuf.Struct")),
+					decls.NewVar("y", decls.NewObjectType("google.protobuf.ListValue")),
+					decls.NewVar("z", decls.NewObjectType("google.protobuf.Value")),
+				},
 			},
+			outType: decls.Bool,
 		},
-		outType: decls.Bool,
-	},
-	{
-		in:  `x + y`,
-		out: ``,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewListType(decls.NewObjectType("google.expr.proto3.test.TestAllTypes"))),
-				decls.NewVar("y", decls.NewListType(decls.Int)),
+		{
+			in:  `x + y`,
+			out: ``,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewListType(decls.NewObjectType("google.expr.proto3.test.TestAllTypes"))),
+					decls.NewVar("y", decls.NewListType(decls.Int)),
+				},
 			},
-		},
-		err: `
+			err: `
 ERROR: <input>:1:3: found no matching overload for '_+_' applied to '(list(google.expr.proto3.test.TestAllTypes), list(int))'
   | x + y
   | ..^
 		`,
-	},
-	{
-		in: `x[1u]`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewListType(decls.NewObjectType("google.expr.proto3.test.TestAllTypes"))),
-			},
 		},
-		err: `
+		{
+			in: `x[1u]`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewListType(decls.NewObjectType("google.expr.proto3.test.TestAllTypes"))),
+				},
+			},
+			err: `
 ERROR: <input>:1:2: found no matching overload for '_[_]' applied to '(list(google.expr.proto3.test.TestAllTypes), uint)'
   | x[1u]
   | .^
 `,
-	},
-	{
-		in: `(x + x)[1].single_int32 == size(x)`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewListType(decls.NewObjectType("google.expr.proto3.test.TestAllTypes"))),
-			},
 		},
-		out: `
+		{
+			in: `(x + x)[1].single_int32 == size(x)`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewListType(decls.NewObjectType("google.expr.proto3.test.TestAllTypes"))),
+				},
+			},
+			out: `
 _==_(_[_](_+_(x~list(google.expr.proto3.test.TestAllTypes)^x,
                 x~list(google.expr.proto3.test.TestAllTypes)^x)
             ~list(google.expr.proto3.test.TestAllTypes)^add_list,
@@ -516,47 +518,47 @@ _==_(_[_](_+_(x~list(google.expr.proto3.test.TestAllTypes)^x,
       size(x~list(google.expr.proto3.test.TestAllTypes)^x)~int^size_list)
   ~bool^equals
 	`,
-		outType: decls.Bool,
-	},
-	{
-		in: `x.repeated_int64[x.single_int32] == 23`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-			},
+			outType: decls.Bool,
 		},
-		out: `
+		{
+			in: `x.repeated_int64[x.single_int32] == 23`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
+			},
+			out: `
 _==_(_[_](x~google.expr.proto3.test.TestAllTypes^x.repeated_int64~list(int),
            x~google.expr.proto3.test.TestAllTypes^x.single_int32~int)
        ~int^index_list,
       23~int)
   ~bool^equals`,
-		outType: decls.Bool,
-	},
-	{
-		in: `size(x.map_int64_nested_type) == 0`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-			},
+			outType: decls.Bool,
 		},
-		out: `
+		{
+			in: `size(x.map_int64_nested_type) == 0`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
+			},
+			out: `
 _==_(size(x~google.expr.proto3.test.TestAllTypes^x.map_int64_nested_type
             ~map(int, google.expr.proto3.test.NestedTestAllTypes))
        ~int^size_map,
       0~int)
   ~bool^equals
 		`,
-		outType: decls.Bool,
-	},
-	{
-		in: `x.all(y, y == true)`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.Bool),
-			},
+			outType: decls.Bool,
 		},
-		out: `
+		{
+			in: `x.all(y, y == true)`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.Bool),
+				},
+			},
+			out: `
 		__comprehension__(
 		// Variable
 		y,
@@ -581,18 +583,18 @@ _==_(size(x~google.expr.proto3.test.TestAllTypes^x.map_int64_nested_type
 		// Result
 		__result__~bool^__result__)~bool
 		`,
-		err: `ERROR: <input>:1:1: expression of type 'bool' cannot be range of a comprehension (must be list, map, or dynamic)
+			err: `ERROR: <input>:1:1: expression of type 'bool' cannot be range of a comprehension (must be list, map, or dynamic)
 		| x.all(y, y == true)
 		| ^`,
-	},
-	{
-		in: `x.repeated_int64.map(x, double(x))`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-			},
 		},
-		out: `
+		{
+			in: `x.repeated_int64.map(x, double(x))`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
+			},
+			out: `
 		__comprehension__(
     		  // Variable
     		  x,
@@ -616,16 +618,16 @@ _==_(size(x~google.expr.proto3.test.TestAllTypes^x.map_int64_nested_type
     		  // Result
     		  __result__~list(double)^__result__)~list(double)
 		`,
-		outType: decls.NewListType(decls.Double),
-	},
-	{
-		in: `x.repeated_int64.map(x, x > 0, double(x))`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-			},
+			outType: decls.NewListType(decls.Double),
 		},
-		out: `
+		{
+			in: `x.repeated_int64.map(x, x > 0, double(x))`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
+			},
+			out: `
 	__comprehension__(
     		  // Variable
     		  x,
@@ -656,33 +658,33 @@ _==_(size(x~google.expr.proto3.test.TestAllTypes^x.map_int64_nested_type
     		  // Result
     		  __result__~list(double)^__result__)~list(double)
 		`,
-		outType: decls.NewListType(decls.Double),
-	},
-	{
-		in: `x[2].single_int32 == 23`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x",
-					decls.NewMapType(decls.String,
-						decls.NewObjectType("google.expr.proto3.test.TestAllTypes"))),
-			},
+			outType: decls.NewListType(decls.Double),
 		},
-		err: `
+		{
+			in: `x[2].single_int32 == 23`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x",
+						decls.NewMapType(decls.String,
+							decls.NewObjectType("google.expr.proto3.test.TestAllTypes"))),
+				},
+			},
+			err: `
 ERROR: <input>:1:2: found no matching overload for '_[_]' applied to '(map(string, google.expr.proto3.test.TestAllTypes), int)'
   | x[2].single_int32 == 23
   | .^
 		`,
-	},
-	{
-		in: `x["a"].single_int32 == 23`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x",
-					decls.NewMapType(decls.String,
-						decls.NewObjectType("google.expr.proto3.test.TestAllTypes"))),
-			},
 		},
-		out: `
+		{
+			in: `x["a"].single_int32 == 23`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x",
+						decls.NewMapType(decls.String,
+							decls.NewObjectType("google.expr.proto3.test.TestAllTypes"))),
+				},
+			},
+			out: `
 		_==_(_[_](x~map(string, google.expr.proto3.test.TestAllTypes)^x, "a"~string)
 		~google.expr.proto3.test.TestAllTypes^index_map
 		.
@@ -690,86 +692,86 @@ ERROR: <input>:1:2: found no matching overload for '_[_]' applied to '(map(strin
 		~int,
 		23~int)
 		~bool^equals`,
-		outType: decls.Bool,
-	},
-	{
-		in: `x.single_nested_message.bb == 43 && has(x.single_nested_message)`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-			},
+			outType: decls.Bool,
 		},
+		{
+			in: `x.single_nested_message.bb == 43 && has(x.single_nested_message)`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
+			},
 
-		// Our implementation code is expanding the macro
-		out: `_&&_(
+			// Our implementation code is expanding the macro
+			out: `_&&_(
     		  _==_(
     		    x~google.expr.proto3.test.TestAllTypes^x.single_nested_message~google.expr.proto3.test.TestAllTypes.NestedMessage.bb~int,
     		    43~int
     		  )~bool^equals,
     		  x~google.expr.proto3.test.TestAllTypes^x.single_nested_message~test-only~~bool
     		)~bool^logical_and`,
-		outType: decls.Bool,
-	},
-	{
-		in: `x.single_nested_message.undefined == x.undefined && has(x.single_int32) && has(x.repeated_int32)`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-			},
+			outType: decls.Bool,
 		},
-		err: `
+		{
+			in: `x.single_nested_message.undefined == x.undefined && has(x.single_int32) && has(x.repeated_int32)`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
+			},
+			err: `
 ERROR: <input>:1:24: undefined field 'undefined'
 | x.single_nested_message.undefined == x.undefined && has(x.single_int32) && has(x.repeated_int32)
 | .......................^
 ERROR: <input>:1:39: undefined field 'undefined'
 | x.single_nested_message.undefined == x.undefined && has(x.single_int32) && has(x.repeated_int32)
 | ......................................^`,
-	},
-	{
-		in: `x.single_nested_message != null`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-			},
 		},
-		out: `
+		{
+			in: `x.single_nested_message != null`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
+			},
+			out: `
 		_!=_(x~google.expr.proto3.test.TestAllTypes^x.single_nested_message
 		~google.expr.proto3.test.TestAllTypes.NestedMessage,
 		null~null)
 		~bool^not_equals
 		`,
-		outType: decls.Bool,
-	},
-	{
-		in: `x.single_int64 != null`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-			},
+			outType: decls.Bool,
 		},
-		err: `
+		{
+			in: `x.single_int64 != null`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
+			},
+			err: `
 ERROR: <input>:1:16: found no matching overload for '_!=_' applied to '(int, null)'
  | x.single_int64 != null
  | ...............^
 		`,
-	},
-	{
-		in: `x.single_int64_wrapper == null`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-			},
 		},
-		out: `
+		{
+			in: `x.single_int64_wrapper == null`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
+			},
+			out: `
 		_==_(x~google.expr.proto3.test.TestAllTypes^x.single_int64_wrapper
 		~wrapper(int),
 		null~null)
 		~bool^equals
 		`,
-		outType: decls.Bool,
-	},
-	{
-		in: `x.single_bool_wrapper
+			outType: decls.Bool,
+		},
+		{
+			in: `x.single_bool_wrapper
 		&& x.single_bytes_wrapper == b'hi'
 		&& x.single_double_wrapper != 2.0
 		&& x.single_float_wrapper == 1.0
@@ -778,12 +780,12 @@ ERROR: <input>:1:16: found no matching overload for '_!=_' applied to '(int, nul
 		&& x.single_string_wrapper == 'hi'
 		&& x.single_uint32_wrapper == 1u
 		&& x.single_uint64_wrapper != 42u`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
 			},
-		},
-		out: `
+			out: `
 		_&&_(
 			_&&_(
 				_&&_(
@@ -833,20 +835,20 @@ ERROR: <input>:1:16: found no matching overload for '_!=_' applied to '(int, nul
 				)~bool^logical_and
 			)~bool^logical_and
 		)~bool^logical_and`,
-		outType: decls.Bool,
-	},
-	{
-		in: `x.single_timestamp == google.protobuf.Timestamp{seconds: 20} &&
-		     x.single_duration < google.protobuf.Duration{seconds: 10}`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-			},
+			outType: decls.Bool,
 		},
-		outType: decls.Bool,
-	},
-	{
-		in: `x.single_bool_wrapper == google.protobuf.BoolValue{value: true}
+		{
+			in: `x.single_timestamp == google.protobuf.Timestamp{seconds: 20} &&
+		     x.single_duration < google.protobuf.Duration{seconds: 10}`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
+			},
+			outType: decls.Bool,
+		},
+		{
+			in: `x.single_bool_wrapper == google.protobuf.BoolValue{value: true}
 			&& x.single_bytes_wrapper == google.protobuf.BytesValue{value: b'hi'}
 			&& x.single_double_wrapper != google.protobuf.DoubleValue{value: 2.0}
 			&& x.single_float_wrapper == google.protobuf.FloatValue{value: 1.0}
@@ -856,32 +858,32 @@ ERROR: <input>:1:16: found no matching overload for '_!=_' applied to '(int, nul
 			&& x.single_string_wrapper == google.protobuf.Value{string_value: 'hi'}
 			&& x.single_uint32_wrapper == google.protobuf.UInt32Value{value: 1u}
 			&& x.single_uint64_wrapper != google.protobuf.UInt64Value{value: 42u}`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
 			},
+			outType: decls.Bool,
 		},
-		outType: decls.Bool,
-	},
-	{
-		in: `x.repeated_int64.exists(y, y > 10) && y < 5`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+		{
+			in: `x.repeated_int64.exists(y, y > 10) && y < 5`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
 			},
-		},
-		err: `ERROR: <input>:1:39: undeclared reference to 'y' (in container '')
+			err: `ERROR: <input>:1:39: undeclared reference to 'y' (in container '')
 		| x.repeated_int64.exists(y, y > 10) && y < 5
 		| ......................................^`,
-	},
-	{
-		in: `x.repeated_int64.all(e, e > 0) && x.repeated_int64.exists(e, e < 0) && x.repeated_int64.exists_one(e, e == 0)`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-			},
 		},
-		out: `_&&_(
+		{
+			in: `x.repeated_int64.all(e, e > 0) && x.repeated_int64.exists(e, e < 0) && x.repeated_int64.exists_one(e, e == 0)`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
+			},
+			out: `_&&_(
 			_&&_(
 			  __comprehension__(
 				// Variable
@@ -961,17 +963,17 @@ ERROR: <input>:1:16: found no matching overload for '_!=_' applied to '(int, nul
 				1~int
 			  )~bool^equals)~bool
 		  )~bool^logical_and`,
-		outType: decls.Bool,
-	},
-
-	{
-		in: `x.all(e, 0)`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-			},
+			outType: decls.Bool,
 		},
-		err: `
+
+		{
+			in: `x.all(e, 0)`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
+			},
+			err: `
 ERROR: <input>:1:1: expression of type 'google.expr.proto3.test.TestAllTypes' cannot be range of a comprehension (must be list, map, or dynamic)
  | x.all(e, 0)
  | ^
@@ -979,10 +981,10 @@ ERROR: <input>:1:10: expected type 'bool' but found 'int'
  | x.all(e, 0)
  | .........^
 		`,
-	},
-	{
-		in: `lists.filter(x, x > 1.5)`,
-		out: `__comprehension__(
+		},
+		{
+			in: `lists.filter(x, x > 1.5)`,
+			out: `__comprehension__(
 			// Variable
 			x,
 			// Target
@@ -1009,57 +1011,57 @@ ERROR: <input>:1:10: expected type 'bool' but found 'int'
 			)~list(dyn)^conditional,
 			// Result
 			__result__~list(dyn)^__result__)~list(dyn)`,
-		outType: decls.NewListType(decls.Dyn),
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("lists", decls.Dyn),
+			outType: decls.NewListType(decls.Dyn),
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("lists", decls.Dyn),
+				},
 			},
 		},
-	},
 
-	{
-		in: `.google.expr.proto3.test.TestAllTypes`,
-		out: `google.expr.proto3.test.TestAllTypes
+		{
+			in: `.google.expr.proto3.test.TestAllTypes`,
+			out: `google.expr.proto3.test.TestAllTypes
 	~type(google.expr.proto3.test.TestAllTypes)
 	^google.expr.proto3.test.TestAllTypes`,
-		outType: decls.NewTypeType(
-			decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-	},
+			outType: decls.NewTypeType(
+				decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+		},
 
-	{
-		in:        `test.TestAllTypes`,
-		container: "google.expr.proto3",
-		out: `
+		{
+			in:        `test.TestAllTypes`,
+			container: "google.expr.proto3",
+			out: `
 	google.expr.proto3.test.TestAllTypes
 	~type(google.expr.proto3.test.TestAllTypes)
 	^google.expr.proto3.test.TestAllTypes
 		`,
-		outType: decls.NewTypeType(
-			decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-	},
+			outType: decls.NewTypeType(
+				decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+		},
 
-	{
-		in: `1 + x`,
-		err: `
+		{
+			in: `1 + x`,
+			err: `
 ERROR: <input>:1:5: undeclared reference to 'x' (in container '')
  | 1 + x
  | ....^`,
-	},
+		},
 
-	{
-		in: `x == google.protobuf.Any{
+		{
+			in: `x == google.protobuf.Any{
 				type_url:'types.googleapis.com/google.expr.proto3.test.TestAllTypes'
 			} && x.single_nested_message.bb == 43
 			|| x == google.expr.proto3.test.TestAllTypes{}
 			|| y < x
 			|| x >= x`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.Any),
-				decls.NewVar("y", decls.NewWrapperType(decls.Int)),
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.Any),
+					decls.NewVar("y", decls.NewWrapperType(decls.Int)),
+				},
 			},
-		},
-		out: `
+			out: `
 		_||_(
 			_||_(
 				_&&_(
@@ -1091,24 +1093,24 @@ ERROR: <input>:1:5: undeclared reference to 'x' (in container '')
 			)~bool^logical_or
 		)~bool^logical_or
 		`,
-		outType: decls.Bool,
-	},
+			outType: decls.Bool,
+		},
 
-	{
-		in: `x == google.protobuf.Any{
+		{
+			in: `x == google.protobuf.Any{
 				type_url:'types.googleapis.com/google.expr.proto3.test.TestAllTypes'
 			} && x.single_nested_message.bb == 43
 			|| x == google.expr.proto3.test.TestAllTypes{}
 			|| y < x
 			|| x >= x`,
-		env: testEnv{
-			variadicASTs: true,
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.Any),
-				decls.NewVar("y", decls.NewWrapperType(decls.Int)),
+			env: testEnv{
+				variadicASTs: true,
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.Any),
+					decls.NewVar("y", decls.NewWrapperType(decls.Int)),
+				},
 			},
-		},
-		out: `
+			out: `
 		_||_(
 			_&&_(
 			  _==_(
@@ -1136,24 +1138,24 @@ ERROR: <input>:1:5: undeclared reference to 'x' (in container '')
 			)~bool^greater_equals_bool|greater_equals_bytes|greater_equals_double|greater_equals_double_int64|greater_equals_double_uint64|greater_equals_duration|greater_equals_int64|greater_equals_int64_double|greater_equals_int64_uint64|greater_equals_string|greater_equals_timestamp|greater_equals_uint64|greater_equals_uint64_double|greater_equals_uint64_int64
 		  )~bool^logical_or
 		`,
-		outType: decls.Bool,
-	},
-
-	{
-		in:        `x`,
-		container: "container",
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("container.x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-			},
+			outType: decls.Bool,
 		},
-		out:     `container.x~google.expr.proto3.test.TestAllTypes^container.x`,
-		outType: decls.NewObjectType("google.expr.proto3.test.TestAllTypes"),
-	},
 
-	{
-		in: `list == type([1]) && map == type({1:2u})`,
-		out: `
+		{
+			in:        `x`,
+			container: "container",
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("container.x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
+			},
+			out:     `container.x~google.expr.proto3.test.TestAllTypes^container.x`,
+			outType: decls.NewObjectType("google.expr.proto3.test.TestAllTypes"),
+		},
+
+		{
+			in: `list == type([1]) && map == type({1:2u})`,
+			out: `
 _&&_(_==_(list~type(list(dyn))^list,
            type([1~int]~list(int))~type(list(int))^type)
        ~bool^equals,
@@ -1162,21 +1164,21 @@ _&&_(_==_(list~type(list(dyn))^list,
         ~bool^equals)
   ~bool^logical_and
 	`,
-		outType: decls.Bool,
-	},
-
-	{
-		in: `myfun(1, true, 3u) + 1.myfun(false, 3u).myfun(true, 42u)`,
-		env: testEnv{
-			functions: []*exprpb.Decl{
-				decls.NewFunction("myfun",
-					decls.NewInstanceOverload("myfun_instance",
-						[]*exprpb.Type{decls.Int, decls.Bool, decls.Uint}, decls.Int),
-					decls.NewOverload("myfun_static",
-						[]*exprpb.Type{decls.Int, decls.Bool, decls.Uint}, decls.Int)),
-			},
+			outType: decls.Bool,
 		},
-		out: `_+_(
+
+		{
+			in: `myfun(1, true, 3u) + 1.myfun(false, 3u).myfun(true, 42u)`,
+			env: testEnv{
+				functions: []*exprpb.Decl{
+					decls.NewFunction("myfun",
+						decls.NewInstanceOverload("myfun_instance",
+							[]*exprpb.Type{decls.Int, decls.Bool, decls.Uint}, decls.Int),
+						decls.NewOverload("myfun_static",
+							[]*exprpb.Type{decls.Int, decls.Bool, decls.Uint}, decls.Int)),
+				},
+			},
+			out: `_+_(
     		  myfun(
     		    1~int,
     		    true~bool,
@@ -1190,33 +1192,33 @@ _&&_(_==_(list~type(list(dyn))^list,
     		    42u~uint
     		  )~int^myfun_instance
     		)~int^add_int64`,
-		outType: decls.Int,
-	},
-
-	{
-		in: `size(x) > 4`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-			},
-			functions: []*exprpb.Decl{
-				decls.NewFunction("size",
-					decls.NewOverload("size_message",
-						[]*exprpb.Type{decls.NewObjectType("google.expr.proto3.test.TestAllTypes")},
-						decls.Int)),
-			},
+			outType: decls.Int,
 		},
-		outType: decls.Bool,
-	},
 
-	{
-		in: `x.single_int64_wrapper + 1 != 23`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+		{
+			in: `size(x) > 4`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
+				functions: []*exprpb.Decl{
+					decls.NewFunction("size",
+						decls.NewOverload("size_message",
+							[]*exprpb.Type{decls.NewObjectType("google.expr.proto3.test.TestAllTypes")},
+							decls.Int)),
+				},
 			},
+			outType: decls.Bool,
 		},
-		out: `
+
+		{
+			in: `x.single_int64_wrapper + 1 != 23`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
+			},
+			out: `
 		_!=_(_+_(x~google.expr.proto3.test.TestAllTypes^x.single_int64_wrapper
 		~wrapper(int),
 		1~int)
@@ -1224,18 +1226,18 @@ _&&_(_==_(list~type(list(dyn))^list,
 		23~int)
 		~bool^not_equals
 		`,
-		outType: decls.Bool,
-	},
-
-	{
-		in: `x.single_int64_wrapper + y != 23`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
-				decls.NewVar("y", decls.NewObjectType("google.protobuf.Int32Value")),
-			},
+			outType: decls.Bool,
 		},
-		out: `
+
+		{
+			in: `x.single_int64_wrapper + y != 23`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+					decls.NewVar("y", decls.NewObjectType("google.protobuf.Int32Value")),
+				},
+			},
+			out: `
 		_!=_(
 			_+_(
 			  x~google.expr.proto3.test.TestAllTypes^x.single_int64_wrapper~wrapper(int),
@@ -1244,12 +1246,12 @@ _&&_(_==_(list~type(list(dyn))^list,
 			23~int
 		  )~bool^not_equals
 		`,
-		outType: decls.Bool,
-	},
+			outType: decls.Bool,
+		},
 
-	{
-		in: `1 in [1, 2, 3]`,
-		out: `@in(
+		{
+			in: `1 in [1, 2, 3]`,
+			out: `@in(
     		  1~int,
     		  [
     		    1~int,
@@ -1257,12 +1259,12 @@ _&&_(_==_(list~type(list(dyn))^list,
     		    3~int
     		  ]~list(int)
     		)~bool^in_list`,
-		outType: decls.Bool,
-	},
+			outType: decls.Bool,
+		},
 
-	{
-		in: `1 in dyn([1, 2, 3])`,
-		out: `@in(
+		{
+			in: `1 in dyn([1, 2, 3])`,
+			out: `@in(
 			1~int,
 			dyn(
 			  [
@@ -1272,49 +1274,49 @@ _&&_(_==_(list~type(list(dyn))^list,
 			  ]~list(int)
 			)~dyn^to_dyn
 		  )~bool^in_list|in_map`,
-		outType: decls.Bool,
-	},
+			outType: decls.Bool,
+		},
 
-	{
-		in: `type(null) == null_type`,
-		out: `_==_(
+		{
+			in: `type(null) == null_type`,
+			out: `_==_(
     		  type(
     		    null~null
     		  )~type(null)^type,
     		  null_type~type(null)^null_type
     		)~bool^equals`,
-		outType: decls.Bool,
-	},
+			outType: decls.Bool,
+		},
 
-	{
-		in: `type(type) == type`,
-		out: `_==_(
+		{
+			in: `type(type) == type`,
+			out: `_==_(
 		  type(
 		    type~type(type())^type
 		  )~type(type(type()))^type,
 		  type~type(type())^type
 		)~bool^equals`,
-		outType: decls.Bool,
-	},
-	// Homogeneous aggregate type restriction tests.
-	{
-		in: `name in [1, 2u, 'string']`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("name", decls.String),
-			},
-			functions: []*exprpb.Decl{
-				decls.NewFunction(operators.In,
-					decls.NewOverload(overloads.InList,
-						[]*exprpb.Type{
-							decls.String,
-							decls.NewListType(decls.String),
-						}, decls.Bool)),
-			},
+			outType: decls.Bool,
 		},
-		opts:          []Option{HomogeneousAggregateLiterals(true)},
-		disableStdEnv: true,
-		out: `@in(
+		// Homogeneous aggregate type restriction tests.
+		{
+			in: `name in [1, 2u, 'string']`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("name", decls.String),
+				},
+				functions: []*exprpb.Decl{
+					decls.NewFunction(operators.In,
+						decls.NewOverload(overloads.InList,
+							[]*exprpb.Type{
+								decls.String,
+								decls.NewListType(decls.String),
+							}, decls.Bool)),
+				},
+			},
+			opts:          []Option{HomogeneousAggregateLiterals(true)},
+			disableStdEnv: true,
+			out: `@in(
 			name~string^name,
 			[
 				1~int,
@@ -1322,28 +1324,28 @@ _&&_(_==_(list~type(list(dyn))^list,
 				"string"~string
 			]~list(string)
 		)~bool^in_list`,
-		err: `ERROR: <input>:1:13: expected type 'int' but found 'uint'
+			err: `ERROR: <input>:1:13: expected type 'int' but found 'uint'
 		| name in [1, 2u, 'string']
 		| ............^`,
-	},
-	{
-		in: `name in [1, 2, 3]`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("name", decls.String),
-			},
-			functions: []*exprpb.Decl{
-				decls.NewFunction(operators.In,
-					decls.NewOverload(overloads.InList,
-						[]*exprpb.Type{
-							decls.String,
-							decls.NewListType(decls.String),
-						}, decls.Bool)),
-			},
 		},
-		opts:          []Option{HomogeneousAggregateLiterals(true)},
-		disableStdEnv: true,
-		out: `@in(
+		{
+			in: `name in [1, 2, 3]`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("name", decls.String),
+				},
+				functions: []*exprpb.Decl{
+					decls.NewFunction(operators.In,
+						decls.NewOverload(overloads.InList,
+							[]*exprpb.Type{
+								decls.String,
+								decls.NewListType(decls.String),
+							}, decls.Bool)),
+				},
+			},
+			opts:          []Option{HomogeneousAggregateLiterals(true)},
+			disableStdEnv: true,
+			out: `@in(
 			name~string^name,
 			[
 				1~int,
@@ -1351,28 +1353,28 @@ _&&_(_==_(list~type(list(dyn))^list,
 				3~int
 			]~list(int)
 		)~!error!`,
-		err: `ERROR: <input>:1:6: found no matching overload for '@in' applied to '(string, list(int))'
+			err: `ERROR: <input>:1:6: found no matching overload for '@in' applied to '(string, list(int))'
 		| name in [1, 2, 3]
 		| .....^`,
-	},
-	{
-		in: `name in ["1", "2", "3"]`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("name", decls.String),
-			},
-			functions: []*exprpb.Decl{
-				decls.NewFunction(operators.In,
-					decls.NewOverload(overloads.InList,
-						[]*exprpb.Type{
-							decls.String,
-							decls.NewListType(decls.String),
-						}, decls.Bool)),
-			},
 		},
-		opts:          []Option{HomogeneousAggregateLiterals(true)},
-		disableStdEnv: true,
-		out: `@in(
+		{
+			in: `name in ["1", "2", "3"]`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("name", decls.String),
+				},
+				functions: []*exprpb.Decl{
+					decls.NewFunction(operators.In,
+						decls.NewOverload(overloads.InList,
+							[]*exprpb.Type{
+								decls.String,
+								decls.NewListType(decls.String),
+							}, decls.Bool)),
+				},
+			},
+			opts:          []Option{HomogeneousAggregateLiterals(true)},
+			disableStdEnv: true,
+			out: `@in(
 			name~string^name,
 			[
 				"1"~string,
@@ -1380,11 +1382,11 @@ _&&_(_==_(list~type(list(dyn))^list,
 				"3"~string
 			]~list(string)
 		)~bool^in_list`,
-		outType: decls.Bool,
-	},
-	{
-		in: `([[[1]], [[2]], [[3]]][0][0] + [2, 3, {'four': {'five': 'six'}}])[3]`,
-		out: `_[_](
+			outType: decls.Bool,
+		},
+		{
+			in: `([[[1]], [[2]], [[3]]][0][0] + [2, 3, {'four': {'five': 'six'}}])[3]`,
+			out: `_[_](
 			_+_(
 				_[_](
 					_[_](
@@ -1421,11 +1423,11 @@ _&&_(_==_(list~type(list(dyn))^list,
 			)~list(dyn)^add_list,
 			3~int
 		)~dyn^index_list`,
-		outType: decls.Dyn,
-	},
-	{
-		in: `[1] + [dyn('string')]`,
-		out: `_+_(
+			outType: decls.Dyn,
+		},
+		{
+			in: `[1] + [dyn('string')]`,
+			out: `_+_(
 			[
 				1~int
 			]~list(int),
@@ -1435,11 +1437,11 @@ _&&_(_==_(list~type(list(dyn))^list,
 				)~dyn^to_dyn
 			]~list(dyn)
 		)~list(dyn)^add_list`,
-		outType: decls.NewListType(decls.Dyn),
-	},
-	{
-		in: `[dyn('string')] + [1]`,
-		out: `_+_(
+			outType: decls.NewListType(decls.Dyn),
+		},
+		{
+			in: `[dyn('string')] + [1]`,
+			out: `_+_(
 			[
 				dyn(
 					"string"~string
@@ -1449,18 +1451,18 @@ _&&_(_==_(list~type(list(dyn))^list,
 				1~int
 			]~list(int)
 		)~list(dyn)^add_list`,
-		outType: decls.NewListType(decls.Dyn),
-	},
-	{
-		in: `[].map(x, [].map(y, x in y && y in x))`,
-		err: `
+			outType: decls.NewListType(decls.Dyn),
+		},
+		{
+			in: `[].map(x, [].map(y, x in y && y in x))`,
+			err: `
 		ERROR: <input>:1:33: found no matching overload for '@in' applied to '(list(dyn), dyn)'
 		| [].map(x, [].map(y, x in y && y in x))
 		| ................................^`,
-	},
-	{
-		in: `args.user["myextension"].customAttributes.filter(x, x.name == "hobbies")`,
-		out: `__comprehension__(
+		},
+		{
+			in: `args.user["myextension"].customAttributes.filter(x, x.name == "hobbies")`,
+			out: `__comprehension__(
 			// Variable
 			x,
 			// Target
@@ -1490,16 +1492,16 @@ _&&_(_==_(list~type(list(dyn))^list,
 			)~list(dyn)^conditional,
 			// Result
 			__result__~list(dyn)^__result__)~list(dyn)`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("args", decls.NewMapType(decls.String, decls.Dyn)),
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("args", decls.NewMapType(decls.String, decls.Dyn)),
+				},
 			},
+			outType: decls.NewListType(decls.Dyn),
 		},
-		outType: decls.NewListType(decls.Dyn),
-	},
-	{
-		in: `a.b + 1 == a[0]`,
-		out: `_==_(
+		{
+			in: `a.b + 1 == a[0]`,
+			out: `_==_(
 			_+_(
 			  a~dyn^a.b~dyn,
 			  1~int
@@ -1509,27 +1511,27 @@ _&&_(_==_(list~type(list(dyn))^list,
 			  0~int
 			)~dyn^index_list|index_map
 		  )~bool^equals`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("a", decls.NewTypeParamType("T")),
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("a", decls.NewTypeParamType("T")),
+				},
 			},
+			outType: decls.Bool,
 		},
-		outType: decls.Bool,
-	},
-	{
-		in: `!has(pb2.single_int64)
+		{
+			in: `!has(pb2.single_int64)
 		&& !has(pb2.repeated_int32)
 		&& !has(pb2.map_string_string)
 		&& !has(pb3.single_int64)
 		&& !has(pb3.repeated_int32)
 		&& !has(pb3.map_string_string)`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("pb2", decls.NewObjectType("google.expr.proto2.test.TestAllTypes")),
-				decls.NewVar("pb3", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("pb2", decls.NewObjectType("google.expr.proto2.test.TestAllTypes")),
+					decls.NewVar("pb3", decls.NewObjectType("google.expr.proto3.test.TestAllTypes")),
+				},
 			},
-		},
-		out: `
+			out: `
 		_&&_(
 			_&&_(
 			  _&&_(
@@ -1558,77 +1560,77 @@ _&&_(_==_(list~type(list(dyn))^list,
 			  )~bool^logical_not
 			)~bool^logical_and
 		  )~bool^logical_and`,
-		outType: decls.Bool,
-	},
-	{
-		in:        `TestAllTypes{}.repeated_nested_message`,
-		container: "google.expr.proto2.test",
-		out: `
+			outType: decls.Bool,
+		},
+		{
+			in:        `TestAllTypes{}.repeated_nested_message`,
+			container: "google.expr.proto2.test",
+			out: `
 		google.expr.proto2.test.TestAllTypes{}~google.expr.proto2.test.TestAllTypes^
 		google.expr.proto2.test.TestAllTypes.repeated_nested_message
 		~list(google.expr.proto2.test.TestAllTypes.NestedMessage)`,
-		outType: decls.NewListType(
-			decls.NewObjectType(
-				"google.expr.proto2.test.TestAllTypes.NestedMessage",
+			outType: decls.NewListType(
+				decls.NewObjectType(
+					"google.expr.proto2.test.TestAllTypes.NestedMessage",
+				),
 			),
-		),
-	},
-	{
-		in:        `TestAllTypes{}.repeated_nested_message`,
-		container: "google.expr.proto3.test",
-		out: `
+		},
+		{
+			in:        `TestAllTypes{}.repeated_nested_message`,
+			container: "google.expr.proto3.test",
+			out: `
 		google.expr.proto3.test.TestAllTypes{}~google.expr.proto3.test.TestAllTypes^
 		google.expr.proto3.test.TestAllTypes.repeated_nested_message
 		~list(google.expr.proto3.test.TestAllTypes.NestedMessage)`,
-		outType: decls.NewListType(
-			decls.NewObjectType(
-				"google.expr.proto3.test.TestAllTypes.NestedMessage",
+			outType: decls.NewListType(
+				decls.NewObjectType(
+					"google.expr.proto3.test.TestAllTypes.NestedMessage",
+				),
 			),
-		),
-	},
-	{
-		in: `base64.encode('hello')`,
-		env: testEnv{
-			functions: []*exprpb.Decl{
-				decls.NewFunction("base64.encode",
-					decls.NewOverload(
-						"base64_encode_string",
-						[]*exprpb.Type{decls.String},
-						decls.String)),
-			},
 		},
-		out: `
+		{
+			in: `base64.encode('hello')`,
+			env: testEnv{
+				functions: []*exprpb.Decl{
+					decls.NewFunction("base64.encode",
+						decls.NewOverload(
+							"base64_encode_string",
+							[]*exprpb.Type{decls.String},
+							decls.String)),
+				},
+			},
+			out: `
 		base64.encode(
 			"hello"~string
 		)~string^base64_encode_string`,
-		outType: decls.String,
-	},
-	{
-		in:        `encode('hello')`,
-		container: `base64`,
-		env: testEnv{
-			functions: []*exprpb.Decl{
-				decls.NewFunction("base64.encode",
-					decls.NewOverload(
-						"base64_encode_string",
-						[]*exprpb.Type{decls.String},
-						decls.String)),
-			},
+			outType: decls.String,
 		},
-		out: `
+		{
+			in:        `encode('hello')`,
+			container: `base64`,
+			env: testEnv{
+				functions: []*exprpb.Decl{
+					decls.NewFunction("base64.encode",
+						decls.NewOverload(
+							"base64_encode_string",
+							[]*exprpb.Type{decls.String},
+							decls.String)),
+				},
+			},
+			out: `
 		base64.encode(
 			"hello"~string
 		)~string^base64_encode_string`,
-		outType: decls.String,
-	},
-	{
-		in:      `{}`,
-		out:     `{}~map(dyn, dyn)`,
-		outType: decls.NewMapType(decls.Dyn, decls.Dyn),
-	},
-	{
-		in: `set([1, 2, 3])`,
-		out: `
+			outType: decls.String,
+		},
+		{
+			in:      `{}`,
+			out:     `{}~map(dyn, dyn)`,
+			outType: decls.NewMapType(decls.Dyn, decls.Dyn),
+		},
+		{
+			in: `set([1, 2, 3])`,
+			out: `
 		set(
 		  [
 		    1~int,
@@ -1636,103 +1638,103 @@ _&&_(_==_(list~type(list(dyn))^list,
 		    3~int
 		  ]~list(int)
 		)~set(int)^set_list`,
-		env: testEnv{
-			functions: []*exprpb.Decl{
-				decls.NewFunction("set",
-					decls.NewParameterizedOverload(
-						"set_list", []*exprpb.Type{
-							decls.NewListType(decls.NewTypeParamType("T")),
-						}, decls.NewAbstractType("set", decls.NewTypeParamType("T")),
-						[]string{"T"})),
+			env: testEnv{
+				functions: []*exprpb.Decl{
+					decls.NewFunction("set",
+						decls.NewParameterizedOverload(
+							"set_list", []*exprpb.Type{
+								decls.NewListType(decls.NewTypeParamType("T")),
+							}, decls.NewAbstractType("set", decls.NewTypeParamType("T")),
+							[]string{"T"})),
+				},
 			},
+			outType: decls.NewAbstractType("set", decls.Int),
 		},
-		outType: decls.NewAbstractType("set", decls.Int),
-	},
-	{
-		in: `set([1, 2]) == set([2, 1])`,
-		out: `
+		{
+			in: `set([1, 2]) == set([2, 1])`,
+			out: `
 		_==_(
 		  set([1~int, 2~int]~list(int))~set(int)^set_list,
 		  set([2~int, 1~int]~list(int))~set(int)^set_list
 		)~bool^equals`,
-		env: testEnv{
-			functions: []*exprpb.Decl{
-				decls.NewFunction("set",
-					decls.NewParameterizedOverload(
-						"set_list", []*exprpb.Type{
-							decls.NewListType(decls.NewTypeParamType("T")),
-						}, decls.NewAbstractType("set", decls.NewTypeParamType("T")),
-						[]string{"T"})),
+			env: testEnv{
+				functions: []*exprpb.Decl{
+					decls.NewFunction("set",
+						decls.NewParameterizedOverload(
+							"set_list", []*exprpb.Type{
+								decls.NewListType(decls.NewTypeParamType("T")),
+							}, decls.NewAbstractType("set", decls.NewTypeParamType("T")),
+							[]string{"T"})),
+				},
 			},
+			outType: decls.Bool,
 		},
-		outType: decls.Bool,
-	},
-	{
-		in: `set([1, 2]) == x`,
-		out: `
+		{
+			in: `set([1, 2]) == x`,
+			out: `
 		_==_(
 		  set([1~int, 2~int]~list(int))~set(int)^set_list,
 		  x~set(int)^x
 		)~bool^equals`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("x", decls.NewAbstractType("set", decls.NewTypeParamType("T"))),
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("x", decls.NewAbstractType("set", decls.NewTypeParamType("T"))),
+				},
+				functions: []*exprpb.Decl{
+					decls.NewFunction("set",
+						decls.NewParameterizedOverload(
+							"set_list", []*exprpb.Type{
+								decls.NewListType(decls.NewTypeParamType("T")),
+							}, decls.NewAbstractType("set", decls.NewTypeParamType("T")),
+							[]string{"T"})),
+				},
 			},
-			functions: []*exprpb.Decl{
-				decls.NewFunction("set",
-					decls.NewParameterizedOverload(
-						"set_list", []*exprpb.Type{
-							decls.NewListType(decls.NewTypeParamType("T")),
-						}, decls.NewAbstractType("set", decls.NewTypeParamType("T")),
-						[]string{"T"})),
-			},
+			outType: decls.Bool,
 		},
-		outType: decls.Bool,
-	},
-	{
-		in: `int{}`,
-		err: `
+		{
+			in: `int{}`,
+			err: `
 		ERROR: <input>:1:4: 'int' is not a message type
 		 | int{}
 		 | ...^
 		`,
-	},
-	{
-		in: `Msg{}`,
-		err: `
+		},
+		{
+			in: `Msg{}`,
+			err: `
 		ERROR: <input>:1:4: undeclared reference to 'Msg' (in container '')
 		 | Msg{}
 		 | ...^
 		`,
-	},
-	{
-		in: `fun()`,
-		err: `
+		},
+		{
+			in: `fun()`,
+			err: `
 		ERROR: <input>:1:4: undeclared reference to 'fun' (in container '')
 		 | fun()
 		 | ...^
 		`,
-	},
-	{
-		in: `'string'.fun()`,
-		err: `
+		},
+		{
+			in: `'string'.fun()`,
+			err: `
 		ERROR: <input>:1:13: undeclared reference to 'fun' (in container '')
 		 | 'string'.fun()
 		 | ............^
 		`,
-	},
-	{
-		in: `[].length`,
-		err: `
+		},
+		{
+			in: `[].length`,
+			err: `
 		ERROR: <input>:1:3: type 'list(_var0)' does not support field selection
 		 | [].length
 		 | ..^
 		`,
-	},
-	{
-		in:   `1 <= 1.0 && 1u <= 1.0 && 1.0 <= 1 && 1.0 <= 1u && 1 <= 1u && 1u <= 1`,
-		opts: []Option{CrossTypeNumericComparisons(false)},
-		err: `
+		},
+		{
+			in:   `1 <= 1.0 && 1u <= 1.0 && 1.0 <= 1 && 1.0 <= 1u && 1 <= 1u && 1u <= 1`,
+			opts: []Option{CrossTypeNumericComparisons(false)},
+			err: `
 		ERROR: <input>:1:3: found no matching overload for '_<=_' applied to '(int, double)'
 		 | 1 <= 1.0 && 1u <= 1.0 && 1.0 <= 1 && 1.0 <= 1u && 1 <= 1u && 1u <= 1
 		 | ..^
@@ -1752,12 +1754,12 @@ _&&_(_==_(list~type(list(dyn))^list,
 		 | 1 <= 1.0 && 1u <= 1.0 && 1.0 <= 1 && 1.0 <= 1u && 1 <= 1u && 1u <= 1
 		 | ................................................................^
 		`,
-	},
-	{
-		in:      `1 <= 1.0 && 1u <= 1.0 && 1.0 <= 1 && 1.0 <= 1u && 1 <= 1u && 1u <= 1`,
-		opts:    []Option{CrossTypeNumericComparisons(true)},
-		outType: decls.Bool,
-		out: `
+		},
+		{
+			in:      `1 <= 1.0 && 1u <= 1.0 && 1.0 <= 1 && 1.0 <= 1u && 1 <= 1u && 1u <= 1`,
+			opts:    []Option{CrossTypeNumericComparisons(true)},
+			outType: decls.Bool,
+			out: `
 		_&&_(
 			_&&_(
 			  _&&_(
@@ -1792,12 +1794,12 @@ _&&_(_==_(list~type(list(dyn))^list,
 			  )~bool^less_equals_uint64_int64
 			)~bool^logical_and
 		  )~bool^logical_and`,
-	},
-	{
-		in:      `1 < 1.0 && 1u < 1.0 && 1.0 < 1 && 1.0 < 1u && 1 < 1u && 1u < 1`,
-		opts:    []Option{CrossTypeNumericComparisons(true)},
-		outType: decls.Bool,
-		out: `
+		},
+		{
+			in:      `1 < 1.0 && 1u < 1.0 && 1.0 < 1 && 1.0 < 1u && 1 < 1u && 1u < 1`,
+			opts:    []Option{CrossTypeNumericComparisons(true)},
+			outType: decls.Bool,
+			out: `
 		_&&_(
 			_&&_(
 			  _&&_(
@@ -1832,12 +1834,12 @@ _&&_(_==_(list~type(list(dyn))^list,
 			  )~bool^less_uint64_int64
 			)~bool^logical_and
 		  )~bool^logical_and`,
-	},
-	{
-		in:      `1 > 1.0 && 1u > 1.0 && 1.0 > 1 && 1.0 > 1u && 1 > 1u && 1u > 1`,
-		opts:    []Option{CrossTypeNumericComparisons(true)},
-		outType: decls.Bool,
-		out: `
+		},
+		{
+			in:      `1 > 1.0 && 1u > 1.0 && 1.0 > 1 && 1.0 > 1u && 1 > 1u && 1u > 1`,
+			opts:    []Option{CrossTypeNumericComparisons(true)},
+			outType: decls.Bool,
+			out: `
 		_&&_(
 			_&&_(
 			  _&&_(
@@ -1872,12 +1874,12 @@ _&&_(_==_(list~type(list(dyn))^list,
 			  )~bool^greater_uint64_int64
 			)~bool^logical_and
 		  )~bool^logical_and`,
-	},
-	{
-		in:      `1 >= 1.0 && 1u >= 1.0 && 1.0 >= 1 && 1.0 >= 1u && 1 >= 1u && 1u >= 1`,
-		opts:    []Option{CrossTypeNumericComparisons(true)},
-		outType: decls.Bool,
-		out: `
+		},
+		{
+			in:      `1 >= 1.0 && 1u >= 1.0 && 1.0 >= 1 && 1.0 >= 1u && 1 >= 1u && 1u >= 1`,
+			opts:    []Option{CrossTypeNumericComparisons(true)},
+			outType: decls.Bool,
+			out: `
 		_&&_(
 			_&&_(
 			  _&&_(
@@ -1912,13 +1914,13 @@ _&&_(_==_(list~type(list(dyn))^list,
 			  )~bool^greater_equals_uint64_int64
 			)~bool^logical_and
 		  )~bool^logical_and`,
-	},
-	{
-		in:      `1 >= 1.0 && 1u >= 1.0 && 1.0 >= 1 && 1.0 >= 1u && 1 >= 1u && 1u >= 1`,
-		opts:    []Option{CrossTypeNumericComparisons(true)},
-		env:     testEnv{variadicASTs: true},
-		outType: decls.Bool,
-		out: `
+		},
+		{
+			in:      `1 >= 1.0 && 1u >= 1.0 && 1.0 >= 1 && 1.0 >= 1u && 1 >= 1u && 1u >= 1`,
+			opts:    []Option{CrossTypeNumericComparisons(true)},
+			env:     testEnv{variadicASTs: true},
+			outType: decls.Bool,
+			out: `
 		_&&_(
 			_>=_(
 			  1~int,
@@ -1945,11 +1947,11 @@ _&&_(_==_(list~type(list(dyn))^list,
 			  1~int
 			)~bool^greater_equals_uint64_int64
 		  )~bool^logical_and`,
-	},
-	{
-		in:      `[1].map(x, [x, x]).map(x, [x, x])`,
-		outType: decls.NewListType(decls.NewListType(decls.NewListType(decls.Int))),
-		out: `__comprehension__(
+		},
+		{
+			in:      `[1].map(x, [x, x]).map(x, [x, x])`,
+			outType: decls.NewListType(decls.NewListType(decls.NewListType(decls.Int))),
+			out: `__comprehension__(
 			// Variable
 			x,
 			// Target
@@ -1997,16 +1999,16 @@ _&&_(_==_(list~type(list(dyn))^list,
 			// Result
 			__result__~list(list(list(int)))^__result__)~list(list(list(int)))
 		  `,
-	},
-	{
-		in:      `values.filter(i, i.content != "").map(i, i.content)`,
-		outType: decls.NewListType(decls.String),
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("values", decls.NewListType(decls.NewMapType(decls.String, decls.String))),
-			},
 		},
-		out: `__comprehension__(
+		{
+			in:      `values.filter(i, i.content != "").map(i, i.content)`,
+			outType: decls.NewListType(decls.String),
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("values", decls.NewListType(decls.NewMapType(decls.String, decls.String))),
+				},
+			},
+			out: `__comprehension__(
 			// Variable
 			i,
 			// Target
@@ -2052,11 +2054,11 @@ _&&_(_==_(list~type(list(dyn))^list,
 			)~list(string)^add_list,
 			// Result
 			__result__~list(string)^__result__)~list(string)`,
-	},
-	{
-		in:      `[{}.map(c,c,c)]+[{}.map(c,c,c)]`,
-		outType: decls.NewListType(decls.NewListType(decls.Bool)),
-		out: `_+_(
+		},
+		{
+			in:      `[{}.map(c,c,c)]+[{}.map(c,c,c)]`,
+			outType: decls.NewListType(decls.NewListType(decls.Bool)),
+			out: `_+_(
 			[
 			  __comprehension__(
 				// Variable
@@ -2110,85 +2112,85 @@ _&&_(_==_(list~type(list(dyn))^list,
 				__result__~list(bool)^__result__)~list(bool)
 			]~list(list(bool))
 		  )~list(list(bool))^add_list`,
-	},
-	{
-		in: "type(testAllTypes.nestedgroup.nested_id) == int",
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("testAllTypes", decls.NewObjectType("google.expr.proto2.test.TestAllTypes")),
-			},
 		},
-		outType: decls.Bool,
-		out: `_==_(
+		{
+			in: "type(testAllTypes.nestedgroup.nested_id) == int",
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("testAllTypes", decls.NewObjectType("google.expr.proto2.test.TestAllTypes")),
+				},
+			},
+			outType: decls.Bool,
+			out: `_==_(
 			type(
 			  testAllTypes~google.expr.proto2.test.TestAllTypes^testAllTypes.nestedgroup~google.expr.proto2.test.TestAllTypes.NestedGroup.nested_id~int
 			)~type(int)^type,
 			int~type(int)^int
 		  )~bool^equals`,
-	},
-	{
-		in: `a.?b`,
-		env: testEnv{
-			optionalSyntax: true,
-			idents: []*exprpb.Decl{
-				decls.NewVar("a", decls.NewMapType(decls.String, decls.String)),
-			},
 		},
-		outType: decls.NewOptionalType(decls.String),
-		out: `_?._(
+		{
+			in: `a.?b`,
+			env: testEnv{
+				optionalSyntax: true,
+				idents: []*exprpb.Decl{
+					decls.NewVar("a", decls.NewMapType(decls.String, decls.String)),
+				},
+			},
+			outType: decls.NewOptionalType(decls.String),
+			out: `_?._(
 			a~map(string, string)^a,
 			"b"
 		  )~optional(string)^select_optional_field`,
-	},
-	{
-		in: `a.b`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("a", decls.NewOptionalType(decls.NewMapType(decls.String, decls.String))),
-			},
 		},
-		outType: decls.NewOptionalType(decls.String),
-		out:     `a~optional(map(string, string))^a.b~optional(string)`,
-	},
-	{
-		in: `a.dynamic`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("a", decls.NewOptionalType(decls.Dyn)),
+		{
+			in: `a.b`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("a", decls.NewOptionalType(decls.NewMapType(decls.String, decls.String))),
+				},
 			},
+			outType: decls.NewOptionalType(decls.String),
+			out:     `a~optional(map(string, string))^a.b~optional(string)`,
 		},
-		outType: decls.NewOptionalType(decls.Dyn),
-		out:     `a~optional(dyn)^a.dynamic~optional(dyn)`,
-	},
-	{
-		in: `has(a.dynamic)`,
-		env: testEnv{
-			idents: []*exprpb.Decl{
-				decls.NewVar("a", decls.NewOptionalType(decls.Dyn)),
+		{
+			in: `a.dynamic`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("a", decls.NewOptionalType(decls.Dyn)),
+				},
 			},
+			outType: decls.NewOptionalType(decls.Dyn),
+			out:     `a~optional(dyn)^a.dynamic~optional(dyn)`,
 		},
-		outType: decls.Bool,
-		out:     `a~optional(dyn)^a.dynamic~test-only~~bool`,
-	},
-	{
-		in: `has(a.?b.c)`,
-		env: testEnv{
-			optionalSyntax: true,
-			idents: []*exprpb.Decl{
-				decls.NewVar("a", decls.NewOptionalType(decls.NewMapType(decls.String, decls.Dyn))),
+		{
+			in: `has(a.dynamic)`,
+			env: testEnv{
+				idents: []*exprpb.Decl{
+					decls.NewVar("a", decls.NewOptionalType(decls.Dyn)),
+				},
 			},
+			outType: decls.Bool,
+			out:     `a~optional(dyn)^a.dynamic~test-only~~bool`,
 		},
-		outType: decls.Bool,
-		out: `_?._(
+		{
+			in: `has(a.?b.c)`,
+			env: testEnv{
+				optionalSyntax: true,
+				idents: []*exprpb.Decl{
+					decls.NewVar("a", decls.NewOptionalType(decls.NewMapType(decls.String, decls.Dyn))),
+				},
+			},
+			outType: decls.Bool,
+			out: `_?._(
 			a~optional(map(string, dyn))^a,
 			"b"
 		  )~optional(dyn)^select_optional_field.c~test-only~~bool`,
-	},
-	{
-		in:      `{?'key': {'a': 'b'}.?value}`,
-		env:     testEnv{optionalSyntax: true},
-		outType: decls.NewMapType(decls.String, decls.String),
-		out: `{
+		},
+		{
+			in:      `{?'key': {'a': 'b'}.?value}`,
+			env:     testEnv{optionalSyntax: true},
+			outType: decls.NewMapType(decls.String, decls.String),
+			out: `{
 			?"key"~string:_?._(
 			  {
 				"a"~string:"b"~string
@@ -2196,12 +2198,12 @@ _&&_(_==_(list~type(list(dyn))^list,
 			  "value"
 			)~optional(string)^select_optional_field
 		  }~map(string, string)`,
-	},
-	{
-		in:      `{?'key': {'a': 'b'}.?value}.key`,
-		env:     testEnv{optionalSyntax: true},
-		outType: decls.String,
-		out: `{
+		},
+		{
+			in:      `{?'key': {'a': 'b'}.?value}.key`,
+			env:     testEnv{optionalSyntax: true},
+			outType: decls.String,
+			out: `{
 			?"key"~string:_?._(
 			  {
 				"a"~string:"b"~string
@@ -2209,72 +2211,73 @@ _&&_(_==_(list~type(list(dyn))^list,
 			  "value"
 			)~optional(string)^select_optional_field
 		  }~map(string, string).key~string`,
-	},
-	{
-		in: `{?'nested': a.b}`,
-		env: testEnv{
-			optionalSyntax: true,
-			idents: []*exprpb.Decl{
-				decls.NewVar("a", decls.NewOptionalType(decls.NewMapType(decls.String, decls.String))),
-			},
 		},
-		outType: decls.NewMapType(decls.String, decls.String),
-		out: `{
+		{
+			in: `{?'nested': a.b}`,
+			env: testEnv{
+				optionalSyntax: true,
+				idents: []*exprpb.Decl{
+					decls.NewVar("a", decls.NewOptionalType(decls.NewMapType(decls.String, decls.String))),
+				},
+			},
+			outType: decls.NewMapType(decls.String, decls.String),
+			out: `{
 			?"nested"~string:a~optional(map(string, string))^a.b~optional(string)
 		  }~map(string, string)`,
-	},
-	{
-		in:  `{?'key': 'hi'}`,
-		env: testEnv{optionalSyntax: true},
-		err: `ERROR: <input>:1:10: expected type 'optional(string)' but found 'string'
+		},
+		{
+			in:  `{?'key': 'hi'}`,
+			env: testEnv{optionalSyntax: true},
+			err: `ERROR: <input>:1:10: expected type 'optional(string)' but found 'string'
 		| {?'key': 'hi'}
 		| .........^`,
-	},
-	{
-		in: `[?a, ?b, 'world']`,
-		env: testEnv{
-			optionalSyntax: true,
-			idents: []*exprpb.Decl{
-				decls.NewVar("a", decls.NewOptionalType(decls.String)),
-				decls.NewVar("b", decls.NewOptionalType(decls.String)),
-			},
 		},
-		outType: decls.NewListType(decls.String),
-		out: `[
+		{
+			in: `[?a, ?b, 'world']`,
+			env: testEnv{
+				optionalSyntax: true,
+				idents: []*exprpb.Decl{
+					decls.NewVar("a", decls.NewOptionalType(decls.String)),
+					decls.NewVar("b", decls.NewOptionalType(decls.String)),
+				},
+			},
+			outType: decls.NewListType(decls.String),
+			out: `[
 			a~optional(string)^a,
 			b~optional(string)^b,
 			"world"~string
 		  ]~list(string)`,
-	},
-	{
-		in:  `[?'value']`,
-		env: testEnv{optionalSyntax: true},
-		err: `ERROR: <input>:1:3: expected type 'optional(string)' but found 'string'
+		},
+		{
+			in:  `[?'value']`,
+			env: testEnv{optionalSyntax: true},
+			err: `ERROR: <input>:1:3: expected type 'optional(string)' but found 'string'
 		| [?'value']
 		| ..^`,
-	},
-	{
-		in:        `TestAllTypes{?single_int32: {}.?i}`,
-		container: "google.expr.proto2.test",
-		env:       testEnv{optionalSyntax: true},
-		out: `google.expr.proto2.test.TestAllTypes{
+		},
+		{
+			in:        `TestAllTypes{?single_int32: {}.?i}`,
+			container: "google.expr.proto2.test",
+			env:       testEnv{optionalSyntax: true},
+			out: `google.expr.proto2.test.TestAllTypes{
 			?single_int32:_?._(
 			  {}~map(dyn, int),
 			  "i"
 			)~optional(int)^select_optional_field
 		  }~google.expr.proto2.test.TestAllTypes^google.expr.proto2.test.TestAllTypes`,
-		outType: decls.NewObjectType(
-			"google.expr.proto2.test.TestAllTypes",
-		),
-	},
-	{
-		in:        `TestAllTypes{?single_int32: 1}`,
-		container: "google.expr.proto2.test",
-		env:       testEnv{optionalSyntax: true},
-		err: `ERROR: <input>:1:29: expected type 'optional(int)' but found 'int'
+			outType: decls.NewObjectType(
+				"google.expr.proto2.test.TestAllTypes",
+			),
+		},
+		{
+			in:        `TestAllTypes{?single_int32: 1}`,
+			container: "google.expr.proto2.test",
+			env:       testEnv{optionalSyntax: true},
+			err: `ERROR: <input>:1:29: expected type 'optional(int)' but found 'int'
 		| TestAllTypes{?single_int32: 1}
 		| ............................^`,
-	},
+		},
+	}
 }
 
 var testEnvs = map[string]testEnv{
@@ -2339,14 +2342,10 @@ func TestCheck(t *testing.T) {
 		t.Fatalf("parser.NewParser() failed: %v", err)
 	}
 
-	for i, tst := range testCases {
+	for i, tst := range testCases(t) {
 		name := fmt.Sprintf("%d %s", i, tst.in)
 		tc := tst
 		t.Run(name, func(t *testing.T) {
-			// Runs the tests in parallel to ensure that there are no data races
-			// due to shared mutable state across tests.
-			t.Parallel()
-
 			tcParser := p
 			if tc.env.optionalSyntax || tc.env.variadicASTs {
 				tcParser, err = parser.NewParser(
@@ -2354,7 +2353,14 @@ func TestCheck(t *testing.T) {
 					parser.EnableOptionalSyntax(tc.env.optionalSyntax),
 					parser.EnableVariadicOperatorASTs(tc.env.variadicASTs),
 				)
+				if err != nil {
+					t.Fatalf("parser.NewParser() failed: %v", err)
+				}
 			}
+			// Runs the tests in parallel to ensure that there are no data races
+			// due to shared mutable state across tests.
+			t.Parallel()
+
 			src := common.NewTextSource(tc.in)
 			pAst, errors := tcParser.Parse(src)
 			if len(errors.GetErrors()) > 0 {
@@ -2417,6 +2423,98 @@ func TestCheck(t *testing.T) {
 				actualStr := Print(pAst.Expr, cAst)
 				if !test.Compare(actualStr, tc.out) {
 					t.Error(test.DiffMessage("Structure error", actualStr, tc.out))
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkCheck(b *testing.B) {
+	p, err := parser.NewParser(
+		parser.Macros(parser.AllMacros...),
+	)
+	if err != nil {
+		b.Fatalf("parser.NewParser() failed: %v", err)
+	}
+
+	for i, tst := range testCases(b) {
+		name := fmt.Sprintf("%d %s", i, tst.in)
+		tc := tst
+		b.Run(name, func(b *testing.B) {
+			tcParser := p
+			if tc.env.optionalSyntax || tc.env.variadicASTs {
+				tcParser, err = parser.NewParser(
+					parser.Macros(parser.AllMacros...),
+					parser.EnableOptionalSyntax(tc.env.optionalSyntax),
+					parser.EnableVariadicOperatorASTs(tc.env.variadicASTs),
+				)
+				if err != nil {
+					b.Fatalf("parser.NewParser() failed: %v", err)
+				}
+			}
+			src := common.NewTextSource(tc.in)
+			pAst, errors := tcParser.Parse(src)
+			if len(errors.GetErrors()) > 0 {
+				b.Fatalf("Unexpected parse errors: %v", errors.ToDisplayString())
+			}
+			reg, err := types.NewRegistry(&proto2pb.TestAllTypes{}, &proto3pb.TestAllTypes{})
+			if err != nil {
+				b.Fatalf("types.NewRegistry() failed: %v", err)
+			}
+			cont, err := containers.NewContainer(containers.Name(tc.container))
+			if err != nil {
+				b.Fatalf("containers.NewContainer() failed: %v", err)
+			}
+			opts := []Option{CrossTypeNumericComparisons(true)}
+			if len(tc.opts) != 0 {
+				opts = tc.opts
+			}
+			env, err := NewEnv(cont, reg, opts...)
+			if err != nil {
+				b.Fatalf("NewEnv(cont, reg) failed: %v", err)
+			}
+			if !tc.disableStdEnv {
+				env.Add(stdlib.TypeExprDecls()...)
+				env.Add(stdlib.FunctionExprDecls()...)
+			}
+			if tc.env.idents != nil {
+				for _, ident := range tc.env.idents {
+					env.Add(ident)
+				}
+			}
+			if tc.env.functions != nil {
+				for _, fn := range tc.env.functions {
+					env.Add(fn)
+				}
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				cAst, errors := Check(pAst, src, env)
+				if len(errors.GetErrors()) > 0 {
+					errorString := errors.ToDisplayString()
+					if tc.err != "" {
+						if !test.Compare(errorString, tc.err) {
+							b.Error(test.DiffMessage("Error mismatch", errorString, tc.err))
+						}
+					} else {
+						b.Errorf("Unexpected type-check errors: %v", errorString)
+					}
+				} else if tc.err != "" {
+					b.Errorf("Expected error not thrown: %s", tc.err)
+				}
+
+				actual := cAst.TypeMap[pAst.Expr.Id]
+				if tc.err == "" {
+					if actual == nil || !proto.Equal(actual, tc.outType) {
+						b.Error(test.DiffMessage("Type Error", actual, tc.outType))
+					}
+				}
+
+				if tc.out != "" {
+					actualStr := Print(pAst.Expr, cAst)
+					if !test.Compare(actualStr, tc.out) {
+						b.Error(test.DiffMessage("Structure error", actualStr, tc.out))
+					}
 				}
 			}
 		})


### PR DESCRIPTION
An upcoming change to shift the type-checker to go-native type values will require the checker tests
to be parameterized with a `testing.TB` instance in order to construct some of the test inputs. To reduce
noise in the forthcoming PR, this change is being made in isolation.