### PR TITLE
Expose Copy() methods for AST, SourceInfo, and Expr values

### DIFF
--- a/common/ast/ast_test.go
+++ b/common/ast/ast_test.go
@@ -25,6 +25,31 @@ import (
 	"github.com/google/cel-go/common/types"
 )
 
+func TestASTCopy(t *testing.T) {
+	tests := []string{
+		`'a' == 'b'`,
+		`'a'.size()`,
+		`size('a')`,
+		`has({'a': 1}.a)`,
+		`{'a': 1}`,
+		`{'a': 1}['a']`,
+		`[1, 2, 3].exists(i, i % 2 == 1)`,
+		`google.expr.proto3.test.TestAllTypes{}`,
+		`google.expr.proto3.test.TestAllTypes{repeated_int32: [1, 2]}`,
+	}
+
+	for _, tst := range tests {
+		checked := mustTypeCheck(t, tst)
+		copied := ast.Copy(checked)
+		if !reflect.DeepEqual(copied.Expr(), checked.Expr()) {
+			t.Errorf("Copy() got expr %v, wanted %v", copied.Expr(), checked.Expr())
+		}
+		if !reflect.DeepEqual(copied.SourceInfo(), checked.SourceInfo()) {
+			t.Errorf("Copy() got source info %v, wanted %v", copied.SourceInfo(), checked.SourceInfo())
+		}
+	}
+}
+
 func TestASTNilSafety(t *testing.T) {
 	ex, err := ast.ProtoToExpr(nil)
 	if err != nil {

--- a/common/ast/expr_test.go
+++ b/common/ast/expr_test.go
@@ -88,8 +88,17 @@ func TestSetKindCase(t *testing.T) {
 					t.Errorf("got %v, wanted %v", expr, tst)
 				}
 			case ast.MapKind:
+				if !reflect.DeepEqual(expr.AsMap(), tst.AsMap()) {
+					t.Errorf("got %v, wanted %v", expr, tst)
+				}
 			case ast.SelectKind:
+				if !reflect.DeepEqual(expr.AsSelect(), tst.AsSelect()) {
+					t.Errorf("got %v, wanted %v", expr, tst)
+				}
 			case ast.StructKind:
+				if !reflect.DeepEqual(expr.AsStruct(), tst.AsStruct()) {
+					t.Errorf("got %v, wanted %v", expr, tst)
+				}
 			default:
 				t.Errorf("unable to determine kind case: %v", tst)
 			}

--- a/common/ast/navigable_test.go
+++ b/common/ast/navigable_test.go
@@ -446,7 +446,10 @@ func TestNavigableSelectExpr_TestOnly(t *testing.T) {
 
 func mustTypeCheck(t testing.TB, expr string) *ast.AST {
 	t.Helper()
-	p, err := parser.NewParser(parser.Macros(parser.AllMacros...), parser.EnableOptionalSyntax(true))
+	p, err := parser.NewParser(
+		parser.Macros(parser.AllMacros...),
+		parser.EnableOptionalSyntax(true),
+		parser.PopulateMacroCalls(true))
 	if err != nil {
 		t.Fatalf("parser.NewParser() failed: %v", err)
 	}


### PR DESCRIPTION
During AST optimization, being able to copy an expression, mutate it, and
assign it back without disrupting or altering the original input values is
important for idempotent transformations. Also for ensuring that changes
within the core AST are not accidentally copied back into macros.