### PR TITLE
Fix SetKindCase and Renumbering bugs

### DIFF
--- a/common/ast/expr.go
+++ b/common/ast/expr.go
@@ -387,6 +387,7 @@ func (e *expr) SetKindCase(other Expr) {
 			function: c.FunctionName(),
 			target:   c.Target(),
 			args:     c.Args(),
+			isMember: c.IsMemberFunction(),
 		}
 	case ComprehensionKind:
 		c := other.AsComprehension()
@@ -432,11 +433,13 @@ func (e *expr) SetKindCase(other Expr) {
 }
 
 func (e *expr) RenumberIDs(idGen IDGenerator) {
-	if e.Kind() == UnspecifiedExprKind {
+	if e == nil {
 		return
 	}
 	e.id = idGen(e.id)
-	e.exprKindCase.renumberIDs(idGen)
+	if e.exprKindCase != nil {
+		e.exprKindCase.renumberIDs(idGen)
+	}
 }
 
 type baseCallExpr struct {

--- a/common/ast/expr_test.go
+++ b/common/ast/expr_test.go
@@ -20,13 +20,16 @@ import (
 	"testing"
 
 	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/overloads"
 	"github.com/google/cel-go/common/types"
 )
 
 func TestSetKindCase(t *testing.T) {
 	fac := ast.NewExprFactory()
 	tests := []ast.Expr{
+		fac.NewUnspecifiedExpr(1),
 		fac.NewCall(1, "_==_", fac.NewLiteral(2, types.True), fac.NewLiteral(3, types.False)),
+		fac.NewMemberCall(1, overloads.Size, fac.NewLiteral(2, types.String("hello"))),
 		fac.NewComprehension(12,
 			fac.NewList(1, []ast.Expr{}, []int32{}),
 			"i",
@@ -79,6 +82,10 @@ func TestSetKindCase(t *testing.T) {
 			case ast.ListKind:
 				if !reflect.DeepEqual(expr.AsList(), tst.AsList()) {
 					t.Errorf("got %v, wanted %v", expr.AsList(), tst.AsList())
+				}
+			case ast.UnspecifiedExprKind:
+				if !reflect.DeepEqual(expr, tst) {
+					t.Errorf("got %v, wanted %v", expr, tst)
 				}
 			case ast.MapKind:
 			case ast.SelectKind:
@@ -162,8 +169,8 @@ func TestCallNil(t *testing.T) {
 		t.Errorf("empty Target() got %d, wanted 0", call.Target().ID())
 	}
 	expr.RenumberIDs(testIDGen(100))
-	if expr.ID() != 1 {
-		t.Errorf("Renumbering an unspecified expression mutated the value: %v", expr)
+	if expr.ID() != 101 {
+		t.Errorf("RenumberIDs() got %d, wanted 101", expr.ID())
 	}
 }
 
@@ -241,8 +248,8 @@ func TestComprehensionNil(t *testing.T) {
 		t.Errorf("Result() got %v, wanted unspecified", comp.Result().Kind())
 	}
 	expr.RenumberIDs(testIDGen(100))
-	if expr.ID() != 1 {
-		t.Errorf("Renumbering an unspecified expression mutated the value: %v", expr)
+	if expr.ID() != 101 {
+		t.Errorf("RenumberIDs() got %d, wanted 101", expr.ID())
 	}
 }
 
@@ -459,6 +466,20 @@ func TestStructFieldNil(t *testing.T) {
 	}
 	if field.IsOptional() {
 		t.Errorf("field.IsOptional() got %v, wanted ''", field.IsOptional())
+	}
+}
+
+func TestRenumberIDs(t *testing.T) {
+	fac := ast.NewExprFactory()
+	e := fac.NewUnspecifiedExpr(10)
+	e.RenumberIDs(testIDGen(100))
+	if e.ID() != 101 {
+		t.Errorf("RenumberIDs() got %d, wanted 101", e.ID())
+	}
+	e = fac.NewLiteral(20, types.True)
+	e.RenumberIDs(testIDGen(200))
+	if e.ID() != 201 {
+		t.Errorf("RenumberIDs() got %d, wanted 201", e.ID())
 	}
 }
 


### PR DESCRIPTION
There was a missing field initialization during `SetKindCase` which caused
member calls to become flagged as global calls, and renumbering was not
updating unspecified expressions which could cause issues with macros.