### PR TITLE
Introduce pre-order / post-order visitor pattern

### DIFF
--- a/common/ast/ast.go
+++ b/common/ast/ast.go
@@ -147,6 +147,13 @@ func Copy(a *AST) *AST {
 	return NewCheckedAST(NewAST(e, CopySourceInfo(a.SourceInfo())), typesCopy, refsCopy)
 }
 
+// MaxID returns the upper-bound, non-inclusive, of ids present within the AST's Expr value.
+func MaxID(a *AST) int64 {
+	visitor := &maxIDVisitor{maxID: 1}
+	PostOrderVisit(a.Expr(), visitor)
+	return visitor.maxID + 1
+}
+
 // NewSourceInfo creates a simple SourceInfo object from an input common.Source value.
 func NewSourceInfo(src common.Source) *SourceInfo {
 	var lineOffsets []int32
@@ -396,4 +403,22 @@ func (r *ReferenceInfo) Equals(other *ReferenceInfo) bool {
 		return false
 	}
 	return true
+}
+
+type maxIDVisitor struct {
+	maxID int64
+}
+
+// VisitExpr updates the max identifier if the incoming expression id is greater than previously observed.
+func (v *maxIDVisitor) VisitExpr(e Expr) {
+	if v.maxID < e.ID() {
+		v.maxID = e.ID()
+	}
+}
+
+// VisitEntryExpr updates the max identifier if the incoming entry id is greater than previously observed.
+func (v *maxIDVisitor) VisitEntryExpr(e EntryExpr) {
+	if v.maxID < e.ID() {
+		v.maxID = e.ID()
+	}
 }

--- a/common/ast/conversion.go
+++ b/common/ast/conversion.go
@@ -533,7 +533,7 @@ func SourceInfoToProto(info *SourceInfo) (*exprpb.SourceInfo, error) {
 	return sourceInfo, nil
 }
 
