### PR TITLE
Backport "Fix cost estimates to propagate result sizes" to 0.12 release branch.

### DIFF
--- a/checker/cost.go
+++ b/checker/cost.go
@@ -499,11 +499,23 @@ func (c *coster) functionCost(function, overloadID string, target *AstNode, args
 
 	if est := c.estimator.EstimateCallCost(function, overloadID, target, args); est != nil {
 		callEst := *est
-		return CallEstimate{CostEstimate: callEst.Add(argCostSum())}
+		return CallEstimate{CostEstimate: callEst.Add(argCostSum()), ResultSize: est.ResultSize}
 	}
 	switch overloadID {
 	// O(n) functions
-	case overloads.StartsWithString, overloads.EndsWithString, overloads.StringToBytes, overloads.BytesToString:
+	case overloads.StringToBytes:
+		if len(args) == 1 {
+			sz := c.sizeEstimate(args[0])
+			// ResultSize max is when each char converts to 4 bytes.
+			return CallEstimate{CostEstimate: sz.MultiplyByCostFactor(common.StringTraversalCostFactor).Add(argCostSum()), ResultSize: &SizeEstimate{Min: sz.Min, Max: sz.Max * 4}}
+		}
+	case overloads.BytesToString:
+		if len(args) == 1 {
+			sz := c.sizeEstimate(args[0])
+			// ResultSize min is when 4 bytes convert to 1 char.
+			return CallEstimate{CostEstimate: sz.MultiplyByCostFactor(common.StringTraversalCostFactor).Add(argCostSum()), ResultSize: &SizeEstimate{Min: sz.Min / 4, Max: sz.Max}}
+		}
+	case overloads.StartsWithString, overloads.EndsWithString:
 		if len(args) == 1 {
 			return CallEstimate{CostEstimate: c.sizeEstimate(args[0]).MultiplyByCostFactor(common.StringTraversalCostFactor).Add(argCostSum())}
 		}

--- a/checker/cost_test.go
+++ b/checker/cost_test.go
@@ -212,11 +212,27 @@ func TestCost(t *testing.T) {
 			wanted: CostEstimate{Min: 1, Max: 51},
 		},
 		{
+			name:  "bytes to string conversion equality",
+			decls: []*exprpb.Decl{decls.NewVar("input", decls.Bytes)},
+			hints: map[string]int64{"input": 500},
+			// equality check ensures that the resultSize calculation is included in cost
+			expr:   `string(input) == string(input)`,
+			wanted: CostEstimate{Min: 3, Max: 152},
+		},
+		{
 			name:   "string to bytes conversion",
 			decls:  []*exprpb.Decl{decls.NewVar("input", decls.String)},
 			hints:  map[string]int64{"input": 500},
 			expr:   `bytes(input)`,
 			wanted: CostEstimate{Min: 1, Max: 51},
+		},
+		{
+			name:  "string to bytes conversion equality",
+			decls: []*exprpb.Decl{decls.NewVar("input", decls.String)},
+			hints: map[string]int64{"input": 500},
+			// equality check ensures that the resultSize calculation is included in cost
+			expr:   `bytes(input) == bytes(input)`,
+			wanted: CostEstimate{Min: 3, Max: 302},
 		},
 		{
 			name:   "int to string conversion",


### PR DESCRIPTION
https://github.com/google/cel-go/pull/787 to release-0.12

Patch was modified for this branch since it does not have "quote" or "format" functions.