### PR TITLE
Migrate the type-checker to a native AST representation

### DIFF
--- a/cel/io.go
+++ b/cel/io.go
@@ -112,9 +112,7 @@ func AstToParsedExpr(a *Ast) (*exprpb.ParsedExpr, error) {
 // Note, the conversion may not be an exact replica of the original expression, but will produce
 // a string that is semantically equivalent and whose textual representation is stable.
 func AstToString(a *Ast) (string, error) {
-	expr := a.Expr()
-	info := a.SourceInfo()
-	return parser.Unparse(expr, info)
+	return parser.Unparse(a.expr, a.info)
 }
 
 // RefValueToValue converts between ref.Val and api.expr.Value.

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -39,7 +39,7 @@ type checker struct {
 
 // Check performs type checking, giving a typed AST.
 //
-// The input is a ParsedExpr proto and an env which encapsulates type binding of variables,
+// The input is a parsed AST and an env which encapsulates type binding of variables,
 // declarations of built-in functions, descriptions of protocol buffers, and a registry for
 // errors.
 //

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -25,18 +25,16 @@ import (
 	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/types"
-
-	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	"github.com/google/cel-go/common/types/ref"
 )
 
 type checker struct {
+	*ast.AST
+	ast.ExprFactory
 	env                *Env
 	errors             *typeErrors
 	mappings           *mapping
 	freeTypeVarCounter int
-	sourceInfo         *exprpb.SourceInfo
-	types              map[int64]*types.Type
-	references         map[int64]*ast.ReferenceInfo
 }
 
 // Check performs type checking, giving a typed AST.
@@ -47,121 +45,76 @@ type checker struct {
 //
 // Returns a type-checked AST, which might not be usable if there are errors in the error
 // registry.
-func Check(parsedExpr *exprpb.ParsedExpr, source common.Source, env *Env) (*ast.AST, *common.Errors) {
+func Check(parsed *ast.AST, source common.Source, env *Env) (*ast.AST, *common.Errors) {
 	errs := common.NewErrors(source)
+	typeMap := make(map[int64]*types.Type)
+	refMap := make(map[int64]*ast.ReferenceInfo)
 	c := checker{
+		AST:                ast.NewCheckedAST(parsed, typeMap, refMap),
+		ExprFactory:        ast.NewExprFactory(),
 		env:                env,
 		errors:             &typeErrors{errs: errs},
 		mappings:           newMapping(),
 		freeTypeVarCounter: 0,
-		sourceInfo:         parsedExpr.GetSourceInfo(),
-		types:              make(map[int64]*types.Type),
-		references:         make(map[int64]*ast.ReferenceInfo),
 	}
-	c.check(parsedExpr.GetExpr())
+	c.check(c.Expr())
 
-	// Walk over the final type map substituting any type parameters either by their bound value or
-	// by DYN.
-	m := make(map[int64]*types.Type)
-	for id, t := range c.types {
-		m[id] = substitute(c.mappings, t, true)
+	// Walk over the final type map substituting any type parameters either by their bound value
+	// or by DYN.
+	for id, t := range c.TypeMap() {
+		c.SetType(id, substitute(c.mappings, t, true))
 	}
-	e, err := ast.ProtoToExpr(parsedExpr.GetExpr())
-	if err != nil {
-		errs.ReportError(common.NoLocation, err.Error())
-	}
-	info, err := ast.ProtoToSourceInfo(parsedExpr.GetSourceInfo())
-	if err != nil {
-		errs.ReportError(common.NoLocation, err.Error())
-	}
-	return ast.NewCheckedAST(ast.NewAST(e, info), m, c.references), errs
+	return c.AST, errs
 }
 
-func (c *checker) check(e *exprpb.Expr) {
+func (c *checker) check(e ast.Expr) {
 	if e == nil {
 		return
 	}
-	switch e.GetExprKind().(type) {
-	case *exprpb.Expr_ConstExpr:
-		literal := e.GetConstExpr()
-		switch literal.GetConstantKind().(type) {
-		case *exprpb.Constant_BoolValue:
-			c.checkBoolLiteral(e)
-		case *exprpb.Constant_BytesValue:
-			c.checkBytesLiteral(e)
-		case *exprpb.Constant_DoubleValue:
-			c.checkDoubleLiteral(e)
-		case *exprpb.Constant_Int64Value:
-			c.checkInt64Literal(e)
-		case *exprpb.Constant_NullValue:
-			c.checkNullLiteral(e)
-		case *exprpb.Constant_StringValue:
-			c.checkStringLiteral(e)
-		case *exprpb.Constant_Uint64Value:
-			c.checkUint64Literal(e)
+	switch e.Kind() {
+	case ast.LiteralKind:
+		literal := ref.Val(e.AsLiteral())
+		switch literal.Type() {
+		case types.BoolType, types.BytesType, types.DoubleType, types.IntType,
+			types.NullType, types.StringType, types.UintType:
+			c.setType(e, literal.Type().(*types.Type))
 		}
-	case *exprpb.Expr_IdentExpr:
+	case ast.IdentKind:
 		c.checkIdent(e)
-	case *exprpb.Expr_SelectExpr:
+	case ast.SelectKind:
 		c.checkSelect(e)
-	case *exprpb.Expr_CallExpr:
+	case ast.CallKind:
 		c.checkCall(e)
-	case *exprpb.Expr_ListExpr:
+	case ast.ListKind:
 		c.checkCreateList(e)
-	case *exprpb.Expr_StructExpr:
+	case ast.MapKind:
+		c.checkCreateMap(e)
+	case ast.StructKind:
 		c.checkCreateStruct(e)
-	case *exprpb.Expr_ComprehensionExpr:
+	case ast.ComprehensionKind:
 		c.checkComprehension(e)
 	default:
-		c.errors.unexpectedASTType(e.GetId(), c.location(e), e)
+		c.errors.unexpectedASTType(e.ID(), c.location(e), e)
 	}
 }
 
-func (c *checker) checkInt64Literal(e *exprpb.Expr) {
-	c.setType(e, types.IntType)
-}
-
-func (c *checker) checkUint64Literal(e *exprpb.Expr) {
-	c.setType(e, types.UintType)
-}
-
-func (c *checker) checkStringLiteral(e *exprpb.Expr) {
-	c.setType(e, types.StringType)
-}
-
-func (c *checker) checkBytesLiteral(e *exprpb.Expr) {
-	c.setType(e, types.BytesType)
-}
-
-func (c *checker) checkDoubleLiteral(e *exprpb.Expr) {
-	c.setType(e, types.DoubleType)
-}
-
-func (c *checker) checkBoolLiteral(e *exprpb.Expr) {
-	c.setType(e, types.BoolType)
-}
-
-func (c *checker) checkNullLiteral(e *exprpb.Expr) {
-	c.setType(e, types.NullType)
-}
-
-func (c *checker) checkIdent(e *exprpb.Expr) {
-	identExpr := e.GetIdentExpr()
+func (c *checker) checkIdent(e ast.Expr) {
+	identName := e.AsIdent()
 	// Check to see if the identifier is declared.
-	if ident := c.env.LookupIdent(identExpr.GetName()); ident != nil {
+	if ident := c.env.LookupIdent(identName); ident != nil {
 		c.setType(e, ident.Type())
 		c.setReference(e, ast.NewIdentReference(ident.Name(), ident.Value()))
 		// Overwrite the identifier with its fully qualified name.
-		identExpr.Name = ident.Name()
+		e.SetKindCase(c.NewIdent(e.ID(), ident.Name()))
 		return
 	}
 
 	c.setType(e, types.ErrorType)
-	c.errors.undeclaredReference(e.GetId(), c.location(e), c.env.container.Name(), identExpr.GetName())
+	c.errors.undeclaredReference(e.ID(), c.location(e), c.env.container.Name(), identName)
 }
 
-func (c *checker) checkSelect(e *exprpb.Expr) {
-	sel := e.GetSelectExpr()
+func (c *checker) checkSelect(e ast.Expr) {
+	sel := e.AsSelect()
 	// Before traversing down the tree, try to interpret as qualified name.
 	qname, found := containers.ToQualifiedName(e)
 	if found {
@@ -174,31 +127,26 @@ func (c *checker) checkSelect(e *exprpb.Expr) {
 			// variable name.
 			c.setType(e, ident.Type())
 			c.setReference(e, ast.NewIdentReference(ident.Name(), ident.Value()))
-			identName := ident.Name()
-			e.ExprKind = &exprpb.Expr_IdentExpr{
-				IdentExpr: &exprpb.Expr_Ident{
-					Name: identName,
-				},
-			}
+			e.SetKindCase(c.NewIdent(e.ID(), ident.Name()))
 			return
 		}
 	}
 
-	resultType := c.checkSelectField(e, sel.GetOperand(), sel.GetField(), false)
-	if sel.TestOnly {
+	resultType := c.checkSelectField(e, sel.Operand(), sel.FieldName(), false)
+	if sel.IsTestOnly() {
 		resultType = types.BoolType
 	}
 	c.setType(e, substitute(c.mappings, resultType, false))
 }
 
-func (c *checker) checkOptSelect(e *exprpb.Expr) {
+func (c *checker) checkOptSelect(e ast.Expr) {
 	// Collect metadata related to the opt select call packaged by the parser.
-	call := e.GetCallExpr()
-	operand := call.GetArgs()[0]
-	field := call.GetArgs()[1]
+	call := e.AsCall()
+	operand := call.Args()[0]
+	field := call.Args()[1]
 	fieldName, isString := maybeUnwrapString(field)
 	if !isString {
-		c.errors.notAnOptionalFieldSelection(field.GetId(), c.location(field), field)
+		c.errors.notAnOptionalFieldSelection(field.ID(), c.location(field), field)
 		return
 	}
 
@@ -208,7 +156,7 @@ func (c *checker) checkOptSelect(e *exprpb.Expr) {
 	c.setReference(e, ast.NewFunctionReference("select_optional_field"))
 }
 
-func (c *checker) checkSelectField(e, operand *exprpb.Expr, field string, optional bool) *types.Type {
+func (c *checker) checkSelectField(e, operand ast.Expr, field string, optional bool) *types.Type {
 	// Interpret as field selection, first traversing down the operand.
 	c.check(operand)
 	operandType := substitute(c.mappings, c.getType(operand), false)
@@ -226,7 +174,7 @@ func (c *checker) checkSelectField(e, operand *exprpb.Expr, field string, option
 		// Objects yield their field type declaration as the selection result type, but only if
 		// the field is defined.
 		messageType := targetType
-		if fieldType, found := c.lookupFieldType(e.GetId(), messageType.TypeName(), field); found {
+		if fieldType, found := c.lookupFieldType(e.ID(), messageType.TypeName(), field); found {
 			resultType = fieldType
 		}
 	case types.TypeParamKind:
@@ -240,7 +188,7 @@ func (c *checker) checkSelectField(e, operand *exprpb.Expr, field string, option
 		// Dynamic / error values are treated as DYN type. Errors are handled this way as well
 		// in order to allow forward progress on the check.
 		if !isDynOrError(targetType) {
-			c.errors.typeDoesNotSupportFieldSelection(e.GetId(), c.location(e), targetType)
+			c.errors.typeDoesNotSupportFieldSelection(e.ID(), c.location(e), targetType)
 		}
 		resultType = types.DynType
 	}
@@ -252,35 +200,34 @@ func (c *checker) checkSelectField(e, operand *exprpb.Expr, field string, option
 	return resultType
 }
 
-func (c *checker) checkCall(e *exprpb.Expr) {
+func (c *checker) checkCall(e ast.Expr) {
 	// Note: similar logic exists within the `interpreter/planner.go`. If making changes here
 	// please consider the impact on planner.go and consolidate implementations or mirror code
 	// as appropriate.
-	call := e.GetCallExpr()
-	fnName := call.GetFunction()
+	call := e.AsCall()
+	fnName := call.FunctionName()
 	if fnName == operators.OptSelect {
 		c.checkOptSelect(e)
 		return
 	}
 
-	args := call.GetArgs()
+	args := call.Args()
 	// Traverse arguments.
 	for _, arg := range args {
 		c.check(arg)
 	}
 
-	target := call.GetTarget()
 	// Regular static call with simple name.
-	if target == nil {
+	if !call.IsMemberFunction() {
 		// Check for the existence of the function.
 		fn := c.env.LookupFunction(fnName)
 		if fn == nil {
-			c.errors.undeclaredReference(e.GetId(), c.location(e), c.env.container.Name(), fnName)
+			c.errors.undeclaredReference(e.ID(), c.location(e), c.env.container.Name(), fnName)
 			c.setType(e, types.ErrorType)
 			return
 		}
 		// Overwrite the function name with its fully qualified resolved name.
-		call.Function = fn.Name()
+		e.SetKindCase(c.NewCall(e.ID(), fn.Name(), args...))
 		// Check to see whether the overload resolves.
 		c.resolveOverloadOrError(e, fn, nil, args)
 		return
@@ -291,6 +238,7 @@ func (c *checker) checkCall(e *exprpb.Expr) {
 	// target a.b.
 	//
 	// Check whether the target is a namespaced function name.
+	target := call.Target()
 	qualifiedPrefix, maybeQualified := containers.ToQualifiedName(target)
 	if maybeQualified {
 		maybeQualifiedName := qualifiedPrefix + "." + fnName
@@ -299,15 +247,14 @@ func (c *checker) checkCall(e *exprpb.Expr) {
 			// The function name is namespaced and so preserving the target operand would
 			// be an inaccurate representation of the desired evaluation behavior.
 			// Overwrite with fully-qualified resolved function name sans receiver target.
-			call.Target = nil
-			call.Function = fn.Name()
+			e.SetKindCase(c.NewCall(e.ID(), fn.Name(), args...))
 			c.resolveOverloadOrError(e, fn, nil, args)
 			return
 		}
 	}
 
 	// Regular instance call.
-	c.check(call.Target)
+	c.check(target)
 	fn := c.env.LookupFunction(fnName)
 	// Function found, attempt overload resolution.
 	if fn != nil {
@@ -316,11 +263,11 @@ func (c *checker) checkCall(e *exprpb.Expr) {
 	}
 	// Function name not declared, record error.
 	c.setType(e, types.ErrorType)
-	c.errors.undeclaredReference(e.GetId(), c.location(e), c.env.container.Name(), fnName)
+	c.errors.undeclaredReference(e.ID(), c.location(e), c.env.container.Name(), fnName)
 }
 
 func (c *checker) resolveOverloadOrError(
-	e *exprpb.Expr, fn *decls.FunctionDecl, target *exprpb.Expr, args []*exprpb.Expr) {
+	e ast.Expr, fn *decls.FunctionDecl, target ast.Expr, args []ast.Expr) {
 	// Attempt to resolve the overload.
 	resolution := c.resolveOverload(e, fn, target, args)
 	// No such overload, error noted in the resolveOverload call, type recorded here.
@@ -334,7 +281,7 @@ func (c *checker) resolveOverloadOrError(
 }
 
 func (c *checker) resolveOverload(
-	call *exprpb.Expr, fn *decls.FunctionDecl, target *exprpb.Expr, args []*exprpb.Expr) *overloadResolution {
+	call ast.Expr, fn *decls.FunctionDecl, target ast.Expr, args []ast.Expr) *overloadResolution {
 
 	var argTypes []*types.Type
 	if target != nil {
@@ -366,8 +313,8 @@ func (c *checker) resolveOverload(
 			for i, argType := range argTypes {
 				if !c.isAssignable(argType, types.BoolType) {
 					c.errors.typeMismatch(
-						args[i].GetId(),
-						c.locationByID(args[i].GetId()),
+						args[i].ID(),
+						c.locationByID(args[i].ID()),
 						types.BoolType,
 						argType)
 					resultType = types.ErrorType
@@ -412,29 +359,29 @@ func (c *checker) resolveOverload(
 		for i, argType := range argTypes {
 			argTypes[i] = substitute(c.mappings, argType, true)
 		}
-		c.errors.noMatchingOverload(call.GetId(), c.location(call), fn.Name(), argTypes, target != nil)
+		c.errors.noMatchingOverload(call.ID(), c.location(call), fn.Name(), argTypes, target != nil)
 		return nil
 	}
 
 	return newResolution(checkedRef, resultType)
 }
 
-func (c *checker) checkCreateList(e *exprpb.Expr) {
-	create := e.GetListExpr()
+func (c *checker) checkCreateList(e ast.Expr) {
+	create := e.AsList()
 	var elemsType *types.Type
-	optionalIndices := create.GetOptionalIndices()
+	optionalIndices := create.OptionalIndices()
 	optionals := make(map[int32]bool, len(optionalIndices))
 	for _, optInd := range optionalIndices {
 		optionals[optInd] = true
 	}
-	for i, e := range create.GetElements() {
+	for i, e := range create.Elements() {
 		c.check(e)
 		elemType := c.getType(e)
 		if optionals[int32(i)] {
 			var isOptional bool
 			elemType, isOptional = maybeUnwrapOptional(elemType)
 			if !isOptional && !isDyn(elemType) {
-				c.errors.typeMismatch(e.GetId(), c.location(e), types.NewOptionalType(elemType), elemType)
+				c.errors.typeMismatch(e.ID(), c.location(e), types.NewOptionalType(elemType), elemType)
 			}
 		}
 		elemsType = c.joinTypes(e, elemsType, elemType)
@@ -446,32 +393,24 @@ func (c *checker) checkCreateList(e *exprpb.Expr) {
 	c.setType(e, types.NewListType(elemsType))
 }
 
-func (c *checker) checkCreateStruct(e *exprpb.Expr) {
-	str := e.GetStructExpr()
-	if str.GetMessageName() != "" {
-		c.checkCreateMessage(e)
-	} else {
-		c.checkCreateMap(e)
-	}
-}
-
-func (c *checker) checkCreateMap(e *exprpb.Expr) {
-	mapVal := e.GetStructExpr()
+func (c *checker) checkCreateMap(e ast.Expr) {
+	mapVal := e.AsMap()
 	var mapKeyType *types.Type
 	var mapValueType *types.Type
-	for _, ent := range mapVal.GetEntries() {
-		key := ent.GetMapKey()
+	for _, e := range mapVal.Entries() {
+		entry := e.AsMapEntry()
+		key := entry.Key()
 		c.check(key)
 		mapKeyType = c.joinTypes(key, mapKeyType, c.getType(key))
 
-		val := ent.GetValue()
+		val := entry.Value()
 		c.check(val)
 		valType := c.getType(val)
-		if ent.GetOptionalEntry() {
+		if entry.IsOptional() {
 			var isOptional bool
 			valType, isOptional = maybeUnwrapOptional(valType)
 			if !isOptional && !isDyn(valType) {
-				c.errors.typeMismatch(val.GetId(), c.location(val), types.NewOptionalType(valType), valType)
+				c.errors.typeMismatch(val.ID(), c.location(val), types.NewOptionalType(valType), valType)
 			}
 		}
 		mapValueType = c.joinTypes(val, mapValueType, valType)
@@ -484,25 +423,28 @@ func (c *checker) checkCreateMap(e *exprpb.Expr) {
 	c.setType(e, types.NewMapType(mapKeyType, mapValueType))
 }
 
-func (c *checker) checkCreateMessage(e *exprpb.Expr) {
-	msgVal := e.GetStructExpr()
+func (c *checker) checkCreateStruct(e ast.Expr) {
+	msgVal := e.AsStruct()
 	// Determine the type of the message.
 	resultType := types.ErrorType
-	ident := c.env.LookupIdent(msgVal.GetMessageName())
+	ident := c.env.LookupIdent(msgVal.TypeName())
 	if ident == nil {
 		c.errors.undeclaredReference(
-			e.GetId(), c.location(e), c.env.container.Name(), msgVal.GetMessageName())
+			e.ID(), c.location(e), c.env.container.Name(), msgVal.TypeName())
 		c.setType(e, types.ErrorType)
 		return
 	}
 	// Ensure the type name is fully qualified in the AST.
 	typeName := ident.Name()
-	msgVal.MessageName = typeName
-	c.setReference(e, ast.NewIdentReference(ident.Name(), nil))
+	if msgVal.TypeName() != typeName {
+		e.SetKindCase(c.NewStruct(e.ID(), typeName, msgVal.Fields()))
+		msgVal = e.AsStruct()
+	}
+	c.setReference(e, ast.NewIdentReference(typeName, nil))
 	identKind := ident.Type().Kind()
 	if identKind != types.ErrorKind {
 		if identKind != types.TypeKind {
-			c.errors.notAType(e.GetId(), c.location(e), ident.Type().DeclaredTypeName())
+			c.errors.notAType(e.ID(), c.location(e), ident.Type().DeclaredTypeName())
 		} else {
 			resultType = ident.Type().Parameters()[0]
 			// Backwards compatibility test between well-known types and message types
@@ -513,7 +455,7 @@ func (c *checker) checkCreateMessage(e *exprpb.Expr) {
 			} else if resultType.Kind() == types.StructKind {
 				typeName = resultType.DeclaredTypeName()
 			} else {
-				c.errors.notAMessageType(e.GetId(), c.location(e), resultType.DeclaredTypeName())
+				c.errors.notAMessageType(e.ID(), c.location(e), resultType.DeclaredTypeName())
 				resultType = types.ErrorType
 			}
 		}
@@ -521,37 +463,38 @@ func (c *checker) checkCreateMessage(e *exprpb.Expr) {
 	c.setType(e, resultType)
 
 	// Check the field initializers.
-	for _, ent := range msgVal.GetEntries() {
-		field := ent.GetFieldKey()
-		value := ent.GetValue()
+	for _, f := range msgVal.Fields() {
+		field := f.AsStructField()
+		fieldName := field.Name()
+		value := field.Value()
 		c.check(value)
 
 		fieldType := types.ErrorType
-		ft, found := c.lookupFieldType(ent.GetId(), typeName, field)
+		ft, found := c.lookupFieldType(f.ID(), typeName, fieldName)
 		if found {
 			fieldType = ft
 		}
 
 		valType := c.getType(value)
-		if ent.GetOptionalEntry() {
+		if field.IsOptional() {
 			var isOptional bool
 			valType, isOptional = maybeUnwrapOptional(valType)
 			if !isOptional && !isDyn(valType) {
-				c.errors.typeMismatch(value.GetId(), c.location(value), types.NewOptionalType(valType), valType)
+				c.errors.typeMismatch(value.ID(), c.location(value), types.NewOptionalType(valType), valType)
 			}
 		}
 		if !c.isAssignable(fieldType, valType) {
-			c.errors.fieldTypeMismatch(ent.GetId(), c.locationByID(ent.GetId()), field, fieldType, valType)
+			c.errors.fieldTypeMismatch(f.ID(), c.locationByID(f.ID()), fieldName, fieldType, valType)
 		}
 	}
 }
 
-func (c *checker) checkComprehension(e *exprpb.Expr) {
-	comp := e.GetComprehensionExpr()
-	c.check(comp.GetIterRange())
-	c.check(comp.GetAccuInit())
-	accuType := c.getType(comp.GetAccuInit())
-	rangeType := substitute(c.mappings, c.getType(comp.GetIterRange()), false)
+func (c *checker) checkComprehension(e ast.Expr) {
+	comp := e.AsComprehension()
+	c.check(comp.IterRange())
+	c.check(comp.AccuInit())
+	accuType := c.getType(comp.AccuInit())
+	rangeType := substitute(c.mappings, c.getType(comp.IterRange()), false)
 	var varType *types.Type
 
 	switch rangeType.Kind() {
@@ -568,32 +511,32 @@ func (c *checker) checkComprehension(e *exprpb.Expr) {
 		// Set the range iteration variable to type DYN as well.
 		varType = types.DynType
 	default:
-		c.errors.notAComprehensionRange(comp.GetIterRange().GetId(), c.location(comp.GetIterRange()), rangeType)
+		c.errors.notAComprehensionRange(comp.IterRange().ID(), c.location(comp.IterRange()), rangeType)
 		varType = types.ErrorType
 	}
 
 	// Create a scope for the comprehension since it has a local accumulation variable.
 	// This scope will contain the accumulation variable used to compute the result.
 	c.env = c.env.enterScope()
-	c.env.AddIdents(decls.NewVariable(comp.GetAccuVar(), accuType))
+	c.env.AddIdents(decls.NewVariable(comp.AccuVar(), accuType))
 	// Create a block scope for the loop.
 	c.env = c.env.enterScope()
-	c.env.AddIdents(decls.NewVariable(comp.GetIterVar(), varType))
+	c.env.AddIdents(decls.NewVariable(comp.IterVar(), varType))
 	// Check the variable references in the condition and step.
-	c.check(comp.GetLoopCondition())
-	c.assertType(comp.GetLoopCondition(), types.BoolType)
-	c.check(comp.GetLoopStep())
-	c.assertType(comp.GetLoopStep(), accuType)
+	c.check(comp.LoopCondition())
+	c.assertType(comp.LoopCondition(), types.BoolType)
+	c.check(comp.LoopStep())
+	c.assertType(comp.LoopStep(), accuType)
 	// Exit the loop's block scope before checking the result.
 	c.env = c.env.exitScope()
-	c.check(comp.GetResult())
+	c.check(comp.Result())
 	// Exit the comprehension scope.
 	c.env = c.env.exitScope()
-	c.setType(e, substitute(c.mappings, c.getType(comp.GetResult()), false))
+	c.setType(e, substitute(c.mappings, c.getType(comp.Result()), false))
 }
 
 // Checks compatibility of joined types, and returns the most general common type.
-func (c *checker) joinTypes(e *exprpb.Expr, previous, current *types.Type) *types.Type {
+func (c *checker) joinTypes(e ast.Expr, previous, current *types.Type) *types.Type {
 	if previous == nil {
 		return current
 	}
@@ -603,7 +546,7 @@ func (c *checker) joinTypes(e *exprpb.Expr, previous, current *types.Type) *type
 	if c.dynAggregateLiteralElementTypesEnabled() {
 		return types.DynType
 	}
-	c.errors.typeMismatch(e.GetId(), c.location(e), previous, current)
+	c.errors.typeMismatch(e.ID(), c.location(e), previous, current)
 	return types.ErrorType
 }
 
@@ -637,41 +580,41 @@ func (c *checker) isAssignableList(l1, l2 []*types.Type) bool {
 	return false
 }
 
-func maybeUnwrapString(e *exprpb.Expr) (string, bool) {
-	switch e.GetExprKind().(type) {
-	case *exprpb.Expr_ConstExpr:
-		literal := e.GetConstExpr()
-		switch literal.GetConstantKind().(type) {
-		case *exprpb.Constant_StringValue:
-			return literal.GetStringValue(), true
+func maybeUnwrapString(e ast.Expr) (string, bool) {
+	switch e.Kind() {
+	case ast.LiteralKind:
+		literal := e.AsLiteral()
+		switch v := literal.(type) {
+		case types.String:
+			return string(v), true
 		}
 	}
 	return "", false
 }
 
-func (c *checker) setType(e *exprpb.Expr, t *types.Type) {
-	if old, found := c.types[e.GetId()]; found && !old.IsExactType(t) {
-		c.errors.incompatibleType(e.GetId(), c.location(e), e, old, t)
+func (c *checker) setType(e ast.Expr, t *types.Type) {
+	if old, found := c.TypeMap()[e.ID()]; found && !old.IsExactType(t) {
+		c.errors.incompatibleType(e.ID(), c.location(e), e, old, t)
 		return
 	}
-	c.types[e.GetId()] = t
+	c.SetType(e.ID(), t)
 }
 
-func (c *checker) getType(e *exprpb.Expr) *types.Type {
-	return c.types[e.GetId()]
+func (c *checker) getType(e ast.Expr) *types.Type {
+	return c.TypeMap()[e.ID()]
 }
 
-func (c *checker) setReference(e *exprpb.Expr, r *ast.ReferenceInfo) {
-	if old, found := c.references[e.GetId()]; found && !old.Equals(r) {
-		c.errors.referenceRedefinition(e.GetId(), c.location(e), e, old, r)
+func (c *checker) setReference(e ast.Expr, r *ast.ReferenceInfo) {
+	if old, found := c.ReferenceMap()[e.ID()]; found && !old.Equals(r) {
+		c.errors.referenceRedefinition(e.ID(), c.location(e), e, old, r)
 		return
 	}
-	c.references[e.GetId()] = r
+	c.SetReference(e.ID(), r)
 }
 
-func (c *checker) assertType(e *exprpb.Expr, t *types.Type) {
+func (c *checker) assertType(e ast.Expr, t *types.Type) {
 	if !c.isAssignable(t, c.getType(e)) {
-		c.errors.typeMismatch(e.GetId(), c.location(e), t, c.getType(e))
+		c.errors.typeMismatch(e.ID(), c.location(e), t, c.getType(e))
 	}
 }
 
@@ -687,26 +630,12 @@ func newResolution(r *ast.ReferenceInfo, t *types.Type) *overloadResolution {
 	}
 }
 
-func (c *checker) location(e *exprpb.Expr) common.Location {
-	return c.locationByID(e.GetId())
+func (c *checker) location(e ast.Expr) common.Location {
+	return c.locationByID(e.ID())
 }
 
 func (c *checker) locationByID(id int64) common.Location {
-	positions := c.sourceInfo.GetPositions()
-	var line = 1
-	if offset, found := positions[id]; found {
-		col := int(offset)
-		for _, lineOffset := range c.sourceInfo.GetLineOffsets() {
-			if lineOffset < offset {
-				line++
-				col = int(offset - lineOffset)
-			} else {
-				break
-			}
-		}
-		return common.NewLocation(line, col)
-	}
-	return common.NoLocation
+	return c.SourceInfo().GetStartLocation(id)
 }
 
 func (c *checker) lookupFieldType(exprID int64, structType, fieldName string) (*types.Type, bool) {

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/google/cel-go/common"
-	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/containers"
 	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/stdlib"
@@ -2350,7 +2349,7 @@ func TestCheck(t *testing.T) {
 				t.Errorf("Expected error not thrown: %s", tc.err)
 			}
 
-			actual := cAst.GetType(pAst.Expr.Id)
+			actual := cAst.GetType(pAst.Expr().ID())
 			if tc.err == "" {
 				if actual == nil || !actual.IsEquivalentType(tc.outType) {
 					t.Error(test.DiffMessage("Type Error", actual, tc.outType))
@@ -2358,11 +2357,7 @@ func TestCheck(t *testing.T) {
 			}
 
 			if tc.out != "" {
-				chkExpr, err := ast.ToProto(cAst)
-				if err != nil {
-					t.Fatalf("CheckedAstToCheckedExpr() failed: %v", err)
-				}
-				actualStr := Print(pAst.Expr, chkExpr)
+				actualStr := Print(pAst.Expr(), cAst)
 				if !test.Compare(actualStr, tc.out) {
 					t.Error(test.DiffMessage("Structure error", actualStr, tc.out))
 				}
@@ -2445,7 +2440,7 @@ func BenchmarkCheck(b *testing.B) {
 					b.Errorf("Expected error not thrown: %s", tc.err)
 				}
 
-				actual := cAst.GetType(pAst.Expr.Id)
+				actual := cAst.GetType(pAst.Expr().ID())
 				if tc.err == "" {
 					if actual == nil || !actual.IsEquivalentType(tc.outType) {
 						b.Error(test.DiffMessage("Type Error", actual, tc.outType))
@@ -2453,11 +2448,7 @@ func BenchmarkCheck(b *testing.B) {
 				}
 
 				if tc.out != "" {
-					chkExpr, err := ast.ToProto(cAst)
-					if err != nil {
-						b.Fatalf("CheckedAstToCheckedExpr() failed: %v", err)
-					}
-					actualStr := Print(pAst.Expr, chkExpr)
+					actualStr := Print(pAst.Expr(), cAst)
 					if !test.Compare(actualStr, tc.out) {
 						b.Error(test.DiffMessage("Structure error", actualStr, tc.out))
 					}

--- a/checker/cost.go
+++ b/checker/cost.go
@@ -304,9 +304,9 @@ func PresenceTestHasCost(hasCost bool) CostOption {
 }
 
 // Cost estimates the cost of the parsed and type checked CEL expression.
-func Cost(checker *ast.AST, estimator CostEstimator, opts ...CostOption) (CostEstimate, error) {
+func Cost(checked *ast.AST, estimator CostEstimator, opts ...CostOption) (CostEstimate, error) {
 	c := &coster{
-		checkedAST:       checker,
+		checkedAST:       checked,
 		estimator:        estimator,
 		exprPath:         map[int64][]string{},
 		iterRanges:       map[string][]int64{},
@@ -319,7 +319,7 @@ func Cost(checker *ast.AST, estimator CostEstimator, opts ...CostOption) (CostEs
 			return CostEstimate{}, err
 		}
 	}
-	epb, err := ast.ExprToProto(checker.Expr())
+	epb, err := ast.ExprToProto(checked.Expr())
 	if err != nil {
 		return CostEstimate{}, err
 	}

--- a/checker/cost_test.go
+++ b/checker/cost_test.go
@@ -263,7 +263,7 @@ func TestCost(t *testing.T) {
 		},
 		{
 			name:  "bytes to string conversion equality",
-			decls: []*exprpb.Decl{decls.NewVar("input", decls.Bytes)},
+			vars:  []*decls.VariableDecl{decls.NewVariable("input", types.BytesType)},
 			hints: map[string]int64{"input": 500},
 			// equality check ensures that the resultSize calculation is included in cost
 			expr:   `string(input) == string(input)`,
@@ -278,7 +278,7 @@ func TestCost(t *testing.T) {
 		},
 		{
 			name:  "string to bytes conversion equality",
-			decls: []*exprpb.Decl{decls.NewVar("input", decls.String)},
+			vars:  []*decls.VariableDecl{decls.NewVariable("input", types.StringType)},
 			hints: map[string]int64{"input": 500},
 			// equality check ensures that the resultSize calculation is included in cost
 			expr:   `bytes(input) == bytes(input)`,

--- a/checker/errors.go
+++ b/checker/errors.go
@@ -20,8 +20,6 @@ import (
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/types"
-
-	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 // typeErrors is a specialization of Errors.
@@ -34,9 +32,9 @@ func (e *typeErrors) fieldTypeMismatch(id int64, l common.Location, name string,
 		name, FormatCELType(field), FormatCELType(value))
 }
 
-func (e *typeErrors) incompatibleType(id int64, l common.Location, ex *exprpb.Expr, prev, next *types.Type) {
+func (e *typeErrors) incompatibleType(id int64, l common.Location, ex ast.Expr, prev, next *types.Type) {
 	e.errs.ReportErrorAtID(id, l,
-		"incompatible type already exists for expression: %v(%d) old:%v, new:%v", ex, ex.GetId(), prev, next)
+		"incompatible type already exists for expression: %v(%d) old:%v, new:%v", ex, ex.ID(), prev, next)
 }
 
 func (e *typeErrors) noMatchingOverload(id int64, l common.Location, name string, args []*types.Type, isInstance bool) {
@@ -49,7 +47,7 @@ func (e *typeErrors) notAComprehensionRange(id int64, l common.Location, t *type
 		FormatCELType(t))
 }
 
-func (e *typeErrors) notAnOptionalFieldSelection(id int64, l common.Location, field *exprpb.Expr) {
+func (e *typeErrors) notAnOptionalFieldSelection(id int64, l common.Location, field ast.Expr) {
 	e.errs.ReportErrorAtID(id, l, "unsupported optional field selection: %v", field)
 }
 
@@ -61,9 +59,9 @@ func (e *typeErrors) notAMessageType(id int64, l common.Location, typeName strin
 	e.errs.ReportErrorAtID(id, l, "'%s' is not a message type", typeName)
 }
 
-func (e *typeErrors) referenceRedefinition(id int64, l common.Location, ex *exprpb.Expr, prev, next *ast.ReferenceInfo) {
+func (e *typeErrors) referenceRedefinition(id int64, l common.Location, ex ast.Expr, prev, next *ast.ReferenceInfo) {
 	e.errs.ReportErrorAtID(id, l,
-		"reference already exists for expression: %v(%d) old:%v, new:%v", ex, ex.GetId(), prev, next)
+		"reference already exists for expression: %v(%d) old:%v, new:%v", ex, ex.ID(), prev, next)
 }
 
 func (e *typeErrors) typeDoesNotSupportFieldSelection(id int64, l common.Location, t *types.Type) {
@@ -87,6 +85,6 @@ func (e *typeErrors) unexpectedFailedResolution(id int64, l common.Location, typ
 	e.errs.ReportErrorAtID(id, l, "unexpected failed resolution of '%s'", typeName)
 }
 
-func (e *typeErrors) unexpectedASTType(id int64, l common.Location, ex *exprpb.Expr) {
+func (e *typeErrors) unexpectedASTType(id int64, l common.Location, ex ast.Expr) {
 	e.errs.ReportErrorAtID(id, l, "unrecognized ast type: %v", reflect.TypeOf(ex))
 }

--- a/common/ast/BUILD.bazel
+++ b/common/ast/BUILD.bazel
@@ -7,6 +7,7 @@ package(
         "//common:__subpackages__",
         "//ext:__subpackages__",
         "//interpreter:__subpackages__",
+        "//parser:__subpackages__",
     ],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/common/ast/ast.go
+++ b/common/ast/ast.go
@@ -54,6 +54,14 @@ func (a *AST) GetType(id int64) *types.Type {
 	return types.DynType
 }
 
+// SetType sets the type of the expression node at the given id.
+func (a *AST) SetType(id int64, t *types.Type) {
+	if a == nil {
+		return
+	}
+	a.typeMap[id] = t
+}
+
 // TypeMap returns the map of expression ids to type-checked types.
 //
 // If the AST is not type-checked, the map will be empty.
@@ -80,6 +88,14 @@ func (a *AST) ReferenceMap() map[int64]*ReferenceInfo {
 		return map[int64]*ReferenceInfo{}
 	}
 	return a.refMap
+}
+
+// SetReference adds a reference to the checked AST type map.
+func (a *AST) SetReference(id int64, r *ReferenceInfo) {
+	if a == nil {
+		return
+	}
+	a.refMap[id] = r
 }
 
 // IsChecked returns whether the AST is type-checked.

--- a/common/ast/conversion.go
+++ b/common/ast/conversion.go
@@ -298,7 +298,7 @@ func EntryExprToProto(e EntryExpr) (*exprpb.Expr_CreateStruct_Entry, error) {
 
 func protoCall(id int64, call CallExpr) (*exprpb.Expr, error) {
 	var err error
-	var target *exprpb.Expr = nil
+	var target *exprpb.Expr
 	if call.IsMemberFunction() {
 		target, err = ExprToProto(call.Target())
 		if err != nil {

--- a/common/ast/conversion.go
+++ b/common/ast/conversion.go
@@ -273,6 +273,11 @@ func ExprToProto(e Expr) (*exprpb.Expr, error) {
 	case StructKind:
 		return protoStruct(e.ID(), e.AsStruct())
 	case UnspecifiedExprKind:
+		// Handle the case where a macro reference may be getting translated.
+		// A nested macro 'pointer' is a non-zero expression id with no kind set.
+		if e.ID() != 0 {
+			return &exprpb.Expr{Id: e.ID()}, nil
+		}
 		return &exprpb.Expr{}, nil
 	}
 	return nil, fmt.Errorf("unsupported expr kind: %v", e)
@@ -293,7 +298,7 @@ func EntryExprToProto(e EntryExpr) (*exprpb.Expr_CreateStruct_Entry, error) {
 
 func protoCall(id int64, call CallExpr) (*exprpb.Expr, error) {
 	var err error
-	var target *exprpb.Expr
+	var target *exprpb.Expr = nil
 	if call.IsMemberFunction() {
 		target, err = ExprToProto(call.Target())
 		if err != nil {

--- a/common/ast/conversion_test.go
+++ b/common/ast/conversion_test.go
@@ -203,25 +203,23 @@ func TestConvertExpr(t *testing.T) {
 			if len(errs.GetErrors()) != 0 {
 				t.Fatalf("Parse() failed: %s", errs.ToDisplayString())
 			}
+			gotPBExpr, err := ast.ExprToProto(parsed.Expr())
+			if err != nil {
+				t.Fatalf("ast.ExprToProto() failed: %v", err)
+			}
 			wantPBExpr, err := ast.ExprToProto(tc.wantExpr)
 			if err != nil {
 				t.Fatalf("ast.ExprToProto() failed: %v", err)
 			}
-			if !proto.Equal(parsed.GetExpr(), wantPBExpr) {
+			if !proto.Equal(gotPBExpr, wantPBExpr) {
 				t.Errorf("got %v\n, wanted %v",
-					prototext.Format(parsed.GetExpr()), prototext.Format(wantPBExpr))
+					prototext.Format(gotPBExpr), prototext.Format(wantPBExpr))
 			}
-			gotExpr, err := ast.ProtoToExpr(parsed.GetExpr())
-			if err != nil {
-				t.Fatalf("ast.ProtoToExpr() failed: %v", err)
-			}
+			gotExpr := parsed.Expr()
 			if !reflect.DeepEqual(gotExpr, tc.wantExpr) {
 				t.Errorf("got %v, wanted %v", gotExpr, tc.wantExpr)
 			}
-			info, err := ast.ProtoToSourceInfo(parsed.GetSourceInfo())
-			if err != nil {
-				t.Fatalf("ast.ProtoToSourceInfo() failed: %v", err)
-			}
+			info := parsed.SourceInfo()
 			for id, wantCall := range tc.macroCalls {
 				call, found := info.GetMacroCall(id)
 				if !found {
@@ -230,14 +228,6 @@ func TestConvertExpr(t *testing.T) {
 				if !reflect.DeepEqual(call, wantCall) {
 					t.Errorf("macro call got %v, wanted %v", call, wantCall)
 				}
-			}
-			pbInfo, err := ast.SourceInfoToProto(info)
-			if err != nil {
-				t.Fatalf("ast.SourceInfoToProto() failed: %v", err)
-			}
-			if !proto.Equal(parsed.GetSourceInfo(), pbInfo) {
-				t.Errorf("source info roundtrip got %v, wanted %v",
-					prototext.Format(pbInfo), prototext.Format(parsed.GetSourceInfo()))
 			}
 		})
 	}

--- a/common/containers/BUILD.bazel
+++ b/common/containers/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
     ],
     importpath = "github.com/google/cel-go/common/containers",
     deps = [
-        "@org_golang_google_genproto_googleapis_api//expr/v1alpha1:go_default_library",
+        "//common/ast:go_default_library",
     ],
 )
 
@@ -26,6 +26,6 @@ go_test(
         ":go_default_library",
     ],
     deps = [
-        "@org_golang_google_genproto_googleapis_api//expr/v1alpha1:go_default_library",
+        "//common/ast:go_default_library",
     ],
 )

--- a/common/containers/container.go
+++ b/common/containers/container.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	"github.com/google/cel-go/common/ast"
 )
 
 var (
@@ -297,19 +297,19 @@ func Name(name string) ContainerOption {
 
 // ToQualifiedName converts an expression AST into a qualified name if possible, with a boolean
 // 'found' value that indicates if the conversion is successful.
-func ToQualifiedName(e *exprpb.Expr) (string, bool) {
-	switch e.GetExprKind().(type) {
-	case *exprpb.Expr_IdentExpr:
-		id := e.GetIdentExpr()
-		return id.GetName(), true
-	case *exprpb.Expr_SelectExpr:
-		sel := e.GetSelectExpr()
+func ToQualifiedName(e ast.Expr) (string, bool) {
+	switch e.Kind() {
+	case ast.IdentKind:
+		id := e.AsIdent()
+		return id, true
+	case ast.SelectKind:
+		sel := e.AsSelect()
 		// Test only expressions are not valid as qualified names.
-		if sel.GetTestOnly() {
+		if sel.IsTestOnly() {
 			return "", false
 		}
-		if qual, found := ToQualifiedName(sel.GetOperand()); found {
-			return qual + "." + sel.GetField(), true
+		if qual, found := ToQualifiedName(sel.Operand()); found {
+			return qual + "." + sel.FieldName(), true
 		}
 	}
 	return "", false

--- a/common/debug/BUILD.bazel
+++ b/common/debug/BUILD.bazel
@@ -13,6 +13,8 @@ go_library(
     importpath = "github.com/google/cel-go/common/debug",
     deps = [
         "//common:go_default_library",
-        "@org_golang_google_genproto_googleapis_api//expr/v1alpha1:go_default_library",
+        "//common/ast:go_default_library",
+        "//common/types:go_default_library",
+        "//common/types/ref:go_default_library",
     ],
 )

--- a/common/debug/debug.go
+++ b/common/debug/debug.go
@@ -22,7 +22,9 @@ import (
 	"strconv"
 	"strings"
 
-	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
 )
 
 // Adorner returns debug metadata that will be tacked on to the string
@@ -38,7 +40,7 @@ type Writer interface {
 
 	// Buffer pushes an expression into an internal queue of expressions to
 	// write to a string.
-	Buffer(e *exprpb.Expr)
+	Buffer(e ast.Expr)
 }
 
 type emptyDebugAdorner struct {
@@ -51,12 +53,12 @@ func (a *emptyDebugAdorner) GetMetadata(e any) string {
 }
 
 // ToDebugString gives the unadorned string representation of the Expr.
-func ToDebugString(e *exprpb.Expr) string {
+func ToDebugString(e ast.Expr) string {
 	return ToAdornedDebugString(e, emptyAdorner)
 }
 
 // ToAdornedDebugString gives the adorned string representation of the Expr.
-func ToAdornedDebugString(e *exprpb.Expr, adorner Adorner) string {
+func ToAdornedDebugString(e ast.Expr, adorner Adorner) string {
 	w := newDebugWriter(adorner)
 	w.Buffer(e)
 	return w.String()
@@ -78,49 +80,51 @@ func newDebugWriter(a Adorner) *debugWriter {
 	}
 }
 
-func (w *debugWriter) Buffer(e *exprpb.Expr) {
+func (w *debugWriter) Buffer(e ast.Expr) {
 	if e == nil {
 		return
 	}
-	switch e.ExprKind.(type) {
-	case *exprpb.Expr_ConstExpr:
-		w.append(formatLiteral(e.GetConstExpr()))
-	case *exprpb.Expr_IdentExpr:
-		w.append(e.GetIdentExpr().Name)
-	case *exprpb.Expr_SelectExpr:
-		w.appendSelect(e.GetSelectExpr())
-	case *exprpb.Expr_CallExpr:
-		w.appendCall(e.GetCallExpr())
-	case *exprpb.Expr_ListExpr:
-		w.appendList(e.GetListExpr())
-	case *exprpb.Expr_StructExpr:
-		w.appendStruct(e.GetStructExpr())
-	case *exprpb.Expr_ComprehensionExpr:
-		w.appendComprehension(e.GetComprehensionExpr())
+	switch e.Kind() {
+	case ast.LiteralKind:
+		w.append(formatLiteral(e.AsLiteral()))
+	case ast.IdentKind:
+		w.append(e.AsIdent())
+	case ast.SelectKind:
+		w.appendSelect(e.AsSelect())
+	case ast.CallKind:
+		w.appendCall(e.AsCall())
+	case ast.ListKind:
+		w.appendList(e.AsList())
+	case ast.MapKind:
+		w.appendMap(e.AsMap())
+	case ast.StructKind:
+		w.appendStruct(e.AsStruct())
+	case ast.ComprehensionKind:
+		w.appendComprehension(e.AsComprehension())
 	}
 	w.adorn(e)
 }
 
-func (w *debugWriter) appendSelect(sel *exprpb.Expr_Select) {
-	w.Buffer(sel.GetOperand())
+func (w *debugWriter) appendSelect(sel ast.SelectExpr) {
+	w.Buffer(sel.Operand())
 	w.append(".")
-	w.append(sel.GetField())
-	if sel.TestOnly {
+	w.append(sel.FieldName())
+	if sel.IsTestOnly() {
 		w.append("~test-only~")
 	}
 }
 
-func (w *debugWriter) appendCall(call *exprpb.Expr_Call) {
-	if call.Target != nil {
-		w.Buffer(call.GetTarget())
+func (w *debugWriter) appendCall(call ast.CallExpr) {
+	if call.IsMemberFunction() {
+		w.Buffer(call.Target())
 		w.append(".")
 	}
-	w.append(call.GetFunction())
+	w.append(call.FunctionName())
 	w.append("(")
-	if len(call.GetArgs()) > 0 {
+	if len(call.Args()) > 0 {
 		w.addIndent()
 		w.appendLine()
-		for i, arg := range call.GetArgs() {
+		for i, arg := range call.Args() {
 			if i > 0 {
 				w.append(",")
 				w.appendLine()
@@ -133,12 +137,12 @@ func (w *debugWriter) appendCall(call *exprpb.Expr_Call) {
 	w.append(")")
 }
 
-func (w *debugWriter) appendList(list *exprpb.Expr_CreateList) {
+func (w *debugWriter) appendList(list ast.ListExpr) {
 	w.append("[")
-	if len(list.GetElements()) > 0 {
+	if len(list.Elements()) > 0 {
 		w.appendLine()
 		w.addIndent()
-		for i, elem := range list.GetElements() {
+		for i, elem := range list.Elements() {
 			if i > 0 {
 				w.append(",")
 				w.appendLine()
@@ -151,32 +155,25 @@ func (w *debugWriter) appendList(list *exprpb.Expr_CreateList) {
 	w.append("]")
 }
 
-func (w *debugWriter) appendStruct(obj *exprpb.Expr_CreateStruct) {
-	if obj.MessageName != "" {
-		w.appendObject(obj)
-	} else {
-		w.appendMap(obj)
-	}
-}
-
-func (w *debugWriter) appendObject(obj *exprpb.Expr_CreateStruct) {
-	w.append(obj.GetMessageName())
+func (w *debugWriter) appendStruct(obj ast.StructExpr) {
+	w.append(obj.TypeName())
 	w.append("{")
-	if len(obj.GetEntries()) > 0 {
+	if len(obj.Fields()) > 0 {
 		w.appendLine()
 		w.addIndent()
-		for i, entry := range obj.GetEntries() {
+		for i, f := range obj.Fields() {
+			field := f.AsStructField()
 			if i > 0 {
 				w.append(",")
 				w.appendLine()
 			}
-			if entry.GetOptionalEntry() {
+			if field.IsOptional() {
 				w.append("?")
 			}
-			w.append(entry.GetFieldKey())
+			w.append(field.Name())
 			w.append(":")
-			w.Buffer(entry.GetValue())
-			w.adorn(entry)
+			w.Buffer(field.Value())
+			w.adorn(f)
 		}
 		w.removeIndent()
 		w.appendLine()
@@ -184,23 +181,24 @@ func (w *debugWriter) appendObject(obj *exprpb.Expr_CreateStruct) {
 	w.append("}")
 }
 
-func (w *debugWriter) appendMap(obj *exprpb.Expr_CreateStruct) {
+func (w *debugWriter) appendMap(m ast.MapExpr) {
 	w.append("{")
-	if len(obj.GetEntries()) > 0 {
+	if m.Size() > 0 {
 		w.appendLine()
 		w.addIndent()
-		for i, entry := range obj.GetEntries() {
+		for i, e := range m.Entries() {
+			entry := e.AsMapEntry()
 			if i > 0 {
 				w.append(",")
 				w.appendLine()
 			}
-			if entry.GetOptionalEntry() {
+			if entry.IsOptional() {
 				w.append("?")
 			}
-			w.Buffer(entry.GetMapKey())
+			w.Buffer(entry.Key())
 			w.append(":")
-			w.Buffer(entry.GetValue())
-			w.adorn(entry)
+			w.Buffer(entry.Value())
+			w.adorn(e)
 		}
 		w.removeIndent()
 		w.appendLine()
@@ -208,62 +206,62 @@ func (w *debugWriter) appendMap(obj *exprpb.Expr_CreateStruct) {
 	w.append("}")
 }
 
-func (w *debugWriter) appendComprehension(comprehension *exprpb.Expr_Comprehension) {
+func (w *debugWriter) appendComprehension(comprehension ast.ComprehensionExpr) {
 	w.append("__comprehension__(")
 	w.addIndent()
 	w.appendLine()
 	w.append("// Variable")
 	w.appendLine()
-	w.append(comprehension.GetIterVar())
+	w.append(comprehension.IterVar())
 	w.append(",")
 	w.appendLine()
 	w.append("// Target")
 	w.appendLine()
-	w.Buffer(comprehension.GetIterRange())
+	w.Buffer(comprehension.IterRange())
 	w.append(",")
 	w.appendLine()
 	w.append("// Accumulator")
 	w.appendLine()
-	w.append(comprehension.GetAccuVar())
+	w.append(comprehension.AccuVar())
 	w.append(",")
 	w.appendLine()
 	w.append("// Init")
 	w.appendLine()
-	w.Buffer(comprehension.GetAccuInit())
+	w.Buffer(comprehension.AccuInit())
 	w.append(",")
 	w.appendLine()
 	w.append("// LoopCondition")
 	w.appendLine()
-	w.Buffer(comprehension.GetLoopCondition())
+	w.Buffer(comprehension.LoopCondition())
 	w.append(",")
 	w.appendLine()
 	w.append("// LoopStep")
 	w.appendLine()
-	w.Buffer(comprehension.GetLoopStep())
+	w.Buffer(comprehension.LoopStep())
 	w.append(",")
 	w.appendLine()
 	w.append("// Result")
 	w.appendLine()
-	w.Buffer(comprehension.GetResult())
+	w.Buffer(comprehension.Result())
 	w.append(")")
 	w.removeIndent()
 }
 
-func formatLiteral(c *exprpb.Constant) string {
-	switch c.GetConstantKind().(type) {
-	case *exprpb.Constant_BoolValue:
-		return fmt.Sprintf("%t", c.GetBoolValue())
-	case *exprpb.Constant_BytesValue:
-		return fmt.Sprintf("b\"%s\"", string(c.GetBytesValue()))
-	case *exprpb.Constant_DoubleValue:
-		return fmt.Sprintf("%v", c.GetDoubleValue())
-	case *exprpb.Constant_Int64Value:
-		return fmt.Sprintf("%d", c.GetInt64Value())
-	case *exprpb.Constant_StringValue:
-		return strconv.Quote(c.GetStringValue())
-	case *exprpb.Constant_Uint64Value:
-		return fmt.Sprintf("%du", c.GetUint64Value())
-	case *exprpb.Constant_NullValue:
+func formatLiteral(c ref.Val) string {
+	switch v := c.(type) {
+	case types.Bool:
+		return fmt.Sprintf("%t", v)
+	case types.Bytes:
+		return fmt.Sprintf("b\"%s\"", string(v))
+	case types.Double:
+		return fmt.Sprintf("%v", float64(v))
+	case types.Int:
+		return fmt.Sprintf("%d", int64(v))
+	case types.String:
+		return strconv.Quote(string(v))
+	case types.Uint:
+		return fmt.Sprintf("%du", uint64(v))
+	case types.Null:
 		return "null"
 	default:
 		panic("Unknown constant type")

--- a/parser/BUILD.bazel
+++ b/parser/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//common:go_default_library",
+        "//common/ast:go_default_library",
         "//common/operators:go_default_library",
         "//common/runes:go_default_library",
         "//parser/gen:go_default_library",
@@ -43,7 +44,9 @@ go_test(
         ":go_default_library",
     ],
     deps = [
+        "//common/ast:go_default_library",
         "//common/debug:go_default_library",
+        "//common/types:go_default_library",
         "//parser/gen:go_default_library",
         "//test:go_default_library",
         "@com_github_antlr_antlr4_runtime_go_antlr_v4//:go_default_library",


### PR DESCRIPTION
This change shifts the parse / check top-level APIs to use the native AST and Expr
representations. 

Updates to the parser internals, macro expansion signatures, cost estimation,
and unparsing APIs will be provided in subsequent PRs.

#789 