### PR TITLE
Clarify replace with/by empty string

### DIFF
--- a/ext/strings.go
+++ b/ext/strings.go
@@ -202,6 +202,8 @@ const (
 //	'hello hello'.replace('he', 'we', -1) // returns 'wello wello'
 //	'hello hello'.replace('he', 'we', 1)  // returns 'wello hello'
 //	'hello hello'.replace('he', 'we', 0)  // returns 'hello hello'
+//	'hello hello'.replace('', '_')  // returns '_h_e_l_l_o_ _h_e_l_l_o_'
+//	'hello hello'.replace('h', '')  // returns 'ello ello'
 //
 // # Split
 //
@@ -514,7 +516,7 @@ func (lib *stringLib) CompileOptions() []cel.EnvOption {
 		)
 	}
 	if lib.version >= 3 {
-		opts = append( opts,
+		opts = append(opts,
 			cel.Function("reverse",
 				cel.MemberOverload("reverse", []*cel.Type{cel.StringType}, cel.StringType,
 					cel.UnaryBinding(func(str ref.Val) ref.Val {

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -82,6 +82,8 @@ var stringTests = []struct {
 	{expr: `"{0} days {0} hours".replace("{0}", "2") == "2 days 2 hours"`},
 	{expr: `"{0} days {0} hours".replace("{0}", "2", 1).replace("{0}", "23") == "2 days 23 hours"`},
 	{expr: `"1 ©αT taco".replace("αT", "o©α") == "1 ©o©α taco"`},
+	{expr: `"hello hello".replace("", "_") == "_h_e_l_l_o_ _h_e_l_l_o_"`},
+	{expr: `"hello hello".replace("h", "") == "ello ello"`},
 	// Split tests.
 	{expr: `"hello world".split(" ") == ["hello", "world"]`},
 	{expr: `"hello world events!".split(" ", 0) == []`},


### PR DESCRIPTION
This behavior is not entirely obvious, particularly what happens when the string being replaced is empty (golang doesn't document it well on ReplaceAll either).