### PR TITLE
Add support for a relative offset within ast.SourceInfo

### DIFF
--- a/common/ast/ast.go
+++ b/common/ast/ast.go
@@ -158,13 +158,24 @@ func MaxID(a *AST) int64 {
 func NewSourceInfo(src common.Source) *SourceInfo {
 	var lineOffsets []int32
 	var desc string
+	baseLine := int32(0)
+	baseCol := int32(0)
 	if src != nil {
 		desc = src.Description()
 		lineOffsets = src.LineOffsets()
+		// Determine whether the source metadata should be computed relative
+		// to a base line and column value. This can be determined by requesting
+		// the location for offset 0 from the source object.
+		if loc, found := src.OffsetLocation(0); found {
+			baseLine = int32(loc.Line()) - 1
+			baseCol = int32(loc.Column())
+		}
 	}
 	return &SourceInfo{
 		desc:         desc,
 		lines:        lineOffsets,
+		baseLine:     baseLine,
+		baseCol:      baseCol,
 		offsetRanges: make(map[int64]OffsetRange),
 		macroCalls:   make(map[int64]Expr),
 	}
@@ -200,6 +211,8 @@ type SourceInfo struct {
 	syntax       string
 	desc         string
 	lines        []int32
+	baseLine     int32
+	baseCol      int32
 	offsetRanges map[int64]OffsetRange
 	macroCalls   map[int64]Expr
 }
@@ -326,6 +339,10 @@ func (s *SourceInfo) GetStopLocation(id int64) common.Location {
 
 // ComputeOffset calculates the 0-based character offset from a 1-based line and 0-based column.
 func (s *SourceInfo) ComputeOffset(line, col int32) int32 {
+	if s != nil {
+		line = s.baseLine + line
+		col = s.baseCol + col
+	}
 	if line == 1 {
 		return col
 	}


### PR DESCRIPTION
Introduce support for a base line and column to be computed
by querying offset 0 on the `common.Source` value provided
to `NewSourceInfo`. 

Previously, the `common.Source` was used directly within the
parser and implementations could override the behavior of
`OffsetLocation` and `LocationOffset` to produce values which
treated the parse input as relative source in some larger context;
however, with the shift away from proto (#789) and toward more
uniform and featureful internal data types, the `ast.SourceInfo`
object attempted to unify the id to offset relationship and removed
this feature on accident.