### PR TITLE
Introduce the basis for a native AST

### DIFF
--- a/common/ast/BUILD.bazel
+++ b/common/ast/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "ast.go",
+    ],
+    importpath = "github.com/google/cel-go/common/ast",
+    deps = [    
+        "//common/types:go_default_library",
+        "//common/types/ref:go_default_library",
+        "@org_golang_google_genproto_googleapis_api//expr/v1alpha1:go_default_library",
+        "@org_golang_google_protobuf//types/known/structpb:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "ast_test.go",
+    ],
+    embed = [
+        ":go_default_library",
+    ],
+    deps = [    
+        "//checker/decls:go_default_library",
+        "//common/overloads:go_default_library",
+        "//common/types:go_default_library",
+        "//common/types/ref:go_default_library",
+        "@org_golang_google_genproto_googleapis_api//expr/v1alpha1:go_default_library",
+        "@org_golang_google_protobuf//proto:go_default_library",
+    ],
+)

--- a/common/ast/BUILD.bazel
+++ b/common/ast/BUILD.bazel
@@ -1,7 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(
-    default_visibility = ["//visibility:public"],
+    default_visibility = [
+        "//cel:__subpackages__",
+        "//checker:__subpackages__",
+        "//common:__subpackages__",
+    ],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/common/ast/ast.go
+++ b/common/ast/ast.go
@@ -1,0 +1,226 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ast declares data structures useful for parsed and checked abstract syntax trees
+package ast
+
+import (
+	"fmt"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+
+	structpb "google.golang.org/protobuf/types/known/structpb"
+
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+// CheckedAST contains a protobuf expression and source info along with CEL-native type and reference information.
+type CheckedAST struct {
+	Expr         *exprpb.Expr
+	SourceInfo   *exprpb.SourceInfo
+	TypeMap      map[int64]*types.Type
+	ReferenceMap map[int64]*ReferenceInfo
+}
+
+// CheckedASTToCheckedExpr converts a CheckedAST to a CheckedExpr protobouf.
+func CheckedASTToCheckedExpr(ast *CheckedAST) (*exprpb.CheckedExpr, error) {
+	refMap := make(map[int64]*exprpb.Reference, len(ast.ReferenceMap))
+	for id, ref := range ast.ReferenceMap {
+		r, err := ReferenceInfoToReferenceExpr(ref)
+		if err != nil {
+			return nil, err
+		}
+		refMap[id] = r
+	}
+	typeMap := make(map[int64]*exprpb.Type, len(ast.TypeMap))
+	for id, typ := range ast.TypeMap {
+		t, err := types.TypeToExprType(typ)
+		if err != nil {
+			return nil, err
+		}
+		typeMap[id] = t
+	}
+	return &exprpb.CheckedExpr{
+		Expr:         ast.Expr,
+		SourceInfo:   ast.SourceInfo,
+		ReferenceMap: refMap,
+		TypeMap:      typeMap,
+	}, nil
+}
+
+// CheckedExprToCheckedAST converts a CheckedExpr protobuf to a CheckedAST instance.
+func CheckedExprToCheckedAST(checked *exprpb.CheckedExpr) (*CheckedAST, error) {
+	refMap := make(map[int64]*ReferenceInfo, len(checked.GetReferenceMap()))
+	for id, ref := range checked.GetReferenceMap() {
+		r, err := ReferenceExprToReferenceInfo(ref)
+		if err != nil {
+			return nil, err
+		}
+		refMap[id] = r
+	}
+	typeMap := make(map[int64]*types.Type, len(checked.GetTypeMap()))
+	for id, typ := range checked.GetTypeMap() {
+		t, err := types.ExprTypeToType(typ)
+		if err != nil {
+			return nil, err
+		}
+		typeMap[id] = t
+	}
+	return &CheckedAST{
+		Expr:         checked.GetExpr(),
+		SourceInfo:   checked.GetSourceInfo(),
+		ReferenceMap: refMap,
+		TypeMap:      typeMap,
+	}, nil
+}
+
+// ReferenceInfo contains a CEL native representation of an identifier reference which may refer to
+// either a qualified identifier name, a set of overload ids, or a constant value from an enum.
+type ReferenceInfo struct {
+	Name        string
+	OverloadIDs []string
+	Value       ref.Val
+}
+
+// NewIdentReference creates a ReferenceInfo instance for an identifier with an optional constant value.
+func NewIdentReference(name string, value ref.Val) *ReferenceInfo {
+	return &ReferenceInfo{Name: name, Value: value}
+}
+
+// NewFunctionReference creates a ReferenceInfo instance for a set of function overloads.
+func NewFunctionReference(overloads ...string) *ReferenceInfo {
+	info := &ReferenceInfo{}
+	for _, id := range overloads {
+		info.AddOverload(id)
+	}
+	return info
+}
+
+// AddOverload appends a function overload ID to the ReferenceInfo.
+func (r *ReferenceInfo) AddOverload(overloadID string) {
+	for _, id := range r.OverloadIDs {
+		if id == overloadID {
+			return
+		}
+	}
+	r.OverloadIDs = append(r.OverloadIDs, overloadID)
+}
+
+// Equals returns whether two references are identical to each other.
+func (r *ReferenceInfo) Equals(other *ReferenceInfo) bool {
+	if r.Name != other.Name {
+		return false
+	}
+	if len(r.OverloadIDs) != len(other.OverloadIDs) {
+		return false
+	}
+	if len(r.OverloadIDs) != 0 {
+		overloadMap := make(map[string]struct{}, len(r.OverloadIDs))
+		for _, id := range r.OverloadIDs {
+			overloadMap[id] = struct{}{}
+		}
+		for _, id := range other.OverloadIDs {
+			_, found := overloadMap[id]
+			if !found {
+				return false
+			}
+		}
+	}
+	if r.Value == nil && other.Value == nil {
+		return true
+	}
+	if r.Value == nil && other.Value != nil ||
+		r.Value != nil && other.Value == nil ||
+		r.Value.Equal(other.Value) != types.True {
+		return false
+	}
+	return true
+}
+
+// ReferenceInfoToReferenceExpr converts a ReferenceInfo instance to a protobuf Reference suitable for serialization.
+func ReferenceInfoToReferenceExpr(info *ReferenceInfo) (*exprpb.Reference, error) {
+	c, err := ValToConstant(info.Value)
+	if err != nil {
+		return nil, err
+	}
+	return &exprpb.Reference{
+		Name:       info.Name,
+		OverloadId: info.OverloadIDs,
+		Value:      c,
+	}, nil
+}
+
+// ReferenceExprToReferenceInfo converts a protobuf Reference into a CEL-native ReferenceInfo instance.
+func ReferenceExprToReferenceInfo(ref *exprpb.Reference) (*ReferenceInfo, error) {
+	v, err := ConstantToVal(ref.GetValue())
+	if err != nil {
+		return nil, err
+	}
+	return &ReferenceInfo{
+		Name:        ref.GetName(),
+		OverloadIDs: ref.GetOverloadId(),
+		Value:       v,
+	}, nil
+}
+
+// ValToConstant converts a CEL-native ref.Val to a protobuf Constant.
+//
+// Only simple scalar types are supported by this method.
+func ValToConstant(v ref.Val) (*exprpb.Constant, error) {
+	if v == nil {
+		return nil, nil
+	}
+	switch v.Type() {
+	case types.BoolType:
+		return &exprpb.Constant{ConstantKind: &exprpb.Constant_BoolValue{BoolValue: v.Value().(bool)}}, nil
+	case types.BytesType:
+		return &exprpb.Constant{ConstantKind: &exprpb.Constant_BytesValue{BytesValue: v.Value().([]byte)}}, nil
+	case types.DoubleType:
+		return &exprpb.Constant{ConstantKind: &exprpb.Constant_DoubleValue{DoubleValue: v.Value().(float64)}}, nil
+	case types.IntType:
+		return &exprpb.Constant{ConstantKind: &exprpb.Constant_Int64Value{Int64Value: v.Value().(int64)}}, nil
+	case types.NullType:
+		return &exprpb.Constant{ConstantKind: &exprpb.Constant_NullValue{NullValue: structpb.NullValue_NULL_VALUE}}, nil
+	case types.StringType:
+		return &exprpb.Constant{ConstantKind: &exprpb.Constant_StringValue{StringValue: v.Value().(string)}}, nil
+	case types.UintType:
+		return &exprpb.Constant{ConstantKind: &exprpb.Constant_Uint64Value{Uint64Value: v.Value().(uint64)}}, nil
+	}
+	return nil, fmt.Errorf("unsupported constant kind: %v", v.Type())
+}
+
+// ConstantToVal converts a protobuf Constant to a CEL-native ref.Val.
+func ConstantToVal(c *exprpb.Constant) (ref.Val, error) {
+	if c == nil {
+		return nil, nil
+	}
+	switch c.GetConstantKind().(type) {
+	case *exprpb.Constant_BoolValue:
+		return types.Bool(c.GetBoolValue()), nil
+	case *exprpb.Constant_BytesValue:
+		return types.Bytes(c.GetBytesValue()), nil
+	case *exprpb.Constant_DoubleValue:
+		return types.Double(c.GetDoubleValue()), nil
+	case *exprpb.Constant_Int64Value:
+		return types.Int(c.GetInt64Value()), nil
+	case *exprpb.Constant_NullValue:
+		return types.NullValue, nil
+	case *exprpb.Constant_StringValue:
+		return types.String(c.GetStringValue()), nil
+	case *exprpb.Constant_Uint64Value:
+		return types.Uint(c.GetUint64Value()), nil
+	}
+	return nil, fmt.Errorf("unsupported constant kind: %v", c.GetConstantKind())
+}

--- a/common/ast/ast_test.go
+++ b/common/ast/ast_test.go
@@ -1,0 +1,227 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	chkdecls "github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/overloads"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+func TestConvertAST(t *testing.T) {
+	ast := &CheckedAST{
+		Expr:       &exprpb.Expr{},
+		SourceInfo: &exprpb.SourceInfo{},
+		TypeMap: map[int64]*types.Type{
+			1: types.BoolType,
+			2: types.DynType,
+		},
+		ReferenceMap: map[int64]*ReferenceInfo{
+			1: NewFunctionReference(overloads.LogicalNot),
+			2: NewIdentReference("TRUE", types.True),
+		},
+	}
+
+	exprAST := &exprpb.CheckedExpr{
+		Expr:       &exprpb.Expr{},
+		SourceInfo: &exprpb.SourceInfo{},
+		TypeMap: map[int64]*exprpb.Type{
+			1: chkdecls.Bool,
+			2: chkdecls.Dyn,
+		},
+		ReferenceMap: map[int64]*exprpb.Reference{
+			1: {OverloadId: []string{overloads.LogicalNot}},
+			2: {
+				Name: "TRUE",
+				Value: &exprpb.Constant{
+					ConstantKind: &exprpb.Constant_BoolValue{BoolValue: true},
+				},
+			},
+		},
+	}
+
+	checkedAST, err := CheckedExprToCheckedAST(exprAST)
+	if err != nil {
+		t.Fatalf("CheckedExprToCheckedAST() failed: %v", err)
+	}
+	if !reflect.DeepEqual(checkedAST.ReferenceMap, ast.ReferenceMap) ||
+		!reflect.DeepEqual(checkedAST.TypeMap, ast.TypeMap) {
+		t.Errorf("conversion to AST did not produce identical results: got %v, wanted %v", checkedAST, ast)
+	}
+	if !checkedAST.ReferenceMap[1].Equals(ast.ReferenceMap[1]) ||
+		!checkedAST.ReferenceMap[2].Equals(ast.ReferenceMap[2]) {
+		t.Error("converted reference info values not equal")
+	}
+	checkedExpr, err := CheckedASTToCheckedExpr(ast)
+	if err != nil {
+		t.Fatalf("CheckedASTToCheckedExpr() failed: %v", err)
+	}
+	if !proto.Equal(checkedExpr, exprAST) {
+		t.Errorf("conversion to protobuf did not produce identical results: got %v, wanted %v", checkedExpr, exprAST)
+	}
+}
+
+func TestReferenceInfoEquals(t *testing.T) {
+	tests := []struct {
+		name  string
+		a     *ReferenceInfo
+		b     *ReferenceInfo
+		equal bool
+	}{
+		{
+			name:  "single overload equal",
+			a:     NewFunctionReference(overloads.AddBytes),
+			b:     NewFunctionReference(overloads.AddBytes),
+			equal: true,
+		},
+		{
+			name:  "single overload not equal",
+			a:     NewFunctionReference(overloads.AddBytes),
+			b:     NewFunctionReference(overloads.AddDouble),
+			equal: false,
+		},
+		{
+			name:  "single and multiple overload not equal",
+			a:     NewFunctionReference(overloads.AddBytes),
+			b:     NewFunctionReference(overloads.AddBytes, overloads.AddDouble),
+			equal: false,
+		},
+		{
+			name:  "multiple overloads equal",
+			a:     NewFunctionReference(overloads.AddBytes, overloads.AddDouble),
+			b:     NewFunctionReference(overloads.AddDouble, overloads.AddBytes),
+			equal: true,
+		},
+		{
+			name:  "identifier reference equal",
+			a:     NewIdentReference("BYTES", nil),
+			b:     NewIdentReference("BYTES", nil),
+			equal: true,
+		},
+		{
+			name:  "identifier reference not equal",
+			a:     NewIdentReference("BYTES", nil),
+			b:     NewIdentReference("TRUE", nil),
+			equal: false,
+		},
+		{
+			name:  "identifier and constant reference not equal",
+			a:     NewIdentReference("BYTES", nil),
+			b:     NewIdentReference("BYTES", types.Bytes("bytes")),
+			equal: false,
+		},
+		{
+			name:  "constant references equal",
+			a:     NewIdentReference("BYTES", types.Bytes("bytes")),
+			b:     NewIdentReference("BYTES", types.Bytes("bytes")),
+			equal: true,
+		},
+		{
+			name:  "constant references not equal",
+			a:     NewIdentReference("BYTES", types.Bytes("bytes")),
+			b:     NewIdentReference("BYTES", types.Bytes("bytes-other")),
+			equal: false,
+		},
+		{
+			name:  "constant and overload reference not equal",
+			a:     NewIdentReference("BYTES", types.Bytes("bytes")),
+			b:     NewFunctionReference(overloads.AddDouble, overloads.AddBytes),
+			equal: false,
+		},
+	}
+	for _, tst := range tests {
+		tc := tst
+		t.Run(tc.name, func(t *testing.T) {
+			out := tc.a.Equals(tc.b)
+			if out != tc.equal {
+				t.Errorf("%v.Equals(%v) got %v, wanted %v", tc.a, tc.b, out, tc.equal)
+			}
+		})
+	}
+}
+
+func TestReferenceInfoAddOverload(t *testing.T) {
+	add := NewFunctionReference(overloads.AddBytes)
+	add.AddOverload(overloads.AddDouble)
+	if !add.Equals(NewFunctionReference(overloads.AddBytes, overloads.AddDouble)) {
+		t.Error("AddOverload() did not produce equal references")
+	}
+	add.AddOverload(overloads.AddDouble)
+	if !add.Equals(NewFunctionReference(overloads.AddBytes, overloads.AddDouble)) {
+		t.Error("repeated AddOverload() did not produce equal references")
+	}
+}
+
+func TestReferenceInfoToReferenceExprError(t *testing.T) {
+	out, err := ReferenceInfoToReferenceExpr(NewIdentReference("SECOND", types.Duration{Duration: time.Duration(1) * time.Second}))
+	if err == nil {
+		t.Errorf("ReferenceInfoToReferenceExpr() got %v, wanted error", out)
+	}
+}
+
+func TestReferenceExprToReferenceInfoError(t *testing.T) {
+	out, err := ReferenceExprToReferenceInfo(&exprpb.Reference{Value: &exprpb.Constant{}})
+	if err == nil {
+		t.Errorf("ReferenceExprToReferenceInfo() got %v, wanted error", out)
+	}
+}
+
+func TestConvertVal(t *testing.T) {
+	tests := []ref.Val{
+		types.True,
+		types.Bytes("bytes"),
+		types.Double(3.2),
+		types.Int(-1),
+		types.NullValue,
+		types.String("string"),
+		types.Uint(27),
+	}
+	for _, tst := range tests {
+		c, err := ValToConstant(tst)
+		if err != nil {
+			t.Errorf("ValToConstant(%v) failed: %v", tst, err)
+		}
+		v, err := ConstantToVal(c)
+		if err != nil {
+			t.Errorf("ValToConstant(%v) failed: %v", c, err)
+		}
+		if tst.Equal(v) != types.True {
+			t.Errorf("roundtrip from %v to %v and back did not produce equal results, got %v, wanted %v", tst, c, v, tst)
+		}
+	}
+}
+
+func TestValToConstantError(t *testing.T) {
+	out, err := ValToConstant(types.Duration{Duration: time.Duration(10)})
+	if err == nil {
+		t.Errorf("ValToConstant() got %v, wanted error", out)
+	}
+}
+
+func TestConstantToValError(t *testing.T) {
+	out, err := ConstantToVal(&exprpb.Constant{})
+	if err == nil {
+		t.Errorf("ConstantToVal() got %v, wanted error", out)
+	}
+}


### PR DESCRIPTION
Introduce an AST with a native representation for types and references.

Future PRs will further remove protobuf dependencies and produce/consume the new
`CheckedAST`.
