### PR TITLE
Ensure stable ordering of overload candidates

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -2081,7 +2081,8 @@ func TestDynamicDispatch(t *testing.T) {
 		),
 	)
 	out, err := interpret(t, env, `
-		[1, 2].first() == 1
+		dyn([]).first() == 0
+		&& [1, 2].first() == 1
 		&& [1.0, 2.0].first() == 1.0
 		&& ["hello", "world"].first() == "hello"
 		&& [["hello"], ["world", "!"]].first().first() == "hello"

--- a/common/decls/decls.go
+++ b/common/decls/decls.go
@@ -243,7 +243,8 @@ func (f *FunctionDecl) Bindings() ([]*functions.Overload, error) {
 	// performs dynamic dispatch to the proper overload based on the argument types.
 	bindings := append([]*functions.Overload{}, overloads...)
 	funcDispatch := func(args ...ref.Val) ref.Val {
-		for _, o := range f.overloads {
+		for _, oID := range f.overloadOrdinals {
+			o := f.overloads[oID]
 			// During dynamic dispatch over multiple functions, signature agreement checks
 			// are preserved in order to assist with the function resolution step.
 			switch len(args) {


### PR DESCRIPTION
Ensure stable ordering of overload candidates

There was a map traversal happening during dynamic dispatch
which would cause random ordering of overload candidates, and
in cases where the overload resolution was ambiguous, the result
might randomly fail.

Closes #816 