### PR TITLE
Restore iter range pruning on comprehension ASTs

### DIFF
--- a/interpreter/prune_test.go
+++ b/interpreter/prune_test.go
@@ -379,8 +379,9 @@ var testCases = []testInfo{
 		in: partialActivation(map[string]any{
 			"users": []string{"alice", "bob"},
 		}, NewAttributePattern("r").QualString("attr").Wildcard()),
-		expr: `users.filter(u, r.attr.prefix.endsWith(u))`,
-		out:  `["alice", "bob"].filter(u, r.attr.prefix.endsWith(u))`,
+		expr:      `users.filter(u, r.attr.prefix.endsWith(u))`,
+		out:       `["alice", "bob"].filter(u, r.attr.prefix.endsWith(u))`,
+		iterRange: `["alice", "bob"]`,
 	},
 	{
 		in:   unknownActivation("four"),
@@ -388,9 +389,10 @@ var testCases = []testInfo{
 		out:  `[4, 4, 4, four]`,
 	},
 	{
-		in:   unknownActivation("four"),
-		expr: `[1+3, 2+2, 3+1, four].exists(x, x == four)`,
-		out:  `[4, 4, 4, four].exists(x, x == four)`,
+		in:        unknownActivation("four"),
+		expr:      `[1+3, 2+2, 3+1, four].exists(x, x == four)`,
+		out:       `[4, 4, 4, four].exists(x, x == four)`,
+		iterRange: `[4, 4, 4, four]`,
 	},
 	{
 		in:   unknownActivation("a", "c"),
@@ -408,8 +410,9 @@ var testCases = []testInfo{
 		in: partialActivation(map[string]any{
 			"a": map[string]any{},
 		}, "c"),
-		expr: `[has(a.b), has(c.d)].exists(x, x == true)`,
-		out:  `[false, has(c.d)].exists(x, x == true)`,
+		expr:      `[has(a.b), has(c.d)].exists(x, x == true)`,
+		out:       `[false, has(c.d)].exists(x, x == true)`,
+		iterRange: `[false, has(c.d)]`,
 	},
 	{
 		in: partialActivation(map[string]any{
@@ -471,7 +474,7 @@ func TestPrune(t *testing.T) {
 		if tst.iterRange != "" {
 			compre := newExpr.GetExpr().GetComprehensionExpr()
 			if compre == nil {
-				t.Fatal("iter range check cannot operator on non comprehension output")
+				t.Fatalf("iter range check cannot operate on non comprehension output: %v", newExpr.GetExpr())
 			}
 			gotIterRange, err := parser.Unparse(compre.GetIterRange(), newExpr.GetSourceInfo())
 			if err != nil {


### PR DESCRIPTION
Closes #735 and adds a small test to ensure the AST transformation is preserved.