-// ProtoToSourceInfo deserializes
+// ProtoToSourceInfo deserializes the protobuf into a native SourceInfo value.
 func ProtoToSourceInfo(info *exprpb.SourceInfo) (*SourceInfo, error) {
 	sourceInfo := &SourceInfo{
 		syntax:       info.GetSyntaxVersion(),

--- a/common/ast/conversion_test.go
+++ b/common/ast/conversion_test.go
@@ -219,6 +219,13 @@ func TestConvertExpr(t *testing.T) {
 			if !reflect.DeepEqual(gotExpr, tc.wantExpr) {
 				t.Errorf("got %v, wanted %v", gotExpr, tc.wantExpr)
 			}
+			gotExprRoundtrip, err := ast.ProtoToExpr(gotPBExpr)
+			if err != nil {
+				t.Fatalf("ast.ProtoToExpr() failed: %v", err)
+			}
+			if !reflect.DeepEqual(parsed.Expr(), gotExprRoundtrip) {
+				t.Errorf("ast.ProtoToExpr() got %v, wanted %v", gotExprRoundtrip, parsed.Expr())
+			}
 			info := parsed.SourceInfo()
 			for id, wantCall := range tc.macroCalls {
 				call, found := info.GetMacroCall(id)

--- a/common/ast/factory.go
+++ b/common/ast/factory.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ast
 
 import "github.com/google/cel-go/common/types/ref"
@@ -183,6 +197,10 @@ func (fac *baseExprFactory) NewUnspecifiedExpr(id int64) Expr {
 }
 
 func (fac *baseExprFactory) CopyExpr(e Expr) Expr {
+	// unwrap navigable expressions to avoid unnecessary allocations during copying.
+	if nav, ok := e.(*navigableExprImpl); ok {
+		e = nav.Expr
+	}
 	switch e.Kind() {
 	case CallKind:
 		c := e.AsCall()

--- a/common/ast/navigable.go
+++ b/common/ast/navigable.go
@@ -188,6 +188,9 @@ const (
 	postOrder
 )
 
+// TODO: consider exposing a way to configure a limit for the max visit depth.
+// It's possible that we could want to configure this on the NewExprVisitor()
+// and through MatchDescendents() / MaxID().
 func visit(expr Expr, visitor Visitor, order visitOrder, depth, maxDepth int) {
 	if maxDepth > 0 && depth == maxDepth {
 		return

--- a/common/ast/navigable_test.go
+++ b/common/ast/navigable_test.go
@@ -135,16 +135,53 @@ func TestNavigateAST(t *testing.T) {
 	}
 }
 
-func TestNavigableExprChildren(t *testing.T) {
+func TestExprVisitor(t *testing.T) {
 	tests := []struct {
-		expr string
+		expr         string
+		preOrderIDs  []int64
+		postOrderIDs []int64
 	}{
-		{expr: `'a' == 'b'`},
-		{expr: `'a'.size()`},
-		{expr: `type(1) == int`},
-		{expr: `{'hello': 'world'}.hello`},
-		{expr: `google.expr.proto3.test.TestAllTypes{single_int32: 1}`},
-		{expr: `[true].exists(i, i)`},
+		{
+			// [2] ==, [1] 'a', [3] 'b'
+			expr:         `'a' == 'b'`,
+			preOrderIDs:  []int64{2, 1, 3},
+			postOrderIDs: []int64{1, 3, 2},
+		},
+		{
+			// [2] size(), [1] 'a'
+			expr:         `'a'.size()`,
+			preOrderIDs:  []int64{2, 1},
+			postOrderIDs: []int64{1, 2},
+		},
+		{
+			// [3] ==, [1] type(), [2] 1, [4] int
+			expr:         `type(1) == int`,
+			preOrderIDs:  []int64{3, 1, 2, 4},
+			postOrderIDs: []int64{2, 1, 4, 3},
+		},
+		{
+			// [5] .hello, [1] {}, [3] 'hello', [4] 'world'
+			expr:         `{'hello': 'world'}.hello`,
+			preOrderIDs:  []int64{5, 1, 3, 4},
+			postOrderIDs: []int64{3, 4, 1, 5},
+		},
+		{
+			// [1] TestAllTypes, [3] 1
+			expr:         `google.expr.proto3.test.TestAllTypes{single_int32: 1}`,
+			preOrderIDs:  []int64{1, 3},
+			postOrderIDs: []int64{3, 1},
+		},
+		{
+			// [13] comprehension
+			// range:    [1] [], [2] true
+			// accuInit: [6] result=false
+			// loopCond: [9] @not_strictly_false, [8] !, [7] result
+			// loopStep: [11] ||, [10] result [5] i
+			// result:   [12] result
+			expr:         `[true].exists(i, i)`,
+			preOrderIDs:  []int64{13, 1, 2, 6, 9, 8, 7, 11, 10, 5, 12},
+			postOrderIDs: []int64{2, 1, 6, 7, 8, 9, 10, 5, 11, 12, 13},
+		},
 	}
 
 	for _, tst := range tests {
@@ -152,22 +189,38 @@ func TestNavigableExprChildren(t *testing.T) {
 		t.Run(tc.expr, func(t *testing.T) {
 			checked := mustTypeCheck(t, tc.expr)
 			root := ast.NavigateAST(checked)
+			// Verify pre order visit behavior
 			preOrderExprIDs := []int64{}
 			navVisitor := ast.NewExprVisitor(func(e ast.Expr) {
 				nav := e.(ast.NavigableExpr)
 				preOrderExprIDs = append(preOrderExprIDs, nav.ID())
 			})
 			ast.PreOrderVisit(root, navVisitor)
+			if !reflect.DeepEqual(tc.preOrderIDs, preOrderExprIDs) {
+				t.Errorf("PreOrderVisit() got %v expressions, wanted %v", tc.preOrderIDs, preOrderExprIDs)
+			}
 
-			allExprs := []int64{}
+			// Demonstrate preOrder visit behavior with Children()
+			preOrderExprIDs = []int64{}
 			visited := []ast.NavigableExpr{root}
 			for len(visited) > 0 {
 				e := visited[0]
-				allExprs = append(allExprs, e.ID())
+				preOrderExprIDs = append(preOrderExprIDs, e.ID())
 				visited = append(e.Children()[:], visited[1:]...)
 			}
-			if !reflect.DeepEqual(allExprs, preOrderExprIDs) {
-				t.Fatalf("Children() got %v expressions, wanted %v", allExprs, preOrderExprIDs)
+			if !reflect.DeepEqual(tc.preOrderIDs, preOrderExprIDs) {
+				t.Errorf("PreOrderVisit() got %v expressions, wanted %v", tc.preOrderIDs, preOrderExprIDs)
+			}
+
+			// Verify post order visit behavior.
+			postOrderExprIDs := []int64{}
+			navVisitor = ast.NewExprVisitor(func(e ast.Expr) {
+				nav := e.(ast.NavigableExpr)
+				postOrderExprIDs = append(postOrderExprIDs, nav.ID())
+			})
+			ast.PostOrderVisit(root, navVisitor)
+			if !reflect.DeepEqual(tc.postOrderIDs, postOrderExprIDs) {
+				t.Errorf("PostOrderVisit() got %v expressions, wanted %v", tc.postOrderIDs, postOrderExprIDs)
 			}
 		})
 	}


### PR DESCRIPTION
Introduce a visitor with pre and post-order traversal methods.

This change also ensures that `MatchDescendents()` is bottom-up traversal
and that `Children()` can be used to model top-down traversal.

There are a couple of missing LICENSE notices added as well.