### PR TITLE
Open the ASTValidator API to external authors

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -911,16 +911,16 @@ func TestContextEval(t *testing.T) {
 	}
 
 	ctx := context.TODO()
-	items := make([]int64, 1000)
-	for i := int64(0); i < 1000; i++ {
+	items := make([]int64, 2000)
+	for i := int64(0); i < 2000; i++ {
 		items[i] = i
 	}
 	out, _, err := prg.ContextEval(ctx, map[string]any{"items": items})
 	if err != nil {
 		t.Fatalf("prg.ContextEval() failed: %v", err)
 	}
-	if out != types.Int(975) {
-		t.Errorf("prg.ContextEval() got %v, wanted 75", out)
+	if out != types.Int(1975) {
+		t.Errorf("prg.ContextEval() got %v, wanted 1975", out)
 	}
 
 	evalCtx, cancel := context.WithTimeout(ctx, time.Microsecond)

--- a/cel/env.go
+++ b/cel/env.go
@@ -709,6 +709,11 @@ func (i *Issues) ReportErrorAtID(id int64, message string, args ...any) {
 	i.errs.ReportErrorAtID(id, locationByID(id, i.info), message, args...)
 }
 
+// locationByID returns a common.Location given an expression id.
+//
+// TODO: move this functionality into the native SourceInfo and an overhaul of the common.Source
+// as this implementation relies on the abstractions present in the protobuf SourceInfo object,
+// and is replicated in the checker.
 func locationByID(id int64, sourceInfo *exprpb.SourceInfo) common.Location {
 	positions := sourceInfo.GetPositions()
 	var line = 1

--- a/cel/validator.go
+++ b/cel/validator.go
@@ -16,13 +16,26 @@ package cel
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 
-	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/overloads"
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+const (
+	homogeneousValidatorName = "cel.lib.std.validate.types.homogeneous"
+
+	// HomogeneousAggregateLiteralExemptFunctions is the ValidatorConfig key used to configure
+	// the set of function names which are exempt from homogeneous type checks. The expected type
+	// is a string list of function names.
+	//
+	// As an example, the `<string>.format([args])` call expects the input arguments list to be
+	// comprised of a variety of types which correspond to the types expected by the format control
+	// clauses; however, all other uses of a mixed element type list, would be unexpected.
+	HomogeneousAggregateLiteralExemptFunctions = homogeneousValidatorName + ".exempt"
 )
 
 // ASTValidators configures a set of ASTValidator instances into the target environment.
@@ -49,9 +62,72 @@ type ASTValidator interface {
 	Name() string
 
 	// Validate validates a given Ast within an Environment and collects a set of potential issues.
-	Validate(*Env, *Ast, *Issues)
+	//
+	// The ValidatorConfig is generated from the set of ASTValidatorConfigurer instances prior to
+	// the invocation of the Validate call. The expectation is that the validator configuration
+	// is created in sequence and immutable once provided to the Validate call.
+	//
+	// See individual validators for more information on their configuration keys and configuration
+	// properties.
+	Validate(*Env, ValidatorConfig, *ast.CheckedAST, *Issues)
+}
 
-	is_validator()
+// ValidatorConfig provides an accessor method for querying validator configuration state.
+type ValidatorConfig interface {
+	GetOrDefault(name string, value any) any
+}
+
+// MutableValidatorConfig provides mutation methods for querying and updating validator configuration
+// settings.
+type MutableValidatorConfig interface {
+	ValidatorConfig
+	Set(name string, value any) error
+}
+
+// ASTValidatorConfigurer indicates that this object, currently expected to be an ASTValidator,
+// participates in validator configuration settings.
+//
+// This interface may be split from the expectation of being an ASTValidator instance in the future.
+type ASTValidatorConfigurer interface {
+	Configure(MutableValidatorConfig) error
+}
+
+// validatorConfig implements the ValidatorConfig and MutableValidatorConfig interfaces.
+type validatorConfig struct {
+	data map[string]any
+}
+
+// newValidatorConfig initializes the validator config with default values for core CEL validators.
+func newValidatorConfig() *validatorConfig {
+	return &validatorConfig{
+		data: map[string]any{
+			HomogeneousAggregateLiteralExemptFunctions: []string{},
+		},
+	}
+}
+
+// GetOrDefault returns the configured value for the name, if present, else the input default value.
+//
+// Note, the type-agreement between the input default and configured value is not checked on read.
+func (config *validatorConfig) GetOrDefault(name string, value any) any {
+	v, found := config.data[name]
+	if !found {
+		return value
+	}
+	return v
+}
+
+// Set configures a validator option with the given name and value.
+//
+// If the value had previously been set, the new value must have the same reflection type as the old one,
+// or the call will error.
+func (config *validatorConfig) Set(name string, value any) error {
+	v, found := config.data[name]
+	if found && reflect.TypeOf(v) != reflect.TypeOf(value) {
+		return fmt.Errorf("incompatible configuration type for %s, got %T, wanted %T", name, value, v)
+	}
+	config.data[name] = value
+	return nil
 }
 
 // ExtendedValidations collects a set of common AST validations which reduce the likelihood of runtime errors.
@@ -127,9 +203,8 @@ func (v formatValidator) Name() string {
 
 // Validate searches the AST for uses of a given function name with a constant argument and performs a check
 // on whether the argument is a valid literal value.
-func (v formatValidator) Validate(e *Env, a *Ast, iss *Issues) {
-	errs := errorReporter{iss: iss, info: a.info}
-	root := ast.NavigateCheckedAST(astToCheckedAST(a))
+func (v formatValidator) Validate(e *Env, _ ValidatorConfig, a *ast.CheckedAST, iss *Issues) {
+	root := ast.NavigateCheckedAST(a)
 	funcCalls := ast.MatchDescendants(root, ast.FunctionMatcher(v.funcName))
 	for _, call := range funcCalls {
 		callArgs := call.AsCall().Args()
@@ -141,7 +216,7 @@ func (v formatValidator) Validate(e *Env, a *Ast, iss *Issues) {
 			continue
 		}
 		if err := v.check(e, call, litArg); err != nil {
-			errs.reportErrorAtID(litArg.ID(), "invalid %s argument", v.funcName)
+			iss.ReportErrorAtID(litArg.ID(), "invalid %s argument", v.funcName)
 		}
 	}
 }
@@ -162,28 +237,35 @@ func compileRegex(_ *Env, _, arg ast.NavigableExpr) error {
 	return err
 }
 
-func (formatValidator) is_validator() {}
-
 type homogeneousAggregateLiteralValidator struct{}
 
 // Name returns the unique name of the homogeneous type validator.
 func (homogeneousAggregateLiteralValidator) Name() string {
-	return "cel.lib.std.validate.types.homogeneous"
+	return homogeneousValidatorName
+}
+
+// Configure implements the ASTValidatorConfigurer interface and currently sets the list of standard
+// and exempt functions from homogeneous aggregate literal checks.
+//
+// TODO: Move this call into the string.format() ASTValidator once ported.
+func (homogeneousAggregateLiteralValidator) Configure(c MutableValidatorConfig) error {
+	emptyList := []string{}
+	exemptFunctions := c.GetOrDefault(HomogeneousAggregateLiteralExemptFunctions, emptyList).([]string)
+	exemptFunctions = append(exemptFunctions, "format")
+	return c.Set(HomogeneousAggregateLiteralExemptFunctions, exemptFunctions)
 }
 
 // Validate validates that all lists and map literals have homogeneous types, i.e. don't contain dyn types.
 //
 // This validator makes an exception for list and map literals which occur at any level of nesting within
 // string format calls.
-func (v homogeneousAggregateLiteralValidator) Validate(e *Env, a *Ast, iss *Issues) {
-	errs := errorReporter{iss: iss, info: a.info}
-	root := ast.NavigateCheckedAST(astToCheckedAST(a))
+func (v homogeneousAggregateLiteralValidator) Validate(_ *Env, c ValidatorConfig, a *ast.CheckedAST, iss *Issues) {
+	var exemptedFunctions []string
+	exemptedFunctions = c.GetOrDefault(HomogeneousAggregateLiteralExemptFunctions, exemptedFunctions).([]string)
+	root := ast.NavigateCheckedAST(a)
 	listExprs := ast.MatchDescendants(root, ast.KindMatcher(ast.ListKind))
 	for _, listExpr := range listExprs {
-		// TODO: Add a validator config object which allows libraries to influence validation options
-		// for validators that *might* be configured. In this case, a way of skipping certain function
-		// overloads.
-		if hasStringFormatAncestor(listExpr) {
+		if inExemptFunction(listExpr, exemptedFunctions) {
 			continue
 		}
 		l := listExpr.AsList()
@@ -200,14 +282,14 @@ func (v homogeneousAggregateLiteralValidator) Validate(e *Env, a *Ast, iss *Issu
 				continue
 			}
 			if !elemType.IsEquivalentType(et) {
-				v.typeMismatch(errs, e.ID(), elemType, et)
+				v.typeMismatch(iss, e.ID(), elemType, et)
 				break
 			}
 		}
 	}
 	mapExprs := ast.MatchDescendants(root, ast.KindMatcher(ast.MapKind))
 	for _, mapExpr := range mapExprs {
-		if hasStringFormatAncestor(mapExpr) {
+		if inExemptFunction(mapExpr, exemptedFunctions) {
 			continue
 		}
 		m := mapExpr.AsMap()
@@ -224,22 +306,27 @@ func (v homogeneousAggregateLiteralValidator) Validate(e *Env, a *Ast, iss *Issu
 				continue
 			}
 			if !keyType.IsEquivalentType(kt) {
-				v.typeMismatch(errs, key.ID(), keyType, kt)
+				v.typeMismatch(iss, key.ID(), keyType, kt)
 			}
 			if !valType.IsEquivalentType(vt) {
-				v.typeMismatch(errs, val.ID(), valType, vt)
+				v.typeMismatch(iss, val.ID(), valType, vt)
 			}
 		}
 	}
 }
 
-func hasStringFormatAncestor(e ast.NavigableExpr) bool {
+func inExemptFunction(e ast.NavigableExpr, exemptFunctions []string) bool {
 	if parent, found := e.Parent(); found {
-		if parent.Kind() == ast.CallKind && parent.AsCall().FunctionName() == "format" {
-			return true
+		if parent.Kind() == ast.CallKind {
+			fnName := parent.AsCall().FunctionName()
+			for _, exempt := range exemptFunctions {
+				if exempt == fnName {
+					return true
+				}
+			}
 		}
 		if parent.Kind() == ast.ListKind || parent.Kind() == ast.MapKind {
-			return hasStringFormatAncestor(parent)
+			return inExemptFunction(parent, exemptFunctions)
 		}
 	}
 	return false
@@ -254,11 +341,9 @@ func isOptionalIndex(i int, optIndices []int32) bool {
 	return false
 }
 
-func (homogeneousAggregateLiteralValidator) typeMismatch(errs errorReporter, id int64, expected, actual *Type) {
-	errs.reportErrorAtID(id, "expected type '%s' but found '%s'", FormatCelType(expected), FormatCelType(actual))
+func (homogeneousAggregateLiteralValidator) typeMismatch(iss *Issues, id int64, expected, actual *Type) {
+	iss.ReportErrorAtID(id, "expected type '%s' but found '%s'", FormatCelType(expected), FormatCelType(actual))
 }
-
-func (homogeneousAggregateLiteralValidator) is_validator() {}
 
 type nestingLimitValidator struct {
 	limit int
@@ -268,9 +353,8 @@ func (v nestingLimitValidator) Name() string {
 	return "cel.lib.std.validate.comprehension_nesting_limit"
 }
 
-func (v nestingLimitValidator) Validate(e *Env, a *Ast, iss *Issues) {
-	errs := errorReporter{iss: iss, info: a.info}
-	root := ast.NavigateCheckedAST(astToCheckedAST(a))
+func (v nestingLimitValidator) Validate(e *Env, _ ValidatorConfig, a *ast.CheckedAST, iss *Issues) {
+	root := ast.NavigateCheckedAST(a)
 	comprehensions := ast.MatchDescendants(root, ast.KindMatcher(ast.ComprehensionKind))
 	if len(comprehensions) <= v.limit {
 		return
@@ -295,48 +379,10 @@ func (v nestingLimitValidator) Validate(e *Env, a *Ast, iss *Issues) {
 			// Otherwise check the nesting limit.
 			count++
 			if count > v.limit {
-				errs.reportErrorAtID(comp.ID(), "comprehension exceeds nesting limit")
+				iss.ReportErrorAtID(comp.ID(), "comprehension exceeds nesting limit")
 				break
 			}
 			e, hasParent = e.Parent()
 		}
-	}
-}
-
-func (nestingLimitValidator) is_validator() {}
-
-type errorReporter struct {
-	iss  *Issues
-	info *exprpb.SourceInfo
-}
-
-func (er *errorReporter) reportErrorAtID(id int64, message string, args ...any) {
-	er.iss.errs.ReportErrorAtID(id, locationByID(id, er.info), message, args...)
-}
-
-func locationByID(id int64, sourceInfo *exprpb.SourceInfo) common.Location {
-	positions := sourceInfo.GetPositions()
-	var line = 1
-	if offset, found := positions[id]; found {
-		col := int(offset)
-		for _, lineOffset := range sourceInfo.GetLineOffsets() {
-			if lineOffset < offset {
-				line++
-				col = int(offset - lineOffset)
-			} else {
-				break
-			}
-		}
-		return common.NewLocation(line, col)
-	}
-	return common.NoLocation
-}
-
-func astToCheckedAST(a *Ast) *ast.CheckedAST {
-	return &ast.CheckedAST{
-		Expr:         a.expr,
-		SourceInfo:   a.info,
-		TypeMap:      a.typeMap,
-		ReferenceMap: a.refMap,
 	}
 }

--- a/cel/validator_test.go
+++ b/cel/validator_test.go
@@ -15,6 +15,7 @@
 package cel
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/google/cel-go/common/operators"
@@ -393,5 +394,25 @@ func TestExtendedValidations(t *testing.T) {
 				t.Fatalf("e.Compile(%v) failed: %v", tc.expr, iss.Err())
 			}
 		})
+	}
+}
+
+func TestValidatorConfig(t *testing.T) {
+	config := newValidatorConfig()
+	result := config.GetOrDefault("ext.validate.custom", 2)
+	if result != 2 {
+		t.Errorf("config.GetOrDefault() got %v, wanted default of 2", result)
+	}
+	result = config.GetOrDefault(HomogeneousAggregateLiteralExemptFunctions, []string{})
+	if reflect.TypeOf(result) != reflect.TypeOf([]string{}) {
+		t.Errorf("config.GetOrDefault() got %T, wanted type %T", result, []string{})
+	}
+	err := config.Set(HomogeneousAggregateLiteralExemptFunctions, []string{"_==_"})
+	if err != nil {
+		t.Errorf("config.Set() failed: %v", err)
+	}
+	err = config.Set(HomogeneousAggregateLiteralExemptFunctions, map[string]any{})
+	if err == nil {
+		t.Error("config.Set() with incorrect value type did not fail")
 	}
 }


### PR DESCRIPTION
Remove the private interface method from the `ASTValidator`

Also, introduce a `ValidatorConfig` which is computed prior to calling `Validate`.
The `ValidatorConfig` allows validators to interact with each other. Currently, to
interact with another validator's configuration, the user must also implement the
`ASTValidator` interface as well. These concerns may be separated in the future.