### PR TITLE
Update types.Unknown with attribute trails

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -1438,21 +1438,21 @@ func TestPartialVars(t *testing.T) {
 				interpreter.NewAttributePattern("x"),
 				interpreter.NewAttributePattern("y"),
 			},
-			out: types.Unknown{1},
+			out: types.NewUnknown(1, types.NewAttributeTrail("x")),
 		},
 		{
 			in: map[string]any{"x": "10"},
 			unk: []*interpreter.AttributePattern{
 				interpreter.NewAttributePattern("y"),
 			},
-			out: types.Unknown{4},
+			out: types.NewUnknown(4, types.NewAttributeTrail("y")),
 		},
 		{
 			in: map[string]any{"y": 10},
 			unk: []*interpreter.AttributePattern{
 				interpreter.NewAttributePattern("x"),
 			},
-			out: types.Unknown{1},
+			out: types.NewUnknown(1, types.NewAttributeTrail("x")),
 		},
 		{
 			in:  map[string]any{"x": "10", "y": 10},
@@ -1468,19 +1468,19 @@ func TestPartialVars(t *testing.T) {
 			in:         map[string]any{"y": 10},
 			unk:        []*interpreter.AttributePattern{},
 			out:        types.NewErr("no such attribute: x"),
-			partialOut: types.Unknown{1},
+			partialOut: types.NewUnknown(1, types.NewAttributeTrail("x")),
 		},
 		{
 			in:         map[string]any{"x": "10"},
 			unk:        []*interpreter.AttributePattern{},
 			out:        types.NewErr("no such attribute: y"),
-			partialOut: types.Unknown{4},
+			partialOut: types.NewUnknown(4, types.NewAttributeTrail("y")),
 		},
 		{
 			in:         map[string]any{},
 			unk:        []*interpreter.AttributePattern{},
 			out:        types.NewErr("no such attribute: x"),
-			partialOut: types.Unknown{1},
+			partialOut: types.NewUnknown(1, types.NewAttributeTrail("x")),
 		},
 	}
 	for i, tst := range tests {

--- a/cel/decls_test.go
+++ b/cel/decls_test.go
@@ -72,11 +72,11 @@ var dispatchTests = []struct {
 	},
 	{
 		expr: "max(unk, unk)",
-		out:  types.Unknown{42},
+		out:  types.NewUnknown(42, nil),
 	},
 	{
 		expr: "max(unk, unk, unk)",
-		out:  types.Unknown{42},
+		out:  types.NewUnknown(42, nil),
 	},
 }
 
@@ -395,11 +395,11 @@ func TestUnaryBinding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Program() failed: %v", err)
 	}
-	out, _, err := prg.Eval(map[string]any{"x": types.Unknown{1}})
+	out, _, err := prg.Eval(map[string]any{"x": types.NewUnknown(1, nil)})
 	if err != nil {
 		t.Fatalf("prg.Eval(x=unk) failed: %v", err)
 	}
-	if !reflect.DeepEqual(out, types.Unknown{1}) {
+	if !types.NewUnknown(1, nil).Contains(out.(*types.Unknown)) {
 		t.Errorf("prg.Eval(x=unk) returned %v, wanted unknown{1}", out)
 	}
 }
@@ -439,14 +439,14 @@ func TestBinaryBinding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Program() failed: %v", err)
 	}
-	out, _, err := prg.Eval(map[string]any{"x": types.Unknown{1}, "y": 1})
+	out, _, err := prg.Eval(map[string]any{"x": types.NewUnknown(1, nil), "y": 1})
 	if err != nil {
 		t.Fatalf("prg.Eval(x=unk) failed: %v", err)
 	}
 	if !reflect.DeepEqual(out, types.IntOne) {
 		t.Errorf("prg.Eval(x=unk, y=1) returned %v, wanted 1", out)
 	}
-	out, _, err = prg.Eval(map[string]any{"x": 2, "y": types.Unknown{2}})
+	out, _, err = prg.Eval(map[string]any{"x": 2, "y": types.NewUnknown(2, nil)})
 	if err != nil {
 		t.Fatalf("prg.Eval(x=2, y=unk) failed: %v", err)
 	}
