### PR TITLE
Export FormatCelType in the 'cel' package

### DIFF
--- a/cel/env.go
+++ b/cel/env.go
@@ -93,8 +93,17 @@ func (ast *Ast) Source() Source {
 }
 
 // FormatType converts a type message into a string representation.
+//
+// Deprecated: prefer FormatCelType
 func FormatType(t *exprpb.Type) string {
 	return checker.FormatCheckedType(t)
+}
+
+// FormatCelType formats a cel.Type value to a string representation.
+//
+// The type formatting is identical to FormatType.
+func FormatCelType(t *Type) string {
+	return checker.FormatCelType(t)
 }
 
 // Env encapsulates the context necessary to perform parsing, type checking, or generation of

--- a/cel/env_test.go
+++ b/cel/env_test.go
@@ -84,6 +84,30 @@ ERROR: <input>:1:2: Syntax error: mismatched input '<EOF>' expecting {'[', '{', 
 	}
 }
 
+func TestFormatCelTypeEquivalence(t *testing.T) {
+	values := []*Type{
+		AnyType,
+		MapType(StringType, DynType),
+		types.NewTypeTypeWithParam(ListType(IntType)),
+		TypeType,
+		NullableType(DoubleType),
+	}
+	for _, v := range values {
+		v := v
+		t.Run(v.String(), func(t *testing.T) {
+			celStr := FormatCelType(v)
+			et, err := TypeToExprType(v)
+			if err != nil {
+				t.Fatalf("TypeToExprType(%v) failed: %v", v, err)
+			}
+			exprStr := FormatType(et)
+			if celStr != exprStr {
+				t.Errorf("FormatCelType(%v) got %s, wanted %s", v, celStr, exprStr)
+			}
+		})
+	}
+}
+
 func TestEnvCheckExtendRace(t *testing.T) {
 	t.Parallel()
 	for i := 0; i < 500; i++ {

--- a/checker/errors.go
+++ b/checker/errors.go
@@ -31,7 +31,7 @@ type typeErrors struct {
 
 func (e *typeErrors) fieldTypeMismatch(id int64, l common.Location, name string, field, value *types.Type) {
 	e.errs.ReportErrorAtID(id, l, "expected type of field '%s' is '%s' but provided type is '%s'",
-		name, formatCelType(field), formatCelType(value))
+		name, FormatCelType(field), FormatCelType(value))
 }
 
 func (e *typeErrors) incompatibleType(id int64, l common.Location, ex *exprpb.Expr, prev, next *types.Type) {
@@ -46,7 +46,7 @@ func (e *typeErrors) noMatchingOverload(id int64, l common.Location, name string
 
 func (e *typeErrors) notAComprehensionRange(id int64, l common.Location, t *types.Type) {
 	e.errs.ReportErrorAtID(id, l, "expression of type '%s' cannot be range of a comprehension (must be list, map, or dynamic)",
-		formatCelType(t))
+		FormatCelType(t))
 }
 
 func (e *typeErrors) notAnOptionalFieldSelection(id int64, l common.Location, field *exprpb.Expr) {
@@ -67,12 +67,12 @@ func (e *typeErrors) referenceRedefinition(id int64, l common.Location, ex *expr
 }
 
 func (e *typeErrors) typeDoesNotSupportFieldSelection(id int64, l common.Location, t *types.Type) {
-	e.errs.ReportErrorAtID(id, l, "type '%s' does not support field selection", formatCelType(t))
+	e.errs.ReportErrorAtID(id, l, "type '%s' does not support field selection", FormatCelType(t))
 }
 
 func (e *typeErrors) typeMismatch(id int64, l common.Location, expected, actual *types.Type) {
 	e.errs.ReportErrorAtID(id, l, "expected type '%s' but found '%s'",
-		formatCelType(expected), formatCelType(actual))
+		FormatCelType(expected), FormatCelType(actual))
 }
 
 func (e *typeErrors) undefinedField(id int64, l common.Location, field string) {

--- a/checker/format.go
+++ b/checker/format.go
@@ -103,7 +103,10 @@ func FormatCheckedType(t *exprpb.Type) string {
 
 type formatter func(any) string
 
-func formatCelType(t any) string {
+// FormatCelType formats a types.Type value to a string representation.
+//
+// The type formatting is identical to FormatCheckedType.
+func FormatCelType(t any) string {
 	dt := t.(*types.Type)
 	switch dt.Kind() {
 	case types.AnyKind:
@@ -132,7 +135,7 @@ func formatCelType(t any) string {
 	}
 	paramTypeNames := make([]string, 0, len(dt.Parameters()))
 	for _, p := range dt.Parameters() {
-		paramTypeNames = append(paramTypeNames, formatCelType(p))
+		paramTypeNames = append(paramTypeNames, FormatCelType(p))
 	}
 	return fmt.Sprintf("%s(%s)", dt.TypeName(), strings.Join(paramTypeNames, ", "))
 }
@@ -149,7 +152,7 @@ func formatFunctionExprType(resultType *exprpb.Type, argTypes []*exprpb.Type, is
 }
 
 func formatFunctionDeclType(resultType *types.Type, argTypes []*types.Type, isInstance bool) string {
-	return formatFunctionInternal[*types.Type](resultType, argTypes, isInstance, formatCelType)
+	return formatFunctionInternal[*types.Type](resultType, argTypes, isInstance, FormatCelType)
 }
 
 func formatFunctionInternal[T any](resultType T, argTypes []T, isInstance bool, format formatter) string {

--- a/checker/format_test.go
+++ b/checker/format_test.go
@@ -51,9 +51,9 @@ func TestFormatType(t *testing.T) {
 			if err != nil {
 				t.Fatalf("types.TypeToExprType(%v) failed: %v", tc, err)
 			}
-			if formatCelType(tc) != FormatCheckedType(exprType) {
+			if FormatCelType(tc) != FormatCheckedType(exprType) {
 				t.Errorf("formatCelType(%v) not equal to FormatCheckedType(%v), got %s, wanted %s",
-					tc, exprType, formatCelType(tc), FormatCheckedType(exprType))
+					tc, exprType, FormatCelType(tc), FormatCheckedType(exprType))
 			}
 		})
 	}
@@ -61,7 +61,7 @@ func TestFormatType(t *testing.T) {
 
 func TestFormatFunctionType(t *testing.T) {
 	// native type representation of function(string, int) -> bool
-	ct := formatCelType(newFunctionType(types.BoolType, types.StringType, types.IntType))
+	ct := FormatCelType(newFunctionType(types.BoolType, types.StringType, types.IntType))
 	// protobuf-based function type
 	et := FormatCheckedType(decls.NewFunctionType(decls.Bool, decls.String, decls.Int))
 	if ct != et {

--- a/checker/mapping.go
+++ b/checker/mapping.go
@@ -29,11 +29,11 @@ func newMapping() *mapping {
 }
 
 func (m *mapping) add(from, to *types.Type) {
-	m.mapping[formatCelType(from)] = to
+	m.mapping[FormatCelType(from)] = to
 }
 
 func (m *mapping) find(from *types.Type) (*types.Type, bool) {
-	if r, found := m.mapping[formatCelType(from)]; found {
+	if r, found := m.mapping[FormatCelType(from)]; found {
 		return r, found
 	}
 	return nil, false


### PR DESCRIPTION
Export FormatCelType to print `cel.Type` values in the same style
as their protobuf equivalents.