### PR TITLE
Minor test, code, and error hygiene changes

### DIFF
--- a/cel/BUILD.bazel
+++ b/cel/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
         "decls_test.go",
         "env_test.go",
         "io_test.go",
+        "validator_test.go",
     ],
     data = [
         "//cel/testdata:gen_test_fds",

--- a/cel/io.go
+++ b/cel/io.go
@@ -61,11 +61,7 @@ func AstToCheckedExpr(a *Ast) (*exprpb.CheckedExpr, error) {
 	if !a.IsChecked() {
 		return nil, fmt.Errorf("cannot convert unchecked ast")
 	}
-	checked, err := astToExprAST(a)
-	if err != nil {
-		return nil, err
-	}
-	return ast.ToProto(checked)
+	return ast.ToProto(a.impl)
 }
 
 // ParsedExprToAst converts a parsed expression proto message to an Ast.

--- a/cel/io_test.go
+++ b/cel/io_test.go
@@ -107,7 +107,7 @@ func TestAstToProto(t *testing.T) {
 	}
 	checked, err := AstToCheckedExpr(ast)
 	if err != nil {
-		t.Fatalf("AstToCheckeExpr(ast) failed: %v", err)
+		t.Fatalf("AstToCheckedExpr(ast) failed: %v", err)
 	}
 	ast4 := CheckedExprToAst(checked)
 	if !proto.Equal(ast4.Expr(), ast.Expr()) {

--- a/cel/program.go
+++ b/cel/program.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter"
@@ -244,11 +243,7 @@ func newProgram(e *Env, a *Ast, opts []ProgramOption) (Program, error) {
 
 func (p *prog) initInterpretable(a *Ast, decs []interpreter.InterpretableDecorator) (*prog, error) {
 	// When the AST has been exprAST it contains metadata that can be used to speed up program execution.
-	exprAST, err := astToExprAST(a)
-	if err != nil {
-		return nil, err
-	}
-	interpretable, err := p.interpreter.NewInterpretable(exprAST, decs...)
+	interpretable, err := p.interpreter.NewInterpretable(a.impl, decs...)
 	if err != nil {
 		return nil, err
 	}
@@ -515,10 +510,6 @@ func (p *evalActivationPool) Put(value any) {
 		delete(a.lazyVars, k)
 	}
 	p.Pool.Put(a)
-}
-
-func astToExprAST(a *Ast) (*ast.AST, error) {
-	return a.impl, nil
 }
 
 var (

--- a/common/errors.go
+++ b/common/errors.go
@@ -64,7 +64,7 @@ func (e *Errors) GetErrors() []*Error {
 // Append creates a new Errors object with the current and input errors.
 func (e *Errors) Append(errs []*Error) *Errors {
 	return &Errors{
-		errors:            append(e.errors, errs...),
+		errors:            append(e.errors[:], errs...),
 		source:            e.source,
 		numErrors:         e.numErrors + len(errs),
 		maxErrorsToReport: e.maxErrorsToReport,


### PR DESCRIPTION
* Missing `validator_test.go` from cel bazel test list
* Remove dead code for `astToExprAST`
* Fix test error message
* Ensure `Append` call in errors.go does not mutate storage