@@ -790,10 +790,10 @@ func testParse(t testing.TB, env *Env, expr string, want any) {
 	if err != nil {
 		t.Fatalf("env.Program() failed: %v", err)
 	}
-	out, _, err := prg.Eval(map[string]any{"err": types.NewErr("error argument"), "unk": types.Unknown{42}})
+	out, _, err := prg.Eval(map[string]any{"err": types.NewErr("error argument"), "unk": types.NewUnknown(42, nil)})
 	switch want := want.(type) {
-	case types.Unknown:
-		if !reflect.DeepEqual(want, out.(types.Unknown)) {
+	case *types.Unknown:
+		if !want.Contains(out.(*types.Unknown)) {
 			t.Errorf("prg.Eval() got %v, wanted %v", out, want)
 		}
 	case ref.Val:
@@ -817,10 +817,10 @@ func testCompile(t testing.TB, env *Env, expr string, want any) {
 	if err != nil {
 		t.Fatalf("env.Program() failed: %v", err)
 	}
-	out, _, err := prg.Eval(map[string]any{"err": types.NewErr("error argument"), "unk": types.Unknown{42}})
+	out, _, err := prg.Eval(map[string]any{"err": types.NewErr("error argument"), "unk": types.NewUnknown(42, nil)})
 	switch want := want.(type) {
-	case types.Unknown:
-		if !reflect.DeepEqual(want, out.(types.Unknown)) {
+	case *types.Unknown:
+		if !want.Contains(out.(*types.Unknown)) {
 			t.Errorf("prg.Eval() got %v, wanted %v", out, want)
 		}
 	case ref.Val:

--- a/common/decls/decls.go
+++ b/common/decls/decls.go
@@ -275,17 +275,17 @@ func (f *FunctionDecl) Bindings() ([]*functions.Overload, error) {
 // to return an unknown set, or to produce a new error for a missing function signature.
 func MaybeNoSuchOverload(funcName string, args ...ref.Val) ref.Val {
 	argTypes := make([]string, len(args))
-	var unk types.Unknown
+	var unk *types.Unknown = nil
 	for i, arg := range args {
 		if types.IsError(arg) {
 			return arg
 		}
 		if types.IsUnknown(arg) {
-			unk = append(unk, arg.(types.Unknown)...)
+			unk = types.MergeUnknowns(arg.(*types.Unknown), unk)
 		}
 		argTypes[i] = arg.Type().TypeName()
 	}
-	if len(unk) != 0 {
+	if unk != nil {
 		return unk
 	}
 	signature := strings.Join(argTypes, ", ")

--- a/common/decls/decls_test.go
+++ b/common/decls/decls_test.go
@@ -142,7 +142,7 @@ func TestFunctionVariableArgBindings(t *testing.T) {
 			if !types.IsError(celErr) || !strings.Contains(celErr.(*types.Err).String(), "no such overload") {
 				t.Errorf("binding.Binary(bytes, string) got %v, wanted no such overload", celErr)
 			}
-			celUnk := binding.Binary(types.Bytes("hi"), types.Unknown{1})
+			celUnk := binding.Binary(types.Bytes("hi"), types.NewUnknown(1, types.NewAttributeTrail("x")))
 			if !types.IsUnknown(celUnk) {
 				t.Errorf("binding.Binary(bytes, unk) got %v, wanted unknown{1}", celUnk)
 			}

--- a/common/types/unknown.go
+++ b/common/types/unknown.go
@@ -15,45 +15,173 @@
 package types
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
+	"unicode"
 
 	"github.com/google/cel-go/common/types/ref"
 )
 
-// Unknown type implementation which collects expression ids which caused the
-// current value to become unknown.
-type Unknown []int64
+var (
+	unspecifiedAttribute = &AttributeTrail{qualifierPath: []any{}}
+)
+
+// NewAttributeTrail creates a new simple attribute from a variable name.
+func NewAttributeTrail(variable string) *AttributeTrail {
+	if variable == "" {
+		return unspecifiedAttribute
+	}
+	return &AttributeTrail{variable: variable}
+}
+
+// AttributeTrail specifies a variable with an optional qualifier path. An attribute value is expected to
+// correspond to an AbsoluteAttribute, meaning a field selection which starts with a top-level variable.
+//
+// The qualifer path elements adhere to the AttributeQualifier type constraint.
+type AttributeTrail struct {
+	variable      string
+	qualifierPath []any
+}
+
+// Equals returns whether two attribute values have the same variable name and qualifier paths.
+func (a *AttributeTrail) Equal(other *AttributeTrail) bool {
+	if a.Variable() != other.Variable() || len(a.QualifierPath()) != len(other.QualifierPath()) {
+		return false
+	}
+	for i, q := range a.QualifierPath() {
+		qual := other.QualifierPath()[i]
+		if q != qual {
+			return false
+		}
+	}
+	return true
+}
+
+// Variable returns the variable name associated with the attribute.
+func (a *AttributeTrail) Variable() string {
+	return a.variable
+}
+
+// QualifierPath returns the optional set of qualifying fields or indices applied to the variable.
+func (a *AttributeTrail) QualifierPath() []any {
+	return a.qualifierPath
+}
+
+// String returns the string representation of the Attribute.
+func (a *AttributeTrail) String() string {
+	if a.variable == "" {
+		return "<unspecified>"
+	}
+	var str strings.Builder
+	str.WriteString(a.variable)
+	for _, q := range a.qualifierPath {
+		switch q := q.(type) {
+		case bool, int64:
+			str.WriteString(fmt.Sprintf("[%v]", q))
+		case uint64:
+			str.WriteString(fmt.Sprintf("[%vu]", q))
+		case string:
+			if isIdentifierCharacter(q) {
+				str.WriteString(fmt.Sprintf(".%v", q))
+			} else {
+				str.WriteString(fmt.Sprintf("[%q]", q))
+			}
+		}
+	}
+	return str.String()
+}
+
+func isIdentifierCharacter(str string) bool {
+	for _, c := range str {
+		if unicode.IsLetter(c) || unicode.IsDigit(c) || string(c) == "_" {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// AttributeQualifier constrains the possible types which may be used to qualify an attribute.
+type AttributeQualifier interface {
+	bool | int64 | uint64 | string
+}
+
+// QualifyAttribute qualifies an attribute using a valid AttributeQualifier type.
+func QualifyAttribute[T AttributeQualifier](attr *AttributeTrail, qualifier T) *AttributeTrail {
+	attr.qualifierPath = append(attr.qualifierPath, qualifier)
+	return attr
+}
+
+// Unknown type which collects expression ids which caused the current value to become unknown.
+type Unknown struct {
+	attributeTrails map[int64]*AttributeTrail
+}
+
+// NewUnknown creates a new unknown at a given expression id for an attribute.
+//
+// If the attribute is nil, the attribute value will be the `unspecifiedAttribute`.
+func NewUnknown(id int64, attr *AttributeTrail) *Unknown {
+	if attr == nil {
+		attr = unspecifiedAttribute
+	}
+	return &Unknown{
+		attributeTrails: map[int64]*AttributeTrail{id: attr},
+	}
+}
+
+// Contains returns true if the input unknown is a subset of the current unknown.
+func (u *Unknown) Contains(other *Unknown) bool {
+	for id, trail := range other.attributeTrails {
+		t, found := u.attributeTrails[id]
+		if !found || !t.Equal(trail) {
+			return false
+		}
+	}
+	return true
+}
 
 // ConvertToNative implements ref.Val.ConvertToNative.
-func (u Unknown) ConvertToNative(typeDesc reflect.Type) (any, error) {
+func (u *Unknown) ConvertToNative(typeDesc reflect.Type) (any, error) {
 	return u.Value(), nil
 }
 
 // ConvertToType is an identity function since unknown values cannot be modified.
-func (u Unknown) ConvertToType(typeVal ref.Type) ref.Val {
+func (u *Unknown) ConvertToType(typeVal ref.Type) ref.Val {
 	return u
 }
 
 // Equal is an identity function since unknown values cannot be modified.
-func (u Unknown) Equal(other ref.Val) ref.Val {
+func (u *Unknown) Equal(other ref.Val) ref.Val {
 	return u
 }
 
+// String implements the Stringer interface
+func (u *Unknown) String() string {
+	var str strings.Builder
+	for id, attr := range u.attributeTrails {
+		if str.Len() != 0 {
+			str.WriteString(", ")
+		}
+		str.WriteString(fmt.Sprintf("%v (%d)", attr, id))
+	}
+	return str.String()
+}
+
 // Type implements ref.Val.Type.
-func (u Unknown) Type() ref.Type {
+func (u *Unknown) Type() ref.Type {
 	return UnknownType
 }
 
 // Value implements ref.Val.Value.
-func (u Unknown) Value() any {
-	return []int64(u)
+func (u *Unknown) Value() any {
+	return u
 }
 
-// IsUnknown returns whether the element ref.Type or ref.Val is equal to the
-// UnknownType singleton.
+// IsUnknown returns whether the element ref.Val is in instance of *types.Unknown
 func IsUnknown(val ref.Val) bool {
 	switch val.(type) {
-	case Unknown:
+	case *Unknown:
 		return true
 	default:
 		return false
@@ -66,16 +194,33 @@ func IsUnknown(val ref.Val) bool {
 // If the input `val` is another Unknown, then the result will be the merge of the `val` and the input
 // `unk`. If the `val` is not unknown, then the result will depend on whether the input `unk` is nil.
 // If both values are non-nil and unknown, then the return value will be a merge of both unknowns.
-func MaybeMergeUnknowns(val ref.Val, unk Unknown) (Unknown, bool) {
-	src, isUnk := val.(Unknown)
+func MaybeMergeUnknowns(val ref.Val, unk *Unknown) (*Unknown, bool) {
+	src, isUnk := val.(*Unknown)
 	if !isUnk {
 		if unk != nil {
 			return unk, true
 		}
-		return nil, false
+		return unk, false
 	}
-	if unk == nil {
-		return src, true
+	return MergeUnknowns(src, unk), true
+}
+
+// MergeUnknowns combines two unknown values into a new unknown value.
+func MergeUnknowns(unk1, unk2 *Unknown) *Unknown {
+	if unk1 == nil {
+		return unk2
 	}
-	return append(unk, src...), true
+	if unk2 == nil {
+		return unk1
+	}
+	out := &Unknown{
+		attributeTrails: make(map[int64]*AttributeTrail, len(unk1.attributeTrails)+len(unk2.attributeTrails)),
+	}
+	for id, at := range unk1.attributeTrails {
+		out.attributeTrails[id] = at
+	}
+	for id, at := range unk2.attributeTrails {
+		out.attributeTrails[id] = at
+	}
+	return out
 }

--- a/common/types/unknown_test.go
+++ b/common/types/unknown_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestIsUnknown(t *testing.T) {
-	if IsUnknown(Unknown{}) != true {
+	if IsUnknown(&Unknown{}) != true {
 		t.Error("IsUnknown(Unknown{}) returned false, wanted true")
 	}
 	if IsUnknown(Bool(true)) != false {
@@ -30,35 +30,231 @@ func TestIsUnknown(t *testing.T) {
 	}
 }
 
+func TestNewAttribute(t *testing.T) {
+	if NewAttributeTrail("") != unspecifiedAttribute {
+		t.Error("An empty attribute must be the unspecified attribute")
+	}
+	if NewAttributeTrail("v").Equal(unspecifiedAttribute) {
+		t.Error("A non-empty attribute must not be equal to the unspecified attribute")
+	}
+}
+
+func TestAttributeEquals(t *testing.T) {
+	tests := []struct {
+		a     *AttributeTrail
+		b     *AttributeTrail
+		equal bool
+	}{
+		{
+			a:     unspecifiedAttribute,
+			b:     NewAttributeTrail(""),
+			equal: true,
+		},
+		{
+			a:     NewAttributeTrail("a"),
+			b:     NewAttributeTrail(""),
+			equal: false,
+		},
+		{
+			a:     NewAttributeTrail("a"),
+			b:     NewAttributeTrail("a"),
+			equal: true,
+		},
+		{
+			a:     QualifyAttribute[string](NewAttributeTrail("a"), "b"),
+			b:     NewAttributeTrail("a"),
+			equal: false,
+		},
+		{
+			a:     QualifyAttribute[string](NewAttributeTrail("a"), "b"),
+			b:     QualifyAttribute[int64](NewAttributeTrail("a"), 1),
+			equal: false,
+		},
+		{
+			a:     QualifyAttribute[string](NewAttributeTrail("a"), "b"),
+			b:     QualifyAttribute[string](NewAttributeTrail("a"), "b"),
+			equal: true,
+		},
+	}
+	for i, tst := range tests {
+		tc := tst
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			out := tc.a.Equal(tc.b)
+			if out != tc.equal {
+				t.Errorf("%v.Equal(%v) got %v, wanted %v", tc.a, tc.b, out, tc.equal)
+			}
+		})
+	}
+}
+
+func TestAttributeString(t *testing.T) {
+	tests := []struct {
+		attr *AttributeTrail
+		out  string
+	}{
+		{
+			attr: unspecifiedAttribute,
+			out:  "<unspecified>",
+		},
+		{
+			attr: NewAttributeTrail("a"),
+			out:  "a",
+		},
+		{
+			attr: QualifyAttribute[bool](NewAttributeTrail("a"), false),
+			out:  "a[false]",
+		},
+		{
+			attr: QualifyAttribute[string](NewAttributeTrail("a"), "b"),
+			out:  "a.b",
+		},
+		{
+			attr: QualifyAttribute(QualifyAttribute[string](NewAttributeTrail("a"), "b"), "$this"),
+			out:  `a.b["$this"]`,
+		},
+		{
+			attr: QualifyAttribute[int64](NewAttributeTrail("a"), 12),
+			out:  "a[12]",
+		},
+		{
+			attr: QualifyAttribute[uint64](NewAttributeTrail("a"), 24),
+			out:  "a[24u]",
+		},
+	}
+	for i, tst := range tests {
+		tc := tst
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			out := tc.attr.String()
+			if out != tc.out {
+				t.Errorf("%v.String() got %v, wanted %v", tc.attr, out, tc.out)
+			}
+		})
+	}
+}
+
+func TestUnknownContains(t *testing.T) {
+	tests := []struct {
+		unk   *Unknown
+		other *Unknown
+		out   bool
+	}{
+		{
+			unk:   NewUnknown(1, nil),
+			other: NewUnknown(1, unspecifiedAttribute),
+			out:   true,
+		},
+		{
+			unk:   NewUnknown(3, QualifyAttribute[bool](NewAttributeTrail("a"), true)),
+			other: NewUnknown(4, QualifyAttribute[string](NewAttributeTrail("a"), "b")),
+			out:   false,
+		},
+		{
+			unk:   NewUnknown(3, QualifyAttribute[string](NewAttributeTrail("a"), "b")),
+			other: NewUnknown(4, QualifyAttribute[string](NewAttributeTrail("a"), "b")),
+			out:   false,
+		},
+		{
+			unk:   NewUnknown(3, QualifyAttribute[string](NewAttributeTrail("a"), "c")),
+			other: NewUnknown(3, QualifyAttribute[string](NewAttributeTrail("a"), "b")),
+			out:   false,
+		},
+		{
+			unk: MergeUnknowns(
+				NewUnknown(3, QualifyAttribute[bool](NewAttributeTrail("a"), true)),
+				NewUnknown(4, QualifyAttribute[string](NewAttributeTrail("a"), "b")),
+			),
+			other: NewUnknown(3, QualifyAttribute[bool](NewAttributeTrail("a"), true)),
+			out:   true,
+		},
+		{
+			unk: NewUnknown(3, QualifyAttribute[bool](NewAttributeTrail("a"), true)),
+			other: MergeUnknowns(
+				NewUnknown(3, QualifyAttribute[bool](NewAttributeTrail("a"), true)),
+				NewUnknown(4, QualifyAttribute[string](NewAttributeTrail("a"), "b")),
+			),
+			out: false,
+		},
+	}
+	for i, tst := range tests {
+		tc := tst
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			out := tc.unk.Contains(tc.other)
+			if out != tc.out {
+				t.Errorf("%v.Contains(%v) got %v, wanted %v", tc.unk, tc.other, out, tc.out)
+			}
+		})
+	}
+}
+
+func TestUnknownString(t *testing.T) {
+	tests := []struct {
+		unk *Unknown
+		out string
+	}{
+		{
+			unk: NewUnknown(1, nil),
+			out: "<unspecified> (1)",
+		},
+		{
+			unk: NewUnknown(1, unspecifiedAttribute),
+			out: "<unspecified> (1)",
+		},
+		{
+			unk: NewUnknown(2, NewAttributeTrail("a")),
+			out: "a (2)",
+		},
+		{
+			unk: NewUnknown(3, QualifyAttribute[bool](NewAttributeTrail("a"), false)),
+			out: "a[false] (3)",
+		},
+		{
+			unk: MergeUnknowns(
+				NewUnknown(3, QualifyAttribute[bool](NewAttributeTrail("a"), true)),
+				NewUnknown(4, QualifyAttribute[string](NewAttributeTrail("a"), "b")),
+			),
+			out: "a[true] (3), a.b (4)",
+		},
+	}
+	for i, tst := range tests {
+		tc := tst
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			out := tc.unk.String()
+			if out != tc.out {
+				t.Errorf("%v.String() got %v, wanted %v", tc.unk, out, tc.out)
+			}
+		})
+	}
+}
+
 func TestMaybeMergeUnknowns(t *testing.T) {
 	tests := []struct {
 		in    ref.Val
-		unk   Unknown
-		want  Unknown
+		unk   *Unknown
+		want  *Unknown
 		isUnk bool
 	}{
+		// one of the unknowns is empty
 		{
 			in:    String(""),
 			unk:   nil,
-			want:  nil,
 			isUnk: false,
 		},
+		// both unknowns are empty
 		{
 			in:    String(""),
-			unk:   Unknown{},
-			want:  Unknown{},
+			unk:   &Unknown{},
+			want:  &Unknown{},
 			isUnk: true,
 		},
 		{
-			in:    Unknown{2},
-			unk:   Unknown{1},
-			want:  Unknown{1, 2},
+			in:    newUnk(t, 2, "x"),
+			unk:   newUnk(t, 1, "y"),
+			want:  MergeUnknowns(newUnk(t, 2, "x"), newUnk(t, 1, "y")),
 			isUnk: true,
 		},
 		{
-			in:    Unknown{2},
-			unk:   nil,
-			want:  Unknown{2},
+			in:    newUnk(t, 2, "x"),
+			want:  newUnk(t, 2, "x"),
 			isUnk: true,
 		},
 	}
@@ -72,4 +268,11 @@ func TestMaybeMergeUnknowns(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newUnk(t *testing.T, id int64, varName string) *Unknown {
+	t.Helper()
+	attr := NewAttributeTrail(varName)
+	unk := NewUnknown(id, attr)
+	return unk
 }

--- a/common/types/util.go
+++ b/common/types/util.go
@@ -21,7 +21,7 @@ import (
 // IsUnknownOrError returns whether the input element ref.Val is an ErrType or UnknownType.
 func IsUnknownOrError(val ref.Val) bool {
 	switch val.(type) {
-	case Unknown, *Err:
+	case *Unknown, *Err:
 		return true
 	}
 	return false

--- a/common/types/util_test.go
+++ b/common/types/util_test.go
@@ -18,7 +18,7 @@ import "testing"
 
 func BenchmarkIsUnknownOrError(b *testing.B) {
 	err := NewErr("test")
-	unk := Unknown{}
+	unk := &Unknown{}
 	for i := 0; i < b.N; i++ {
 		if !(IsUnknownOrError(unk) && IsUnknownOrError(err) && !IsUnknownOrError(IntOne)) {
 			b.Fatal("IsUnknownOrError() provided an incorrect result.")

--- a/interpreter/attribute_patterns.go
+++ b/interpreter/attribute_patterns.go
@@ -15,6 +15,8 @@
 package interpreter
 
 import (
+	"fmt"
+
 	"github.com/google/cel-go/common/containers"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
@@ -241,12 +243,15 @@ func (fac *partialAttributeFactory) matchesUnknownPatterns(
 	vars PartialActivation,
 	attrID int64,
 	variableNames []string,
-	qualifiers []Qualifier) (types.Unknown, error) {
+	qualifiers []Qualifier) (*types.Unknown, error) {
 	patterns := vars.UnknownAttributePatterns()
 	candidateIndices := map[int]struct{}{}
 	for _, variable := range variableNames {
 		for i, pat := range patterns {
 			if pat.VariableMatches(variable) {
+				if len(qualifiers) == 0 {
+					return types.NewUnknown(attrID, types.NewAttributeTrail(variable)), nil
+				}
 				candidateIndices[i] = struct{}{}
 			}
 		}
@@ -254,10 +259,6 @@ func (fac *partialAttributeFactory) matchesUnknownPatterns(
 	// Determine whether to return early if there are no candidate unknown patterns.
 	if len(candidateIndices) == 0 {
 		return nil, nil
-	}
-	// Determine whether to return early if there are no qualifiers.
-	if len(qualifiers) == 0 {
-		return types.Unknown{attrID}, nil
 	}
 	// Resolve the attribute qualifiers into a static set. This prevents more dynamic
 	// Attribute resolutions than necessary when there are multiple unknown patterns
@@ -300,7 +301,28 @@ func (fac *partialAttributeFactory) matchesUnknownPatterns(
 			}
 		}
 		if isUnk {
-			return types.Unknown{matchExprID}, nil
+			attr := types.NewAttributeTrail(pat.variable)
+			for i := 0; i < len(qualPats) && i < len(newQuals); i++ {
+				if qual, ok := newQuals[i].(ConstantQualifier); ok {
+					switch v := qual.Value().Value().(type) {
+					case bool:
+						types.QualifyAttribute[bool](attr, v)
+					case float64:
+						types.QualifyAttribute[int64](attr, int64(v))
+					case int64:
+						types.QualifyAttribute[int64](attr, v)
+					case string:
+						types.QualifyAttribute[string](attr, v)
+					case uint64:
+						types.QualifyAttribute[uint64](attr, v)
+					default:
+						types.QualifyAttribute[string](attr, fmt.Sprintf("%v", v))
+					}
+				} else {
+					types.QualifyAttribute[string](attr, "*")
+				}
+			}
+			return types.NewUnknown(matchExprID, attr), nil
 		}
 	}
 	return nil, nil

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -655,7 +655,7 @@ func newQualifier(adapter types.Adapter, id int64, v any, opt bool) (Qualifier, 
 		qual = &doubleQualifier{
 			id: id, value: float64(val), celValue: val, adapter: adapter, optional: opt,
 		}
-	case types.Unknown:
+	case *types.Unknown:
 		qual = &unknownQualifier{id: id, value: val}
 	default:
 		if q, ok := v.(Qualifier); ok {
@@ -1129,7 +1129,7 @@ func (q *doubleQualifier) Value() ref.Val {
 // for any value subject to qualification. This is consistent with CEL's unknown handling elsewhere.
 type unknownQualifier struct {
 	id    int64
-	value types.Unknown
+	value *types.Unknown
 }
 
 // ID is an implementation of the Qualifier interface method.
@@ -1226,7 +1226,7 @@ func attrQualifyIfPresent(fac AttributeFactory, vars Activation, obj any, qualAt
 func refQualify(adapter types.Adapter, obj any, idx ref.Val, presenceTest, presenceOnly bool) (ref.Val, bool, error) {
 	celVal := adapter.NativeToValue(obj)
 	switch v := celVal.(type) {
-	case types.Unknown:
+	case *types.Unknown:
 		return v, true, nil
 	case *types.Err:
 		return nil, false, v

--- a/interpreter/attributes_test.go
+++ b/interpreter/attributes_test.go
@@ -740,13 +740,12 @@ func TestAttributesConditionalAttrErrorUnknown(t *testing.T) {
 	}
 
 	// unk ? a : b
-	condUnk := attrs.ConditionalAttribute(1, NewConstValue(0, types.Unknown{1}), tv, fv)
+	condUnk := attrs.ConditionalAttribute(1, NewConstValue(0, types.NewUnknown(1, nil)), tv, fv)
 	out, err = condUnk.Resolve(EmptyActivation())
 	if err != nil {
 		t.Fatal(err)
 	}
-	unk, ok := out.(types.Unknown)
-	if !ok || !types.IsUnknown(unk) {
+	if !types.IsUnknown(out.(ref.Val)) {
 		t.Errorf("Got %v, wanted unknown", out)
 	}
 }
@@ -845,7 +844,7 @@ func TestAttributeMissingMsgUnknownField(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, isUnk := out.(types.Unknown)
+	_, isUnk := out.(*types.Unknown)
 	if !isUnk {
 		t.Errorf("got %v, wanted unknown value", out)
 	}
@@ -1085,7 +1084,7 @@ func TestAttributeStateTracking(t *testing.T) {
 				},
 				NewAttributePattern("a").QualString("b"),
 			),
-			out: types.Unknown{5},
+			out: types.NewUnknown(5, types.QualifyAttribute[string](types.NewAttributeTrail("a"), "b")),
 		},
 	}
 	for _, test := range tests {

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -1450,7 +1450,7 @@ func TestInterpreter(t *testing.T) {
 				want = tc.out.(ref.Val)
 			}
 			got := prg.Eval(vars)
-			_, expectUnk := want.(types.Unknown)
+			_, expectUnk := want.(*types.Unknown)
 			if expectUnk {
 				if !reflect.DeepEqual(got, want) {
 					t.Fatalf("Got %v, wanted %v", got, want)
@@ -1486,7 +1486,7 @@ func TestInterpreter(t *testing.T) {
 				}
 				t.Run(mode, func(t *testing.T) {
 					got := prg.Eval(vars)
-					_, expectUnk := want.(types.Unknown)
+					_, expectUnk := want.(*types.Unknown)
 					if expectUnk {
 						if !reflect.DeepEqual(got, want) {
 							t.Errorf("Got %v, wanted %v", got, want)

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -59,7 +59,7 @@ type testCase struct {
 	unchecked bool
 	extraOpts []InterpretableDecorator
 
-	in      map[string]any
+	in      any
 	out     any
 	err     string
 	progErr string
@@ -1215,8 +1215,8 @@ func testData(t testing.TB) []testCase {
 			attrs: &custAttrFactory{
 				AttributeFactory: NewAttributeFactory(
 					testContainer("google.expr.proto3.test"),
-					types.DefaultTypeAdapter,
-					types.NewEmptyRegistry(),
+					newTestRegistry(t, &proto3pb.TestAllTypes_NestedMessage{}),
+					newTestRegistry(t, &proto3pb.TestAllTypes_NestedMessage{}),
 				),
 			},
 			in: map[string]any{
@@ -1225,6 +1225,29 @@ func testData(t testing.TB) []testCase {
 				},
 			},
 			out: types.True,
+		},
+		{
+			name:      "select_custom_pb3_optional_field",
+			expr:      `a.?bb`,
+			container: "google.expr.proto3.test",
+			types:     []proto.Message{&proto3pb.TestAllTypes_NestedMessage{}},
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("a",
+					types.NewObjectType("google.expr.proto3.test.TestAllTypes.NestedMessage")),
+			},
+			attrs: &custAttrFactory{
+				AttributeFactory: NewAttributeFactory(
+					testContainer("google.expr.proto3.test"),
+					newTestRegistry(t, &proto3pb.TestAllTypes_NestedMessage{}),
+					newTestRegistry(t, &proto3pb.TestAllTypes_NestedMessage{}),
+				),
+			},
+			in: map[string]any{
+				"a": &proto3pb.TestAllTypes_NestedMessage{
+					Bb: 101,
+				},
+			},
+			out: types.OptionalOf(types.Int(101)),
 		},
 		{
 			name: "select_relative",
@@ -1390,6 +1413,36 @@ func testData(t testing.TB) []testCase {
 			expr:      `pkg.mylistundef[0]`,
 			unchecked: true,
 			err:       `no such attribute(s): goog.pkg.mylistundef, pkg.mylistundef`,
+		},
+		{
+			name: "unknown_attribute",
+			expr: `a[0]`,
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("a",
+					types.NewMapType(types.IntType, types.BoolType)),
+			},
+			attrs: NewPartialAttributeFactory(testContainer(""), types.DefaultTypeAdapter, types.NewEmptyRegistry()),
+			in: newTestPartialActivation(t, map[string]any{
+				"a": map[int64]any{
+					1: true,
+				},
+			}, NewAttributePattern("a").QualInt(0)),
+			out: types.NewUnknown(2, types.QualifyAttribute[int64](types.NewAttributeTrail("a"), 0)),
+		},
+		{
+			name: "unknown_attribute_mixed_qualifier",
+			expr: `a[dyn(0u)]`,
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("a",
+					types.NewMapType(types.IntType, types.BoolType)),
+			},
+			attrs: NewPartialAttributeFactory(testContainer(""), types.DefaultTypeAdapter, types.NewEmptyRegistry()),
+			in: newTestPartialActivation(t, map[string]any{
+				"a": map[int64]any{
+					1: true,
+				},
+			}, NewAttributePattern("a").QualInt(0)),
+			out: types.NewUnknown(2, types.QualifyAttribute[uint64](types.NewAttributeTrail("a"), 0)),
 		},
 	}
 }
@@ -1956,7 +2009,10 @@ func program(ctx testing.TB, tst *testCase, opts ...InterpretableDecorator) (Int
 	// Configure the program input.
 	vars := EmptyActivation()
 	if tst.in != nil {
-		vars, _ = NewActivation(tst.in)
+		vars, err = NewActivation(tst.in)
+		if err != nil {
+			ctx.Fatalf("NewActivation(%v) failed: %v", tst.in, err)
+		}
 	}
 	// Adapt the test output, if needed.
 	if tst.out != nil {
@@ -2060,6 +2116,15 @@ func newTestRegistry(t testing.TB, msgs ...proto.Message) *types.Registry {
 	return reg
 }
 
+func newTestPartialActivation(t testing.TB, in any, unknowns ...*AttributePattern) any {
+	t.Helper()
+	vars, err := NewPartialActivation(in, unknowns...)
+	if err != nil {
+		t.Fatalf("NewPartialActivation(%v) failed: %v", in, err)
+	}
+	return vars
+}
+
 // newStandardInterpreter builds a Dispatcher and TypeProvider with support for all of the CEL
 // builtins defined in the language definition.
 func newStandardInterpreter(t *testing.T,
@@ -2107,40 +2172,4 @@ func funcBindings(t testing.TB, funcs ...*decls.FunctionDecl) []*functions.Overl
 		bindings = append(bindings, overloads...)
 	}
 	return bindings
-}
-
-func funcExprDecl(t testing.TB, fn *decls.FunctionDecl) *exprpb.Decl {
-	t.Helper()
-	d, err := decls.FunctionDeclToExprDecl(fn)
-	if err != nil {
-		t.Fatalf("decls.FunctionDeclToExprDecl(%v) failed: %v", fn, err)
-	}
-	return d
-}
-
-func funcExprDecls(t testing.TB, funcs ...*decls.FunctionDecl) []*exprpb.Decl {
-	t.Helper()
-	d := make([]*exprpb.Decl, 0, len(funcs))
-	for _, fn := range funcs {
-		d = append(d, funcExprDecl(t, fn))
-	}
-	return d
-}
-
-func varExprDecl(t testing.TB, v *decls.VariableDecl) *exprpb.Decl {
-	t.Helper()
-	d, err := decls.VariableDeclToExprDecl(v)
-	if err != nil {
-		t.Fatalf("decls.VariableDeclToExprDecl(%v) failed: %v", v, err)
-	}
-	return d
-}
-
-func varExprDecls(t testing.TB, vars ...*decls.VariableDecl) []*exprpb.Decl {
-	t.Helper()
-	d := make([]*exprpb.Decl, 0, len(vars))
-	for _, v := range vars {
-		d = append(d, varExprDecl(t, v))
-	}
-	return d
 }

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -473,7 +473,7 @@ func (p *planner) planCallConditional(expr *exprpb.Expr, args []Interpretable) (
 func (p *planner) planCallIndex(expr *exprpb.Expr, args []Interpretable, optional bool) (Interpretable, error) {
 	op := args[0]
 	ind := args[1]
-	opType := p.typeMap[expr.GetCallExpr().GetTarget().GetId()]
+	opType := p.typeMap[op.ID()]
 
 	// Establish the attribute reference.
 	var err error

--- a/server/server.go
+++ b/server/server.go
@@ -202,7 +202,14 @@ func ExprValueToRefValue(adapter types.Adapter, ev *exprpb.ExprValue) (ref.Val, 
 		// TODO(jimlarson) make a convention for this.
 		return types.NewErr("XXX add details later"), nil
 	case *exprpb.ExprValue_Unknown:
-		return types.Unknown(ev.GetUnknown().Exprs), nil
+		var unk *types.Unknown
+		for _, id := range ev.GetUnknown().GetExprs() {
+			if unk == nil {
+				unk = types.NewUnknown(id, nil)
+			}
+			unk = types.MergeUnknowns(types.NewUnknown(id, nil), unk)
+		}
+		return unk, nil
 	}
 	return nil, invalidArgument("unknown ExprValue kind")
 }


### PR DESCRIPTION
Update the types.Unknown definition.

## Breaking change

Use `*types.Unknown` rather than `types.Unknown` during
type casting as the underlying type has changed from a slice
to a structured object.

Specifically, shift `types.Unknown` from a simple list of ints
to a structured object which contains the set of unknown 
expression ids, as well as the attribute trails associated with
each. 

In the future this object may be further augmented with
information about missing function invocations.

Closes #771 