### PR TITLE
Migrate type-checker to native types and declarations

### DIFF
--- a/cel/BUILD.bazel
+++ b/cel/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//checker:go_default_library",
         "//checker/decls:go_default_library",
         "//common:go_default_library",
+        "//common/ast:go_default_library",
         "//common/containers:go_default_library",
         "//common/decls:go_default_library",
         "//common/functions:go_default_library",

--- a/cel/decls.go
+++ b/cel/decls.go
@@ -17,7 +17,6 @@ package cel
 import (
 	"fmt"
 
-	chkdecls "github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/functions"
 	"github.com/google/cel-go/common/types"
@@ -134,11 +133,7 @@ type Type = types.Type
 // Variable creates an instance of a variable declaration with a variable name and type.
 func Variable(name string, t *Type) EnvOption {
 	return func(e *Env) (*Env, error) {
-		et, err := TypeToExprType(t)
-		if err != nil {
-			return nil, err
-		}
-		e.declarations = append(e.declarations, chkdecls.NewVar(name, et))
+		e.variables = append(e.variables, decls.NewVariable(name, t))
 		return e, nil
 	}
 }

--- a/cel/decls.go
+++ b/cel/decls.go
@@ -173,13 +173,13 @@ func Function(name string, opts ...FunctionOpt) EnvOption {
 		if err != nil {
 			return nil, err
 		}
-		if existing, found := e.functions[fn.Name]; found {
+		if existing, found := e.functions[fn.Name()]; found {
 			fn, err = existing.Merge(fn)
 			if err != nil {
 				return nil, err
 			}
 		}
-		e.functions[fn.Name] = fn
+		e.functions[fn.Name()] = fn
 		return e, nil
 	}
 }

--- a/cel/env.go
+++ b/cel/env.go
@@ -413,7 +413,7 @@ func (e *Env) UnknownVars() interpreter.PartialActivation {
 	var unknownPatterns []*interpreter.AttributePattern
 	for _, v := range e.variables {
 		unknownPatterns = append(unknownPatterns,
-			interpreter.NewAttributePattern(v.Name))
+			interpreter.NewAttributePattern(v.Name()))
 	}
 	part, _ := PartialVars(
 		interpreter.EmptyActivation(),

--- a/cel/env.go
+++ b/cel/env.go
@@ -16,12 +16,12 @@ package cel
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/google/cel-go/checker"
 	chkdecls "github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common"
+	celast "github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/containers"
 	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/types"
@@ -41,8 +41,8 @@ type Ast struct {
 	expr    *exprpb.Expr
 	info    *exprpb.SourceInfo
 	source  Source
-	refMap  map[int64]*exprpb.Reference
-	typeMap map[int64]*exprpb.Type
+	refMap  map[int64]*celast.ReferenceInfo
+	typeMap map[int64]*types.Type
 }
 
 // Expr returns the proto serializable instance of the parsed/checked expression.
@@ -61,21 +61,26 @@ func (ast *Ast) SourceInfo() *exprpb.SourceInfo {
 }
 
 // ResultType returns the output type of the expression if the Ast has been type-checked, else
-// returns decls.Dyn as the parse step cannot infer the type.
+// returns chkdecls.Dyn as the parse step cannot infer the type.
 //
 // Deprecated: use OutputType
 func (ast *Ast) ResultType() *exprpb.Type {
 	if !ast.IsChecked() {
 		return chkdecls.Dyn
 	}
-	return ast.typeMap[ast.expr.GetId()]
+	out := ast.OutputType()
+	t, err := TypeToExprType(out)
+	if err != nil {
+		return chkdecls.Dyn
+	}
+	return t
 }
 
 // OutputType returns the output type of the expression if the Ast has been type-checked, else
 // returns cel.DynType as the parse step cannot infer types.
 func (ast *Ast) OutputType() *Type {
-	t, err := ExprTypeToType(ast.ResultType())
-	if err != nil {
+	t, found := ast.typeMap[ast.expr.GetId()]
+	if !found {
 		return DynType
 	}
 	return t
@@ -96,8 +101,8 @@ func FormatType(t *exprpb.Type) string {
 // evaluable programs for different expressions.
 type Env struct {
 	Container       *containers.Container
+	variables       []*decls.VariableDecl
 	functions       map[string]*decls.FunctionDecl
-	declarations    []*exprpb.Decl
 	macros          []parser.Macro
 	adapter         ref.TypeAdapter
 	provider        ref.TypeProvider
@@ -155,7 +160,7 @@ func NewCustomEnv(opts ...EnvOption) (*Env, error) {
 		return nil, err
 	}
 	return (&Env{
-		declarations:    []*exprpb.Decl{},
+		variables:       []*decls.VariableDecl{},
 		functions:       map[string]*decls.FunctionDecl{},
 		macros:          []parser.Macro{},
 		Container:       containers.DefaultContainer,
@@ -195,10 +200,10 @@ func (e *Env) Check(ast *Ast) (*Ast, *Issues) {
 	// detailed than the information provided by Check), is returned to the caller.
 	return &Ast{
 		source:  ast.Source(),
-		expr:    res.GetExpr(),
-		info:    res.GetSourceInfo(),
-		refMap:  res.GetReferenceMap(),
-		typeMap: res.GetTypeMap()}, nil
+		expr:    res.Expr,
+		info:    res.SourceInfo,
+		refMap:  res.ReferenceMap,
+		typeMap: res.TypeMap}, nil
 }
 
 // Compile combines the Parse and Check phases CEL program compilation to produce an Ast and
@@ -256,7 +261,7 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 	copy(chkOptsCopy, e.chkOpts)
 
 	// Copy the declarations if needed.
-	decsCopy := []*exprpb.Decl{}
+	varsCopy := []*decls.VariableDecl{}
 	if chk != nil {
 		// If the type-checker has already been instantiated, then the e.declarations have been
 		// validated within the chk instance.
@@ -264,8 +269,8 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 	} else {
 		// If the type-checker has not been instantiated, ensure the unvalidated declarations are
 		// provided to the extended Env instance.
-		decsCopy = make([]*exprpb.Decl, len(e.declarations))
-		copy(decsCopy, e.declarations)
+		varsCopy = make([]*decls.VariableDecl, len(e.variables))
+		copy(varsCopy, e.variables)
 	}
 
 	// Copy macros and program options
@@ -320,7 +325,7 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 
 	ext := &Env{
 		Container:       e.Container,
-		declarations:    decsCopy,
+		variables:       varsCopy,
 		functions:       funcsCopy,
 		macros:          macsCopy,
 		progOpts:        progOptsCopy,
@@ -406,12 +411,9 @@ func (e *Env) TypeProvider() ref.TypeProvider {
 // unless the PartialAttributes option is provided as a ProgramOption.
 func (e *Env) UnknownVars() interpreter.PartialActivation {
 	var unknownPatterns []*interpreter.AttributePattern
-	for _, d := range e.declarations {
-		switch d.GetDeclKind().(type) {
-		case *exprpb.Decl_Ident:
-			unknownPatterns = append(unknownPatterns,
-				interpreter.NewAttributePattern(d.GetName()))
-		}
+	for _, v := range e.variables {
+		unknownPatterns = append(unknownPatterns,
+			interpreter.NewAttributePattern(v.Name))
 	}
 	part, _ := PartialVars(
 		interpreter.EmptyActivation(),
@@ -464,9 +466,11 @@ func (e *Env) ResidualAst(a *Ast, details *EvalDetails) (*Ast, error) {
 // EstimateCost estimates the cost of a type checked CEL expression using the length estimates of input data and
 // extension functions provided by estimator.
 func (e *Env) EstimateCost(ast *Ast, estimator checker.CostEstimator, opts ...checker.CostOption) (checker.CostEstimate, error) {
-	checked, err := AstToCheckedExpr(ast)
-	if err != nil {
-		return checker.CostEstimate{}, fmt.Errorf("EsimateCost could not inspect Ast: %v", err)
+	checked := &celast.CheckedAST{
+		Expr:         ast.Expr(),
+		SourceInfo:   ast.SourceInfo(),
+		TypeMap:      ast.typeMap,
+		ReferenceMap: ast.refMap,
 	}
 	return checker.Cost(checked, estimator, opts...)
 }
@@ -532,7 +536,7 @@ func (e *Env) initChecker() (*checker.Env, error) {
 			return
 		}
 		// Add the statically configured declarations.
-		err = ce.Add(e.declarations...)
+		err = ce.AddIdents(e.variables...)
 		if err != nil {
 			e.setCheckerOrError(nil, err)
 			return
@@ -542,12 +546,7 @@ func (e *Env) initChecker() (*checker.Env, error) {
 			if fn.IsDeclarationDisabled() {
 				continue
 			}
-			fnDecl, err := decls.FunctionDeclToExprDecl(fn)
-			if err != nil {
-				e.setCheckerOrError(nil, err)
-				return
-			}
-			err = ce.Add(fnDecl)
+			err = ce.AddFunctions(fn)
 			if err != nil {
 				e.setCheckerOrError(nil, err)
 				return

--- a/cel/io.go
+++ b/cel/io.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/google/cel-go/common"
+	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
@@ -33,7 +34,8 @@ import (
 
 // CheckedExprToAst converts a checked expression proto message to an Ast.
 func CheckedExprToAst(checkedExpr *exprpb.CheckedExpr) *Ast {
-	return CheckedExprToAstWithSource(checkedExpr, nil)
+	checked, _ := CheckedExprToAstWithSource(checkedExpr, nil)
+	return checked
 }
 
 // CheckedExprToAstWithSource converts a checked expression proto message to an Ast,
@@ -44,29 +46,18 @@ func CheckedExprToAst(checkedExpr *exprpb.CheckedExpr) *Ast {
 // through future calls.
 //
 // Prefer CheckedExprToAst if loading expressions from storage.
-func CheckedExprToAstWithSource(checkedExpr *exprpb.CheckedExpr, src Source) *Ast {
-	refMap := checkedExpr.GetReferenceMap()
-	if refMap == nil {
-		refMap = map[int64]*exprpb.Reference{}
-	}
-	typeMap := checkedExpr.GetTypeMap()
-	if typeMap == nil {
-		typeMap = map[int64]*exprpb.Type{}
-	}
-	si := checkedExpr.GetSourceInfo()
-	if si == nil {
-		si = &exprpb.SourceInfo{}
-	}
-	if src == nil {
-		src = common.NewInfoSource(si)
+func CheckedExprToAstWithSource(checkedExpr *exprpb.CheckedExpr, src Source) (*Ast, error) {
+	checkedAST, err := ast.CheckedExprToCheckedAST(checkedExpr)
+	if err != nil {
+		return nil, err
 	}
 	return &Ast{
-		expr:    checkedExpr.GetExpr(),
-		info:    si,
+		expr:    checkedAST.Expr,
+		info:    checkedAST.SourceInfo,
 		source:  src,
-		refMap:  refMap,
-		typeMap: typeMap,
-	}
+		refMap:  checkedAST.ReferenceMap,
+		typeMap: checkedAST.TypeMap,
+	}, nil
 }
 
 // AstToCheckedExpr converts an Ast to an protobuf CheckedExpr value.
@@ -76,12 +67,13 @@ func AstToCheckedExpr(a *Ast) (*exprpb.CheckedExpr, error) {
 	if !a.IsChecked() {
 		return nil, fmt.Errorf("cannot convert unchecked ast")
 	}
-	return &exprpb.CheckedExpr{
-		Expr:         a.Expr(),
-		SourceInfo:   a.SourceInfo(),
+	cAst := &ast.CheckedAST{
+		Expr:         a.expr,
+		SourceInfo:   a.info,
 		ReferenceMap: a.refMap,
 		TypeMap:      a.typeMap,
-	}, nil
+	}
+	return ast.CheckedASTToCheckedExpr(cAst)
 }
 
 // ParsedExprToAst converts a parsed expression proto message to an Ast.

--- a/cel/io_test.go
+++ b/cel/io_test.go
@@ -113,7 +113,10 @@ func TestAstToProto(t *testing.T) {
 	if !proto.Equal(ast4.Expr(), ast.Expr()) {
 		t.Fatalf("got ast %v, wanted %v", ast4, ast)
 	}
-	ast5 := CheckedExprToAstWithSource(checked, ast.Source())
+	ast5, err := CheckedExprToAstWithSource(checked, ast.Source())
+	if err != nil {
+		t.Fatalf("CheckedExprToAstWithSource() failed: %v", err)
+	}
 	if !proto.Equal(ast5.Expr(), ast.Expr()) {
 		t.Errorf("got expr %v, wanted %v", ast5, ast)
 	}

--- a/cel/library.go
+++ b/cel/library.go
@@ -112,14 +112,14 @@ func (stdLibrary) CompileOptions() []EnvOption {
 		func(e *Env) (*Env, error) {
 			var err error
 			for _, fn := range stdlib.Functions() {
-				existing, found := e.functions[fn.Name]
+				existing, found := e.functions[fn.Name()]
 				if found {
 					fn, err = existing.Merge(fn)
 					if err != nil {
 						return nil, err
 					}
 				}
-				e.functions[fn.Name] = fn
+				e.functions[fn.Name()] = fn
 			}
 			return e, nil
 		},

--- a/cel/program.go
+++ b/cel/program.go
@@ -211,7 +211,7 @@ func newProgram(e *Env, ast *Ast, opts []ProgramOption) (Program, error) {
 		if ast.IsChecked() {
 			isValidType = func(id int64, validTypes ...ref.Type) (bool, error) {
 				t := ast.typeMap[id]
-				if t.Kind == DynKind {
+				if t.Kind() == DynKind {
 					return true, nil
 				}
 				for _, vt := range validTypes {
@@ -219,7 +219,7 @@ func newProgram(e *Env, ast *Ast, opts []ProgramOption) (Program, error) {
 					if err != nil {
 						return false, err
 					}
-					if k == t.Kind {
+					if t.Kind() == k {
 						return true, nil
 					}
 				}

--- a/checker/BUILD.bazel
+++ b/checker/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "cost.go",
         "env.go",
         "errors.go",
+        "format.go",
         "mapping.go",
         "options.go",
         "printer.go",
@@ -23,8 +24,10 @@ go_library(
     deps = [
         "//checker/decls:go_default_library",
         "//common:go_default_library",
+        "//common/ast:go_default_library",
         "//common/containers:go_default_library",
         "//common/debug:go_default_library",
+        "//common/decls:go_default_library",
         "//common/operators:go_default_library",
         "//common/overloads:go_default_library",
         "//common/stdlib:go_default_library",
@@ -46,6 +49,7 @@ go_test(
         "checker_test.go",
         "cost_test.go",
         "env_test.go",
+        "format_test.go",
     ],
     embed = [
         ":go_default_library",

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -19,13 +19,12 @@ package checker
 import (
 	"fmt"
 
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common"
+	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/containers"
+	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/operators"
-	"github.com/google/cel-go/common/types/ref"
-
-	"google.golang.org/protobuf/proto"
+	"github.com/google/cel-go/common/types"
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
@@ -36,8 +35,8 @@ type checker struct {
 	mappings           *mapping
 	freeTypeVarCounter int
 	sourceInfo         *exprpb.SourceInfo
-	types              map[int64]*exprpb.Type
-	references         map[int64]*exprpb.Reference
+	types              map[int64]*types.Type
+	references         map[int64]*ast.ReferenceInfo
 }
 
 // Check performs type checking, giving a typed AST.
@@ -46,9 +45,7 @@ type checker struct {
 // descriptions of protocol buffers, and a registry for errors.
 // Returns a CheckedExpr proto, which might not be usable if
 // there are errors in the error registry.
-func Check(parsedExpr *exprpb.ParsedExpr,
-	source common.Source,
-	env *Env) (*exprpb.CheckedExpr, *common.Errors) {
+func Check(parsedExpr *exprpb.ParsedExpr, source common.Source, env *Env) (*ast.CheckedAST, *common.Errors) {
 	errs := common.NewErrors(source)
 	c := checker{
 		env:                env,
@@ -56,19 +53,19 @@ func Check(parsedExpr *exprpb.ParsedExpr,
 		mappings:           newMapping(),
 		freeTypeVarCounter: 0,
 		sourceInfo:         parsedExpr.GetSourceInfo(),
-		types:              make(map[int64]*exprpb.Type),
-		references:         make(map[int64]*exprpb.Reference),
+		types:              make(map[int64]*types.Type),
+		references:         make(map[int64]*ast.ReferenceInfo),
 	}
 	c.check(parsedExpr.GetExpr())
 
 	// Walk over the final type map substituting any type parameters either by their bound value or
 	// by DYN.
-	m := make(map[int64]*exprpb.Type)
-	for k, v := range c.types {
-		m[k] = substitute(c.mappings, v, true)
+	m := make(map[int64]*types.Type)
+	for id, t := range c.types {
+		m[id] = substitute(c.mappings, t, true)
 	}
 
-	return &exprpb.CheckedExpr{
+	return &ast.CheckedAST{
 		Expr:         parsedExpr.GetExpr(),
 		SourceInfo:   parsedExpr.GetSourceInfo(),
 		TypeMap:      m,
@@ -118,45 +115,45 @@ func (c *checker) check(e *exprpb.Expr) {
 }
 
 func (c *checker) checkInt64Literal(e *exprpb.Expr) {
-	c.setType(e, decls.Int)
+	c.setType(e, types.IntType)
 }
 
 func (c *checker) checkUint64Literal(e *exprpb.Expr) {
-	c.setType(e, decls.Uint)
+	c.setType(e, types.UintType)
 }
 
 func (c *checker) checkStringLiteral(e *exprpb.Expr) {
-	c.setType(e, decls.String)
+	c.setType(e, types.StringType)
 }
 
 func (c *checker) checkBytesLiteral(e *exprpb.Expr) {
-	c.setType(e, decls.Bytes)
+	c.setType(e, types.BytesType)
 }
 
 func (c *checker) checkDoubleLiteral(e *exprpb.Expr) {
-	c.setType(e, decls.Double)
+	c.setType(e, types.DoubleType)
 }
 
 func (c *checker) checkBoolLiteral(e *exprpb.Expr) {
-	c.setType(e, decls.Bool)
+	c.setType(e, types.BoolType)
 }
 
 func (c *checker) checkNullLiteral(e *exprpb.Expr) {
-	c.setType(e, decls.Null)
+	c.setType(e, types.NullType)
 }
 
 func (c *checker) checkIdent(e *exprpb.Expr) {
 	identExpr := e.GetIdentExpr()
 	// Check to see if the identifier is declared.
 	if ident := c.env.LookupIdent(identExpr.GetName()); ident != nil {
-		c.setType(e, ident.GetIdent().GetType())
-		c.setReference(e, newIdentReference(ident.GetName(), ident.GetIdent().GetValue()))
+		c.setType(e, ident.Type)
+		c.setReference(e, ast.NewIdentReference(ident.Name, ident.Value))
 		// Overwrite the identifier with its fully qualified name.
-		identExpr.Name = ident.GetName()
+		identExpr.Name = ident.Name
 		return
 	}
 
-	c.setType(e, decls.Error)
+	c.setType(e, types.ErrorType)
 	c.errors.undeclaredReference(e.GetId(), c.location(e), c.env.container.Name(), identExpr.GetName())
 }
 
@@ -172,9 +169,9 @@ func (c *checker) checkSelect(e *exprpb.Expr) {
 
 			// Rewrite the node to be a variable reference to the resolved fully-qualified
 			// variable name.
-			c.setType(e, ident.GetIdent().GetType())
-			c.setReference(e, newIdentReference(ident.GetName(), ident.GetIdent().GetValue()))
-			identName := ident.GetName()
+			c.setType(e, ident.Type)
+			c.setReference(e, ast.NewIdentReference(ident.Name, ident.Value))
+			identName := ident.Name
 			e.ExprKind = &exprpb.Expr_IdentExpr{
 				IdentExpr: &exprpb.Expr_Ident{
 					Name: identName,
@@ -186,7 +183,7 @@ func (c *checker) checkSelect(e *exprpb.Expr) {
 
 	resultType := c.checkSelectField(e, sel.GetOperand(), sel.GetField(), false)
 	if sel.TestOnly {
-		resultType = decls.Bool
+		resultType = types.BoolType
 	}
 	c.setType(e, substitute(c.mappings, resultType, false))
 }
@@ -205,10 +202,10 @@ func (c *checker) checkOptSelect(e *exprpb.Expr) {
 	// Perform type-checking using the field selection logic.
 	resultType := c.checkSelectField(e, operand, fieldName, true)
 	c.setType(e, substitute(c.mappings, resultType, false))
-	c.setReference(e, newFunctionReference("select_optional_field"))
+	c.setReference(e, ast.NewFunctionReference("select_optional_field"))
 }
 
-func (c *checker) checkSelectField(e, operand *exprpb.Expr, field string, optional bool) *exprpb.Type {
+func (c *checker) checkSelectField(e, operand *exprpb.Expr, field string, optional bool) *types.Type {
 	// Interpret as field selection, first traversing down the operand.
 	c.check(operand)
 	operandType := substitute(c.mappings, c.getType(operand), false)
@@ -217,38 +214,37 @@ func (c *checker) checkSelectField(e, operand *exprpb.Expr, field string, option
 	targetType, isOpt := maybeUnwrapOptional(operandType)
 
 	// Assume error type by default as most types do not support field selection.
-	resultType := decls.Error
-	switch kindOf(targetType) {
-	case kindMap:
+	resultType := types.ErrorType
+	switch targetType.Kind {
+	case types.MapKind:
 		// Maps yield their value type as the selection result type.
-		mapType := targetType.GetMapType()
-		resultType = mapType.GetValueType()
-	case kindObject:
+		resultType = targetType.Parameters[1]
+	case types.StructKind:
 		// Objects yield their field type declaration as the selection result type, but only if
 		// the field is defined.
 		messageType := targetType
-		if fieldType, found := c.lookupFieldType(e.GetId(), messageType.GetMessageType(), field); found {
-			resultType = fieldType.Type
+		if fieldType, found := c.lookupFieldType(e.GetId(), messageType.TypeName(), field); found {
+			resultType = fieldType
 		}
-	case kindTypeParam:
+	case types.TypeParamKind:
 		// Set the operand type to DYN to prevent assignment to a potentially incorrect type
 		// at a later point in type-checking. The isAssignable call will update the type
 		// substitutions for the type param under the covers.
-		c.isAssignable(decls.Dyn, targetType)
+		c.isAssignable(types.DynType, targetType)
 		// Also, set the result type to DYN.
-		resultType = decls.Dyn
+		resultType = types.DynType
 	default:
 		// Dynamic / error values are treated as DYN type. Errors are handled this way as well
 		// in order to allow forward progress on the check.
 		if !isDynOrError(targetType) {
 			c.errors.typeDoesNotSupportFieldSelection(e.GetId(), c.location(e), targetType)
 		}
-		resultType = decls.Dyn
+		resultType = types.DynType
 	}
 
 	// If the target type was optional coming in, then the result must be optional going out.
 	if isOpt || optional {
-		return decls.NewOptionalType(resultType)
+		return types.NewOptionalType(resultType)
 	}
 	return resultType
 }
@@ -277,11 +273,11 @@ func (c *checker) checkCall(e *exprpb.Expr) {
 		fn := c.env.LookupFunction(fnName)
 		if fn == nil {
 			c.errors.undeclaredReference(e.GetId(), c.location(e), c.env.container.Name(), fnName)
-			c.setType(e, decls.Error)
+			c.setType(e, types.ErrorType)
 			return
 		}
 		// Overwrite the function name with its fully qualified resolved name.
-		call.Function = fn.GetName()
+		call.Function = fn.Name
 		// Check to see whether the overload resolves.
 		c.resolveOverloadOrError(e, fn, nil, args)
 		return
@@ -301,7 +297,7 @@ func (c *checker) checkCall(e *exprpb.Expr) {
 			// be an inaccurate representation of the desired evaluation behavior.
 			// Overwrite with fully-qualified resolved function name sans receiver target.
 			call.Target = nil
-			call.Function = fn.GetName()
+			call.Function = fn.Name
 			c.resolveOverloadOrError(e, fn, nil, args)
 			return
 		}
@@ -316,17 +312,17 @@ func (c *checker) checkCall(e *exprpb.Expr) {
 		return
 	}
 	// Function name not declared, record error.
+	c.setType(e, types.ErrorType)
 	c.errors.undeclaredReference(e.GetId(), c.location(e), c.env.container.Name(), fnName)
 }
 
 func (c *checker) resolveOverloadOrError(
-	e *exprpb.Expr,
-	fn *exprpb.Decl, target *exprpb.Expr, args []*exprpb.Expr) {
+	e *exprpb.Expr, fn *decls.FunctionDecl, target *exprpb.Expr, args []*exprpb.Expr) {
 	// Attempt to resolve the overload.
 	resolution := c.resolveOverload(e, fn, target, args)
 	// No such overload, error noted in the resolveOverload call, type recorded here.
 	if resolution == nil {
-		c.setType(e, decls.Error)
+		c.setType(e, types.ErrorType)
 		return
 	}
 	// Overload found.
@@ -335,10 +331,9 @@ func (c *checker) resolveOverloadOrError(
 }
 
 func (c *checker) resolveOverload(
-	call *exprpb.Expr,
-	fn *exprpb.Decl, target *exprpb.Expr, args []*exprpb.Expr) *overloadResolution {
+	call *exprpb.Expr, fn *decls.FunctionDecl, target *exprpb.Expr, args []*exprpb.Expr) *overloadResolution {
 
-	var argTypes []*exprpb.Type
+	var argTypes []*types.Type
 	if target != nil {
 		argTypes = append(argTypes, c.getType(target))
 	}
@@ -346,65 +341,66 @@ func (c *checker) resolveOverload(
 		argTypes = append(argTypes, c.getType(arg))
 	}
 
-	var resultType *exprpb.Type
-	var checkedRef *exprpb.Reference
-	for _, overload := range fn.GetFunction().GetOverloads() {
+	var resultType *types.Type
+	var checkedRef *ast.ReferenceInfo
+	for _, overload := range fn.OverloadDecls() {
 		// Determine whether the overload is currently considered.
-		if c.env.isOverloadDisabled(overload.GetOverloadId()) {
+		if c.env.isOverloadDisabled(overload.ID) {
 			continue
 		}
 
 		// Ensure the call style for the overload matches.
-		if (target == nil && overload.GetIsInstanceFunction()) ||
-			(target != nil && !overload.GetIsInstanceFunction()) {
+		if (target == nil && overload.IsMemberFunction) ||
+			(target != nil && !overload.IsMemberFunction) {
 			// not a compatible call style.
 			continue
 		}
 
 		// Alternative type-checking behavior when the logical operators are compacted into
 		// variadic AST representations.
-		if fn.GetName() == operators.LogicalAnd || fn.GetName() == operators.LogicalOr {
-			checkedRef = newFunctionReference(overload.GetOverloadId())
+		if fn.Name == operators.LogicalAnd || fn.Name == operators.LogicalOr {
+			checkedRef = ast.NewFunctionReference(overload.ID)
 			for i, argType := range argTypes {
-				if !c.isAssignable(argType, decls.Bool) {
+				if !c.isAssignable(argType, types.BoolType) {
 					c.errors.typeMismatch(
 						args[i].GetId(),
 						c.locationByID(args[i].GetId()),
-						decls.Bool,
+						types.BoolType,
 						argType)
-					resultType = decls.Error
+					resultType = types.ErrorType
 				}
 			}
 			if isError(resultType) {
 				return nil
 			}
-			return newResolution(checkedRef, decls.Bool)
+			return newResolution(checkedRef, types.BoolType)
 		}
 
-		overloadType := decls.NewFunctionType(overload.ResultType, overload.Params...)
-		if len(overload.GetTypeParams()) > 0 {
+		overloadType := newFunctionType(overload.ResultType, overload.ArgTypes...)
+		typeParams := overload.GetTypeParams()
+		if len(typeParams) != 0 {
 			// Instantiate overload's type with fresh type variables.
 			substitutions := newMapping()
-			for _, typePar := range overload.GetTypeParams() {
-				substitutions.add(decls.NewTypeParamType(typePar), c.newTypeVar())
+			for _, typePar := range typeParams {
+				substitutions.add(types.NewTypeParamType(typePar), c.newTypeVar())
 			}
 			overloadType = substitute(substitutions, overloadType, false)
 		}
 
-		candidateArgTypes := overloadType.GetFunction().GetArgTypes()
+		candidateArgTypes := overloadType.Parameters[1:]
 		if c.isAssignableList(argTypes, candidateArgTypes) {
 			if checkedRef == nil {
-				checkedRef = newFunctionReference(overload.GetOverloadId())
+				checkedRef = ast.NewFunctionReference(overload.ID)
 			} else {
-				checkedRef.OverloadId = append(checkedRef.GetOverloadId(), overload.GetOverloadId())
+				checkedRef.AddOverload(overload.ID)
 			}
 
 			// First matching overload, determines result type.
-			fnResultType := substitute(c.mappings, overloadType.GetFunction().GetResultType(), false)
+			fnResultType := substitute(c.mappings, overloadType.Parameters[0], false)
 			if resultType == nil {
 				resultType = fnResultType
-			} else if !isDyn(resultType) && !proto.Equal(fnResultType, resultType) {
-				resultType = decls.Dyn
+			} else if !isDyn(resultType) && !fnResultType.IsExactType(resultType) {
+				resultType = types.DynType
 			}
 		}
 	}
@@ -413,7 +409,7 @@ func (c *checker) resolveOverload(
 		for i, argType := range argTypes {
 			argTypes[i] = substitute(c.mappings, argType, true)
 		}
-		c.errors.noMatchingOverload(call.GetId(), c.location(call), fn.GetName(), argTypes, target != nil)
+		c.errors.noMatchingOverload(call.GetId(), c.location(call), fn.Name, argTypes, target != nil)
 		return nil
 	}
 
@@ -422,7 +418,7 @@ func (c *checker) resolveOverload(
 
 func (c *checker) checkCreateList(e *exprpb.Expr) {
 	create := e.GetListExpr()
-	var elemsType *exprpb.Type
+	var elemsType *types.Type
 	optionalIndices := create.GetOptionalIndices()
 	optionals := make(map[int32]bool, len(optionalIndices))
 	for _, optInd := range optionalIndices {
@@ -435,7 +431,7 @@ func (c *checker) checkCreateList(e *exprpb.Expr) {
 			var isOptional bool
 			elemType, isOptional = maybeUnwrapOptional(elemType)
 			if !isOptional && !isDyn(elemType) {
-				c.errors.typeMismatch(e.GetId(), c.location(e), decls.NewOptionalType(elemType), elemType)
+				c.errors.typeMismatch(e.GetId(), c.location(e), types.NewOptionalType(elemType), elemType)
 			}
 		}
 		elemsType = c.joinTypes(e, elemsType, elemType)
@@ -444,7 +440,7 @@ func (c *checker) checkCreateList(e *exprpb.Expr) {
 		// If the list is empty, assign free type var to elem type.
 		elemsType = c.newTypeVar()
 	}
-	c.setType(e, decls.NewListType(elemsType))
+	c.setType(e, types.NewListType(elemsType))
 }
 
 func (c *checker) checkCreateStruct(e *exprpb.Expr) {
@@ -458,8 +454,8 @@ func (c *checker) checkCreateStruct(e *exprpb.Expr) {
 
 func (c *checker) checkCreateMap(e *exprpb.Expr) {
 	mapVal := e.GetStructExpr()
-	var mapKeyType *exprpb.Type
-	var mapValueType *exprpb.Type
+	var mapKeyType *types.Type
+	var mapValueType *types.Type
 	for _, ent := range mapVal.GetEntries() {
 		key := ent.GetMapKey()
 		c.check(key)
@@ -472,7 +468,7 @@ func (c *checker) checkCreateMap(e *exprpb.Expr) {
 			var isOptional bool
 			valType, isOptional = maybeUnwrapOptional(valType)
 			if !isOptional && !isDyn(valType) {
-				c.errors.typeMismatch(val.GetId(), c.location(val), decls.NewOptionalType(valType), valType)
+				c.errors.typeMismatch(val.GetId(), c.location(val), types.NewOptionalType(valType), valType)
 			}
 		}
 		mapValueType = c.joinTypes(val, mapValueType, valType)
@@ -482,52 +478,44 @@ func (c *checker) checkCreateMap(e *exprpb.Expr) {
 		mapKeyType = c.newTypeVar()
 		mapValueType = c.newTypeVar()
 	}
-	c.setType(e, decls.NewMapType(mapKeyType, mapValueType))
+	c.setType(e, types.NewMapType(mapKeyType, mapValueType))
 }
 
 func (c *checker) checkCreateMessage(e *exprpb.Expr) {
 	msgVal := e.GetStructExpr()
 	// Determine the type of the message.
-	messageType := decls.Error
-	decl := c.env.LookupIdent(msgVal.GetMessageName())
-	if decl == nil {
+	resultType := types.ErrorType
+	ident := c.env.LookupIdent(msgVal.GetMessageName())
+	if ident == nil {
 		c.errors.undeclaredReference(
 			e.GetId(), c.location(e), c.env.container.Name(), msgVal.GetMessageName())
+		c.setType(e, types.ErrorType)
 		return
 	}
 	// Ensure the type name is fully qualified in the AST.
-	msgVal.MessageName = decl.GetName()
-	c.setReference(e, newIdentReference(decl.GetName(), nil))
-	ident := decl.GetIdent()
-	identKind := kindOf(ident.GetType())
-	if identKind != kindError {
-		if identKind != kindType {
-			c.errors.notAType(e.GetId(), c.location(e), ident.GetType())
+	typeName := ident.Name
+	msgVal.MessageName = typeName
+	c.setReference(e, ast.NewIdentReference(ident.Name, nil))
+	identKind := ident.Type.Kind
+	if identKind != types.ErrorKind {
+		if identKind != types.TypeKind {
+			c.errors.notAType(e.GetId(), c.location(e), ident.Type.DeclaredTypeName())
 		} else {
-			messageType = ident.GetType().GetType()
-			kind := kindOf(messageType)
+			resultType = ident.Type.Parameters[0]
 			// Backwards compatibility test between well-known types and message types
 			// In this context, the type is being instantiated by its protobuf name which
 			// is not ideal or recommended, but some users expect this to work.
-			if kind == kindWellKnown || kind == kindWrapper {
-				messageType = &exprpb.Type{
-					TypeKind: &exprpb.Type_MessageType{
-						MessageType: decl.GetName(),
-					},
-				}
-				kind = kindObject
-			}
-			if kind != kindObject {
-				c.errors.notAMessageType(e.GetId(), c.location(e), messageType)
-				messageType = decls.Error
+			if isWellKnownType(resultType) {
+				typeName = getWellKnownTypeName(resultType)
+			} else if resultType.Kind == types.StructKind {
+				typeName = resultType.DeclaredTypeName()
+			} else {
+				c.errors.notAMessageType(e.GetId(), c.location(e), resultType.DeclaredTypeName())
+				resultType = types.ErrorType
 			}
 		}
 	}
-	if isObjectWellKnownType(messageType) {
-		c.setType(e, getObjectWellKnownType(messageType))
-	} else {
-		c.setType(e, messageType)
-	}
+	c.setType(e, resultType)
 
 	// Check the field initializers.
 	for _, ent := range msgVal.GetEntries() {
@@ -535,10 +523,10 @@ func (c *checker) checkCreateMessage(e *exprpb.Expr) {
 		value := ent.GetValue()
 		c.check(value)
 
-		fieldType := decls.Error
-		ft, found := c.lookupFieldType(ent.GetId(), messageType.GetMessageType(), field)
+		fieldType := types.ErrorType
+		ft, found := c.lookupFieldType(ent.GetId(), typeName, field)
 		if found {
-			fieldType = ft.Type
+			fieldType = ft
 		}
 
 		valType := c.getType(value)
@@ -546,7 +534,7 @@ func (c *checker) checkCreateMessage(e *exprpb.Expr) {
 			var isOptional bool
 			valType, isOptional = maybeUnwrapOptional(valType)
 			if !isOptional && !isDyn(valType) {
-				c.errors.typeMismatch(value.GetId(), c.location(value), decls.NewOptionalType(valType), valType)
+				c.errors.typeMismatch(value.GetId(), c.location(value), types.NewOptionalType(valType), valType)
 			}
 		}
 		if !c.isAssignable(fieldType, valType) {
@@ -561,36 +549,36 @@ func (c *checker) checkComprehension(e *exprpb.Expr) {
 	c.check(comp.GetAccuInit())
 	accuType := c.getType(comp.GetAccuInit())
 	rangeType := substitute(c.mappings, c.getType(comp.GetIterRange()), false)
-	var varType *exprpb.Type
+	var varType *types.Type
 
-	switch kindOf(rangeType) {
-	case kindList:
-		varType = rangeType.GetListType().GetElemType()
-	case kindMap:
+	switch rangeType.Kind {
+	case types.ListKind:
+		varType = rangeType.Parameters[0]
+	case types.MapKind:
 		// Ranges over the keys.
-		varType = rangeType.GetMapType().GetKeyType()
-	case kindDyn, kindError, kindTypeParam:
+		varType = rangeType.Parameters[0]
+	case types.DynKind, types.ErrorKind, types.TypeParamKind:
 		// Set the range type to DYN to prevent assignment to a potentially incorrect type
 		// at a later point in type-checking. The isAssignable call will update the type
 		// substitutions for the type param under the covers.
-		c.isAssignable(decls.Dyn, rangeType)
+		c.isAssignable(types.DynType, rangeType)
 		// Set the range iteration variable to type DYN as well.
-		varType = decls.Dyn
+		varType = types.DynType
 	default:
 		c.errors.notAComprehensionRange(comp.GetIterRange().GetId(), c.location(comp.GetIterRange()), rangeType)
-		varType = decls.Error
+		varType = types.ErrorType
 	}
 
 	// Create a scope for the comprehension since it has a local accumulation variable.
 	// This scope will contain the accumulation variable used to compute the result.
 	c.env = c.env.enterScope()
-	c.env.Add(decls.NewVar(comp.GetAccuVar(), accuType))
+	c.env.AddIdents(decls.NewVariable(comp.GetAccuVar(), accuType))
 	// Create a block scope for the loop.
 	c.env = c.env.enterScope()
-	c.env.Add(decls.NewVar(comp.GetIterVar(), varType))
+	c.env.AddIdents(decls.NewVariable(comp.GetIterVar(), varType))
 	// Check the variable references in the condition and step.
 	c.check(comp.GetLoopCondition())
-	c.assertType(comp.GetLoopCondition(), decls.Bool)
+	c.assertType(comp.GetLoopCondition(), types.BoolType)
 	c.check(comp.GetLoopStep())
 	c.assertType(comp.GetLoopStep(), accuType)
 	// Exit the loop's block scope before checking the result.
@@ -602,7 +590,7 @@ func (c *checker) checkComprehension(e *exprpb.Expr) {
 }
 
 // Checks compatibility of joined types, and returns the most general common type.
-func (c *checker) joinTypes(e *exprpb.Expr, previous, current *exprpb.Type) *exprpb.Type {
+func (c *checker) joinTypes(e *exprpb.Expr, previous, current *types.Type) *types.Type {
 	if previous == nil {
 		return current
 	}
@@ -610,23 +598,23 @@ func (c *checker) joinTypes(e *exprpb.Expr, previous, current *exprpb.Type) *exp
 		return mostGeneral(previous, current)
 	}
 	if c.dynAggregateLiteralElementTypesEnabled() {
-		return decls.Dyn
+		return types.DynType
 	}
 	c.errors.typeMismatch(e.GetId(), c.location(e), previous, current)
-	return decls.Error
+	return types.ErrorType
 }
 
 func (c *checker) dynAggregateLiteralElementTypesEnabled() bool {
 	return c.env.aggLitElemType == dynElementType
 }
 
-func (c *checker) newTypeVar() *exprpb.Type {
+func (c *checker) newTypeVar() *types.Type {
 	id := c.freeTypeVarCounter
 	c.freeTypeVarCounter++
-	return decls.NewTypeParamType(fmt.Sprintf("_var%d", id))
+	return types.NewTypeParamType(fmt.Sprintf("_var%d", id))
 }
 
-func (c *checker) isAssignable(t1 *exprpb.Type, t2 *exprpb.Type) bool {
+func (c *checker) isAssignable(t1, t2 *types.Type) bool {
 	subs := isAssignable(c.mappings, t1, t2)
 	if subs != nil {
 		c.mappings = subs
@@ -636,7 +624,7 @@ func (c *checker) isAssignable(t1 *exprpb.Type, t2 *exprpb.Type) bool {
 	return false
 }
 
-func (c *checker) isAssignableList(l1 []*exprpb.Type, l2 []*exprpb.Type) bool {
+func (c *checker) isAssignableList(l1, l2 []*types.Type) bool {
 	subs := isAssignableList(c.mappings, l1, l2)
 	if subs != nil {
 		c.mappings = subs
@@ -646,55 +634,52 @@ func (c *checker) isAssignableList(l1 []*exprpb.Type, l2 []*exprpb.Type) bool {
 	return false
 }
 
-func (c *checker) lookupFieldType(exprID int64, messageType, fieldName string) (*ref.FieldType, bool) {
-	if _, found := c.env.provider.FindType(messageType); !found {
-		// This should not happen, anyway, report an error.
-		c.errors.unexpectedFailedResolution(exprID, c.locationByID(exprID), messageType)
-		return nil, false
+func maybeUnwrapString(e *exprpb.Expr) (string, bool) {
+	switch e.GetExprKind().(type) {
+	case *exprpb.Expr_ConstExpr:
+		literal := e.GetConstExpr()
+		switch literal.GetConstantKind().(type) {
+		case *exprpb.Constant_StringValue:
+			return literal.GetStringValue(), true
+		}
 	}
-
-	if ft, found := c.env.provider.FindFieldType(messageType, fieldName); found {
-		return ft, found
-	}
-
-	c.errors.undefinedField(exprID, c.locationByID(exprID), fieldName)
-	return nil, false
+	return "", false
 }
 
-func (c *checker) setType(e *exprpb.Expr, t *exprpb.Type) {
-	if old, found := c.types[e.GetId()]; found && !proto.Equal(old, t) {
+func (c *checker) setType(e *exprpb.Expr, t *types.Type) {
+	if old, found := c.types[e.GetId()]; found && !old.IsExactType(t) {
 		c.errors.incompatibleType(e.GetId(), c.location(e), e, old, t)
 		return
 	}
 	c.types[e.GetId()] = t
 }
 
-func (c *checker) getType(e *exprpb.Expr) *exprpb.Type {
+func (c *checker) getType(e *exprpb.Expr) *types.Type {
 	return c.types[e.GetId()]
 }
 
-func (c *checker) setReference(e *exprpb.Expr, r *exprpb.Reference) {
-	if old, found := c.references[e.GetId()]; found && !proto.Equal(old, r) {
+func (c *checker) setReference(e *exprpb.Expr, r *ast.ReferenceInfo) {
+	if old, found := c.references[e.GetId()]; found && !old.Equals(r) {
 		c.errors.referenceRedefinition(e.GetId(), c.location(e), e, old, r)
 		return
 	}
 	c.references[e.GetId()] = r
 }
 
-func (c *checker) assertType(e *exprpb.Expr, t *exprpb.Type) {
+func (c *checker) assertType(e *exprpb.Expr, t *types.Type) {
 	if !c.isAssignable(t, c.getType(e)) {
 		c.errors.typeMismatch(e.GetId(), c.location(e), t, c.getType(e))
 	}
 }
 
 type overloadResolution struct {
-	Reference *exprpb.Reference
-	Type      *exprpb.Type
+	Type      *types.Type
+	Reference *ast.ReferenceInfo
 }
 
-func newResolution(checkedRef *exprpb.Reference, t *exprpb.Type) *overloadResolution {
+func newResolution(r *ast.ReferenceInfo, t *types.Type) *overloadResolution {
 	return &overloadResolution{
-		Reference: checkedRef,
+		Reference: r,
 		Type:      t,
 	}
 }
@@ -721,10 +706,61 @@ func (c *checker) locationByID(id int64) common.Location {
 	return common.NoLocation
 }
 
-func newIdentReference(name string, value *exprpb.Constant) *exprpb.Reference {
-	return &exprpb.Reference{Name: name, Value: value}
+func (c *checker) lookupFieldType(exprID int64, messageType, fieldName string) (*types.Type, bool) {
+	if _, found := c.env.provider.FindType(messageType); !found {
+		// This should not happen, anyway, report an error.
+		c.errors.unexpectedFailedResolution(exprID, c.locationByID(exprID), messageType)
+		return nil, false
+	}
+
+	if ft, found := c.env.provider.FindFieldType(messageType, fieldName); found {
+		dt, err := types.ExprTypeToType(ft.Type)
+		if err != nil {
+			c.errors.undefinedField(exprID, c.locationByID(exprID), fieldName)
+		}
+		return dt, found
+	}
+
+	c.errors.undefinedField(exprID, c.locationByID(exprID), fieldName)
+	return nil, false
 }
 
-func newFunctionReference(overloads ...string) *exprpb.Reference {
-	return &exprpb.Reference{OverloadId: overloads}
+func isWellKnownType(t *types.Type) bool {
+	kind := t.Kind
+	switch kind {
+	case types.AnyKind, types.TimestampKind, types.DurationKind, types.DynKind, types.NullTypeKind:
+		return true
+	case types.BoolKind, types.BytesKind, types.DoubleKind, types.IntKind, types.StringKind, types.UintKind:
+		return t.IsAssignableType(types.NullType)
+	case types.ListKind:
+		return t.Parameters[0] == types.DynType
+	case types.MapKind:
+		return t.Parameters[0] == types.StringType && t.Parameters[1] == types.DynType
+	}
+	return false
 }
+
+func getWellKnownTypeName(t *types.Type) string {
+	if name, found := wellKnownTypes[t.Kind]; found {
+		return name
+	}
+	return ""
+}
+
+var (
+	wellKnownTypes = map[types.Kind]string{
+		types.AnyKind:       "google.protobuf.Any",
+		types.BoolKind:      "google.protobuf.BoolValue",
+		types.BytesKind:     "google.protobuf.BytesValue",
+		types.DoubleKind:    "google.protobuf.DoubleValue",
+		types.DurationKind:  "google.protobuf.Duration",
+		types.DynKind:       "google.protobuf.Value",
+		types.IntKind:       "google.protobuf.Int64Value",
+		types.ListKind:      "google.protobuf.ListValue",
+		types.NullTypeKind:  "google.protobuf.NullValue",
+		types.MapKind:       "google.protobuf.Struct",
+		types.StringKind:    "google.protobuf.StringValue",
+		types.TimestampKind: "google.protobuf.Timestamp",
+		types.UintKind:      "google.protobuf.UInt64Value",
+	}
+)

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -146,10 +146,10 @@ func (c *checker) checkIdent(e *exprpb.Expr) {
 	identExpr := e.GetIdentExpr()
 	// Check to see if the identifier is declared.
 	if ident := c.env.LookupIdent(identExpr.GetName()); ident != nil {
-		c.setType(e, ident.Type)
-		c.setReference(e, ast.NewIdentReference(ident.Name, ident.Value))
+		c.setType(e, ident.Type())
+		c.setReference(e, ast.NewIdentReference(ident.Name(), ident.Value()))
 		// Overwrite the identifier with its fully qualified name.
-		identExpr.Name = ident.Name
+		identExpr.Name = ident.Name()
 		return
 	}
 
@@ -169,9 +169,9 @@ func (c *checker) checkSelect(e *exprpb.Expr) {
 
 			// Rewrite the node to be a variable reference to the resolved fully-qualified
 			// variable name.
-			c.setType(e, ident.Type)
-			c.setReference(e, ast.NewIdentReference(ident.Name, ident.Value))
-			identName := ident.Name
+			c.setType(e, ident.Type())
+			c.setReference(e, ast.NewIdentReference(ident.Name(), ident.Value()))
+			identName := ident.Name()
 			e.ExprKind = &exprpb.Expr_IdentExpr{
 				IdentExpr: &exprpb.Expr_Ident{
 					Name: identName,
@@ -493,15 +493,15 @@ func (c *checker) checkCreateMessage(e *exprpb.Expr) {
 		return
 	}
 	// Ensure the type name is fully qualified in the AST.
-	typeName := ident.Name
+	typeName := ident.Name()
 	msgVal.MessageName = typeName
-	c.setReference(e, ast.NewIdentReference(ident.Name, nil))
-	identKind := ident.Type.Kind()
+	c.setReference(e, ast.NewIdentReference(ident.Name(), nil))
+	identKind := ident.Type().Kind()
 	if identKind != types.ErrorKind {
 		if identKind != types.TypeKind {
-			c.errors.notAType(e.GetId(), c.location(e), ident.Type.DeclaredTypeName())
+			c.errors.notAType(e.GetId(), c.location(e), ident.Type().DeclaredTypeName())
 		} else {
-			resultType = ident.Type.Parameters()[0]
+			resultType = ident.Type().Parameters()[0]
 			// Backwards compatibility test between well-known types and message types
 			// In this context, the type is being instantiated by its protobuf name which
 			// is not ideal or recommended, but some users expect this to work.

--- a/checker/cost.go
+++ b/checker/cost.go
@@ -18,7 +18,9 @@ import (
 	"math"
 
 	"github.com/google/cel-go/common"
+	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/overloads"
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/parser"
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
@@ -54,7 +56,7 @@ type AstNode interface {
 	// The first path element is a variable. All subsequent path elements are one of: field name, '@items', '@keys', '@values'.
 	Path() []string
 	// Type returns the deduced type of the AstNode.
-	Type() *exprpb.Type
+	Type() *types.Type
 	// Expr returns the expression of the AstNode.
 	Expr() *exprpb.Expr
 	// ComputedSize returns a size estimate of the AstNode derived from information available in the CEL expression.
@@ -66,7 +68,7 @@ type AstNode interface {
 
 type astNode struct {
 	path        []string
-	t           *exprpb.Type
+	t           *types.Type
 	expr        *exprpb.Expr
 	derivedSize *SizeEstimate
 }
@@ -75,7 +77,7 @@ func (e astNode) Path() []string {
 	return e.path
 }
 
-func (e astNode) Type() *exprpb.Type {
+func (e astNode) Type() *types.Type {
 	return e.t
 }
 
@@ -259,7 +261,7 @@ type coster struct {
 	iterRanges iterRangeScopes
 	// computedSizes tracks the computed sizes of call results.
 	computedSizes map[int64]SizeEstimate
-	checkedExpr   *exprpb.CheckedExpr
+	checkedAST    *ast.CheckedAST
 	estimator     CostEstimator
 	// presenceTestCost will either be a zero or one based on whether has() macros count against cost computations.
 	presenceTestCost CostEstimate
@@ -302,9 +304,9 @@ func PresenceTestHasCost(hasCost bool) CostOption {
 }
 
 // Cost estimates the cost of the parsed and type checked CEL expression.
-func Cost(checker *exprpb.CheckedExpr, estimator CostEstimator, opts ...CostOption) (CostEstimate, error) {
+func Cost(checker *ast.CheckedAST, estimator CostEstimator, opts ...CostOption) (CostEstimate, error) {
 	c := &coster{
-		checkedExpr:      checker,
+		checkedAST:       checker,
 		estimator:        estimator,
 		exprPath:         map[int64][]string{},
 		iterRanges:       map[string][]int64{},
@@ -317,7 +319,7 @@ func Cost(checker *exprpb.CheckedExpr, estimator CostEstimator, opts ...CostOpti
 			return CostEstimate{}, err
 		}
 	}
-	return c.cost(checker.GetExpr()), nil
+	return c.cost(checker.Expr), nil
 }
 
 func (c *coster) cost(e *exprpb.Expr) CostEstimate {
@@ -351,10 +353,10 @@ func (c *coster) costIdent(e *exprpb.Expr) CostEstimate {
 
 	// build and track the field path
 	if iterRange, ok := c.iterRanges.peek(identExpr.GetName()); ok {
-		switch c.checkedExpr.TypeMap[iterRange].GetTypeKind().(type) {
-		case *exprpb.Type_ListType_:
+		switch c.checkedAST.TypeMap[iterRange].Kind {
+		case types.ListKind:
 			c.addPath(e, append(c.exprPath[iterRange], "@items"))
-		case *exprpb.Type_MapType_:
+		case types.MapKind:
 			c.addPath(e, append(c.exprPath[iterRange], "@keys"))
 		}
 	} else {
@@ -378,8 +380,8 @@ func (c *coster) costSelect(e *exprpb.Expr) CostEstimate {
 	}
 	sum = sum.Add(c.cost(sel.GetOperand()))
 	targetType := c.getType(sel.GetOperand())
-	switch kindOf(targetType) {
-	case kindMap, kindObject, kindTypeParam:
+	switch targetType.Kind {
+	case types.MapKind, types.StructKind, types.TypeParamKind:
 		sum = sum.Add(selectAndIdentCost)
 	}
 
@@ -403,8 +405,8 @@ func (c *coster) costCall(e *exprpb.Expr) CostEstimate {
 		argTypes[i] = c.newAstNode(arg)
 	}
 
-	ref := c.checkedExpr.ReferenceMap[e.GetId()]
-	if ref == nil || len(ref.GetOverloadId()) == 0 {
+	ref := c.checkedAST.ReferenceMap[e.GetId()]
+	if ref == nil || len(ref.OverloadIDs) == 0 {
 		return CostEstimate{}
 	}
 	var targetType AstNode
@@ -417,7 +419,7 @@ func (c *coster) costCall(e *exprpb.Expr) CostEstimate {
 	// Pick a cost estimate range that covers all the overload cost estimation ranges
 	fnCost := CostEstimate{Min: uint64(math.MaxUint64), Max: 0}
 	var resultSize *SizeEstimate
-	for _, overload := range ref.GetOverloadId() {
+	for _, overload := range ref.OverloadIDs {
 		overloadCost := c.functionCost(call.GetFunction(), overload, &targetType, argTypes, argCosts)
 		fnCost = fnCost.Union(overloadCost.CostEstimate)
 		if overloadCost.ResultSize != nil {
@@ -621,8 +623,8 @@ func (c *coster) functionCost(function, overloadID string, target *AstNode, args
 	return CallEstimate{CostEstimate: CostEstimate{Min: 1, Max: 1}.Add(argCostSum())}
 }
 
-func (c *coster) getType(e *exprpb.Expr) *exprpb.Type {
-	return c.checkedExpr.TypeMap[e.GetId()]
+func (c *coster) getType(e *exprpb.Expr) *types.Type {
+	return c.checkedAST.TypeMap[e.GetId()]
 }
 
 func (c *coster) getPath(e *exprpb.Expr) []string {
@@ -643,22 +645,20 @@ func (c *coster) newAstNode(e *exprpb.Expr) *astNode {
 	if size, ok := c.computedSizes[e.GetId()]; ok {
 		derivedSize = &size
 	}
-	return &astNode{path: path, t: c.getType(e), expr: e, derivedSize: derivedSize}
+	return &astNode{
+		path:        path,
+		t:           c.getType(e),
+		expr:        e,
+		derivedSize: derivedSize}
 }
 
 // isScalar returns true if the given type is known to be of a constant size at
 // compile time. isScalar will return false for strings (they are variable-width)
 // in addition to protobuf.Any and protobuf.Value (their size is not knowable at compile time).
-func isScalar(t *exprpb.Type) bool {
-	switch kindOf(t) {
-	case kindPrimitive:
-		if t.GetPrimitive() != exprpb.Type_STRING && t.GetPrimitive() != exprpb.Type_BYTES {
-			return true
-		}
-	case kindWellKnown:
-		if t.GetWellKnown() == exprpb.Type_DURATION || t.GetWellKnown() == exprpb.Type_TIMESTAMP {
-			return true
-		}
+func isScalar(t *types.Type) bool {
+	switch t.Kind {
+	case types.BoolKind, types.DoubleKind, types.DurationKind, types.IntKind, types.TimestampKind, types.UintKind:
+		return true
 	}
 	return false
 }

--- a/checker/cost.go
+++ b/checker/cost.go
@@ -353,7 +353,7 @@ func (c *coster) costIdent(e *exprpb.Expr) CostEstimate {
 
 	// build and track the field path
 	if iterRange, ok := c.iterRanges.peek(identExpr.GetName()); ok {
-		switch c.checkedAST.TypeMap[iterRange].Kind {
+		switch c.checkedAST.TypeMap[iterRange].Kind() {
 		case types.ListKind:
 			c.addPath(e, append(c.exprPath[iterRange], "@items"))
 		case types.MapKind:
@@ -380,7 +380,7 @@ func (c *coster) costSelect(e *exprpb.Expr) CostEstimate {
 	}
 	sum = sum.Add(c.cost(sel.GetOperand()))
 	targetType := c.getType(sel.GetOperand())
-	switch targetType.Kind {
+	switch targetType.Kind() {
 	case types.MapKind, types.StructKind, types.TypeParamKind:
 		sum = sum.Add(selectAndIdentCost)
 	}
@@ -656,7 +656,7 @@ func (c *coster) newAstNode(e *exprpb.Expr) *astNode {
 // compile time. isScalar will return false for strings (they are variable-width)
 // in addition to protobuf.Any and protobuf.Value (their size is not knowable at compile time).
 func isScalar(t *types.Type) bool {
-	switch t.Kind {
+	switch t.Kind() {
 	case types.BoolKind, types.DoubleKind, types.DurationKind, types.IntKind, types.TimestampKind, types.UintKind:
 		return true
 	}

--- a/checker/cost_test.go
+++ b/checker/cost_test.go
@@ -18,34 +18,32 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/containers"
+	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/overloads"
 	"github.com/google/cel-go/common/stdlib"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/parser"
 
 	proto3pb "github.com/google/cel-go/test/proto3pb"
-
-	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 func TestCost(t *testing.T) {
-	allTypes := decls.NewObjectType("google.expr.proto3.test.TestAllTypes")
-	allList := decls.NewListType(allTypes)
-	intList := decls.NewListType(decls.Int)
-	nestedList := decls.NewListType(allList)
+	allTypes := types.NewObjectType("google.expr.proto3.test.TestAllTypes")
+	allList := types.NewListType(allTypes)
+	intList := types.NewListType(types.IntType)
+	nestedList := types.NewListType(allList)
 
-	allMap := decls.NewMapType(decls.String, allTypes)
-	nestedMap := decls.NewMapType(decls.String, allMap)
+	allMap := types.NewMapType(types.StringType, allTypes)
+	nestedMap := types.NewMapType(types.StringType, allMap)
 
 	zeroCost := CostEstimate{}
 	oneCost := CostEstimate{Min: 1, Max: 1}
 	cases := []struct {
 		name    string
 		expr    string
-		decls   []*exprpb.Decl
+		vars    []*decls.VariableDecl
 		hints   map[string]int64
 		options []CostOption
 		wanted  CostEstimate
@@ -58,58 +56,59 @@ func TestCost(t *testing.T) {
 		{
 			name:   "identity",
 			expr:   `input`,
-			decls:  []*exprpb.Decl{decls.NewVar("input", intList)},
+			vars:   []*decls.VariableDecl{decls.NewVariable("input", intList)},
 			wanted: CostEstimate{Min: 1, Max: 1},
 		},
 		{
-			name:   "select: map",
-			expr:   `input['key']`,
-			decls:  []*exprpb.Decl{decls.NewVar("input", decls.NewMapType(decls.String, decls.String))},
+			name: "select: map",
+			expr: `input['key']`,
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("input", types.NewMapType(types.StringType, types.StringType))},
 			wanted: CostEstimate{Min: 2, Max: 2},
 		},
 		{
 			name:   "select: field",
 			expr:   `input.single_int32`,
-			decls:  []*exprpb.Decl{decls.NewVar("input", allTypes)},
+			vars:   []*decls.VariableDecl{decls.NewVariable("input", allTypes)},
 			wanted: CostEstimate{Min: 2, Max: 2},
 		},
 		{
 			name:    "select: field test only no has() cost",
 			expr:    `has(input.single_int32)`,
-			decls:   []*exprpb.Decl{decls.NewVar("input", decls.NewObjectType("google.expr.proto3.test.TestAllTypes"))},
+			vars:    []*decls.VariableDecl{decls.NewVariable("input", types.NewObjectType("google.expr.proto3.test.TestAllTypes"))},
 			wanted:  CostEstimate{Min: 1, Max: 1},
 			options: []CostOption{PresenceTestHasCost(false)},
 		},
 		{
 			name:   "select: field test only",
 			expr:   `has(input.single_int32)`,
-			decls:  []*exprpb.Decl{decls.NewVar("input", decls.NewObjectType("google.expr.proto3.test.TestAllTypes"))},
+			vars:   []*decls.VariableDecl{decls.NewVariable("input", types.NewObjectType("google.expr.proto3.test.TestAllTypes"))},
 			wanted: CostEstimate{Min: 2, Max: 2},
 		},
 		{
 			name:    "select: non-proto field test has() cost",
 			expr:    `has(input.testAttr.nestedAttr)`,
-			decls:   []*exprpb.Decl{decls.NewVar("input", nestedMap)},
+			vars:    []*decls.VariableDecl{decls.NewVariable("input", nestedMap)},
 			wanted:  CostEstimate{Min: 3, Max: 3},
 			options: []CostOption{PresenceTestHasCost(true)},
 		},
 		{
 			name:    "select: non-proto field test no has() cost",
 			expr:    `has(input.testAttr.nestedAttr)`,
-			decls:   []*exprpb.Decl{decls.NewVar("input", nestedMap)},
+			vars:    []*decls.VariableDecl{decls.NewVariable("input", nestedMap)},
 			wanted:  CostEstimate{Min: 2, Max: 2},
 			options: []CostOption{PresenceTestHasCost(false)},
 		},
 		{
 			name:   "select: non-proto field test",
 			expr:   `has(input.testAttr.nestedAttr)`,
-			decls:  []*exprpb.Decl{decls.NewVar("input", nestedMap)},
+			vars:   []*decls.VariableDecl{decls.NewVariable("input", nestedMap)},
 			wanted: CostEstimate{Min: 3, Max: 3},
 		},
 		{
 			name:   "estimated function call",
 			expr:   `input.getFullYear()`,
-			decls:  []*exprpb.Decl{decls.NewVar("input", decls.Timestamp)},
+			vars:   []*decls.VariableDecl{decls.NewVariable("input", types.TimestampType)},
 			wanted: CostEstimate{Min: 8, Max: 8},
 		},
 		{
@@ -129,14 +128,14 @@ func TestCost(t *testing.T) {
 		},
 		{
 			name:   "all comprehension",
-			decls:  []*exprpb.Decl{decls.NewVar("input", allList)},
+			vars:   []*decls.VariableDecl{decls.NewVariable("input", allList)},
 			hints:  map[string]int64{"input": 100},
 			expr:   `input.all(x, true)`,
 			wanted: CostEstimate{Min: 2, Max: 302},
 		},
 		{
 			name:   "nested all comprehension",
-			decls:  []*exprpb.Decl{decls.NewVar("input", nestedList)},
+			vars:   []*decls.VariableDecl{decls.NewVariable("input", nestedList)},
 			hints:  map[string]int64{"input": 50, "input.@items": 10},
 			expr:   `input.all(x, x.all(y, true))`,
 			wanted: CostEstimate{Min: 2, Max: 1752},
@@ -148,7 +147,7 @@ func TestCost(t *testing.T) {
 		},
 		{
 			name:   "variable cost function",
-			decls:  []*exprpb.Decl{decls.NewVar("input", decls.String)},
+			vars:   []*decls.VariableDecl{decls.NewVariable("input", types.StringType)},
 			hints:  map[string]int64{"input": 500},
 			expr:   `input.matches('[0-9]')`,
 			wanted: CostEstimate{Min: 3, Max: 103},
@@ -166,11 +165,11 @@ func TestCost(t *testing.T) {
 		{
 			name: "or accumulated branch cost",
 			expr: `a || b || c || d`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("a", decls.Bool),
-				decls.NewVar("b", decls.Bool),
-				decls.NewVar("c", decls.Bool),
-				decls.NewVar("d", decls.Bool),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("a", types.BoolType),
+				decls.NewVariable("b", types.BoolType),
+				decls.NewVariable("c", types.BoolType),
+				decls.NewVariable("d", types.BoolType),
 			},
 			wanted: CostEstimate{Min: 1, Max: 4},
 		},
@@ -182,11 +181,11 @@ func TestCost(t *testing.T) {
 		{
 			name: "and accumulated branch cost",
 			expr: `a && b && c && d`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("a", decls.Bool),
-				decls.NewVar("b", decls.Bool),
-				decls.NewVar("c", decls.Bool),
-				decls.NewVar("d", decls.Bool),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("a", types.BoolType),
+				decls.NewVariable("b", types.BoolType),
+				decls.NewVariable("c", types.BoolType),
+				decls.NewVariable("d", types.BoolType),
 			},
 			wanted: CostEstimate{Min: 1, Max: 4},
 		},
@@ -257,14 +256,14 @@ func TestCost(t *testing.T) {
 		},
 		{
 			name:   "bytes to string conversion",
-			decls:  []*exprpb.Decl{decls.NewVar("input", decls.Bytes)},
+			vars:   []*decls.VariableDecl{decls.NewVariable("input", types.BytesType)},
 			hints:  map[string]int64{"input": 500},
 			expr:   `string(input)`,
 			wanted: CostEstimate{Min: 1, Max: 51},
 		},
 		{
 			name:   "string to bytes conversion",
-			decls:  []*exprpb.Decl{decls.NewVar("input", decls.String)},
+			vars:   []*decls.VariableDecl{decls.NewVariable("input", types.StringType)},
 			hints:  map[string]int64{"input": 500},
 			expr:   `bytes(input)`,
 			wanted: CostEstimate{Min: 1, Max: 51},
@@ -277,9 +276,9 @@ func TestCost(t *testing.T) {
 		{
 			name: "contains",
 			expr: `input.contains(arg1)`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("input", decls.String),
-				decls.NewVar("arg1", decls.String),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("input", types.StringType),
+				decls.NewVariable("arg1", types.StringType),
 			},
 			hints:  map[string]int64{"input": 500, "arg1": 500},
 			wanted: CostEstimate{Min: 2, Max: 2502},
@@ -287,8 +286,8 @@ func TestCost(t *testing.T) {
 		{
 			name: "matches",
 			expr: `input.matches('\\d+a\\d+b')`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("input", decls.String),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("input", types.StringType),
 			},
 			hints:  map[string]int64{"input": 500},
 			wanted: CostEstimate{Min: 3, Max: 103},
@@ -296,9 +295,9 @@ func TestCost(t *testing.T) {
 		{
 			name: "startsWith",
 			expr: `input.startsWith(arg1)`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("input", decls.String),
-				decls.NewVar("arg1", decls.String),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("input", types.StringType),
+				decls.NewVariable("arg1", types.StringType),
 			},
 			hints:  map[string]int64{"arg1": 500},
 			wanted: CostEstimate{Min: 2, Max: 52},
@@ -306,9 +305,9 @@ func TestCost(t *testing.T) {
 		{
 			name: "endsWith",
 			expr: `input.endsWith(arg1)`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("input", decls.String),
-				decls.NewVar("arg1", decls.String),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("input", types.StringType),
+				decls.NewVariable("arg1", types.StringType),
 			},
 			hints:  map[string]int64{"arg1": 500},
 			wanted: CostEstimate{Min: 2, Max: 52},
@@ -316,26 +315,26 @@ func TestCost(t *testing.T) {
 		{
 			name: "size receiver",
 			expr: `input.size()`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("input", decls.String),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("input", types.StringType),
 			},
 			wanted: CostEstimate{Min: 2, Max: 2},
 		},
 		{
 			name: "size",
 			expr: `size(input)`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("input", decls.String),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("input", types.StringType),
 			},
 			wanted: CostEstimate{Min: 2, Max: 2},
 		},
 		{
 			name: "ternary eval",
 			expr: `(x > 2 ? input1 : input2).all(y, true)`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("x", decls.Int),
-				decls.NewVar("input1", allList),
-				decls.NewVar("input2", allList),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("x", types.IntType),
+				decls.NewVariable("input1", allList),
+				decls.NewVariable("input2", allList),
 			},
 			hints:  map[string]int64{"input1": 1, "input2": 1},
 			wanted: CostEstimate{Min: 4, Max: 7},
@@ -343,8 +342,8 @@ func TestCost(t *testing.T) {
 		{
 			name: "comprehension over map",
 			expr: `input.all(k, input[k].single_int32 > 3)`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("input", allMap),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("input", allMap),
 			},
 			hints:  map[string]int64{"input": 10},
 			wanted: CostEstimate{Min: 2, Max: 82},
@@ -352,8 +351,8 @@ func TestCost(t *testing.T) {
 		{
 			name: "comprehension over nested map of maps",
 			expr: `input.all(k, input[k].all(x, true))`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("input", nestedMap),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("input", nestedMap),
 			},
 			hints:  map[string]int64{"input": 5, "input.@values": 10},
 			wanted: CostEstimate{Min: 2, Max: 187},
@@ -361,8 +360,8 @@ func TestCost(t *testing.T) {
 		{
 			name: "string size of map keys",
 			expr: `input.all(k, k.contains(k))`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("input", nestedMap),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("input", nestedMap),
 			},
 			hints:  map[string]int64{"input": 5, "input.@keys": 10},
 			wanted: CostEstimate{Min: 2, Max: 32},
@@ -370,8 +369,8 @@ func TestCost(t *testing.T) {
 		{
 			name: "comprehension variable shadowing",
 			expr: `input.all(k, input[k].all(k, true) && k.contains(k))`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("input", nestedMap),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("input", nestedMap),
 			},
 			hints:  map[string]int64{"input": 2, "input.@values": 2, "input.@keys": 5},
 			wanted: CostEstimate{Min: 2, Max: 34},
@@ -379,8 +378,8 @@ func TestCost(t *testing.T) {
 		{
 			name: "comprehension variable shadowing",
 			expr: `input.all(k, input[k].all(k, true) && k.contains(k))`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("input", nestedMap),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("input", nestedMap),
 			},
 			hints:  map[string]int64{"input": 2, "input.@values": 2, "input.@keys": 5},
 			wanted: CostEstimate{Min: 2, Max: 34},
@@ -388,9 +387,9 @@ func TestCost(t *testing.T) {
 		{
 			name: "list concat",
 			expr: `(list1 + list2).all(x, true)`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("list1", decls.NewListType(decls.Int)),
-				decls.NewVar("list2", decls.NewListType(decls.Int)),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("list1", types.NewListType(types.IntType)),
+				decls.NewVariable("list2", types.NewListType(types.IntType)),
 			},
 			hints:  map[string]int64{"list1": 10, "list2": 10},
 			wanted: CostEstimate{Min: 4, Max: 64},
@@ -398,9 +397,9 @@ func TestCost(t *testing.T) {
 		{
 			name: "str concat",
 			expr: `"abcdefg".contains(str1 + str2)`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("str1", decls.String),
-				decls.NewVar("str2", decls.String),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("str1", types.StringType),
+				decls.NewVariable("str2", types.StringType),
 			},
 			hints:  map[string]int64{"str1": 10, "str2": 10},
 			wanted: CostEstimate{Min: 2, Max: 6},
@@ -408,29 +407,29 @@ func TestCost(t *testing.T) {
 		{
 			name: "list size comparison",
 			expr: `list1.size() == list2.size()`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("list1", decls.NewListType(decls.Int)),
-				decls.NewVar("list2", decls.NewListType(decls.Int)),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("list1", types.NewListType(types.IntType)),
+				decls.NewVariable("list2", types.NewListType(types.IntType)),
 			},
 			wanted: CostEstimate{Min: 5, Max: 5},
 		},
 		{
 			name: "list size from ternary",
 			expr: `x > y ? list1.size() : list2.size()`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("x", decls.Int),
-				decls.NewVar("y", decls.Int),
-				decls.NewVar("list1", decls.NewListType(decls.Int)),
-				decls.NewVar("list2", decls.NewListType(decls.Int)),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("x", types.IntType),
+				decls.NewVariable("y", types.IntType),
+				decls.NewVariable("list1", types.NewListType(types.IntType)),
+				decls.NewVariable("list2", types.NewListType(types.IntType)),
 			},
 			wanted: CostEstimate{Min: 5, Max: 5},
 		},
 		{
 			name: "str endsWith equality",
 			expr: `str1.endsWith("abcdefghijklmnopqrstuvwxyz") == str2.endsWith("abcdefghijklmnopqrstuvwxyz")`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("str1", decls.String),
-				decls.NewVar("str2", decls.String),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("str1", types.StringType),
+				decls.NewVariable("str2", types.StringType),
 			},
 			wanted: CostEstimate{Min: 9, Max: 9},
 		},
@@ -442,27 +441,27 @@ func TestCost(t *testing.T) {
 		{
 			name: "str size estimate",
 			expr: `string(timestamp1) == string(timestamp2)`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("timestamp1", decls.Timestamp),
-				decls.NewVar("timestamp2", decls.Timestamp),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("timestamp1", types.TimestampType),
+				decls.NewVariable("timestamp2", types.TimestampType),
 			},
 			wanted: CostEstimate{Min: 5, Max: 1844674407370955268},
 		},
 		{
 			name: "timestamp equality check",
 			expr: `timestamp1 == timestamp2`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("timestamp1", decls.Timestamp),
-				decls.NewVar("timestamp2", decls.Timestamp),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("timestamp1", types.TimestampType),
+				decls.NewVariable("timestamp2", types.TimestampType),
 			},
 			wanted: CostEstimate{Min: 3, Max: 3},
 		},
 		{
 			name: "duration inequality check",
 			expr: `duration1 != duration2`,
-			decls: []*exprpb.Decl{
-				decls.NewVar("duration1", decls.Duration),
-				decls.NewVar("duration2", decls.Duration),
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("duration1", types.DurationType),
+				decls.NewVariable("duration2", types.DurationType),
 			},
 			wanted: CostEstimate{Min: 3, Max: 3},
 		},
@@ -491,11 +490,11 @@ func TestCost(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewEnv() failed: %v", err)
 			}
-			err = e.Add(stdlib.FunctionExprDecls()...)
+			err = e.AddFunctions(stdlib.Functions()...)
 			if err != nil {
 				t.Fatalf("environment creation error: %v", err)
 			}
-			err = e.Add(tc.decls...)
+			err = e.AddIdents(tc.vars...)
 			if err != nil {
 				t.Fatalf("environment creation error: %s\n", err)
 			}

--- a/checker/env.go
+++ b/checker/env.go
@@ -202,12 +202,12 @@ func (e *Env) setFunction(fn *decls.FunctionDecl) []errorMsg {
 // addIdent adds the Decl to the declarations in the Env.
 // Returns a non-empty errorMsg if the identifier is already declared in the scope.
 func (e *Env) addIdent(decl *decls.VariableDecl) errorMsg {
-	current := e.declarations.FindIdentInScope(decl.Name)
+	current := e.declarations.FindIdentInScope(decl.Name())
 	if current != nil {
 		if current.DeclarationIsEquivalent(decl) {
 			return ""
 		}
-		return overlappingIdentifierError(decl.Name)
+		return overlappingIdentifierError(decl.Name())
 	}
 	e.declarations.AddIdent(decl)
 	return ""

--- a/checker/env.go
+++ b/checker/env.go
@@ -18,17 +18,12 @@ import (
 	"fmt"
 	"strings"
 
-	"google.golang.org/protobuf/proto"
-
-	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/containers"
+	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/overloads"
 	"github.com/google/cel-go/common/types"
-	"github.com/google/cel-go/common/types/pb"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/parser"
-
-	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 type aggregateLiteralElementType int
@@ -113,24 +108,25 @@ func NewEnv(container *containers.Container, provider ref.TypeProvider, opts ...
 	}, nil
 }
 
-// Add adds new Decl protos to the Env.
-// Returns an error for identifier redeclarations.
-func (e *Env) Add(decls ...*exprpb.Decl) error {
+func (e *Env) AddIdents(declarations ...*decls.VariableDecl) error {
 	errMsgs := make([]errorMsg, 0)
-	for _, decl := range decls {
-		switch decl.DeclKind.(type) {
-		case *exprpb.Decl_Ident:
-			errMsgs = append(errMsgs, e.addIdent(sanitizeIdent(decl)))
-		case *exprpb.Decl_Function:
-			errMsgs = append(errMsgs, e.setFunction(sanitizeFunction(decl))...)
-		}
+	for _, d := range declarations {
+		errMsgs = append(errMsgs, e.addIdent(d))
+	}
+	return formatError(errMsgs)
+}
+
+func (e *Env) AddFunctions(declarations ...*decls.FunctionDecl) error {
+	errMsgs := make([]errorMsg, 0)
+	for _, d := range declarations {
+		errMsgs = append(errMsgs, e.setFunction(d)...)
 	}
 	return formatError(errMsgs)
 }
 
 // LookupIdent returns a Decl proto for typeName as an identifier in the Env.
 // Returns nil if no such identifier is found in the Env.
-func (e *Env) LookupIdent(name string) *exprpb.Decl {
+func (e *Env) LookupIdent(name string) *decls.VariableDecl {
 	for _, candidate := range e.container.ResolveCandidateNames(name) {
 		if ident := e.declarations.FindIdent(candidate); ident != nil {
 			return ident
@@ -140,7 +136,12 @@ func (e *Env) LookupIdent(name string) *exprpb.Decl {
 		// the declaration is added to the outest (global) scope of the
 		// environment, so next time we can access it faster.
 		if t, found := e.provider.FindType(candidate); found {
-			decl := decls.NewVar(candidate, t)
+			dt, err := types.ExprTypeToType(t)
+			// The error case would just be handled as a missing field declaration.
+			if err != nil {
+				return nil
+			}
+			decl := decls.NewVariable(candidate, dt)
 			e.declarations.AddIdent(decl)
 			return decl
 		}
@@ -148,11 +149,7 @@ func (e *Env) LookupIdent(name string) *exprpb.Decl {
 		// Next try to import this as an enum value by splitting the name in a type prefix and
 		// the enum inside.
 		if enumValue := e.provider.EnumValue(candidate); enumValue.Type() != types.ErrType {
-			decl := decls.NewIdent(candidate,
-				decls.Int,
-				&exprpb.Constant{
-					ConstantKind: &exprpb.Constant_Int64Value{
-						Int64Value: int64(enumValue.(types.Int))}})
+			decl := decls.NewConstant(candidate, types.IntType, enumValue)
 			e.declarations.AddIdent(decl)
 			return decl
 		}
@@ -162,7 +159,7 @@ func (e *Env) LookupIdent(name string) *exprpb.Decl {
 
 // LookupFunction returns a Decl proto for typeName as a function in env.
 // Returns nil if no such function is found in env.
-func (e *Env) LookupFunction(name string) *exprpb.Decl {
+func (e *Env) LookupFunction(name string) *decls.FunctionDecl {
 	for _, candidate := range e.container.ResolveCandidateNames(name) {
 		if fn := e.declarations.FindFunction(candidate); fn != nil {
 			return fn
@@ -171,85 +168,43 @@ func (e *Env) LookupFunction(name string) *exprpb.Decl {
 	return nil
 }
 
-// addOverload adds overload to function declaration f.
-// Returns one or more errorMsg values if the overload overlaps with an existing overload or macro.
-func (e *Env) addOverload(f *exprpb.Decl, overload *exprpb.Decl_FunctionDecl_Overload) []errorMsg {
-	errMsgs := make([]errorMsg, 0)
-	function := f.GetFunction()
-	emptyMappings := newMapping()
-	overloadFunction := decls.NewFunctionType(overload.GetResultType(),
-		overload.GetParams()...)
-	overloadErased := substitute(emptyMappings, overloadFunction, true)
-	for _, existing := range function.GetOverloads() {
-		existingFunction := decls.NewFunctionType(existing.GetResultType(), existing.GetParams()...)
-		existingErased := substitute(emptyMappings, existingFunction, true)
-		overlap := isAssignable(emptyMappings, overloadErased, existingErased) != nil ||
-			isAssignable(emptyMappings, existingErased, overloadErased) != nil
-		if overlap &&
-			overload.GetIsInstanceFunction() == existing.GetIsInstanceFunction() {
-			errMsgs = append(errMsgs,
-				overlappingOverloadError(f.Name,
-					overload.GetOverloadId(), overloadFunction,
-					existing.GetOverloadId(), existingFunction))
-		}
-	}
-
-	for _, macro := range parser.AllMacros {
-		if macro.Function() == f.Name &&
-			macro.IsReceiverStyle() == overload.GetIsInstanceFunction() &&
-			macro.ArgCount() == len(overload.GetParams()) {
-			errMsgs = append(errMsgs, overlappingMacroError(f.Name, macro.ArgCount()))
-		}
-	}
-	if len(errMsgs) > 0 {
-		return errMsgs
-	}
-	function.Overloads = append(function.GetOverloads(), overload)
-	return errMsgs
-}
-
 // setFunction adds the function Decl to the Env.
 // Adds a function decl if one doesn't already exist, then adds all overloads from the Decl.
 // If overload overlaps with an existing overload, adds to the errors  in the Env instead.
-func (e *Env) setFunction(decl *exprpb.Decl) []errorMsg {
-	errorMsgs := make([]errorMsg, 0)
-	overloads := decl.GetFunction().GetOverloads()
-	current := e.declarations.FindFunction(decl.Name)
-	if current == nil {
-		//Add the function declaration without overloads and check the overloads below.
-		current = decls.NewFunction(decl.Name)
-	} else {
-		existingOverloads := map[string]*exprpb.Decl_FunctionDecl_Overload{}
-		for _, overload := range current.GetFunction().GetOverloads() {
-			existingOverloads[overload.GetOverloadId()] = overload
+func (e *Env) setFunction(fn *decls.FunctionDecl) []errorMsg {
+	errMsgs := make([]errorMsg, 0)
+	current := e.declarations.FindFunction(fn.Name)
+	if current != nil {
+		var err error
+		current, err = current.Merge(fn)
+		if err != nil {
+			return append(errMsgs, errorMsg(err.Error()))
 		}
-		newOverloads := []*exprpb.Decl_FunctionDecl_Overload{}
-		for _, overload := range overloads {
-			existing, found := existingOverloads[overload.GetOverloadId()]
-			if !found || !overloadsEqual(existing, overload) {
-				newOverloads = append(newOverloads, overload)
+	} else {
+		current = fn
+	}
+	for _, overload := range current.OverloadDecls() {
+		for _, macro := range parser.AllMacros {
+			if macro.Function() == current.Name &&
+				macro.IsReceiverStyle() == overload.IsMemberFunction &&
+				macro.ArgCount() == len(overload.ArgTypes) {
+				errMsgs = append(errMsgs, overlappingMacroError(current.Name, macro.ArgCount()))
 			}
 		}
-		overloads = newOverloads
-		if len(newOverloads) == 0 {
-			return errorMsgs
+		if len(errMsgs) > 0 {
+			return errMsgs
 		}
-		// Copy on write since we don't know where this original definition came from.
-		current = proto.Clone(current).(*exprpb.Decl)
 	}
 	e.declarations.SetFunction(current)
-	for _, overload := range overloads {
-		errorMsgs = append(errorMsgs, e.addOverload(current, overload)...)
-	}
-	return errorMsgs
+	return errMsgs
 }
 
 // addIdent adds the Decl to the declarations in the Env.
 // Returns a non-empty errorMsg if the identifier is already declared in the scope.
-func (e *Env) addIdent(decl *exprpb.Decl) errorMsg {
+func (e *Env) addIdent(decl *decls.VariableDecl) errorMsg {
 	current := e.declarations.FindIdentInScope(decl.Name)
 	if current != nil {
-		if proto.Equal(current, decl) {
+		if current.DeclarationIsEquivalent(decl) {
 			return ""
 		}
 		return overlappingIdentifierError(decl.Name)
@@ -262,108 +217,6 @@ func (e *Env) addIdent(decl *exprpb.Decl) errorMsg {
 func (e *Env) isOverloadDisabled(overloadID string) bool {
 	_, found := e.filteredOverloadIDs[overloadID]
 	return found
-}
-
-// overloadsEqual returns whether two overloads have identical signatures.
-//
-// type parameter names are ignored as they may be specified in any order and have no bearing on overload
-// equivalence
-func overloadsEqual(o1, o2 *exprpb.Decl_FunctionDecl_Overload) bool {
-	return o1.GetOverloadId() == o2.GetOverloadId() &&
-		o1.GetIsInstanceFunction() == o2.GetIsInstanceFunction() &&
-		paramsEqual(o1.GetParams(), o2.GetParams()) &&
-		proto.Equal(o1.GetResultType(), o2.GetResultType())
-}
-
-// paramsEqual returns whether two lists have equal length and all types are equal
-func paramsEqual(p1, p2 []*exprpb.Type) bool {
-	if len(p1) != len(p2) {
-		return false
-	}
-	for i, a := range p1 {
-		b := p2[i]
-		if !proto.Equal(a, b) {
-			return false
-		}
-	}
-	return true
-}
-
-// sanitizeFunction replaces well-known types referenced by message name with their equivalent
-// CEL built-in type instances.
-func sanitizeFunction(decl *exprpb.Decl) *exprpb.Decl {
-	fn := decl.GetFunction()
-	// Determine whether the declaration requires replacements from proto-based message type
-	// references to well-known CEL type references.
-	var needsSanitizing bool
-	for _, o := range fn.GetOverloads() {
-		if isObjectWellKnownType(o.GetResultType()) {
-			needsSanitizing = true
-			break
-		}
-		for _, p := range o.GetParams() {
-			if isObjectWellKnownType(p) {
-				needsSanitizing = true
-				break
-			}
-		}
-	}
-
-	// Early return if the declaration requires no modification.
-	if !needsSanitizing {
-		return decl
-	}
-
-	// Sanitize all of the overloads if any overload requires an update to its type references.
-	overloads := make([]*exprpb.Decl_FunctionDecl_Overload, len(fn.GetOverloads()))
-	for i, o := range fn.GetOverloads() {
-		rt := o.GetResultType()
-		if isObjectWellKnownType(rt) {
-			rt = getObjectWellKnownType(rt)
-		}
-		params := make([]*exprpb.Type, len(o.GetParams()))
-		copy(params, o.GetParams())
-		for j, p := range params {
-			if isObjectWellKnownType(p) {
-				params[j] = getObjectWellKnownType(p)
-			}
-		}
-		// If sanitized, replace the overload definition.
-		if o.IsInstanceFunction {
-			overloads[i] =
-				decls.NewInstanceOverload(o.GetOverloadId(), params, rt)
-		} else {
-			overloads[i] =
-				decls.NewOverload(o.GetOverloadId(), params, rt)
-		}
-	}
-	return decls.NewFunction(decl.GetName(), overloads...)
-}
-
-// sanitizeIdent replaces the identifier's well-known types referenced by message name with
-// references to CEL built-in type instances.
-func sanitizeIdent(decl *exprpb.Decl) *exprpb.Decl {
-	id := decl.GetIdent()
-	t := id.GetType()
-	if !isObjectWellKnownType(t) {
-		return decl
-	}
-	return decls.NewIdent(decl.GetName(), getObjectWellKnownType(t), id.GetValue())
-}
-
-// isObjectWellKnownType returns true if the input type is an OBJECT type with a message name
-// that corresponds the message name of a built-in CEL type.
-func isObjectWellKnownType(t *exprpb.Type) bool {
-	if kindOf(t) != kindObject {
-		return false
-	}
-	_, found := pb.CheckedWellKnowns[t.GetMessageType()]
-	return found
-}
-
-// getObjectWellKnownType returns the built-in CEL type declaration for input type's message name.
-func getObjectWellKnownType(t *exprpb.Type) *exprpb.Type {
-	return pb.CheckedWellKnowns[t.GetMessageType()]
 }
 
 // validatedDeclarations returns a reference to the validated variable and function declaration scope stack.
@@ -400,19 +253,6 @@ type errorMsg string
 
 func overlappingIdentifierError(name string) errorMsg {
 	return errorMsg(fmt.Sprintf("overlapping identifier for name '%s'", name))
-}
-
-func overlappingOverloadError(name string,
-	overloadID1 string, f1 *exprpb.Type,
-	overloadID2 string, f2 *exprpb.Type) errorMsg {
-	return errorMsg(fmt.Sprintf(
-		"overlapping overload for name '%s' (type '%s' with overloadId: '%s' "+
-			"cannot be distinguished from '%s' with overloadId: '%s')",
-		name,
-		FormatCheckedType(f1),
-		overloadID1,
-		FormatCheckedType(f2),
-		overloadID2))
 }
 
 func overlappingMacroError(name string, argCount int) errorMsg {

--- a/checker/env.go
+++ b/checker/env.go
@@ -173,7 +173,7 @@ func (e *Env) LookupFunction(name string) *decls.FunctionDecl {
 // If overload overlaps with an existing overload, adds to the errors  in the Env instead.
 func (e *Env) setFunction(fn *decls.FunctionDecl) []errorMsg {
 	errMsgs := make([]errorMsg, 0)
-	current := e.declarations.FindFunction(fn.Name)
+	current := e.declarations.FindFunction(fn.Name())
 	if current != nil {
 		var err error
 		current, err = current.Merge(fn)
@@ -185,10 +185,10 @@ func (e *Env) setFunction(fn *decls.FunctionDecl) []errorMsg {
 	}
 	for _, overload := range current.OverloadDecls() {
 		for _, macro := range parser.AllMacros {
-			if macro.Function() == current.Name &&
-				macro.IsReceiverStyle() == overload.IsMemberFunction &&
-				macro.ArgCount() == len(overload.ArgTypes) {
-				errMsgs = append(errMsgs, overlappingMacroError(current.Name, macro.ArgCount()))
+			if macro.Function() == current.Name() &&
+				macro.IsReceiverStyle() == overload.IsMemberFunction() &&
+				macro.ArgCount() == len(overload.ArgTypes()) {
+				errMsgs = append(errMsgs, overlappingMacroError(current.Name(), macro.ArgCount()))
 			}
 		}
 		if len(errMsgs) > 0 {

--- a/checker/format.go
+++ b/checker/format.go
@@ -1,0 +1,214 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checker
+
+import (
+	"fmt"
+	"strings"
+
+	chkdecls "github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/types"
+
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+const (
+	kindUnknown = iota + 1
+	kindError
+	kindFunction
+	kindDyn
+	kindPrimitive
+	kindWellKnown
+	kindWrapper
+	kindNull
+	kindAbstract
+	kindType
+	kindList
+	kindMap
+	kindObject
+	kindTypeParam
+)
+
+// FormatCheckedType converts a type message into a string representation.
+func FormatCheckedType(t *exprpb.Type) string {
+	switch kindOf(t) {
+	case kindDyn:
+		return "dyn"
+	case kindFunction:
+		return formatFunctionExprType(t.GetFunction().GetResultType(),
+			t.GetFunction().GetArgTypes(),
+			false)
+	case kindList:
+		return fmt.Sprintf("list(%s)", FormatCheckedType(t.GetListType().GetElemType()))
+	case kindObject:
+		return t.GetMessageType()
+	case kindMap:
+		return fmt.Sprintf("map(%s, %s)",
+			FormatCheckedType(t.GetMapType().GetKeyType()),
+			FormatCheckedType(t.GetMapType().GetValueType()))
+	case kindNull:
+		return "null"
+	case kindPrimitive:
+		switch t.GetPrimitive() {
+		case exprpb.Type_UINT64:
+			return "uint"
+		case exprpb.Type_INT64:
+			return "int"
+		}
+		return strings.Trim(strings.ToLower(t.GetPrimitive().String()), " ")
+	case kindType:
+		if t.GetType() == nil || t.GetType().GetTypeKind() == nil {
+			return "type"
+		}
+		return fmt.Sprintf("type(%s)", FormatCheckedType(t.GetType()))
+	case kindWellKnown:
+		switch t.GetWellKnown() {
+		case exprpb.Type_ANY:
+			return "any"
+		case exprpb.Type_DURATION:
+			return "duration"
+		case exprpb.Type_TIMESTAMP:
+			return "timestamp"
+		}
+	case kindWrapper:
+		return fmt.Sprintf("wrapper(%s)",
+			FormatCheckedType(chkdecls.NewPrimitiveType(t.GetWrapper())))
+	case kindError:
+		return "!error!"
+	case kindTypeParam:
+		return t.GetTypeParam()
+	case kindAbstract:
+		at := t.GetAbstractType()
+		params := at.GetParameterTypes()
+		paramStrs := make([]string, len(params))
+		for i, p := range params {
+			paramStrs[i] = FormatCheckedType(p)
+		}
+		return fmt.Sprintf("%s(%s)", at.GetName(), strings.Join(paramStrs, ", "))
+	}
+	return t.String()
+}
+
+type formatter func(any) string
+
+func formatCelType(t any) string {
+	dt := t.(*types.Type)
+	if dt == nil {
+		return ""
+	}
+	switch dt.Kind {
+	case types.AnyKind:
+		return "any"
+	case types.DurationKind:
+		return "duration"
+	case types.ErrorKind:
+		return "!error!"
+	case types.NullTypeKind:
+		return "null"
+	case types.TimestampKind:
+		return "timestamp"
+	case types.TypeParamKind:
+		return dt.TypeName()
+	case types.OpaqueKind:
+		if dt.TypeName() == "function" {
+			// There is no explicit function type in the new types representation, so information like
+			// whether the function is a member function is absent.
+			return formatFunctionDeclType(dt.Parameters[0], dt.Parameters[1:], false)
+		}
+	}
+	if len(dt.Parameters) == 0 {
+		return dt.DeclaredTypeName()
+	}
+	paramTypeNames := make([]string, 0, len(dt.Parameters))
+	for _, p := range dt.Parameters {
+		paramTypeNames = append(paramTypeNames, formatCelType(p))
+	}
+	return fmt.Sprintf("%s(%s)", dt.TypeName(), strings.Join(paramTypeNames, ", "))
+}
+
+func formatExprType(t any) string {
+	if t == nil {
+		return ""
+	}
+	return FormatCheckedType(t.(*exprpb.Type))
+}
+
+func formatFunctionExprType(resultType *exprpb.Type, argTypes []*exprpb.Type, isInstance bool) string {
+	return formatFunctionInternal[*exprpb.Type](resultType, argTypes, isInstance, formatExprType)
+}
+
+func formatFunctionDeclType(resultType *types.Type, argTypes []*types.Type, isInstance bool) string {
+	return formatFunctionInternal[*types.Type](resultType, argTypes, isInstance, formatCelType)
+}
+
+func formatFunctionInternal[T any](resultType T, argTypes []T, isInstance bool, format formatter) string {
+	result := ""
+	if isInstance {
+		target := argTypes[0]
+		argTypes = argTypes[1:]
+		result += format(target)
+		result += "."
+	}
+	result += "("
+	for i, arg := range argTypes {
+		if i > 0 {
+			result += ", "
+		}
+		result += format(arg)
+	}
+	result += ")"
+	rt := format(resultType)
+	if rt != "" {
+		result += " -> "
+		result += rt
+	}
+	return result
+}
+
+// kindOf returns the kind of the type as defined in the checked.proto.
+func kindOf(t *exprpb.Type) int {
+	if t == nil || t.TypeKind == nil {
+		return kindUnknown
+	}
+	switch t.GetTypeKind().(type) {
+	case *exprpb.Type_Error:
+		return kindError
+	case *exprpb.Type_Function:
+		return kindFunction
+	case *exprpb.Type_Dyn:
+		return kindDyn
+	case *exprpb.Type_Primitive:
+		return kindPrimitive
+	case *exprpb.Type_WellKnown:
+		return kindWellKnown
+	case *exprpb.Type_Wrapper:
+		return kindWrapper
+	case *exprpb.Type_Null:
+		return kindNull
+	case *exprpb.Type_Type:
+		return kindType
+	case *exprpb.Type_ListType_:
+		return kindList
+	case *exprpb.Type_MapType_:
+		return kindMap
+	case *exprpb.Type_MessageType:
+		return kindObject
+	case *exprpb.Type_TypeParam:
+		return kindTypeParam
+	case *exprpb.Type_AbstractType_:
+		return kindAbstract
+	}
+	return kindUnknown
+}

--- a/checker/format.go
+++ b/checker/format.go
@@ -105,10 +105,7 @@ type formatter func(any) string
 
 func formatCelType(t any) string {
 	dt := t.(*types.Type)
-	if dt == nil {
-		return ""
-	}
-	switch dt.Kind {
+	switch dt.Kind() {
 	case types.AnyKind:
 		return "any"
 	case types.DurationKind:
@@ -125,14 +122,16 @@ func formatCelType(t any) string {
 		if dt.TypeName() == "function" {
 			// There is no explicit function type in the new types representation, so information like
 			// whether the function is a member function is absent.
-			return formatFunctionDeclType(dt.Parameters[0], dt.Parameters[1:], false)
+			return formatFunctionDeclType(dt.Parameters()[0], dt.Parameters()[1:], false)
 		}
+	case types.UnspecifiedKind:
+		return ""
 	}
-	if len(dt.Parameters) == 0 {
+	if len(dt.Parameters()) == 0 {
 		return dt.DeclaredTypeName()
 	}
-	paramTypeNames := make([]string, 0, len(dt.Parameters))
-	for _, p := range dt.Parameters {
+	paramTypeNames := make([]string, 0, len(dt.Parameters()))
+	for _, p := range dt.Parameters() {
 		paramTypeNames = append(paramTypeNames, formatCelType(p))
 	}
 	return fmt.Sprintf("%s(%s)", dt.TypeName(), strings.Join(paramTypeNames, ", "))

--- a/checker/format_test.go
+++ b/checker/format_test.go
@@ -1,0 +1,70 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checker
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/types"
+)
+
+func TestFormatType(t *testing.T) {
+	tests := []*types.Type{
+		types.AnyType,
+		types.BoolType,
+		types.BytesType,
+		types.DoubleType,
+		types.DurationType,
+		types.DynType,
+		types.ErrorType,
+		types.IntType,
+		types.NewListType(types.StringType),
+		types.NewMapType(types.IntType, types.DynType),
+		types.NewObjectType("dev.cel.Expr"),
+		types.NewOptionalType(types.BoolType),
+		types.NewNullableType(types.IntType),
+		types.NewTypeParamType("T"),
+		types.NewTypeTypeWithParam(types.NewListType(types.IntType)),
+		types.NullType,
+		types.StringType,
+		types.TimestampType,
+		types.TypeType,
+		types.UintType,
+	}
+	for _, tst := range tests {
+		tc := tst
+		t.Run(tc.DeclaredTypeName(), func(t *testing.T) {
+			exprType, err := types.TypeToExprType(tc)
+			if err != nil {
+				t.Fatalf("types.TypeToExprType(%v) failed: %v", tc, err)
+			}
+			if formatCelType(tc) != FormatCheckedType(exprType) {
+				t.Errorf("formatCelType(%v) not equal to FormatCheckedType(%v), got %s, wanted %s",
+					tc, exprType, formatCelType(tc), FormatCheckedType(exprType))
+			}
+		})
+	}
+}
+
+func TestFormatFunctionType(t *testing.T) {
+	// native type representation of function(string, int) -> bool
+	ct := formatCelType(newFunctionType(types.BoolType, types.StringType, types.IntType))
+	// protobuf-based function type
+	et := FormatCheckedType(decls.NewFunctionType(decls.Bool, decls.String, decls.Int))
+	if ct != et {
+		t.Errorf("formatCelType() not equal to FormatCheckedType(), got %s, wanted %s", ct, et)
+	}
+}

--- a/checker/mapping.go
+++ b/checker/mapping.go
@@ -15,25 +15,25 @@
 package checker
 
 import (
-	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	"github.com/google/cel-go/common/types"
 )
 
 type mapping struct {
-	mapping map[string]*exprpb.Type
+	mapping map[string]*types.Type
 }
 
 func newMapping() *mapping {
 	return &mapping{
-		mapping: make(map[string]*exprpb.Type),
+		mapping: make(map[string]*types.Type),
 	}
 }
 
-func (m *mapping) add(from *exprpb.Type, to *exprpb.Type) {
-	m.mapping[typeKey(from)] = to
+func (m *mapping) add(from, to *types.Type) {
+	m.mapping[formatCelType(from)] = to
 }
 
-func (m *mapping) find(from *exprpb.Type) (*exprpb.Type, bool) {
-	if r, found := m.mapping[typeKey(from)]; found {
+func (m *mapping) find(from *types.Type) (*types.Type, bool) {
+	if r, found := m.mapping[formatCelType(from)]; found {
 		return r, found
 	}
 	return nil, false

--- a/checker/scopes.go
+++ b/checker/scopes.go
@@ -69,7 +69,7 @@ func (s *Scopes) Pop() *Scopes {
 // AddIdent adds the ident Decl in the current scope.
 // Note: If the name collides with an existing identifier in the scope, the Decl is overwritten.
 func (s *Scopes) AddIdent(decl *decls.VariableDecl) {
-	s.scopes.idents[decl.Name] = decl
+	s.scopes.idents[decl.Name()] = decl
 }
 
 // FindIdent finds the first ident Decl with a matching name in Scopes, or nil if one cannot be

--- a/checker/scopes.go
+++ b/checker/scopes.go
@@ -98,7 +98,7 @@ func (s *Scopes) FindIdentInScope(name string) *decls.VariableDecl {
 // SetFunction adds the function Decl to the current scope.
 // Note: Any previous entry for a function in the current scope with the same name is overwritten.
 func (s *Scopes) SetFunction(fn *decls.FunctionDecl) {
-	s.scopes.functions[fn.Name] = fn
+	s.scopes.functions[fn.Name()] = fn
 }
 
 // FindFunction finds the first function Decl with a matching name in Scopes.

--- a/checker/scopes.go
+++ b/checker/scopes.go
@@ -14,7 +14,9 @@
 
 package checker
 
-import exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+import (
+	"github.com/google/cel-go/common/decls"
+)
 
 // Scopes represents nested Decl sets where the Scopes value contains a Groups containing all
 // identifiers in scope and an optional parent representing outer scopes.
@@ -66,14 +68,14 @@ func (s *Scopes) Pop() *Scopes {
 
 // AddIdent adds the ident Decl in the current scope.
 // Note: If the name collides with an existing identifier in the scope, the Decl is overwritten.
-func (s *Scopes) AddIdent(decl *exprpb.Decl) {
+func (s *Scopes) AddIdent(decl *decls.VariableDecl) {
 	s.scopes.idents[decl.Name] = decl
 }
 
 // FindIdent finds the first ident Decl with a matching name in Scopes, or nil if one cannot be
 // found.
 // Note: The search is performed from innermost to outermost.
-func (s *Scopes) FindIdent(name string) *exprpb.Decl {
+func (s *Scopes) FindIdent(name string) *decls.VariableDecl {
 	if ident, found := s.scopes.idents[name]; found {
 		return ident
 	}
@@ -86,7 +88,7 @@ func (s *Scopes) FindIdent(name string) *exprpb.Decl {
 // FindIdentInScope finds the first ident Decl with a matching name in the current Scopes value, or
 // nil if one does not exist.
 // Note: The search is only performed on the current scope and does not search outer scopes.
-func (s *Scopes) FindIdentInScope(name string) *exprpb.Decl {
+func (s *Scopes) FindIdentInScope(name string) *decls.VariableDecl {
 	if ident, found := s.scopes.idents[name]; found {
 		return ident
 	}
@@ -95,14 +97,14 @@ func (s *Scopes) FindIdentInScope(name string) *exprpb.Decl {
 
 // SetFunction adds the function Decl to the current scope.
 // Note: Any previous entry for a function in the current scope with the same name is overwritten.
-func (s *Scopes) SetFunction(fn *exprpb.Decl) {
+func (s *Scopes) SetFunction(fn *decls.FunctionDecl) {
 	s.scopes.functions[fn.Name] = fn
 }
 
 // FindFunction finds the first function Decl with a matching name in Scopes.
 // The search is performed from innermost to outermost.
 // Returns nil if no such function in Scopes.
-func (s *Scopes) FindFunction(name string) *exprpb.Decl {
+func (s *Scopes) FindFunction(name string) *decls.FunctionDecl {
 	if fn, found := s.scopes.functions[name]; found {
 		return fn
 	}
@@ -116,16 +118,16 @@ func (s *Scopes) FindFunction(name string) *exprpb.Decl {
 // Contains separate namespaces for identifier and function Decls.
 // (Should be named "Scope" perhaps?)
 type Group struct {
-	idents    map[string]*exprpb.Decl
-	functions map[string]*exprpb.Decl
+	idents    map[string]*decls.VariableDecl
+	functions map[string]*decls.FunctionDecl
 }
 
 // copy creates a new Group instance with a shallow copy of the variables and functions.
 // If callers need to mutate the exprpb.Decl definitions for a Function, they should copy-on-write.
 func (g *Group) copy() *Group {
 	cpy := &Group{
-		idents:    make(map[string]*exprpb.Decl, len(g.idents)),
-		functions: make(map[string]*exprpb.Decl, len(g.functions)),
+		idents:    make(map[string]*decls.VariableDecl, len(g.idents)),
+		functions: make(map[string]*decls.FunctionDecl, len(g.functions)),
 	}
 	for n, id := range g.idents {
 		cpy.idents[n] = id
@@ -139,7 +141,7 @@ func (g *Group) copy() *Group {
 // newGroup creates a new Group with empty maps for identifiers and functions.
 func newGroup() *Group {
 	return &Group{
-		idents:    make(map[string]*exprpb.Decl),
-		functions: make(map[string]*exprpb.Decl),
+		idents:    make(map[string]*decls.VariableDecl),
+		functions: make(map[string]*decls.FunctionDecl),
 	}
 }

--- a/checker/types.go
+++ b/checker/types.go
@@ -15,154 +15,54 @@
 package checker
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/google/cel-go/checker/decls"
-
-	"google.golang.org/protobuf/proto"
-
-	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	"github.com/google/cel-go/common/types"
 )
-
-const (
-	kindUnknown = iota + 1
-	kindError
-	kindFunction
-	kindDyn
-	kindPrimitive
-	kindWellKnown
-	kindWrapper
-	kindNull
-	kindAbstract
-	kindType
-	kindList
-	kindMap
-	kindObject
-	kindTypeParam
-)
-
-// FormatCheckedType converts a type message into a string representation.
-func FormatCheckedType(t *exprpb.Type) string {
-	switch kindOf(t) {
-	case kindDyn:
-		return "dyn"
-	case kindFunction:
-		return formatFunction(t.GetFunction().GetResultType(),
-			t.GetFunction().GetArgTypes(),
-			false)
-	case kindList:
-		return fmt.Sprintf("list(%s)", FormatCheckedType(t.GetListType().GetElemType()))
-	case kindObject:
-		return t.GetMessageType()
-	case kindMap:
-		return fmt.Sprintf("map(%s, %s)",
-			FormatCheckedType(t.GetMapType().GetKeyType()),
-			FormatCheckedType(t.GetMapType().GetValueType()))
-	case kindNull:
-		return "null"
-	case kindPrimitive:
-		switch t.GetPrimitive() {
-		case exprpb.Type_UINT64:
-			return "uint"
-		case exprpb.Type_INT64:
-			return "int"
-		}
-		return strings.Trim(strings.ToLower(t.GetPrimitive().String()), " ")
-	case kindType:
-		if t.GetType() == nil {
-			return "type"
-		}
-		return fmt.Sprintf("type(%s)", FormatCheckedType(t.GetType()))
-	case kindWellKnown:
-		switch t.GetWellKnown() {
-		case exprpb.Type_ANY:
-			return "any"
-		case exprpb.Type_DURATION:
-			return "duration"
-		case exprpb.Type_TIMESTAMP:
-			return "timestamp"
-		}
-	case kindWrapper:
-		return fmt.Sprintf("wrapper(%s)",
-			FormatCheckedType(decls.NewPrimitiveType(t.GetWrapper())))
-	case kindError:
-		return "!error!"
-	case kindTypeParam:
-		return t.GetTypeParam()
-	case kindAbstract:
-		at := t.GetAbstractType()
-		params := at.GetParameterTypes()
-		paramStrs := make([]string, len(params))
-		for i, p := range params {
-			paramStrs[i] = FormatCheckedType(p)
-		}
-		return fmt.Sprintf("%s(%s)", at.GetName(), strings.Join(paramStrs, ", "))
-	}
-	return t.String()
-}
 
 // isDyn returns true if the input t is either type DYN or a well-known ANY message.
-func isDyn(t *exprpb.Type) bool {
+func isDyn(t *types.Type) bool {
 	// Note: object type values that are well-known and map to a DYN value in practice
 	// are sanitized prior to being added to the environment.
-	switch kindOf(t) {
-	case kindDyn:
+	switch t.Kind {
+	case types.DynKind, types.AnyKind:
 		return true
-	case kindWellKnown:
-		return t.GetWellKnown() == exprpb.Type_ANY
 	default:
 		return false
 	}
 }
 
 // isDynOrError returns true if the input is either an Error, DYN, or well-known ANY message.
-func isDynOrError(t *exprpb.Type) bool {
+func isDynOrError(t *types.Type) bool {
 	return isError(t) || isDyn(t)
 }
 
-func isError(t *exprpb.Type) bool {
-	return kindOf(t) == kindError
+func isError(t *types.Type) bool {
+	return t != nil && t.Kind == types.ErrorKind
 }
 
-func isOptional(t *exprpb.Type) bool {
-	if kindOf(t) == kindAbstract {
-		at := t.GetAbstractType()
-		return at.GetName() == "optional"
+func isOptional(t *types.Type) bool {
+	if t != nil && t.Kind == types.OpaqueKind {
+		return t.TypeName() == "optional"
 	}
 	return false
 }
 
-func maybeUnwrapOptional(t *exprpb.Type) (*exprpb.Type, bool) {
+func maybeUnwrapOptional(t *types.Type) (*types.Type, bool) {
 	if isOptional(t) {
-		at := t.GetAbstractType()
-		return at.GetParameterTypes()[0], true
+		return t.Parameters[0], true
 	}
 	return t, false
 }
 
-func maybeUnwrapString(e *exprpb.Expr) (string, bool) {
-	switch e.GetExprKind().(type) {
-	case *exprpb.Expr_ConstExpr:
-		literal := e.GetConstExpr()
-		switch literal.GetConstantKind().(type) {
-		case *exprpb.Constant_StringValue:
-			return literal.GetStringValue(), true
-		}
-	}
-	return "", false
-}
-
 // isEqualOrLessSpecific checks whether one type is equal or less specific than the other one.
 // A type is less specific if it matches the other type using the DYN type.
-func isEqualOrLessSpecific(t1 *exprpb.Type, t2 *exprpb.Type) bool {
-	kind1, kind2 := kindOf(t1), kindOf(t2)
+func isEqualOrLessSpecific(t1, t2 *types.Type) bool {
+	kind1, kind2 := t1.Kind, t2.Kind
 	// The first type is less specific.
-	if isDyn(t1) || kind1 == kindTypeParam {
+	if isDyn(t1) || kind1 == types.TypeParamKind {
 		return true
 	}
 	// The first type is not less specific.
-	if isDyn(t2) || kind2 == kindTypeParam {
+	if isDyn(t2) || kind2 == types.TypeParamKind {
 		return false
 	}
 	// Types must be of the same kind to be equal.
@@ -173,38 +73,34 @@ func isEqualOrLessSpecific(t1 *exprpb.Type, t2 *exprpb.Type) bool {
 	// With limited exceptions for ANY and JSON values, the types must agree and be equivalent in
 	// order to return true.
 	switch kind1 {
-	case kindAbstract:
-		a1 := t1.GetAbstractType()
-		a2 := t2.GetAbstractType()
-		if a1.GetName() != a2.GetName() ||
-			len(a1.GetParameterTypes()) != len(a2.GetParameterTypes()) {
+	case types.OpaqueKind:
+		if t1.TypeName() != t2.TypeName() ||
+			len(t1.Parameters) != len(t2.Parameters) {
 			return false
 		}
-		for i, p1 := range a1.GetParameterTypes() {
-			if !isEqualOrLessSpecific(p1, a2.GetParameterTypes()[i]) {
+		for i, p1 := range t1.Parameters {
+			if !isEqualOrLessSpecific(p1, t2.Parameters[i]) {
 				return false
 			}
 		}
 		return true
-	case kindList:
-		return isEqualOrLessSpecific(t1.GetListType().GetElemType(), t2.GetListType().GetElemType())
-	case kindMap:
-		m1 := t1.GetMapType()
-		m2 := t2.GetMapType()
-		return isEqualOrLessSpecific(m1.GetKeyType(), m2.GetKeyType()) &&
-			isEqualOrLessSpecific(m1.GetValueType(), m2.GetValueType())
-	case kindType:
+	case types.ListKind:
+		return isEqualOrLessSpecific(t1.Parameters[0], t2.Parameters[0])
+	case types.MapKind:
+		return isEqualOrLessSpecific(t1.Parameters[0], t2.Parameters[0]) &&
+			isEqualOrLessSpecific(t1.Parameters[1], t2.Parameters[1])
+	case types.TypeKind:
 		return true
 	default:
-		return proto.Equal(t1, t2)
+		return t1.IsExactType(t2)
 	}
 }
 
 // / internalIsAssignable returns true if t1 is assignable to t2.
-func internalIsAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) bool {
+func internalIsAssignable(m *mapping, t1, t2 *types.Type) bool {
 	// Process type parameters.
-	kind1, kind2 := kindOf(t1), kindOf(t2)
-	if kind2 == kindTypeParam {
+	kind1, kind2 := t1.Kind, t2.Kind
+	if kind2 == types.TypeParamKind {
 		// If t2 is a valid type substitution for t1, return true.
 		valid, t2HasSub := isValidTypeSubstitution(m, t1, t2)
 		if valid {
@@ -217,7 +113,7 @@ func internalIsAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) bool {
 		}
 		// Otherwise, fall through to check whether t1 is a possible substitution for t2.
 	}
-	if kind1 == kindTypeParam {
+	if kind1 == types.TypeParamKind {
 		// Return whether t1 is a valid substitution for t2. If not, do no additional checks as the
 		// possible type substitutions have been searched in both directions.
 		valid, _ := isValidTypeSubstitution(m, t2, t1)
@@ -228,40 +124,25 @@ func internalIsAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) bool {
 	if isDynOrError(t1) || isDynOrError(t2) {
 		return true
 	}
+	// Preserve the nullness checks of the legacy type-checker.
+	if kind1 == types.NullTypeKind {
+		return internalIsAssignableNull(t2)
+	}
+	if kind2 == types.NullTypeKind {
+		return internalIsAssignableNull(t1)
+	}
 
 	// Test for when the types do not need to agree, but are more specific than dyn.
 	switch kind1 {
-	case kindNull:
-		return internalIsAssignableNull(t2)
-	case kindPrimitive:
-		return internalIsAssignablePrimitive(t1.GetPrimitive(), t2)
-	case kindWrapper:
-		return internalIsAssignable(m, decls.NewPrimitiveType(t1.GetWrapper()), t2)
-	default:
-		if kind1 != kind2 {
-			return false
-		}
-	}
-
-	// Test for when the types must agree.
-	switch kind1 {
-	// ERROR, TYPE_PARAM, and DYN handled above.
-	case kindAbstract:
-		return internalIsAssignableAbstractType(m, t1.GetAbstractType(), t2.GetAbstractType())
-	case kindFunction:
-		return internalIsAssignableFunction(m, t1.GetFunction(), t2.GetFunction())
-	case kindList:
-		return internalIsAssignable(m, t1.GetListType().GetElemType(), t2.GetListType().GetElemType())
-	case kindMap:
-		return internalIsAssignableMap(m, t1.GetMapType(), t2.GetMapType())
-	case kindObject:
-		return t1.GetMessageType() == t2.GetMessageType()
-	case kindType:
-		// A type is a type is a type, any additional parameterization of the
-		// type cannot affect method resolution or assignability.
-		return true
-	case kindWellKnown:
-		return t1.GetWellKnown() == t2.GetWellKnown()
+	case types.BoolKind, types.BytesKind, types.DoubleKind, types.IntKind, types.StringKind, types.UintKind,
+		types.AnyKind, types.DurationKind, types.TimestampKind,
+		types.StructKind:
+		return t1.IsAssignableType(t2)
+	case types.TypeKind:
+		return kind2 == types.TypeKind
+	case types.OpaqueKind, types.ListKind, types.MapKind:
+		return t1.Kind == t2.Kind && t1.TypeName() == t2.TypeName() &&
+			internalIsAssignableList(m, t1.Parameters, t2.Parameters)
 	default:
 		return false
 	}
@@ -274,16 +155,16 @@ func internalIsAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) bool {
 // - t2 has a type substitution (t2sub) equal to t1
 // - t2 has a type substitution (t2sub) assignable to t1
 // - t2 does not occur within t1.
-func isValidTypeSubstitution(m *mapping, t1, t2 *exprpb.Type) (valid, hasSub bool) {
+func isValidTypeSubstitution(m *mapping, t1, t2 *types.Type) (valid, hasSub bool) {
 	// Early return if the t1 and t2 are the same instance.
-	kind1, kind2 := kindOf(t1), kindOf(t2)
-	if kind1 == kind2 && (t1 == t2 || proto.Equal(t1, t2)) {
+	kind1, kind2 := t1.Kind, t2.Kind
+	if kind1 == kind2 && t1.IsExactType(t2) {
 		return true, true
 	}
 	if t2Sub, found := m.find(t2); found {
 		// Early return if t1 and t2Sub are the same instance as otherwise the mapping
 		// might mark a type as being a subtitution for itself.
-		if kind1 == kindOf(t2Sub) && (t1 == t2Sub || proto.Equal(t1, t2Sub)) {
+		if kind1 == t2Sub.Kind && t1.IsExactType(t2Sub) {
 			return true, true
 		}
 		// If the types are compatible, pick the more general type and return true
@@ -305,25 +186,10 @@ func isValidTypeSubstitution(m *mapping, t1, t2 *exprpb.Type) (valid, hasSub boo
 	return false, false
 }
 
-// internalIsAssignableAbstractType returns true if the abstract type names agree and all type
-// parameters are assignable.
-func internalIsAssignableAbstractType(m *mapping, a1 *exprpb.Type_AbstractType, a2 *exprpb.Type_AbstractType) bool {
-	return a1.GetName() == a2.GetName() &&
-		internalIsAssignableList(m, a1.GetParameterTypes(), a2.GetParameterTypes())
-}
-
-// internalIsAssignableFunction returns true if the function return type and arg types are
-// assignable.
-func internalIsAssignableFunction(m *mapping, f1 *exprpb.Type_FunctionType, f2 *exprpb.Type_FunctionType) bool {
-	f1ArgTypes := flattenFunctionTypes(f1)
-	f2ArgTypes := flattenFunctionTypes(f2)
-	return internalIsAssignableList(m, f1ArgTypes, f2ArgTypes)
-}
-
 // internalIsAssignableList returns true if the element types at each index in the list are
 // assignable from l1[i] to l2[i]. The list lengths must also agree for the lists to be
 // assignable.
-func internalIsAssignableList(m *mapping, l1 []*exprpb.Type, l2 []*exprpb.Type) bool {
+func internalIsAssignableList(m *mapping, l1, l2 []*types.Type) bool {
 	if len(l1) != len(l2) {
 		return false
 	}
@@ -335,38 +201,22 @@ func internalIsAssignableList(m *mapping, l1 []*exprpb.Type, l2 []*exprpb.Type) 
 	return true
 }
 
-// internalIsAssignableMap returns true if map m1 may be assigned to map m2.
-func internalIsAssignableMap(m *mapping, m1 *exprpb.Type_MapType, m2 *exprpb.Type_MapType) bool {
-	return internalIsAssignableList(m,
-		[]*exprpb.Type{m1.GetKeyType(), m1.GetValueType()},
-		[]*exprpb.Type{m2.GetKeyType(), m2.GetValueType()})
-}
-
 // internalIsAssignableNull returns true if the type is nullable.
-func internalIsAssignableNull(t *exprpb.Type) bool {
-	switch kindOf(t) {
-	case kindAbstract, kindObject, kindNull, kindWellKnown, kindWrapper:
-		return true
-	default:
-		return false
-	}
+func internalIsAssignableNull(t *types.Type) bool {
+	return isLegacyNullable(t) || t.IsAssignableType(types.NullType)
 }
 
-// internalIsAssignablePrimitive returns true if the target type is the same or if it is a wrapper
-// for the primitive type.
-func internalIsAssignablePrimitive(p exprpb.Type_PrimitiveType, target *exprpb.Type) bool {
-	switch kindOf(target) {
-	case kindPrimitive:
-		return p == target.GetPrimitive()
-	case kindWrapper:
-		return p == target.GetWrapper()
-	default:
-		return false
+// isLegacyNullable preserves the null-ness compatibility of the original type-checker implementation.
+func isLegacyNullable(t *types.Type) bool {
+	switch t.Kind {
+	case types.OpaqueKind, types.StructKind, types.AnyKind, types.DurationKind, types.TimestampKind:
+		return true
 	}
+	return false
 }
 
 // isAssignable returns an updated type substitution mapping if t1 is assignable to t2.
-func isAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) *mapping {
+func isAssignable(m *mapping, t1, t2 *types.Type) *mapping {
 	mCopy := m.copy()
 	if internalIsAssignable(mCopy, t1, t2) {
 		return mCopy
@@ -375,7 +225,7 @@ func isAssignable(m *mapping, t1 *exprpb.Type, t2 *exprpb.Type) *mapping {
 }
 
 // isAssignableList returns an updated type substitution mapping if l1 is assignable to l2.
-func isAssignableList(m *mapping, l1 []*exprpb.Type, l2 []*exprpb.Type) *mapping {
+func isAssignableList(m *mapping, l1, l2 []*types.Type) *mapping {
 	mCopy := m.copy()
 	if internalIsAssignableList(mCopy, l1, l2) {
 		return mCopy
@@ -383,44 +233,8 @@ func isAssignableList(m *mapping, l1 []*exprpb.Type, l2 []*exprpb.Type) *mapping
 	return nil
 }
 
-// kindOf returns the kind of the type as defined in the checked.proto.
-func kindOf(t *exprpb.Type) int {
-	if t == nil || t.TypeKind == nil {
-		return kindUnknown
-	}
-	switch t.GetTypeKind().(type) {
-	case *exprpb.Type_Error:
-		return kindError
-	case *exprpb.Type_Function:
-		return kindFunction
-	case *exprpb.Type_Dyn:
-		return kindDyn
-	case *exprpb.Type_Primitive:
-		return kindPrimitive
-	case *exprpb.Type_WellKnown:
-		return kindWellKnown
-	case *exprpb.Type_Wrapper:
-		return kindWrapper
-	case *exprpb.Type_Null:
-		return kindNull
-	case *exprpb.Type_Type:
-		return kindType
-	case *exprpb.Type_ListType_:
-		return kindList
-	case *exprpb.Type_MapType_:
-		return kindMap
-	case *exprpb.Type_MessageType:
-		return kindObject
-	case *exprpb.Type_TypeParam:
-		return kindTypeParam
-	case *exprpb.Type_AbstractType_:
-		return kindAbstract
-	}
-	return kindUnknown
-}
-
 // mostGeneral returns the more general of two types which are known to unify.
-func mostGeneral(t1 *exprpb.Type, t2 *exprpb.Type) *exprpb.Type {
+func mostGeneral(t1, t2 *types.Type) *types.Type {
 	if isEqualOrLessSpecific(t1, t2) {
 		return t1
 	}
@@ -430,32 +244,25 @@ func mostGeneral(t1 *exprpb.Type, t2 *exprpb.Type) *exprpb.Type {
 // notReferencedIn checks whether the type doesn't appear directly or transitively within the other
 // type. This is a standard requirement for type unification, commonly referred to as the "occurs
 // check".
-func notReferencedIn(m *mapping, t *exprpb.Type, withinType *exprpb.Type) bool {
-	if proto.Equal(t, withinType) {
+func notReferencedIn(m *mapping, t, withinType *types.Type) bool {
+	if t.IsExactType(withinType) {
 		return false
 	}
-	withinKind := kindOf(withinType)
+	withinKind := withinType.Kind
 	switch withinKind {
-	case kindTypeParam:
+	case types.TypeParamKind:
 		wtSub, found := m.find(withinType)
 		if !found {
 			return true
 		}
 		return notReferencedIn(m, t, wtSub)
-	case kindAbstract:
-		for _, pt := range withinType.GetAbstractType().GetParameterTypes() {
+	case types.OpaqueKind, types.ListKind, types.MapKind:
+		for _, pt := range withinType.Parameters {
 			if !notReferencedIn(m, t, pt) {
 				return false
 			}
 		}
 		return true
-	case kindList:
-		return notReferencedIn(m, t, withinType.GetListType().GetElemType())
-	case kindMap:
-		mt := withinType.GetMapType()
-		return notReferencedIn(m, t, mt.GetKeyType()) && notReferencedIn(m, t, mt.GetValueType())
-	case kindWrapper:
-		return notReferencedIn(m, t, decls.NewPrimitiveType(withinType.GetWrapper()))
 	default:
 		return true
 	}
@@ -463,39 +270,25 @@ func notReferencedIn(m *mapping, t *exprpb.Type, withinType *exprpb.Type) bool {
 
 // substitute replaces all direct and indirect occurrences of bound type parameters. Unbound type
 // parameters are replaced by DYN if typeParamToDyn is true.
-func substitute(m *mapping, t *exprpb.Type, typeParamToDyn bool) *exprpb.Type {
+func substitute(m *mapping, t *types.Type, typeParamToDyn bool) *types.Type {
 	if tSub, found := m.find(t); found {
 		return substitute(m, tSub, typeParamToDyn)
 	}
-	kind := kindOf(t)
-	if typeParamToDyn && kind == kindTypeParam {
-		return decls.Dyn
+	kind := t.Kind
+	if typeParamToDyn && kind == types.TypeParamKind {
+		return types.DynType
 	}
 	switch kind {
-	case kindAbstract:
-		at := t.GetAbstractType()
-		params := make([]*exprpb.Type, len(at.GetParameterTypes()))
-		for i, p := range at.GetParameterTypes() {
-			params[i] = substitute(m, p, typeParamToDyn)
-		}
-		return decls.NewAbstractType(at.GetName(), params...)
-	case kindFunction:
-		fn := t.GetFunction()
-		rt := substitute(m, fn.ResultType, typeParamToDyn)
-		args := make([]*exprpb.Type, len(fn.GetArgTypes()))
-		for i, a := range fn.ArgTypes {
-			args[i] = substitute(m, a, typeParamToDyn)
-		}
-		return decls.NewFunctionType(rt, args...)
-	case kindList:
-		return decls.NewListType(substitute(m, t.GetListType().GetElemType(), typeParamToDyn))
-	case kindMap:
-		mt := t.GetMapType()
-		return decls.NewMapType(substitute(m, mt.GetKeyType(), typeParamToDyn),
-			substitute(m, mt.GetValueType(), typeParamToDyn))
-	case kindType:
-		if t.GetType() != nil {
-			return decls.NewTypeType(substitute(m, t.GetType(), typeParamToDyn))
+	case types.OpaqueKind:
+		return types.NewOpaqueType(t.TypeName(), substituteParams(m, t.Parameters, typeParamToDyn)...)
+	case types.ListKind:
+		return types.NewListType(substitute(m, t.Parameters[0], typeParamToDyn))
+	case types.MapKind:
+		return types.NewMapType(substitute(m, t.Parameters[0], typeParamToDyn),
+			substitute(m, t.Parameters[1], typeParamToDyn))
+	case types.TypeKind:
+		if len(t.Parameters) > 0 {
+			return types.NewTypeTypeWithParam(substitute(m, t.Parameters[0], typeParamToDyn))
 		}
 		return t
 	default:
@@ -503,21 +296,14 @@ func substitute(m *mapping, t *exprpb.Type, typeParamToDyn bool) *exprpb.Type {
 	}
 }
 
-func typeKey(t *exprpb.Type) string {
-	return FormatCheckedType(t)
+func substituteParams(m *mapping, typeParams []*types.Type, typeParamToDyn bool) []*types.Type {
+	subParams := make([]*types.Type, len(typeParams))
+	for i, tp := range typeParams {
+		subParams[i] = substitute(m, tp, typeParamToDyn)
+	}
+	return subParams
 }
 
-// flattenFunctionTypes takes a function with arg types T1, T2, ..., TN and result type TR
-// and returns a slice containing {T1, T2, ..., TN, TR}.
-func flattenFunctionTypes(f *exprpb.Type_FunctionType) []*exprpb.Type {
-	argTypes := f.GetArgTypes()
-	if len(argTypes) == 0 {
-		return []*exprpb.Type{f.GetResultType()}
-	}
-	flattend := make([]*exprpb.Type, len(argTypes)+1)
-	for i, at := range argTypes {
-		flattend[i] = at
-	}
-	flattend[len(argTypes)] = f.GetResultType()
-	return flattend
+func newFunctionType(resultType *types.Type, argTypes ...*types.Type) *types.Type {
+	return types.NewOpaqueType("function", append([]*types.Type{resultType}, argTypes...)...)
 }

--- a/common/ast/BUILD.bazel
+++ b/common/ast/BUILD.bazel
@@ -5,6 +5,7 @@ package(
         "//cel:__subpackages__",
         "//checker:__subpackages__",
         "//common:__subpackages__",
+        "//interpreter:__subpackages__",
     ],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/common/decls/decls.go
+++ b/common/decls/decls.go
@@ -748,10 +748,10 @@ func FunctionDeclToExprDecl(f *FunctionDecl) (*exprpb.Decl, error) {
 }
 
 func collectParamNames(paramNames map[string]struct{}, arg *types.Type) {
-	if arg.Kind == types.TypeParamKind {
+	if arg.Kind() == types.TypeParamKind {
 		paramNames[arg.TypeName()] = struct{}{}
 	}
-	for _, param := range arg.Parameters {
+	for _, param := range arg.Parameters() {
 		collectParamNames(paramNames, param)
 	}
 }

--- a/common/decls/decls.go
+++ b/common/decls/decls.go
@@ -726,19 +726,44 @@ func OverloadOperandTrait(trait int) OverloadOpt {
 
 // NewConstant creates a new constant declaration.
 func NewConstant(name string, t *types.Type, v ref.Val) *VariableDecl {
-	return &VariableDecl{Name: name, Type: t, Value: v}
+	return &VariableDecl{name: name, varType: t, value: v}
 }
 
 // NewVariable creates a new variable declaration.
 func NewVariable(name string, t *types.Type) *VariableDecl {
-	return &VariableDecl{Name: name, Type: t}
+	return &VariableDecl{name: name, varType: t}
 }
 
 // VariableDecl defines a variable declaration which may optionally have a constant value.
 type VariableDecl struct {
-	Name  string
-	Type  *types.Type
-	Value ref.Val
+	name    string
+	varType *types.Type
+	value   ref.Val
+}
+
+// Name returns the fully-qualified variable name
+func (v *VariableDecl) Name() string {
+	if v == nil {
+		return ""
+	}
+	return v.name
+}
+
+// Type returns the types.Type value associated with the variable.
+func (v *VariableDecl) Type() *types.Type {
+	if v == nil {
+		// types.Type is nil-safe
+		return nil
+	}
+	return v.varType
+}
+
+// Value returns the constant value associated with the declaration.
+func (v *VariableDecl) Value() ref.Val {
+	if v == nil {
+		return nil
+	}
+	return v.value
 }
 
 // DeclarationIsEquivalent returns true if one variable declaration has the same name and same type as the input.
@@ -746,16 +771,16 @@ func (v *VariableDecl) DeclarationIsEquivalent(other *VariableDecl) bool {
 	if v == other {
 		return true
 	}
-	return v.Name == other.Name && v.Type.IsEquivalentType(other.Type)
+	return v.Name() == other.Name() && v.Type().IsEquivalentType(other.Type())
 }
 
 // VariableDeclToExprDecl converts a go-native variable declaration into a protobuf-type variable declaration.
 func VariableDeclToExprDecl(v *VariableDecl) (*exprpb.Decl, error) {
-	varType, err := types.TypeToExprType(v.Type)
+	varType, err := types.TypeToExprType(v.Type())
 	if err != nil {
 		return nil, err
 	}
-	return chkdecls.NewVar(v.Name, varType), nil
+	return chkdecls.NewVar(v.Name(), varType), nil
 }
 
 // TypeVariable creates a new type identifier for use within a ref.TypeProvider

--- a/common/decls/decls_test.go
+++ b/common/decls/decls_test.go
@@ -273,8 +273,8 @@ func TestFunctionMerge(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Merge() failed: %v", err)
 	}
-	if (sizeMerged.Name) != "size" {
-		t.Errorf("Merge() produced a function with name %v, wanted 'size'", sizeMerged.Name)
+	if sizeMerged.Name() != "size" {
+		t.Errorf("Merge() produced a function with name %v, wanted 'size'", sizeMerged.Name())
 	}
 	if len(sizeMerged.overloads) != 3 {
 		t.Errorf("Merge() produced %d overloads, wanted 3", len(sizeFunc.overloads))
@@ -285,7 +285,7 @@ func TestFunctionMerge(t *testing.T) {
 		"vector_size": true,
 	}
 	for _, o := range sizeMerged.overloads {
-		delete(overloads, o.ID)
+		delete(overloads, o.ID())
 	}
 	if len(overloads) != 0 {
 		t.Errorf("Merge() did not include overloads: %v", overloads)
@@ -681,13 +681,13 @@ func TestFunctionGetTypeParams(t *testing.T) {
 	o1 := fn.OverloadDecls()[0]
 	o2 := fn.OverloadDecls()[1]
 	o3 := fn.OverloadDecls()[2]
-	if len(o1.GetTypeParams()) != 0 {
+	if len(o1.TypeParams()) != 0 {
 		t.Errorf("overload %v did not have zero type-params", o1)
 	}
-	if len(o2.GetTypeParams()) != 1 && !reflect.DeepEqual(o2.GetTypeParams(), []string{"K"}) {
+	if len(o2.TypeParams()) != 1 && !reflect.DeepEqual(o2.TypeParams(), []string{"K"}) {
 		t.Errorf("overload %v did not have a single type param", o2)
 	}
-	if len(o3.GetTypeParams()) != 3 {
+	if len(o3.TypeParams()) != 3 {
 		t.Errorf("overload %v did not have three type params", o3)
 	}
 }

--- a/common/types/types_test.go
+++ b/common/types/types_test.go
@@ -555,29 +555,29 @@ func TestTypeToExprTypeInvalid(t *testing.T) {
 		out string
 	}{
 		{
-			in:  &Type{Kind: ListKind, runtimeTypeName: "list"},
+			in:  &Type{kind: ListKind, runtimeTypeName: "list"},
 			out: "invalid list",
 		},
 		{
 			in: &Type{
-				Kind: ListKind,
-				Parameters: []*Type{
-					{Kind: MapKind, runtimeTypeName: "map"},
+				kind: ListKind,
+				parameters: []*Type{
+					{kind: MapKind, runtimeTypeName: "map"},
 				},
 				runtimeTypeName: "list",
 			},
 			out: "invalid map",
 		},
 		{
-			in:  &Type{Kind: MapKind, runtimeTypeName: "map"},
+			in:  &Type{kind: MapKind, runtimeTypeName: "map"},
 			out: "invalid map",
 		},
 		{
 			in: &Type{
-				Kind: MapKind,
-				Parameters: []*Type{
+				kind: MapKind,
+				parameters: []*Type{
 					StringType,
-					{Kind: MapKind, runtimeTypeName: "map"},
+					{kind: MapKind, runtimeTypeName: "map"},
 				},
 				runtimeTypeName: "map",
 			},
@@ -585,9 +585,9 @@ func TestTypeToExprTypeInvalid(t *testing.T) {
 		},
 		{
 			in: &Type{
-				Kind: MapKind,
-				Parameters: []*Type{
-					{Kind: MapKind, runtimeTypeName: "map"},
+				kind: MapKind,
+				parameters: []*Type{
+					{kind: MapKind, runtimeTypeName: "map"},
 					StringType,
 				},
 				runtimeTypeName: "map",
@@ -596,15 +596,15 @@ func TestTypeToExprTypeInvalid(t *testing.T) {
 		},
 		{
 			in: &Type{
-				Kind:            TypeKind,
-				Parameters:      []*Type{{Kind: ListKind, runtimeTypeName: "list"}},
+				kind:            TypeKind,
+				parameters:      []*Type{{kind: ListKind, runtimeTypeName: "list"}},
 				runtimeTypeName: "type",
 			},
 			out: "invalid list",
 		},
 		{
 			in: NewOpaqueType("bad_list", &Type{
-				Kind:            ListKind,
+				kind:            ListKind,
 				runtimeTypeName: "list",
 			}),
 			out: "invalid list",

--- a/common/types/types_test.go
+++ b/common/types/types_test.go
@@ -85,6 +85,19 @@ func TestTypeString(t *testing.T) {
 			in:  NewTypeParamType("T"),
 			out: "T",
 		},
+		// nil-safety tests
+		{
+			in:  nil,
+			out: "",
+		},
+		{
+			in:  ListType,
+			out: "list()",
+		},
+		{
+			in:  MapType,
+			out: "map(, )",
+		},
 	}
 	for _, tst := range tests {
 		if tst.in.String() != tst.out {

--- a/interpreter/BUILD.bazel
+++ b/interpreter/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     importpath = "github.com/google/cel-go/interpreter",
     deps = [
         "//common:go_default_library",
+        "//common/ast:go_default_library",
         "//common/containers:go_default_library",
         "//common/functions:go_default_library",
         "//common/operators:go_default_library",

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -202,7 +202,7 @@ func (r *attrFactory) NewQualifier(objType *types.Type, qualID int64, val any, o
 	// If so, use the precomputed GetFrom qualification method rather than the standard
 	// stringQualifier.
 	str, isStr := val.(string)
-	if isStr && objType != nil && objType.Kind == types.StructKind {
+	if isStr && objType != nil && objType.Kind() == types.StructKind {
 		ft, found := r.provider.FindFieldType(objType.TypeName(), str)
 		if found && ft.IsSet != nil && ft.GetFrom != nil {
 			return &fieldQualifier{

--- a/interpreter/attributes_test.go
+++ b/interpreter/attributes_test.go
@@ -665,7 +665,7 @@ func TestAttributesOptional(t *testing.T) {
 			optQuals: []any{
 				makeOptQualifier(t,
 					attrs,
-					&exprpb.Type{TypeKind: &exprpb.Type_MessageType{MessageType: "google.expr.proto3.test.TestAllTypes"}},
+					types.NewObjectType("google.expr.proto3.test.TestAllTypes"),
 					103,
 					"single_int32",
 				),
@@ -773,8 +773,8 @@ func BenchmarkResolverFieldQualifier(b *testing.B) {
 	if !found {
 		b.Fatal("FindType() could not find NestedMessage")
 	}
-	attr.AddQualifier(makeQualifier(b, attrs, opType.GetType(), 2, "single_nested_message"))
-	attr.AddQualifier(makeQualifier(b, attrs, fieldType.GetType(), 3, "bb"))
+	attr.AddQualifier(makeQualifier(b, attrs, testExprTypeToType(b, opType), 2, "single_nested_message"))
+	attr.AddQualifier(makeQualifier(b, attrs, testExprTypeToType(b, fieldType), 3, "bb"))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := attr.Resolve(vars)
@@ -796,11 +796,7 @@ func TestResolverCustomQualifier(t *testing.T) {
 		"msg": msg,
 	})
 	attr := attrs.AbsoluteAttribute(1, "msg")
-	fieldType := &exprpb.Type{
-		TypeKind: &exprpb.Type_MessageType{
-			MessageType: "google.expr.proto3.test.TestAllTypes.NestedMessage",
-		},
-	}
+	fieldType := types.NewObjectType("google.expr.proto3.test.TestAllTypes.NestedMessage")
 	qualBB := makeQualifier(t, attrs, fieldType, 2, "bb")
 	attr.AddQualifier(qualBB)
 	out, err := attr.Resolve(vars)
@@ -1113,10 +1109,10 @@ func TestAttributeStateTracking(t *testing.T) {
 			if err != nil {
 				t.Fatalf("checker.NewEnv() failed: %v", err)
 			}
-			env.Add(stdlib.FunctionExprDecls()...)
-			env.Add(funcExprDecls(t, optionalDecls(t)...)...)
+			env.AddFunctions(stdlib.Functions()...)
+			env.AddFunctions(optionalDecls(t)...)
 			if tc.vars != nil {
-				env.Add(varExprDecls(t, tc.vars...)...)
+				env.AddIdents(tc.vars...)
 			}
 			checked, errors := checker.Check(parsed, src, env)
 			if len(errors.GetErrors()) != 0 {
@@ -1182,11 +1178,7 @@ func BenchmarkResolverCustomQualifier(b *testing.B) {
 		"msg": msg,
 	})
 	attr := attrs.AbsoluteAttribute(1, "msg")
-	fieldType := &exprpb.Type{
-		TypeKind: &exprpb.Type_MessageType{
-			MessageType: "google.expr.proto3.test.TestAllTypes.NestedMessage",
-		},
-	}
+	fieldType := types.NewObjectType("google.expr.proto3.test.TestAllTypes.NestedMessage")
 	qualBB := makeQualifier(b, attrs, fieldType, 2, "bb")
 	attr.AddQualifier(qualBB)
 	for i := 0; i < b.N; i++ {
@@ -1198,8 +1190,8 @@ type custAttrFactory struct {
 	AttributeFactory
 }
 
-func (r *custAttrFactory) NewQualifier(objType *exprpb.Type, qualID int64, val any, opt bool) (Qualifier, error) {
-	if objType.GetMessageType() == "google.expr.proto3.test.TestAllTypes.NestedMessage" {
+func (r *custAttrFactory) NewQualifier(objType *types.Type, qualID int64, val any, opt bool) (Qualifier, error) {
+	if objType.Kind == types.StructKind && objType.TypeName() == "google.expr.proto3.test.TestAllTypes.NestedMessage" {
 		return &nestedMsgQualifier{id: qualID, field: val.(string)}, nil
 	}
 	return r.AttributeFactory.NewQualifier(objType, qualID, val, opt)
@@ -1240,7 +1232,7 @@ func addQualifier(t testing.TB, attr Attribute, qual Qualifier) Attribute {
 	return attr
 }
 
-func makeQualifier(t testing.TB, attrs AttributeFactory, fieldType *exprpb.Type, qualID int64, val any) Qualifier {
+func makeQualifier(t testing.TB, attrs AttributeFactory, fieldType *types.Type, qualID int64, val any) Qualifier {
 	t.Helper()
 	qual, err := attrs.NewQualifier(fieldType, qualID, val, false)
 	if err != nil {
@@ -1249,7 +1241,7 @@ func makeQualifier(t testing.TB, attrs AttributeFactory, fieldType *exprpb.Type,
 	return qual
 }
 
-func makeOptQualifier(t testing.TB, attrs AttributeFactory, fieldType *exprpb.Type, qualID int64, val any) Qualifier {
+func makeOptQualifier(t testing.TB, attrs AttributeFactory, fieldType *types.Type, qualID int64, val any) Qualifier {
 	t.Helper()
 	qual, err := attrs.NewQualifier(fieldType, qualID, val, true)
 	if err != nil {
@@ -1263,6 +1255,15 @@ func findField(t testing.TB, reg ref.TypeRegistry, typeName, field string) *ref.
 	ft, found := reg.FindFieldType(typeName, field)
 	if !found {
 		t.Fatalf("reg.FindFieldType(%v, %v) failed", typeName, field)
+	}
+	return ft
+}
+
+func testExprTypeToType(t testing.TB, fieldType *exprpb.Type) *types.Type {
+	t.Helper()
+	ft, err := types.ExprTypeToType(fieldType)
+	if err != nil {
+		t.Fatalf("types.ExprTypeToType() failed: %v", err)
 	}
 	return ft
 }

--- a/interpreter/attributes_test.go
+++ b/interpreter/attributes_test.go
@@ -1191,7 +1191,7 @@ type custAttrFactory struct {
 }
 
 func (r *custAttrFactory) NewQualifier(objType *types.Type, qualID int64, val any, opt bool) (Qualifier, error) {
-	if objType.Kind == types.StructKind && objType.TypeName() == "google.expr.proto3.test.TestAllTypes.NestedMessage" {
+	if objType.Kind() == types.StructKind && objType.TypeName() == "google.expr.proto3.test.TestAllTypes.NestedMessage" {
 		return &nestedMsgQualifier{id: qualID, field: val.(string)}, nil
 	}
 	return r.AttributeFactory.NewQualifier(objType, qualID, val, opt)

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -18,6 +18,7 @@
 package interpreter
 
 import (
+	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/containers"
 	"github.com/google/cel-go/common/types/ref"
 
@@ -28,7 +29,7 @@ import (
 type Interpreter interface {
 	// NewInterpretable creates an Interpretable from a checked expression and an
 	// optional list of InterpretableDecorator values.
-	NewInterpretable(checked *exprpb.CheckedExpr, decorators ...InterpretableDecorator) (Interpretable, error)
+	NewInterpretable(checked *ast.CheckedAST, decorators ...InterpretableDecorator) (Interpretable, error)
 
 	// NewUncheckedInterpretable returns an Interpretable from a parsed expression
 	// and an optional list of InterpretableDecorator values.
@@ -175,7 +176,7 @@ func NewInterpreter(dispatcher Dispatcher,
 
 // NewIntepretable implements the Interpreter interface method.
 func (i *exprInterpreter) NewInterpretable(
-	checked *exprpb.CheckedExpr,
+	checked *ast.CheckedAST,
 	decorators ...InterpretableDecorator) (Interpretable, error) {
 	p := newPlanner(
 		i.dispatcher,
@@ -185,7 +186,7 @@ func (i *exprInterpreter) NewInterpretable(
 		i.container,
 		checked,
 		decorators...)
-	return p.Plan(checked.GetExpr())
+	return p.Plan(checked.Expr)
 }
 
 // NewUncheckedIntepretable implements the Interpreter interface method.

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -1709,10 +1709,9 @@ func TestInterpreter_SetProto2PrimitiveFields(t *testing.T) {
 	cont := testContainer("google.expr.proto2.test")
 	reg := newTestRegistry(t, &proto2pb.TestAllTypes{})
 	env := newTestEnv(t, cont, reg)
-	env.Add(
-		varExprDecl(t,
-			decls.NewVariable("input",
-				types.NewObjectType("google.expr.proto2.test.TestAllTypes"))))
+	env.AddIdents(
+		decls.NewVariable("input",
+			types.NewObjectType("google.expr.proto2.test.TestAllTypes")))
 	checked, errors := checker.Check(parsed, src, env)
 	if len(errors.GetErrors()) != 0 {
 		t.Errorf(errors.ToDisplayString())
@@ -1765,7 +1764,7 @@ func TestInterpreter_MissingIdentInSelect(t *testing.T) {
 	cont := testContainer("test")
 	reg := newTestRegistry(t)
 	env := newTestEnv(t, cont, reg)
-	env.Add(varExprDecl(t, decls.NewVariable("a.b", types.DynType)))
+	env.AddIdents(decls.NewVariable("a.b", types.DynType))
 	checked, errors := checker.Check(parsed, src, env)
 	if len(errors.GetErrors()) != 0 {
 		t.Fatalf(errors.ToDisplayString())
@@ -1958,7 +1957,7 @@ func program(ctx testing.TB, tst *testCase, opts ...InterpretableDecorator) (Int
 		attrs = tst.attrs
 	}
 	if tst.vars != nil {
-		err = env.Add(varExprDecls(ctx, tst.vars...)...)
+		err = env.AddIdents(tst.vars...)
 		if err != nil {
 			return nil, nil, fmt.Errorf("env.Add(%v) failed: %v", tst.vars, err)
 		}
@@ -1976,7 +1975,7 @@ func program(ctx testing.TB, tst *testCase, opts ...InterpretableDecorator) (Int
 	disp := NewDispatcher()
 	addFunctionBindings(ctx, disp)
 	if tst.funcs != nil {
-		err = env.Add(funcExprDecls(ctx, tst.funcs...)...)
+		err = env.AddFunctions(tst.funcs...)
 		if err != nil {
 			return nil, nil, fmt.Errorf("env.Add(%v) failed: %v", tst.funcs, err)
 		}
@@ -2059,13 +2058,13 @@ func newTestEnv(t testing.TB, cont *containers.Container, reg ref.TypeRegistry) 
 	if err != nil {
 		t.Fatalf("checker.NewEnv(%v, %v) failed: %v", cont, reg, err)
 	}
-	err = env.Add(stdlib.TypeExprDecls()...)
+	err = env.AddIdents(stdlib.Types()...)
 	if err != nil {
-		t.Fatalf("env.Add(stdlib.TypeExprDecls()...) failed: %v", err)
+		t.Fatalf("env.Add(stdlib.Types()...) failed: %v", err)
 	}
-	err = env.Add(stdlib.FunctionExprDecls()...)
+	err = env.AddFunctions(stdlib.Functions()...)
 	if err != nil {
-		t.Fatalf("env.Add(stdlib.FunctionExprDecls()...) failed: %v", err)
+		t.Fatalf("env.Add(stdlib.Functions()...) failed: %v", err)
 	}
 	return env
 }

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -18,9 +18,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/containers"
 	"github.com/google/cel-go/common/functions"
 	"github.com/google/cel-go/common/operators"
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
@@ -41,7 +43,7 @@ func newPlanner(disp Dispatcher,
 	adapter ref.TypeAdapter,
 	attrFactory AttributeFactory,
 	cont *containers.Container,
-	checked *exprpb.CheckedExpr,
+	checked *ast.CheckedAST,
 	decorators ...InterpretableDecorator) interpretablePlanner {
 	return &planner{
 		disp:        disp,
@@ -49,8 +51,8 @@ func newPlanner(disp Dispatcher,
 		adapter:     adapter,
 		attrFactory: attrFactory,
 		container:   cont,
-		refMap:      checked.GetReferenceMap(),
-		typeMap:     checked.GetTypeMap(),
+		refMap:      checked.ReferenceMap,
+		typeMap:     checked.TypeMap,
 		decorators:  decorators,
 	}
 }
@@ -70,8 +72,8 @@ func newUncheckedPlanner(disp Dispatcher,
 		adapter:     adapter,
 		attrFactory: attrFactory,
 		container:   cont,
-		refMap:      make(map[int64]*exprpb.Reference),
-		typeMap:     make(map[int64]*exprpb.Type),
+		refMap:      make(map[int64]*ast.ReferenceInfo),
+		typeMap:     make(map[int64]*types.Type),
 		decorators:  decorators,
 	}
 }
@@ -83,8 +85,8 @@ type planner struct {
 	adapter     ref.TypeAdapter
 	attrFactory AttributeFactory
 	container   *containers.Container
-	refMap      map[int64]*exprpb.Reference
-	typeMap     map[int64]*exprpb.Type
+	refMap      map[int64]*ast.ReferenceInfo
+	typeMap     map[int64]*types.Type
 	decorators  []InterpretableDecorator
 }
 
@@ -143,22 +145,19 @@ func (p *planner) planIdent(expr *exprpb.Expr) (Interpretable, error) {
 	}, nil
 }
 
-func (p *planner) planCheckedIdent(id int64, identRef *exprpb.Reference) (Interpretable, error) {
+func (p *planner) planCheckedIdent(id int64, identRef *ast.ReferenceInfo) (Interpretable, error) {
 	// Plan a constant reference if this is the case for this simple identifier.
-	if identRef.GetValue() != nil {
-		return p.Plan(&exprpb.Expr{Id: id,
-			ExprKind: &exprpb.Expr_ConstExpr{
-				ConstExpr: identRef.GetValue(),
-			}})
+	if identRef.Value != nil {
+		return NewConstValue(id, identRef.Value), nil
 	}
 
 	// Check to see whether the type map indicates this is a type name. All types should be
 	// registered with the provider.
 	cType := p.typeMap[id]
-	if cType.GetType() != nil {
-		cVal, found := p.provider.FindIdent(identRef.GetName())
+	if cType.Kind == types.TypeKind {
+		cVal, found := p.provider.FindIdent(identRef.Name)
 		if !found {
-			return nil, fmt.Errorf("reference to undefined type: %s", identRef.GetName())
+			return nil, fmt.Errorf("reference to undefined type: %s", identRef.Name)
 		}
 		return NewConstValue(id, cVal), nil
 	}
@@ -166,7 +165,7 @@ func (p *planner) planCheckedIdent(id int64, identRef *exprpb.Reference) (Interp
 	// Otherwise, return the attribute for the resolved identifier name.
 	return &evalAttr{
 		adapter: p.adapter,
-		attr:    p.attrFactory.AbsoluteAttribute(id, identRef.GetName()),
+		attr:    p.attrFactory.AbsoluteAttribute(id, identRef.Name),
 	}, nil
 }
 
@@ -700,8 +699,8 @@ func (p *planner) resolveFunction(expr *exprpb.Expr) (*exprpb.Expr, string, stri
 	// function name as the fnName value.
 	oRef, hasOverload := p.refMap[expr.GetId()]
 	if hasOverload {
-		if len(oRef.GetOverloadId()) == 1 {
-			return target, fnName, oRef.GetOverloadId()[0]
+		if len(oRef.OverloadIDs) == 1 {
+			return target, fnName, oRef.OverloadIDs[0]
 		}
 		// Note, this namespaced function name will not appear as a fully qualified name in ASTs
 		// built and stored before cel-go v0.5.0; however, this functionality did not work at all

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -154,7 +154,7 @@ func (p *planner) planCheckedIdent(id int64, identRef *ast.ReferenceInfo) (Inter
 	// Check to see whether the type map indicates this is a type name. All types should be
 	// registered with the provider.
 	cType := p.typeMap[id]
-	if cType.Kind == types.TypeKind {
+	if cType.Kind() == types.TypeKind {
 		cVal, found := p.provider.FindIdent(identRef.Name)
 		if !found {
 			return nil, fmt.Errorf("reference to undefined type: %s", identRef.Name)

--- a/interpreter/runtimecost_test.go
+++ b/interpreter/runtimecost_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/google/cel-go/parser"
 
 	proto3pb "github.com/google/cel-go/test/proto3pb"
-	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 func TestTrackCostAdvanced(t *testing.T) {
@@ -109,7 +108,7 @@ func TestTrackCostAdvanced(t *testing.T) {
 	}
 }
 
-func computeCost(t *testing.T, expr string, decls []*exprpb.Decl, ctx Activation, options []CostTrackerOption) (cost uint64, est checker.CostEstimate, err error) {
+func computeCost(t *testing.T, expr string, vars []*decls.VariableDecl, ctx Activation, options []CostTrackerOption) (cost uint64, est checker.CostEstimate, err error) {
 	t.Helper()
 
 	s := common.NewTextSource(expr)
@@ -126,7 +125,7 @@ func computeCost(t *testing.T, expr string, decls []*exprpb.Decl, ctx Activation
 	reg := newTestRegistry(t, &proto3pb.TestAllTypes{})
 	attrs := NewAttributeFactory(cont, reg, reg)
 	env := newTestEnv(t, cont, reg)
-	err = env.Add(decls...)
+	err = env.AddIdents(vars...)
 	if err != nil {
 		t.Fatalf("Failed to initialize env: %v", err)
 	}
@@ -784,7 +783,7 @@ func TestRuntimeCost(t *testing.T) {
 			if costLimit != nil {
 				options = append(options, CostTrackerLimit(*costLimit))
 			}
-			actualCost, est, err := computeCost(t, tc.expr, varExprDecls(t, tc.vars...), ctx, options)
+			actualCost, est, err := computeCost(t, tc.expr, tc.vars, ctx, options)
 			if err != nil {
 				if tc.expectExceedsLimit {
 					return


### PR DESCRIPTION
Migrate the type-checker to native types and declarations

This change simplifies the internals of the type-checker considerably by relying
on function overload collision checks to happen within the `decls.FunctionDecl`
instances on `Merge`. Additionally, the native types have replaced the protobuf
type declarations used throughout the checker previously.

The files with the most non-trivial changes are the `checker/checker.go` and
`checker/types.go`. When reviewing the code, please consider these changes
carefully.

Only one location continues to use the proto-based `exprbp.Type`, and that's
the `ref.TypeProvider` which will be updated in a follow-up PR to complete
#568 