### PR TITLE
ContextProtoVars() to simplify proto-based inputs

### DIFF
--- a/cel/BUILD.bazel
+++ b/cel/BUILD.bazel
@@ -78,5 +78,6 @@ go_test(
         "@org_golang_google_protobuf//proto:go_default_library",
         "@org_golang_google_protobuf//encoding/prototext:go_default_library",
         "@org_golang_google_protobuf//types/known/structpb:go_default_library",
+        "@org_golang_google_protobuf//types/known/wrapperspb:go_default_library",
     ],
 )

--- a/common/types/pb/type.go
+++ b/common/types/pb/type.go
@@ -467,13 +467,13 @@ func unwrapDynamic(desc description, refMsg protoreflect.Message) (any, bool, er
 		unwrappedAny := &anypb.Any{}
 		err := Merge(unwrappedAny, msg)
 		if err != nil {
-			return nil, false, err
+			return nil, false, fmt.Errorf("unwrap dynamic field failed: %v", err)
 		}
 		dynMsg, err := unwrappedAny.UnmarshalNew()
 		if err != nil {
 			// Allow the error to move further up the stack as it should result in an type
 			// conversion error if the caller does not recover it somehow.
-			return nil, false, err
+			return nil, false, fmt.Errorf("unmarshal dynamic any failed: %v", err)
 		}
 		// Attempt to unwrap the dynamic type, otherwise return the dynamic message.
 		unwrapped, nested, err := unwrapDynamic(desc, dynMsg.ProtoReflect())
@@ -564,8 +564,10 @@ func zeroValueOf(msg proto.Message) proto.Message {
 }
 
 var (
+	jsonValueTypeURL = "types.googleapis.com/google.protobuf.Value"
+
 	zeroValueMap = map[string]proto.Message{
-		"google.protobuf.Any":         &anypb.Any{},
+		"google.protobuf.Any":         &anypb.Any{TypeUrl: jsonValueTypeURL},
 		"google.protobuf.Duration":    &dpb.Duration{},
 		"google.protobuf.ListValue":   &structpb.ListValue{},
 		"google.protobuf.Struct":      &structpb.Struct{},

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -346,7 +346,7 @@ func singularFieldDescToCELType(field *pb.FieldDescription) *Type {
 	if field.IsEnum() {
 		return IntType
 	}
-	return protoCELPrimitives[field.ProtoKind()]
+	return ProtoCELPrimitives[field.ProtoKind()]
 }
 
 // defaultTypeAdapter converts go native types to CEL values.
@@ -657,7 +657,8 @@ func fieldTypeConversionError(field *pb.FieldDescription, err error) error {
 }
 
 var (
-	protoCELPrimitives = map[protoreflect.Kind]*Type{
+	// ProtoCELPrimitives provides a map from the protoreflect Kind to the equivalent CEL type.
+	ProtoCELPrimitives = map[protoreflect.Kind]*Type{
 		protoreflect.BoolKind:     BoolType,
 		protoreflect.BytesKind:    BytesType,
 		protoreflect.DoubleKind:   DoubleType,


### PR DESCRIPTION
Additional method to create an `interpreter.Activation` given a protobuf message as input.

This PR addresses feedback present in #684 and provides an evaluation equivalent for `DeclareContextProto`