### PR TITLE
Make `types.CheckedWellknowns` public

### DIFF
--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -351,7 +351,7 @@ func (p *Registry) registerAllTypes(fd *pb.FileDescription) error {
 	for _, typeName := range fd.GetTypeNames() {
 		// skip well-known type names since they're automatically sanitized
 		// during NewObjectType() calls.
-		if _, found := checkedWellKnowns[typeName]; found {
+		if _, found := CheckedWellKnowns[typeName]; found {
 			continue
 		}
 		err := p.RegisterType(NewObjectTypeValue(typeName))

--- a/common/types/types.go
+++ b/common/types/types.go
@@ -514,7 +514,7 @@ func NewOpaqueType(name string, params ...*Type) *Type {
 // type may also indicate additional traits through the use of the optional traits vararg argument.
 func NewObjectType(typeName string, traits ...int) *Type {
 	// Function sanitizes object types on the fly
-	if wkt, found := checkedWellKnowns[typeName]; found {
+	if wkt, found := CheckedWellKnowns[typeName]; found {
 		return wkt
 	}
 	traitMask := 0
@@ -760,7 +760,7 @@ func maybeForeignType(t ref.Type) *Type {
 }
 
 var (
-	checkedWellKnowns = map[string]*Type{
+	CheckedWellKnowns = map[string]*Type{
 		// Wrapper types.
 		"google.protobuf.BoolValue":   NewNullableType(BoolType),
 		"google.protobuf.BytesValue":  NewNullableType(BytesType),


### PR DESCRIPTION
Allow external proto types to be exposed as well known types to override the default `protoObj` behaviors.