### PR TITLE
Unify type adapter / provider representations

### DIFF
--- a/cel/io.go
+++ b/cel/io.go
@@ -211,7 +211,7 @@ var (
 )
 
 // ValueToRefValue converts between exprpb.Value and ref.Val.
-func ValueToRefValue(adapter ref.TypeAdapter, v *exprpb.Value) (ref.Val, error) {
+func ValueToRefValue(adapter types.Adapter, v *exprpb.Value) (ref.Val, error) {
 	switch v.Kind.(type) {
 	case *exprpb.Value_NullValue:
 		return types.NullValue, nil

--- a/cel/io_test.go
+++ b/cel/io_test.go
@@ -42,7 +42,7 @@ func TestRefValueToValueRoundTrip(t *testing.T) {
 		{value: types.Duration{Duration: time.Hour}},
 		{value: types.Timestamp{Time: time.Unix(0, 0)}},
 		{value: types.IntType},
-		{value: types.NewTypeValue("CustomType")},
+		{value: types.NewOpaqueType("CustomType")},
 		{value: map[int64]int64{1: 1}},
 		{value: []any{true, "abc"}},
 		{value: &proto3pb.TestAllTypes{SingleString: "abc"}},

--- a/cel/program.go
+++ b/cel/program.go
@@ -498,7 +498,7 @@ type evalActivation struct {
 // The lazy binding will only be invoked once per evaluation.
 //
 // Values which are not represented as ref.Val types on input may be adapted to a ref.Val using
-// the ref.TypeAdapter configured in the environment.
+// the types.Adapter configured in the environment.
 func (a *evalActivation) ResolveName(name string) (any, bool) {
 	v, found := a.vars[name]
 	if !found {

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -77,7 +77,6 @@ func (c *checker) check(e *exprpb.Expr) {
 	if e == nil {
 		return
 	}
-
 	switch e.GetExprKind().(type) {
 	case *exprpb.Expr_ConstExpr:
 		literal := e.GetConstExpr()
@@ -706,19 +705,15 @@ func (c *checker) locationByID(id int64) common.Location {
 	return common.NoLocation
 }
 
-func (c *checker) lookupFieldType(exprID int64, messageType, fieldName string) (*types.Type, bool) {
-	if _, found := c.env.provider.FindType(messageType); !found {
+func (c *checker) lookupFieldType(exprID int64, structType, fieldName string) (*types.Type, bool) {
+	if _, found := c.env.provider.FindStructType(structType); !found {
 		// This should not happen, anyway, report an error.
-		c.errors.unexpectedFailedResolution(exprID, c.locationByID(exprID), messageType)
+		c.errors.unexpectedFailedResolution(exprID, c.locationByID(exprID), structType)
 		return nil, false
 	}
 
-	if ft, found := c.env.provider.FindFieldType(messageType, fieldName); found {
-		dt, err := types.ExprTypeToType(ft.Type)
-		if err != nil {
-			c.errors.undefinedField(exprID, c.locationByID(exprID), fieldName)
-		}
-		return dt, found
+	if ft, found := c.env.provider.FindStructFieldType(structType, fieldName); found {
+		return ft.Type, found
 	}
 
 	c.errors.undefinedField(exprID, c.locationByID(exprID), fieldName)

--- a/checker/env_test.go
+++ b/checker/env_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/stdlib"
 	"github.com/google/cel-go/common/types"
-	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/parser"
 )
 
@@ -123,7 +122,7 @@ func newStdEnv(t *testing.T) *Env {
 	return env
 }
 
-func newTestRegistry(t testing.TB) ref.TypeRegistry {
+func newTestRegistry(t testing.TB) *types.Registry {
 	t.Helper()
 	reg, err := types.NewRegistry()
 	if err != nil {

--- a/common/ast/expr_test.go
+++ b/common/ast/expr_test.go
@@ -17,7 +17,6 @@ package ast_test
 import (
 	"testing"
 
-	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/google/cel-go/checker"
@@ -27,10 +26,11 @@ import (
 	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/stdlib"
 	"github.com/google/cel-go/common/types"
-	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/parser"
 
 	proto3pb "github.com/google/cel-go/test/proto3pb"
+
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 func TestNavigateExpr(t *testing.T) {
@@ -428,7 +428,7 @@ func mustTypeCheck(t testing.TB, expr string) *ast.CheckedAST {
 	return checked
 }
 
-func newTestRegistry(t testing.TB, msgs ...proto.Message) ref.TypeRegistry {
+func newTestRegistry(t testing.TB, msgs ...proto.Message) *types.Registry {
 	t.Helper()
 	reg, err := types.NewRegistry(msgs...)
 	if err != nil {
@@ -437,7 +437,7 @@ func newTestRegistry(t testing.TB, msgs ...proto.Message) ref.TypeRegistry {
 	return reg
 }
 
-func newTestEnv(t testing.TB, cont *containers.Container, reg ref.TypeRegistry) *checker.Env {
+func newTestEnv(t testing.TB, cont *containers.Container, reg *types.Registry) *checker.Env {
 	t.Helper()
 	env, err := checker.NewEnv(cont, reg, checker.CrossTypeNumericComparisons(true))
 	if err != nil {

--- a/common/decls/decls.go
+++ b/common/decls/decls.go
@@ -783,7 +783,7 @@ func VariableDeclToExprDecl(v *VariableDecl) (*exprpb.Decl, error) {
 	return chkdecls.NewVar(v.Name(), varType), nil
 }
 
-// TypeVariable creates a new type identifier for use within a ref.TypeProvider
+// TypeVariable creates a new type identifier for use within a types.Provider
 func TypeVariable(t *types.Type) *VariableDecl {
 	return NewVariable(t.TypeName(), types.NewTypeTypeWithParam(t))
 }

--- a/common/types/err.go
+++ b/common/types/err.go
@@ -35,7 +35,7 @@ type Err struct {
 
 var (
 	// ErrType singleton.
-	ErrType = NewTypeValue("error")
+	ErrType = NewOpaqueType("error")
 
 	// errDivideByZero is an error indicating a division by zero of an integer value.
 	errDivideByZero = errors.New("division by zero")

--- a/common/types/iterator.go
+++ b/common/types/iterator.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	// IteratorType singleton.
-	IteratorType = NewTypeValue("iterator", traits.IteratorType)
+	IteratorType = NewObjectType("iterator", traits.IteratorType)
 )
 
 // baseIterator is the basis for list, map, and object iterators.

--- a/common/types/list.go
+++ b/common/types/list.go
@@ -32,12 +32,12 @@ import (
 // NewDynamicList returns a traits.Lister with heterogenous elements.
 // value should be an array of "native" types, i.e. any type that
 // NativeToValue() can convert to a ref.Val.
-func NewDynamicList(adapter ref.TypeAdapter, value any) traits.Lister {
+func NewDynamicList(adapter Adapter, value any) traits.Lister {
 	refValue := reflect.ValueOf(value)
 	return &baseList{
-		TypeAdapter: adapter,
-		value:       value,
-		size:        refValue.Len(),
+		Adapter: adapter,
+		value:   value,
+		size:    refValue.Len(),
 		get: func(i int) any {
 			return refValue.Index(i).Interface()
 		},
@@ -45,56 +45,56 @@ func NewDynamicList(adapter ref.TypeAdapter, value any) traits.Lister {
 }
 
 // NewStringList returns a traits.Lister containing only strings.
-func NewStringList(adapter ref.TypeAdapter, elems []string) traits.Lister {
+func NewStringList(adapter Adapter, elems []string) traits.Lister {
 	return &baseList{
-		TypeAdapter: adapter,
-		value:       elems,
-		size:        len(elems),
-		get:         func(i int) any { return elems[i] },
+		Adapter: adapter,
+		value:   elems,
+		size:    len(elems),
+		get:     func(i int) any { return elems[i] },
 	}
 }
 
 // NewRefValList returns a traits.Lister with ref.Val elements.
 //
 // This type specialization is used with list literals within CEL expressions.
-func NewRefValList(adapter ref.TypeAdapter, elems []ref.Val) traits.Lister {
+func NewRefValList(adapter Adapter, elems []ref.Val) traits.Lister {
 	return &baseList{
-		TypeAdapter: adapter,
-		value:       elems,
-		size:        len(elems),
-		get:         func(i int) any { return elems[i] },
+		Adapter: adapter,
+		value:   elems,
+		size:    len(elems),
+		get:     func(i int) any { return elems[i] },
 	}
 }
 
 // NewProtoList returns a traits.Lister based on a pb.List instance.
-func NewProtoList(adapter ref.TypeAdapter, list protoreflect.List) traits.Lister {
+func NewProtoList(adapter Adapter, list protoreflect.List) traits.Lister {
 	return &baseList{
-		TypeAdapter: adapter,
-		value:       list,
-		size:        list.Len(),
-		get:         func(i int) any { return list.Get(i).Interface() },
+		Adapter: adapter,
+		value:   list,
+		size:    list.Len(),
+		get:     func(i int) any { return list.Get(i).Interface() },
 	}
 }
 
 // NewJSONList returns a traits.Lister based on structpb.ListValue instance.
-func NewJSONList(adapter ref.TypeAdapter, l *structpb.ListValue) traits.Lister {
+func NewJSONList(adapter Adapter, l *structpb.ListValue) traits.Lister {
 	vals := l.GetValues()
 	return &baseList{
-		TypeAdapter: adapter,
-		value:       l,
-		size:        len(vals),
-		get:         func(i int) any { return vals[i] },
+		Adapter: adapter,
+		value:   l,
+		size:    len(vals),
+		get:     func(i int) any { return vals[i] },
 	}
 }
 
 // NewMutableList creates a new mutable list whose internal state can be modified.
-func NewMutableList(adapter ref.TypeAdapter) traits.MutableLister {
+func NewMutableList(adapter Adapter) traits.MutableLister {
 	var mutableValues []ref.Val
 	l := &mutableList{
 		baseList: &baseList{
-			TypeAdapter: adapter,
-			value:       mutableValues,
-			size:        0,
+			Adapter: adapter,
+			value:   mutableValues,
+			size:    0,
 		},
 		mutableValues: mutableValues,
 	}
@@ -106,9 +106,9 @@ func NewMutableList(adapter ref.TypeAdapter) traits.MutableLister {
 
 // baseList points to a list containing elements of any type.
 // The `value` is an array of native values, and refValue is its reflection object.
-// The `ref.TypeAdapter` enables native type to CEL type conversions.
+// The `Adapter` enables native type to CEL type conversions.
 type baseList struct {
-	ref.TypeAdapter
+	Adapter
 	value any
 
 	// size indicates the number of elements within the list.
@@ -133,9 +133,9 @@ func (l *baseList) Add(other ref.Val) ref.Val {
 		return l
 	}
 	return &concatList{
-		TypeAdapter: l.TypeAdapter,
-		prevList:    l,
-		nextList:    otherList}
+		Adapter:  l.Adapter,
+		prevList: l,
+		nextList: otherList}
 }
 
 // Contains implements the traits.Container interface method.
@@ -312,13 +312,13 @@ func (l *mutableList) Add(other ref.Val) ref.Val {
 func (l *mutableList) ToImmutableList() traits.Lister {
 	// The reference to internal state is guaranteed to be safe as this call is only performed
 	// when mutations have been completed.
-	return NewRefValList(l.TypeAdapter, l.mutableValues)
+	return NewRefValList(l.Adapter, l.mutableValues)
 }
 
 // concatList combines two list implementations together into a view.
-// The `ref.TypeAdapter` enables native type to CEL type conversions.
+// The `Adapter` enables native type to CEL type conversions.
 type concatList struct {
-	ref.TypeAdapter
+	Adapter
 	value    any
 	prevList traits.Lister
 	nextList traits.Lister
@@ -337,9 +337,9 @@ func (l *concatList) Add(other ref.Val) ref.Val {
 		return l
 	}
 	return &concatList{
-		TypeAdapter: l.TypeAdapter,
-		prevList:    l,
-		nextList:    otherList}
+		Adapter:  l.Adapter,
+		prevList: l,
+		nextList: otherList}
 }
 
 // Contains implements the traits.Container interface method.
@@ -366,7 +366,7 @@ func (l *concatList) Contains(elem ref.Val) ref.Val {
 
 // ConvertToNative implements the ref.Val interface method.
 func (l *concatList) ConvertToNative(typeDesc reflect.Type) (any, error) {
-	combined := NewDynamicList(l.TypeAdapter, l.Value().([]any))
+	combined := NewDynamicList(l.Adapter, l.Value().([]any))
 	return combined.ConvertToNative(typeDesc)
 }
 

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -32,10 +32,10 @@ import (
 )
 
 // NewDynamicMap returns a traits.Mapper value with dynamic key, value pairs.
-func NewDynamicMap(adapter ref.TypeAdapter, value any) traits.Mapper {
+func NewDynamicMap(adapter Adapter, value any) traits.Mapper {
 	refValue := reflect.ValueOf(value)
 	return &baseMap{
-		TypeAdapter: adapter,
+		Adapter:     adapter,
 		mapAccessor: newReflectMapAccessor(adapter, refValue),
 		value:       value,
 		size:        refValue.Len(),
@@ -46,10 +46,10 @@ func NewDynamicMap(adapter ref.TypeAdapter, value any) traits.Mapper {
 // encoded in protocol buffer form.
 //
 // The `adapter` argument provides type adaptation capabilities from proto to CEL.
-func NewJSONStruct(adapter ref.TypeAdapter, value *structpb.Struct) traits.Mapper {
+func NewJSONStruct(adapter Adapter, value *structpb.Struct) traits.Mapper {
 	fields := value.GetFields()
 	return &baseMap{
-		TypeAdapter: adapter,
+		Adapter:     adapter,
 		mapAccessor: newJSONStructAccessor(adapter, fields),
 		value:       value,
 		size:        len(fields),
@@ -57,9 +57,9 @@ func NewJSONStruct(adapter ref.TypeAdapter, value *structpb.Struct) traits.Mappe
 }
 
 // NewRefValMap returns a specialized traits.Mapper with CEL valued keys and values.
-func NewRefValMap(adapter ref.TypeAdapter, value map[ref.Val]ref.Val) traits.Mapper {
+func NewRefValMap(adapter Adapter, value map[ref.Val]ref.Val) traits.Mapper {
 	return &baseMap{
-		TypeAdapter: adapter,
+		Adapter:     adapter,
 		mapAccessor: newRefValMapAccessor(value),
 		value:       value,
 		size:        len(value),
@@ -67,9 +67,9 @@ func NewRefValMap(adapter ref.TypeAdapter, value map[ref.Val]ref.Val) traits.Map
 }
 
 // NewStringInterfaceMap returns a specialized traits.Mapper with string keys and interface values.
-func NewStringInterfaceMap(adapter ref.TypeAdapter, value map[string]any) traits.Mapper {
+func NewStringInterfaceMap(adapter Adapter, value map[string]any) traits.Mapper {
 	return &baseMap{
-		TypeAdapter: adapter,
+		Adapter:     adapter,
 		mapAccessor: newStringIfaceMapAccessor(adapter, value),
 		value:       value,
 		size:        len(value),
@@ -77,9 +77,9 @@ func NewStringInterfaceMap(adapter ref.TypeAdapter, value map[string]any) traits
 }
 
 // NewStringStringMap returns a specialized traits.Mapper with string keys and values.
-func NewStringStringMap(adapter ref.TypeAdapter, value map[string]string) traits.Mapper {
+func NewStringStringMap(adapter Adapter, value map[string]string) traits.Mapper {
 	return &baseMap{
-		TypeAdapter: adapter,
+		Adapter:     adapter,
 		mapAccessor: newStringMapAccessor(value),
 		value:       value,
 		size:        len(value),
@@ -87,10 +87,10 @@ func NewStringStringMap(adapter ref.TypeAdapter, value map[string]string) traits
 }
 
 // NewProtoMap returns a specialized traits.Mapper for handling protobuf map values.
-func NewProtoMap(adapter ref.TypeAdapter, value *pb.Map) traits.Mapper {
+func NewProtoMap(adapter Adapter, value *pb.Map) traits.Mapper {
 	return &protoMap{
-		TypeAdapter: adapter,
-		value:       value,
+		Adapter: adapter,
+		value:   value,
 	}
 }
 
@@ -112,7 +112,7 @@ type mapAccessor interface {
 // Since CEL is side-effect free, the base map represents an immutable object.
 type baseMap struct {
 	// TypeAdapter used to convert keys and values accessed within the map.
-	ref.TypeAdapter
+	Adapter
 
 	// mapAccessor interface implementation used to find and iterate over map keys.
 	mapAccessor
@@ -307,15 +307,15 @@ func (m *baseMap) Value() any {
 	return m.value
 }
 
-func newJSONStructAccessor(adapter ref.TypeAdapter, st map[string]*structpb.Value) mapAccessor {
+func newJSONStructAccessor(adapter Adapter, st map[string]*structpb.Value) mapAccessor {
 	return &jsonStructAccessor{
-		TypeAdapter: adapter,
-		st:          st,
+		Adapter: adapter,
+		st:      st,
 	}
 }
 
 type jsonStructAccessor struct {
-	ref.TypeAdapter
+	Adapter
 	st map[string]*structpb.Value
 }
 
@@ -350,17 +350,17 @@ func (a *jsonStructAccessor) Iterator() traits.Iterator {
 	}
 }
 
-func newReflectMapAccessor(adapter ref.TypeAdapter, value reflect.Value) mapAccessor {
+func newReflectMapAccessor(adapter Adapter, value reflect.Value) mapAccessor {
 	keyType := value.Type().Key()
 	return &reflectMapAccessor{
-		TypeAdapter: adapter,
-		refValue:    value,
-		keyType:     keyType,
+		Adapter:  adapter,
+		refValue: value,
+		keyType:  keyType,
 	}
 }
 
 type reflectMapAccessor struct {
-	ref.TypeAdapter
+	Adapter
 	refValue reflect.Value
 	keyType  reflect.Type
 }
@@ -418,9 +418,9 @@ func (m *reflectMapAccessor) findInternal(key ref.Val) (ref.Val, bool) {
 // Iterator creates a Golang reflection based traits.Iterator.
 func (m *reflectMapAccessor) Iterator() traits.Iterator {
 	return &mapIterator{
-		TypeAdapter: m.TypeAdapter,
-		mapKeys:     m.refValue.MapRange(),
-		len:         m.refValue.Len(),
+		Adapter: m.Adapter,
+		mapKeys: m.refValue.MapRange(),
+		len:     m.refValue.Len(),
 	}
 }
 
@@ -471,9 +471,9 @@ func (a *refValMapAccessor) Find(key ref.Val) (ref.Val, bool) {
 // Iterator produces a new traits.Iterator which iterates over the map keys via Golang reflection.
 func (a *refValMapAccessor) Iterator() traits.Iterator {
 	return &mapIterator{
-		TypeAdapter: DefaultTypeAdapter,
-		mapKeys:     reflect.ValueOf(a.mapVal).MapRange(),
-		len:         len(a.mapVal),
+		Adapter: DefaultTypeAdapter,
+		mapKeys: reflect.ValueOf(a.mapVal).MapRange(),
+		len:     len(a.mapVal),
 	}
 }
 
@@ -515,15 +515,15 @@ func (a *stringMapAccessor) Iterator() traits.Iterator {
 	}
 }
 
-func newStringIfaceMapAccessor(adapter ref.TypeAdapter, mapVal map[string]any) mapAccessor {
+func newStringIfaceMapAccessor(adapter Adapter, mapVal map[string]any) mapAccessor {
 	return &stringIfaceMapAccessor{
-		TypeAdapter: adapter,
-		mapVal:      mapVal,
+		Adapter: adapter,
+		mapVal:  mapVal,
 	}
 }
 
 type stringIfaceMapAccessor struct {
-	ref.TypeAdapter
+	Adapter
 	mapVal map[string]any
 }
 
@@ -560,7 +560,7 @@ func (a *stringIfaceMapAccessor) Iterator() traits.Iterator {
 // protoMap is a specialized, separate implementation of the traits.Mapper interfaces tailored to
 // accessing protoreflect.Map values.
 type protoMap struct {
-	ref.TypeAdapter
+	Adapter
 	value *pb.Map
 }
 
@@ -763,9 +763,9 @@ func (m *protoMap) Iterator() traits.Iterator {
 		return true
 	})
 	return &protoMapIterator{
-		TypeAdapter: m.TypeAdapter,
-		mapKeys:     mapKeys,
-		len:         m.value.Len(),
+		Adapter: m.Adapter,
+		mapKeys: mapKeys,
+		len:     m.value.Len(),
 	}
 }
 
@@ -786,7 +786,7 @@ func (m *protoMap) Value() any {
 
 type mapIterator struct {
 	*baseIterator
-	ref.TypeAdapter
+	Adapter
 	mapKeys *reflect.MapIter
 	cursor  int
 	len     int
@@ -809,7 +809,7 @@ func (it *mapIterator) Next() ref.Val {
 
 type protoMapIterator struct {
 	*baseIterator
-	ref.TypeAdapter
+	Adapter
 	mapKeys []protoreflect.MapKey
 	cursor  int
 	len     int

--- a/common/types/object.go
+++ b/common/types/object.go
@@ -29,7 +29,7 @@ import (
 )
 
 type protoObj struct {
-	ref.TypeAdapter
+	Adapter
 	value     proto.Message
 	typeDesc  *pb.TypeDescription
 	typeValue ref.Val
@@ -42,15 +42,15 @@ type protoObj struct {
 // Note: the type value is pulled from the list of registered types within the
 // type provider. If the proto type is not registered within the type provider,
 // then this will result in an error within the type adapter / provider.
-func NewObject(adapter ref.TypeAdapter,
+func NewObject(adapter Adapter,
 	typeDesc *pb.TypeDescription,
 	typeValue ref.Val,
 	value proto.Message) ref.Val {
 	return &protoObj{
-		TypeAdapter: adapter,
-		value:       value,
-		typeDesc:    typeDesc,
-		typeValue:   typeValue}
+		Adapter:   adapter,
+		value:     value,
+		typeDesc:  typeDesc,
+		typeValue: typeValue}
 }
 
 func (o *protoObj) ConvertToNative(typeDesc reflect.Type) (any, error) {

--- a/common/types/optional.go
+++ b/common/types/optional.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	// OptionalType indicates the runtime type of an optional value.
-	OptionalType = NewTypeValue("optional")
+	OptionalType = NewOpaqueType("optional")
 
 	// OptionalNone is a sentinel value which is used to indicate an empty optional value.
 	OptionalNone = &Optional{}

--- a/common/types/pb/type.go
+++ b/common/types/pb/type.go
@@ -285,7 +285,7 @@ func (fd *FieldDescription) GetFrom(target any) (any, error) {
 
 // IsEnum returns true if the field type refers to an enum value.
 func (fd *FieldDescription) IsEnum() bool {
-	return fd.desc.Kind() == protoreflect.EnumKind
+	return fd.ProtoKind() == protoreflect.EnumKind
 }
 
 // IsMap returns true if the field is of map type.
@@ -295,7 +295,7 @@ func (fd *FieldDescription) IsMap() bool {
 
 // IsMessage returns true if the field is of message type.
 func (fd *FieldDescription) IsMessage() bool {
-	kind := fd.desc.Kind()
+	kind := fd.ProtoKind()
 	return kind == protoreflect.MessageKind || kind == protoreflect.GroupKind
 }
 
@@ -326,6 +326,10 @@ func (fd *FieldDescription) Name() string {
 	return string(fd.desc.Name())
 }
 
+func (fd *FieldDescription) ProtoKind() protoreflect.Kind {
+	return fd.desc.Kind()
+}
+
 // ReflectType returns the Golang reflect.Type for this field.
 func (fd *FieldDescription) ReflectType() reflect.Type {
 	return fd.reflectType
@@ -345,17 +349,17 @@ func (fd *FieldDescription) Zero() proto.Message {
 }
 
 func (fd *FieldDescription) typeDefToType() *exprpb.Type {
-	if fd.desc.Kind() == protoreflect.MessageKind || fd.desc.Kind() == protoreflect.GroupKind {
+	if fd.IsMessage() {
 		msgType := string(fd.desc.Message().FullName())
 		if wk, found := CheckedWellKnowns[msgType]; found {
 			return wk
 		}
 		return checkedMessageType(msgType)
 	}
-	if fd.desc.Kind() == protoreflect.EnumKind {
+	if fd.IsEnum() {
 		return checkedInt
 	}
-	return CheckedPrimitives[fd.desc.Kind()]
+	return CheckedPrimitives[fd.ProtoKind()]
 }
 
 // Map wraps the protoreflect.Map object with a key and value FieldDescription for use in

--- a/common/types/ref/provider.go
+++ b/common/types/ref/provider.go
@@ -23,34 +23,34 @@ import (
 
 // TypeProvider specifies functions for creating new object instances and for
 // resolving enum values by name.
+//
+// Deprecated: use types.Provider
 type TypeProvider interface {
 	// EnumValue returns the numeric value of the given enum value name.
 	EnumValue(enumName string) Val
 
-	// FindIdent takes a qualified identifier name and returns a Value if one
-	// exists.
+	// FindIdent takes a qualified identifier name and returns a Value if one exists.
 	FindIdent(identName string) (Val, bool)
 
-	// FindType looks up the Type given a qualified typeName. Returns false
-	// if not found.
-	//
-	// Used during type-checking only.
+	// FindType looks up the Type given a qualified typeName. Returns false if not found.
 	FindType(typeName string) (*exprpb.Type, bool)
 
-	// FieldFieldType returns the field type for a checked type value. Returns
-	// false if the field could not be found.
-	FindFieldType(messageType string, fieldName string) (*FieldType, bool)
+	// FieldFieldType returns the field type for a checked type value. Returns false if
+	// the field could not be found.
+	FindFieldType(messageType, fieldName string) (*FieldType, bool)
 
-	// NewValue creates a new type value from a qualified name and map of field
-	// name to value.
+	// NewValue creates a new type value from a qualified name and map of field name
+	// to value.
 	//
-	// Note, for each value, the Val.ConvertToNative function will be invoked
-	// to convert the Val to the field's native type. If an error occurs during
-	// conversion, the NewValue will be a types.Err.
+	// Note, for each value, the Val.ConvertToNative function will be invoked to convert
+	// the Val to the field's native type. If an error occurs during conversion, the
+	// NewValue will be a types.Err.
 	NewValue(typeName string, fields map[string]Val) Val
 }
 
 // TypeAdapter converts native Go values of varying type and complexity to equivalent CEL values.
+//
+// Deprecated: use types.Adapter
 type TypeAdapter interface {
 	// NativeToValue converts the input `value` to a CEL `ref.Val`.
 	NativeToValue(value any) Val
@@ -60,6 +60,8 @@ type TypeAdapter interface {
 // implementations support type-customization, so these features are optional. However, a
 // `TypeRegistry` should be a `TypeProvider` and a `TypeAdapter` to ensure that types
 // which are registered can be converted to CEL representations.
+//
+// Deprecated: use types.Registry
 type TypeRegistry interface {
 	TypeAdapter
 	TypeProvider
@@ -76,15 +78,14 @@ type TypeRegistry interface {
 	// If a type is provided more than once with an alternative definition, the
 	// call will result in an error.
 	RegisterType(types ...Type) error
-
-	// Copy the TypeRegistry and return a new registry whose mutable state is isolated.
-	Copy() TypeRegistry
 }
 
 // FieldType represents a field's type value and whether that field supports
 // presence detection.
+//
+// Deprecated: use types.CelFieldType
 type FieldType struct {
-	// Type of the field.
+	// Type of the field as a protobuf type value.
 	Type *exprpb.Type
 
 	// IsSet indicates whether the field is set on an input object.

--- a/ext/native.go
+++ b/ext/native.go
@@ -81,7 +81,7 @@ var (
 // the time that it is invoked.
 func NativeTypes(refTypes ...any) cel.EnvOption {
 	return func(env *cel.Env) (*cel.Env, error) {
-		tp, err := newNativeTypeProvider(env.TypeAdapter(), env.TypeProvider(), refTypes...)
+		tp, err := newNativeTypeProvider(env.CELTypeAdapter(), env.CELTypeProvider(), refTypes...)
 		if err != nil {
 			return nil, err
 		}
@@ -93,7 +93,7 @@ func NativeTypes(refTypes ...any) cel.EnvOption {
 	}
 }
 
-func newNativeTypeProvider(adapter ref.TypeAdapter, provider ref.TypeProvider, refTypes ...any) (*nativeTypeProvider, error) {
+func newNativeTypeProvider(adapter types.Adapter, provider types.Provider, refTypes ...any) (*nativeTypeProvider, error) {
 	nativeTypes := make(map[string]*nativeType, len(refTypes))
 	for _, refType := range refTypes {
 		switch rt := refType.(type) {
@@ -122,18 +122,18 @@ func newNativeTypeProvider(adapter ref.TypeAdapter, provider ref.TypeProvider, r
 
 type nativeTypeProvider struct {
 	nativeTypes  map[string]*nativeType
-	baseAdapter  ref.TypeAdapter
-	baseProvider ref.TypeProvider
+	baseAdapter  types.Adapter
+	baseProvider types.Provider
 }
 
-// EnumValue proxies to the ref.TypeProvider configured at the times the NativeTypes
+// EnumValue proxies to the types.Provider configured at the times the NativeTypes
 // option was configured.
 func (tp *nativeTypeProvider) EnumValue(enumName string) ref.Val {
 	return tp.baseProvider.EnumValue(enumName)
 }
 
 // FindIdent looks up natives type instances by qualified identifier, and if not found
-// proxies to the composed ref.TypeProvider.
+// proxies to the composed types.Provider.
 func (tp *nativeTypeProvider) FindIdent(typeName string) (ref.Val, bool) {
 	if t, found := tp.nativeTypes[typeName]; found {
 		return t, true
@@ -142,12 +142,23 @@ func (tp *nativeTypeProvider) FindIdent(typeName string) (ref.Val, bool) {
 }
 
 // FindType looks up CEL type-checker type definition by qualified identifier, and if not found
-// proxies to the composed ref.TypeProvider.
+// proxies to the composed types.Provider.
 func (tp *nativeTypeProvider) FindType(typeName string) (*exprpb.Type, bool) {
 	if _, found := tp.nativeTypes[typeName]; found {
 		return decls.NewTypeType(decls.NewObjectType(typeName)), true
 	}
-	return tp.baseProvider.FindType(typeName)
+	if celType, found := tp.baseProvider.FindStructType(typeName); found {
+		et, err := types.TypeToExprType(celType)
+		if err != nil {
+			return nil, false
+		}
+		return et, true
+	}
+	return nil, false
+}
+
+func (tp *nativeTypeProvider) FieldStructType(typeName string) (*types.Type, bool) {
+	return tp.baseProvider.FindStructType(typeName)
 }
 
 // FindFieldType looks up a native type's field definition, and if the type name is not a native
@@ -155,7 +166,19 @@ func (tp *nativeTypeProvider) FindType(typeName string) (*exprpb.Type, bool) {
 func (tp *nativeTypeProvider) FindFieldType(typeName, fieldName string) (*ref.FieldType, bool) {
 	t, found := tp.nativeTypes[typeName]
 	if !found {
-		return tp.baseProvider.FindFieldType(typeName, fieldName)
+		cft, found := tp.baseProvider.FindStructFieldType(typeName, fieldName)
+		if !found {
+			return nil, false
+		}
+		et, err := types.TypeToExprType(cft.Type)
+		if err != nil {
+			return nil, false
+		}
+		return &ref.FieldType{
+			Type:    et,
+			IsSet:   cft.IsSet,
+			GetFrom: cft.GetFrom,
+		}, true
 	}
 	refField, isDefined := t.hasField(fieldName)
 	if !found || !isDefined {
@@ -167,6 +190,34 @@ func (tp *nativeTypeProvider) FindFieldType(typeName, fieldName string) (*ref.Fi
 	}
 	return &ref.FieldType{
 		Type: exprType,
+		IsSet: func(obj any) bool {
+			refVal := reflect.Indirect(reflect.ValueOf(obj))
+			refField := refVal.FieldByName(fieldName)
+			return !refField.IsZero()
+		},
+		GetFrom: func(obj any) (any, error) {
+			refVal := reflect.Indirect(reflect.ValueOf(obj))
+			refField := refVal.FieldByName(fieldName)
+			return getFieldValue(tp, refField), nil
+		},
+	}, true
+}
+
+func (tp *nativeTypeProvider) FindStructFieldType(typeName, fieldName string) (*types.FieldType, bool) {
+	t, found := tp.nativeTypes[typeName]
+	if !found {
+		return tp.baseProvider.FindStructFieldType(typeName, fieldName)
+	}
+	refField, isDefined := t.hasField(fieldName)
+	if !found || !isDefined {
+		return nil, false
+	}
+	celType, ok := convertToCelType(refField.Type)
+	if !ok {
+		return nil, false
+	}
+	return &types.FieldType{
+		Type: celType,
 		IsSet: func(obj any) bool {
 			refVal := reflect.Indirect(reflect.ValueOf(obj))
 			refField := refVal.FieldByName(fieldName)
@@ -243,6 +294,59 @@ func (tp *nativeTypeProvider) NativeToValue(val any) ref.Val {
 	}
 }
 
+func convertToCelType(refType reflect.Type) (*cel.Type, bool) {
+	switch refType.Kind() {
+	case reflect.Bool:
+		return cel.BoolType, true
+	case reflect.Float32, reflect.Float64:
+		return cel.DoubleType, true
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if refType == durationType {
+			return cel.DurationType, true
+		}
+		return cel.IntType, true
+	case reflect.String:
+		return cel.StringType, true
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return cel.UintType, true
+	case reflect.Array, reflect.Slice:
+		refElem := refType.Elem()
+		if refElem == reflect.TypeOf(byte(0)) {
+			return cel.BytesType, true
+		}
+		elemType, ok := convertToCelType(refElem)
+		if !ok {
+			return nil, false
+		}
+		return cel.ListType(elemType), true
+	case reflect.Map:
+		keyType, ok := convertToCelType(refType.Key())
+		if !ok {
+			return nil, false
+		}
+		// Ensure the key type is a int, bool, uint, string
+		elemType, ok := convertToCelType(refType.Elem())
+		if !ok {
+			return nil, false
+		}
+		return cel.MapType(keyType, elemType), true
+	case reflect.Struct:
+		if refType == timestampType {
+			return cel.TimestampType, true
+		}
+		return cel.ObjectType(
+			fmt.Sprintf("%s.%s", simplePkgAlias(refType.PkgPath()), refType.Name()),
+		), true
+	case reflect.Pointer:
+		if refType.Implements(pbMsgInterfaceType) {
+			pbMsg := reflect.New(refType.Elem()).Interface().(protoreflect.ProtoMessage)
+			return cel.ObjectType(string(pbMsg.ProtoReflect().Descriptor().FullName())), true
+		}
+		return convertToCelType(refType.Elem())
+	}
+	return nil, false
+}
+
 // convertToExprType converts the Golang reflect.Type to a protobuf exprpb.Type.
 func convertToExprType(refType reflect.Type) (*exprpb.Type, bool) {
 	switch refType.Kind() {
@@ -297,21 +401,21 @@ func convertToExprType(refType reflect.Type) (*exprpb.Type, bool) {
 	return nil, false
 }
 
-func newNativeObject(adapter ref.TypeAdapter, val any, refValue reflect.Value) ref.Val {
+func newNativeObject(adapter types.Adapter, val any, refValue reflect.Value) ref.Val {
 	valType, err := newNativeType(refValue.Type())
 	if err != nil {
 		return types.NewErr(err.Error())
 	}
 	return &nativeObj{
-		TypeAdapter: adapter,
-		val:         val,
-		valType:     valType,
-		refValue:    refValue,
+		Adapter:  adapter,
+		val:      val,
+		valType:  valType,
+		refValue: refValue,
 	}
 }
 
 type nativeObj struct {
-	ref.TypeAdapter
+	types.Adapter
 	val      any
 	valType  *nativeType
 	refValue reflect.Value
@@ -520,11 +624,11 @@ func (t *nativeType) hasField(fieldName string) (reflect.StructField, bool) {
 	return f, true
 }
 
-func adaptFieldValue(adapter ref.TypeAdapter, refField reflect.Value) ref.Val {
+func adaptFieldValue(adapter types.Adapter, refField reflect.Value) ref.Val {
 	return adapter.NativeToValue(getFieldValue(adapter, refField))
 }
 
-func getFieldValue(adapter ref.TypeAdapter, refField reflect.Value) any {
+func getFieldValue(adapter types.Adapter, refField reflect.Value) any {
 	if refField.IsZero() {
 		switch refField.Kind() {
 		case reflect.Array, reflect.Slice:

--- a/interpreter/activation.go
+++ b/interpreter/activation.go
@@ -58,7 +58,7 @@ func (emptyActivation) Parent() Activation             { return nil }
 // The output of the lazy binding will overwrite the variable reference in the internal map.
 //
 // Values which are not represented as ref.Val types on input may be adapted to a ref.Val using
-// the ref.TypeAdapter configured in the environment.
+// the types.Adapter configured in the environment.
 func NewActivation(bindings any) (Activation, error) {
 	if bindings == nil {
 		return nil, errors.New("bindings must be non-nil")

--- a/interpreter/attribute_patterns.go
+++ b/interpreter/attribute_patterns.go
@@ -177,8 +177,8 @@ func numericValueEquals(value any, celValue ref.Val) bool {
 // NewPartialAttributeFactory returns an AttributeFactory implementation capable of performing
 // AttributePattern matches with PartialActivation inputs.
 func NewPartialAttributeFactory(container *containers.Container,
-	adapter ref.TypeAdapter,
-	provider ref.TypeProvider) AttributeFactory {
+	adapter types.Adapter,
+	provider types.Provider) AttributeFactory {
 	fac := NewAttributeFactory(container, adapter, provider)
 	return &partialAttributeFactory{
 		AttributeFactory: fac,
@@ -191,8 +191,8 @@ func NewPartialAttributeFactory(container *containers.Container,
 type partialAttributeFactory struct {
 	AttributeFactory
 	container *containers.Container
-	adapter   ref.TypeAdapter
-	provider  ref.TypeProvider
+	adapter   types.Adapter
+	provider  types.Provider
 }
 
 // AbsoluteAttribute implementation of the AttributeFactory interface which wraps the

--- a/interpreter/attributes_test.go
+++ b/interpreter/attributes_test.go
@@ -759,7 +759,7 @@ func BenchmarkResolverFieldQualifier(b *testing.B) {
 			},
 		},
 	}
-	reg := newBenchRegistry(b, msg)
+	reg := newTestRegistry(b, msg)
 	attrs := NewAttributeFactory(containers.DefaultContainer, reg, reg)
 	vars, _ := NewActivation(map[string]any{
 		"msg": msg,
@@ -1167,7 +1167,7 @@ func TestAttributeStateTracking(t *testing.T) {
 }
 
 func BenchmarkResolverCustomQualifier(b *testing.B) {
-	reg := newBenchRegistry(b)
+	reg := newTestRegistry(b)
 	attrs := &custAttrFactory{
 		AttributeFactory: NewAttributeFactory(containers.DefaultContainer, reg, reg),
 	}

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -52,7 +52,7 @@ type InterpretableAttribute interface {
 	Attr() Attribute
 
 	// Adapter returns the type adapter to be used for adapting resolved Attribute values.
-	Adapter() ref.TypeAdapter
+	Adapter() types.Adapter
 
 	// AddQualifier proxies the Attribute.AddQualifier method.
 	//
@@ -575,7 +575,7 @@ type evalList struct {
 	elems        []Interpretable
 	optionals    []bool
 	hasOptionals bool
-	adapter      ref.TypeAdapter
+	adapter      types.Adapter
 }
 
 // ID implements the Interpretable interface method.
@@ -621,7 +621,7 @@ type evalMap struct {
 	vals         []Interpretable
 	optionals    []bool
 	hasOptionals bool
-	adapter      ref.TypeAdapter
+	adapter      types.Adapter
 }
 
 // ID implements the Interpretable interface method.
@@ -685,7 +685,7 @@ type evalObj struct {
 	vals         []Interpretable
 	optionals    []bool
 	hasOptionals bool
-	provider     ref.TypeProvider
+	provider     types.Provider
 }
 
 // ID implements the Interpretable interface method.
@@ -735,7 +735,7 @@ type evalFold struct {
 	cond          Interpretable
 	step          Interpretable
 	result        Interpretable
-	adapter       ref.TypeAdapter
+	adapter       types.Adapter
 	exhaustive    bool
 	interruptable bool
 }
@@ -891,7 +891,7 @@ func (e *evalWatchAttr) Eval(vars Activation) ref.Val {
 type evalWatchConstQual struct {
 	ConstantQualifier
 	observer EvalObserver
-	adapter  ref.TypeAdapter
+	adapter  types.Adapter
 }
 
 // Qualify observes the qualification of a object via a constant boolean, int, string, or uint.
@@ -934,7 +934,7 @@ func (e *evalWatchConstQual) QualifierValueEquals(value any) bool {
 type evalWatchQual struct {
 	Qualifier
 	observer EvalObserver
-	adapter  ref.TypeAdapter
+	adapter  types.Adapter
 }
 
 // Qualify observes the qualification of a object via a value computed at runtime.
@@ -1092,7 +1092,7 @@ func (and *evalExhaustiveAnd) Eval(ctx Activation) ref.Val {
 // evaluation.
 type evalExhaustiveConditional struct {
 	id      int64
-	adapter ref.TypeAdapter
+	adapter types.Adapter
 	attr    *conditionalAttribute
 }
 
@@ -1124,7 +1124,7 @@ func (cond *evalExhaustiveConditional) Eval(ctx Activation) ref.Val {
 
 // evalAttr evaluates an Attribute value.
 type evalAttr struct {
-	adapter  ref.TypeAdapter
+	adapter  types.Adapter
 	attr     Attribute
 	optional bool
 }
@@ -1149,7 +1149,7 @@ func (a *evalAttr) Attr() Attribute {
 }
 
 // Adapter implements the InterpretableAttribute interface method.
-func (a *evalAttr) Adapter() ref.TypeAdapter {
+func (a *evalAttr) Adapter() types.Adapter {
 	return a.adapter
 }
 

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -20,6 +20,7 @@ package interpreter
 import (
 	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/containers"
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
@@ -154,8 +155,8 @@ func CompileRegexConstants(regexOptimizations ...*RegexOptimization) Interpretab
 type exprInterpreter struct {
 	dispatcher  Dispatcher
 	container   *containers.Container
-	provider    ref.TypeProvider
-	adapter     ref.TypeAdapter
+	provider    types.Provider
+	adapter     types.Adapter
 	attrFactory AttributeFactory
 }
 
@@ -163,8 +164,8 @@ type exprInterpreter struct {
 // throughout the Eval of all Interpretable instances generated from it.
 func NewInterpreter(dispatcher Dispatcher,
 	container *containers.Container,
-	provider ref.TypeProvider,
-	adapter ref.TypeAdapter,
+	provider types.Provider,
+	adapter types.Adapter,
 	attrFactory AttributeFactory) Interpreter {
 	return &exprInterpreter{
 		dispatcher:  dispatcher,

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -39,8 +39,8 @@ type interpretablePlanner interface {
 // functions, types, and namespaced identifiers at plan time rather than at runtime since
 // it only needs to be done once and may be semi-expensive to compute.
 func newPlanner(disp Dispatcher,
-	provider ref.TypeProvider,
-	adapter ref.TypeAdapter,
+	provider types.Provider,
+	adapter types.Adapter,
 	attrFactory AttributeFactory,
 	cont *containers.Container,
 	checked *ast.CheckedAST,
@@ -61,8 +61,8 @@ func newPlanner(disp Dispatcher,
 // TypeAdapter, and Container to resolve functions and types at plan time. Namespaces present in
 // Select expressions are resolved lazily at evaluation time.
 func newUncheckedPlanner(disp Dispatcher,
-	provider ref.TypeProvider,
-	adapter ref.TypeAdapter,
+	provider types.Provider,
+	adapter types.Adapter,
 	attrFactory AttributeFactory,
 	cont *containers.Container,
 	decorators ...InterpretableDecorator) interpretablePlanner {
@@ -81,8 +81,8 @@ func newUncheckedPlanner(disp Dispatcher,
 // planner is an implementation of the interpretablePlanner interface.
 type planner struct {
 	disp        Dispatcher
-	provider    ref.TypeProvider
-	adapter     ref.TypeAdapter
+	provider    types.Provider
+	adapter     types.Adapter
 	attrFactory AttributeFactory
 	container   *containers.Container
 	refMap      map[int64]*ast.ReferenceInfo
@@ -672,7 +672,7 @@ func (p *planner) constValue(c *exprpb.Constant) (ref.Val, error) {
 // namespace resolution rules to it in a scan over possible matching types in the TypeProvider.
 func (p *planner) resolveTypeName(typeName string) (string, bool) {
 	for _, qualifiedTypeName := range p.container.ResolveCandidateNames(typeName) {
-		if _, found := p.provider.FindType(qualifiedTypeName); found {
+		if _, found := p.provider.FindStructType(qualifiedTypeName); found {
 			return qualifiedTypeName, true
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -188,7 +188,7 @@ func RefValueToExprValue(res ref.Val, err error) (*exprpb.ExprValue, error) {
 }
 
 // ExprValueToRefValue converts between exprpb.ExprValue and ref.Val.
-func ExprValueToRefValue(adapter ref.TypeAdapter, ev *exprpb.ExprValue) (ref.Val, error) {
+func ExprValueToRefValue(adapter types.Adapter, ev *exprpb.ExprValue) (ref.Val, error) {
 	switch ev.Kind.(type) {
 	case *exprpb.ExprValue_Value:
 		return cel.ValueToRefValue(adapter, ev.GetValue())


### PR DESCRIPTION
The ref.TypeAdapter, ref.TypeProvider, and ref.TypeRegistry have been deprecated in favor of types.Adapter, types.Provider, and types.Registry respectively.

All existing uses of ref.TypeProvider / ref.TypeAdapter interfaces are wrapped into an interop layer under the covers which ensures that all internal objects refer to the new types and interfaces.

This shift marks the deprecation of the last of the exprpb.Type methods, thus simplifying implementation of custom type providers as implementers need only consider the *types.Type and not the ref.Type, exprpb.Type, or any other alternative.

Closes #568 