### PR TITLE
Update RenumberIDs to support stable id generation

### DIFF
--- a/common/ast/expr.go
+++ b/common/ast/expr.go
@@ -155,8 +155,8 @@ type EntryExpr interface {
 	isEntryExpr()
 }
 
-// IDGenerator produces monotonically increasing ids suitable for tagging expression nodes.
-type IDGenerator func() int64
+// IDGenerator produces unique ids suitable for tagging expression nodes
+type IDGenerator func(originalID int64) int64
 
 // CallExpr defines an interface for inspecting a function call and its arugments.
 type CallExpr interface {
@@ -435,7 +435,7 @@ func (e *expr) RenumberIDs(idGen IDGenerator) {
 	if e.Kind() == UnspecifiedExprKind {
 		return
 	}
-	e.id = idGen()
+	e.id = idGen(e.id)
 	e.exprKindCase.renumberIDs(idGen)
 }
 
@@ -751,7 +751,7 @@ func (e *entryExpr) AsStructField() StructField {
 }
 
 func (e *entryExpr) RenumberIDs(idGen IDGenerator) {
-	e.id = idGen()
+	e.id = idGen(e.id)
 	e.entryExprKindCase.renumberIDs(idGen)
 }
 

--- a/common/ast/expr_test.go
+++ b/common/ast/expr_test.go
@@ -474,8 +474,13 @@ func nilTestExpr(t testing.TB) ast.Expr {
 }
 
 func testIDGen(seed int64) ast.IDGenerator {
-	return func() int64 {
+	seen := map[int64]int64{}
+	return func(originalID int64) int64 {
+		if id, found := seen[originalID]; found {
+			return id
+		}
 		seed++
+		seen[originalID] = seed
 		return seed
 	}
 }


### PR DESCRIPTION
Sometimes macros will contain repeated ids. While this is discouraged
as long as the id refers to the same expression with the same type, it
will type check as a valid expression. Update the `RenumberIDs` to 
ensure well-behaved renumbering even in cases like this one.

#789