### PR TITLE
Sets cost estimation and tracking options

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -1475,7 +1475,7 @@ func TestEstimateCostAndRuntimeCost(t *testing.T) {
 		name  string
 		expr  string
 		decls []EnvOption
-		hints map[string]int64
+		hints map[string]uint64
 		want  checker.CostEstimate
 		in    any
 	}{
@@ -1499,7 +1499,7 @@ func TestEstimateCostAndRuntimeCost(t *testing.T) {
 				Variable("str1", StringType),
 				Variable("str2", StringType),
 			},
-			hints: map[string]int64{"str1": 10, "str2": 10},
+			hints: map[string]uint64{"str1": 10, "str2": 10},
 			want:  checker.CostEstimate{Min: 2, Max: 6},
 			in:    map[string]any{"str1": "val1111111", "str2": "val2222222"},
 		},
@@ -1510,7 +1510,7 @@ func TestEstimateCostAndRuntimeCost(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if tc.hints == nil {
-				tc.hints = map[string]int64{}
+				tc.hints = map[string]uint64{}
 			}
 			env := testEnv(t, tc.decls...)
 			ast, iss := env.Compile(tc.expr)
@@ -2768,12 +2768,12 @@ func BenchmarkDynamicDispatch(b *testing.B) {
 
 // TODO: ideally testCostEstimator and testRuntimeCostEstimator would be shared in a test fixtures package
 type testCostEstimator struct {
-	hints map[string]int64
+	hints map[string]uint64
 }
 
 func (tc testCostEstimator) EstimateSize(element checker.AstNode) *checker.SizeEstimate {
 	if l, ok := tc.hints[strings.Join(element.Path(), ".")]; ok {
-		return &checker.SizeEstimate{Min: 0, Max: uint64(l)}
+		return &checker.SizeEstimate{Min: 0, Max: l}
 	}
 	return nil
 }

--- a/cel/env.go
+++ b/cel/env.go
@@ -129,6 +129,7 @@ type Env struct {
 	appliedFeatures map[int]bool
 	libraries       map[string]bool
 	validators      []ASTValidator
+	costOptions     []checker.CostOption
 
 	// Internal parser representation
 	prsr     *parser.Parser
@@ -191,6 +192,7 @@ func NewCustomEnv(opts ...EnvOption) (*Env, error) {
 		libraries:       map[string]bool{},
 		validators:      []ASTValidator{},
 		progOpts:        []ProgramOption{},
+		costOptions:     []checker.CostOption{},
 	}).configure(opts)
 }
 
@@ -365,6 +367,8 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 	}
 	validatorsCopy := make([]ASTValidator, len(e.validators))
 	copy(validatorsCopy, e.validators)
+	costOptsCopy := make([]checker.CostOption, len(e.costOptions))
+	copy(costOptsCopy, e.costOptions)
 
 	ext := &Env{
 		Container:       e.Container,
@@ -380,6 +384,7 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 		provider:        provider,
 		chkOpts:         chkOptsCopy,
 		prsrOpts:        prsrOptsCopy,
+		costOptions:     costOptsCopy,
 	}
 	return ext.configure(opts)
 }
@@ -556,7 +561,10 @@ func (e *Env) ResidualAst(a *Ast, details *EvalDetails) (*Ast, error) {
 // EstimateCost estimates the cost of a type checked CEL expression using the length estimates of input data and
 // extension functions provided by estimator.
 func (e *Env) EstimateCost(ast *Ast, estimator checker.CostEstimator, opts ...checker.CostOption) (checker.CostEstimate, error) {
-	return checker.Cost(ast.impl, estimator, opts...)
+	extendedOpts := make([]checker.CostOption, 0, len(e.costOptions))
+	extendedOpts = append(extendedOpts, opts...)
+	extendedOpts = append(extendedOpts, e.costOptions...)
+	return checker.Cost(ast.impl, estimator, extendedOpts...)
 }
 
 // configure applies a series of EnvOptions to the current environment.

--- a/cel/options.go
+++ b/cel/options.go
@@ -472,6 +472,14 @@ func InterruptCheckFrequency(checkFrequency uint) ProgramOption {
 	}
 }
 
+// CostEstimatorOptions configure type-check time options for estimating expression cost.
+func CostEstimatorOptions(costOpts ...checker.CostOption) EnvOption {
+	return func(e *Env) (*Env, error) {
+		e.costOptions = append(e.costOptions, costOpts...)
+		return e, nil
+	}
+}
+
 // CostTrackerOptions configures a set of options for cost-tracking.
 //
 // Note, CostTrackerOptions is a no-op unless CostTracking is also enabled.
@@ -637,13 +645,6 @@ func ParserRecursionLimit(limit int) EnvOption {
 func ParserExpressionSizeLimit(limit int) EnvOption {
 	return func(e *Env) (*Env, error) {
 		e.prsrOpts = append(e.prsrOpts, parser.ExpressionSizeCodePointLimit(limit))
-		return e, nil
-	}
-}
-
-func CostEstimatorOptions(costOpts ...checker.CostOption) EnvOption {
-	return func(e *Env) (*Env, error) {
-		e.costOptions = append(e.costOptions, costOpts...)
 		return e, nil
 	}
 }

--- a/cel/options.go
+++ b/cel/options.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/dynamicpb"
 
+	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/common/containers"
 	"github.com/google/cel-go/common/functions"
 	"github.com/google/cel-go/common/types"
@@ -471,6 +472,16 @@ func InterruptCheckFrequency(checkFrequency uint) ProgramOption {
 	}
 }
 
+// CostTrackerOptions configures a set of options for cost-tracking.
+//
+// Note, CostTrackerOptions is a no-op unless CostTracking is also enabled.
+func CostTrackerOptions(costOpts ...interpreter.CostTrackerOption) ProgramOption {
+	return func(p *prog) (*prog, error) {
+		p.costOptions = append(p.costOptions, costOpts...)
+		return p, nil
+	}
+}
+
 // CostTracking enables cost tracking and registers a ActualCostEstimator that can optionally provide a runtime cost estimate for any function calls.
 func CostTracking(costEstimator interpreter.ActualCostEstimator) ProgramOption {
 	return func(p *prog) (*prog, error) {
@@ -626,6 +637,13 @@ func ParserRecursionLimit(limit int) EnvOption {
 func ParserExpressionSizeLimit(limit int) EnvOption {
 	return func(e *Env) (*Env, error) {
 		e.prsrOpts = append(e.prsrOpts, parser.ExpressionSizeCodePointLimit(limit))
+		return e, nil
+	}
+}
+
+func CostEstimatorOptions(costOpts ...checker.CostOption) EnvOption {
+	return func(e *Env) (*Env, error) {
+		e.costOptions = append(e.costOptions, costOpts...)
 		return e, nil
 	}
 }

--- a/cel/program.go
+++ b/cel/program.go
@@ -384,7 +384,10 @@ func (gen *progGen) ContextEval(ctx context.Context, input any) (ref.Val, *EvalD
 	// new EvalState instance for each call to ensure that unique evaluations yield unique stateful
 	// results.
 	state := interpreter.NewEvalState()
-	costTracker := &interpreter.CostTracker{}
+	costTracker, err := interpreter.NewCostTracker(nil)
+	if err != nil {
+		return nil, nil, err
+	}
 	det := &EvalDetails{state: state, costTracker: costTracker}
 
 	// Generate a new instance of the interpretable using the factory configured during the call to

--- a/cel/program.go
+++ b/cel/program.go
@@ -105,7 +105,7 @@ func (ed *EvalDetails) State() interpreter.EvalState {
 // ActualCost returns the tracked cost through the course of execution when `CostTracking` is enabled.
 // Otherwise, returns nil if the cost was not enabled.
 func (ed *EvalDetails) ActualCost() *uint64 {
-	if ed.costTracker == nil {
+	if ed == nil || ed.costTracker == nil {
 		return nil
 	}
 	cost := ed.costTracker.ActualCost()
@@ -129,10 +129,14 @@ type prog struct {
 	// Interpretable configured from an Ast and aggregate decorator set based on program options.
 	interpretable     interpreter.Interpretable
 	callCostEstimator interpreter.ActualCostEstimator
+	costOptions       []interpreter.CostTrackerOption
 	costLimit         *uint64
 }
 
 func (p *prog) clone() *prog {
+	costOptsCopy := make([]interpreter.CostTrackerOption, len(p.costOptions))
+	copy(costOptsCopy, p.costOptions)
+
 	return &prog{
 		Env:                     p.Env,
 		evalOpts:                p.evalOpts,
@@ -154,9 +158,10 @@ func newProgram(e *Env, a *Ast, opts []ProgramOption) (Program, error) {
 	// Ensure the default attribute factory is set after the adapter and provider are
 	// configured.
 	p := &prog{
-		Env:        e,
-		decorators: []interpreter.InterpretableDecorator{},
-		dispatcher: disp,
+		Env:         e,
+		decorators:  []interpreter.InterpretableDecorator{},
+		dispatcher:  disp,
+		costOptions: []interpreter.CostTrackerOption{},
 	}
 
 	// Configure the program via the ProgramOption values.
@@ -213,6 +218,12 @@ func newProgram(e *Env, a *Ast, opts []ProgramOption) (Program, error) {
 		factory := func(state interpreter.EvalState, costTracker *interpreter.CostTracker) (Program, error) {
 			costTracker.Estimator = p.callCostEstimator
 			costTracker.Limit = p.costLimit
+			for _, costOpt := range p.costOptions {
+				err := costOpt(costTracker)
+				if err != nil {
+					return nil, err
+				}
+			}
 			// Limit capacity to guarantee a reallocation when calling 'append(decs, ...)' below. This
 			// prevents the underlying memory from being shared between factory function calls causing
 			// undesired mutations.
@@ -325,7 +336,11 @@ type progGen struct {
 // the test is successful.
 func newProgGen(factory progFactory) (Program, error) {
 	// Test the factory to make sure that configuration errors are spotted at config
-	_, err := factory(interpreter.NewEvalState(), &interpreter.CostTracker{})
+	tracker, err := interpreter.NewCostTracker(nil)
+	if err != nil {
+		return nil, err
+	}
+	_, err = factory(interpreter.NewEvalState(), tracker)
 	if err != nil {
 		return nil, err
 	}
@@ -338,7 +353,10 @@ func (gen *progGen) Eval(input any) (ref.Val, *EvalDetails, error) {
 	// new EvalState instance for each call to ensure that unique evaluations yield unique stateful
 	// results.
 	state := interpreter.NewEvalState()
-	costTracker := &interpreter.CostTracker{}
+	costTracker, err := interpreter.NewCostTracker(nil)
+	if err != nil {
+		return nil, nil, err
+	}
 	det := &EvalDetails{state: state, costTracker: costTracker}
 
 	// Generate a new instance of the interpretable using the factory configured during the call to

--- a/checker/cost.go
+++ b/checker/cost.go
@@ -226,7 +226,7 @@ func addUint64NoOverflow(x, y uint64) uint64 {
 // multiplyUint64NoOverflow multiplies non-negative ints. If the result is exceeds math.MaxUint64, math.MaxUint64
 // is returned.
 func multiplyUint64NoOverflow(x, y uint64) uint64 {
-	if x > 0 && y > 0 && x > math.MaxUint64/y {
+	if y != 0 && x > math.MaxUint64/y {
 		return math.MaxUint64
 	}
 	return x * y
@@ -238,7 +238,11 @@ func multiplyByCostFactor(x uint64, y float64) uint64 {
 	if xFloat > 0 && y > 0 && xFloat > math.MaxUint64/y {
 		return math.MaxUint64
 	}
-	return uint64(math.Ceil(xFloat * y))
+	ceil := math.Ceil(xFloat * y)
+	if ceil >= doubleTwoTo64 {
+		return math.MaxUint64
+	}
+	return uint64(ceil)
 }
 
 var (
@@ -692,3 +696,7 @@ func isScalar(t *types.Type) bool {
 	}
 	return false
 }
+
+var (
+	doubleTwoTo64 = math.Ldexp(1.0, 64)
+)

--- a/checker/cost_test.go
+++ b/checker/cost_test.go
@@ -15,6 +15,7 @@
 package checker
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -44,7 +45,7 @@ func TestCost(t *testing.T) {
 		name    string
 		expr    string
 		vars    []*decls.VariableDecl
-		hints   map[string]int64
+		hints   map[string]uint64
 		options []CostOption
 		wanted  CostEstimate
 	}{
@@ -129,14 +130,14 @@ func TestCost(t *testing.T) {
 		{
 			name:   "all comprehension",
 			vars:   []*decls.VariableDecl{decls.NewVariable("input", allList)},
-			hints:  map[string]int64{"input": 100},
+			hints:  map[string]uint64{"input": 100},
 			expr:   `input.all(x, true)`,
 			wanted: CostEstimate{Min: 2, Max: 302},
 		},
 		{
 			name:   "nested all comprehension",
 			vars:   []*decls.VariableDecl{decls.NewVariable("input", nestedList)},
-			hints:  map[string]int64{"input": 50, "input.@items": 10},
+			hints:  map[string]uint64{"input": 50, "input.@items": 10},
 			expr:   `input.all(x, x.all(y, true))`,
 			wanted: CostEstimate{Min: 2, Max: 1752},
 		},
@@ -148,7 +149,7 @@ func TestCost(t *testing.T) {
 		{
 			name:   "variable cost function",
 			vars:   []*decls.VariableDecl{decls.NewVariable("input", types.StringType)},
-			hints:  map[string]int64{"input": 500},
+			hints:  map[string]uint64{"input": 500},
 			expr:   `input.matches('[0-9]')`,
 			wanted: CostEstimate{Min: 3, Max: 103},
 		},
@@ -257,14 +258,14 @@ func TestCost(t *testing.T) {
 		{
 			name:   "bytes to string conversion",
 			vars:   []*decls.VariableDecl{decls.NewVariable("input", types.BytesType)},
-			hints:  map[string]int64{"input": 500},
+			hints:  map[string]uint64{"input": 500},
 			expr:   `string(input)`,
 			wanted: CostEstimate{Min: 1, Max: 51},
 		},
 		{
 			name:  "bytes to string conversion equality",
 			vars:  []*decls.VariableDecl{decls.NewVariable("input", types.BytesType)},
-			hints: map[string]int64{"input": 500},
+			hints: map[string]uint64{"input": 500},
 			// equality check ensures that the resultSize calculation is included in cost
 			expr:   `string(input) == string(input)`,
 			wanted: CostEstimate{Min: 3, Max: 152},
@@ -272,14 +273,14 @@ func TestCost(t *testing.T) {
 		{
 			name:   "string to bytes conversion",
 			vars:   []*decls.VariableDecl{decls.NewVariable("input", types.StringType)},
-			hints:  map[string]int64{"input": 500},
+			hints:  map[string]uint64{"input": 500},
 			expr:   `bytes(input)`,
 			wanted: CostEstimate{Min: 1, Max: 51},
 		},
 		{
 			name:  "string to bytes conversion equality",
 			vars:  []*decls.VariableDecl{decls.NewVariable("input", types.StringType)},
-			hints: map[string]int64{"input": 500},
+			hints: map[string]uint64{"input": 500},
 			// equality check ensures that the resultSize calculation is included in cost
 			expr:   `bytes(input) == bytes(input)`,
 			wanted: CostEstimate{Min: 3, Max: 302},
@@ -296,7 +297,7 @@ func TestCost(t *testing.T) {
 				decls.NewVariable("input", types.StringType),
 				decls.NewVariable("arg1", types.StringType),
 			},
-			hints:  map[string]int64{"input": 500, "arg1": 500},
+			hints:  map[string]uint64{"input": 500, "arg1": 500},
 			wanted: CostEstimate{Min: 2, Max: 2502},
 		},
 		{
@@ -305,7 +306,7 @@ func TestCost(t *testing.T) {
 			vars: []*decls.VariableDecl{
 				decls.NewVariable("input", types.StringType),
 			},
-			hints:  map[string]int64{"input": 500},
+			hints:  map[string]uint64{"input": 500},
 			wanted: CostEstimate{Min: 3, Max: 103},
 		},
 		{
@@ -315,7 +316,7 @@ func TestCost(t *testing.T) {
 				decls.NewVariable("input", types.StringType),
 				decls.NewVariable("arg1", types.StringType),
 			},
-			hints:  map[string]int64{"arg1": 500},
+			hints:  map[string]uint64{"arg1": 500},
 			wanted: CostEstimate{Min: 2, Max: 52},
 		},
 		{
@@ -325,7 +326,7 @@ func TestCost(t *testing.T) {
 				decls.NewVariable("input", types.StringType),
 				decls.NewVariable("arg1", types.StringType),
 			},
-			hints:  map[string]int64{"arg1": 500},
+			hints:  map[string]uint64{"arg1": 500},
 			wanted: CostEstimate{Min: 2, Max: 52},
 		},
 		{
@@ -352,7 +353,7 @@ func TestCost(t *testing.T) {
 				decls.NewVariable("input1", allList),
 				decls.NewVariable("input2", allList),
 			},
-			hints:  map[string]int64{"input1": 1, "input2": 1},
+			hints:  map[string]uint64{"input1": 1, "input2": 1},
 			wanted: CostEstimate{Min: 4, Max: 7},
 		},
 		{
@@ -361,7 +362,7 @@ func TestCost(t *testing.T) {
 			vars: []*decls.VariableDecl{
 				decls.NewVariable("input", allMap),
 			},
-			hints:  map[string]int64{"input": 10},
+			hints:  map[string]uint64{"input": 10},
 			wanted: CostEstimate{Min: 2, Max: 82},
 		},
 		{
@@ -370,7 +371,7 @@ func TestCost(t *testing.T) {
 			vars: []*decls.VariableDecl{
 				decls.NewVariable("input", nestedMap),
 			},
-			hints:  map[string]int64{"input": 5, "input.@values": 10},
+			hints:  map[string]uint64{"input": 5, "input.@values": 10},
 			wanted: CostEstimate{Min: 2, Max: 187},
 		},
 		{
@@ -379,7 +380,7 @@ func TestCost(t *testing.T) {
 			vars: []*decls.VariableDecl{
 				decls.NewVariable("input", nestedMap),
 			},
-			hints:  map[string]int64{"input": 5, "input.@keys": 10},
+			hints:  map[string]uint64{"input": 5, "input.@keys": 10},
 			wanted: CostEstimate{Min: 2, Max: 32},
 		},
 		{
@@ -388,7 +389,7 @@ func TestCost(t *testing.T) {
 			vars: []*decls.VariableDecl{
 				decls.NewVariable("input", nestedMap),
 			},
-			hints:  map[string]int64{"input": 2, "input.@values": 2, "input.@keys": 5},
+			hints:  map[string]uint64{"input": 2, "input.@values": 2, "input.@keys": 5},
 			wanted: CostEstimate{Min: 2, Max: 34},
 		},
 		{
@@ -397,7 +398,7 @@ func TestCost(t *testing.T) {
 			vars: []*decls.VariableDecl{
 				decls.NewVariable("input", nestedMap),
 			},
-			hints:  map[string]int64{"input": 2, "input.@values": 2, "input.@keys": 5},
+			hints:  map[string]uint64{"input": 2, "input.@values": 2, "input.@keys": 5},
 			wanted: CostEstimate{Min: 2, Max: 34},
 		},
 		{
@@ -407,7 +408,7 @@ func TestCost(t *testing.T) {
 				decls.NewVariable("list1", types.NewListType(types.IntType)),
 				decls.NewVariable("list2", types.NewListType(types.IntType)),
 			},
-			hints:  map[string]int64{"list1": 10, "list2": 10},
+			hints:  map[string]uint64{"list1": 10, "list2": 10},
 			wanted: CostEstimate{Min: 4, Max: 64},
 		},
 		{
@@ -417,8 +418,29 @@ func TestCost(t *testing.T) {
 				decls.NewVariable("str1", types.StringType),
 				decls.NewVariable("str2", types.StringType),
 			},
-			hints:  map[string]int64{"str1": 10, "str2": 10},
+			hints:  map[string]uint64{"str1": 10, "str2": 10},
 			wanted: CostEstimate{Min: 2, Max: 6},
+		},
+		{
+			name: "str concat custom cost estimate",
+			expr: `"abcdefg".contains(str1 + str2)`,
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("str1", types.StringType),
+				decls.NewVariable("str2", types.StringType),
+			},
+			hints: map[string]uint64{"str1": 10, "str2": 10},
+			options: []CostOption{
+				FunctionCostEstimate(overloads.Contains, overloads.ContainsString,
+					func(estimator CostEstimator, target *AstNode, args []AstNode) *CallEstimate {
+						if target != nil && len(args) == 1 {
+							strSize := estimateSize(estimator, *target).MultiplyByCostFactor(0.2)
+							subSize := estimateSize(estimator, args[0]).MultiplyByCostFactor(0.2)
+							return &CallEstimate{CostEstimate: strSize.Multiply(subSize)}
+						}
+						return nil
+					}),
+			},
+			wanted: CostEstimate{Min: 2, Max: 12},
 		},
 		{
 			name: "list size comparison",
@@ -486,7 +508,7 @@ func TestCost(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.hints == nil {
-				tc.hints = map[string]int64{}
+				tc.hints = map[string]uint64{}
 			}
 			p, err := parser.NewParser(parser.Macros(parser.AllMacros...))
 			if err != nil {
@@ -531,12 +553,12 @@ func TestCost(t *testing.T) {
 }
 
 type testCostEstimator struct {
-	hints map[string]int64
+	hints map[string]uint64
 }
 
 func (tc testCostEstimator) EstimateSize(element AstNode) *SizeEstimate {
 	if l, ok := tc.hints[strings.Join(element.Path(), ".")]; ok {
-		return &SizeEstimate{Min: 0, Max: uint64(l)}
+		return &SizeEstimate{Min: 0, Max: l}
 	}
 	return nil
 }
@@ -547,4 +569,14 @@ func (tc testCostEstimator) EstimateCallCost(function, overloadID string, target
 		return &CallEstimate{CostEstimate: CostEstimate{Min: 7, Max: 7}}
 	}
 	return nil
+}
+
+func estimateSize(estimator CostEstimator, node AstNode) SizeEstimate {
+	if l := node.ComputedSize(); l != nil {
+		return *l
+	}
+	if l := estimator.EstimateSize(node); l != nil {
+		return *l
+	}
+	return SizeEstimate{Min: 0, Max: math.MaxUint64}
 }

--- a/checker/cost_test.go
+++ b/checker/cost_test.go
@@ -430,7 +430,7 @@ func TestCost(t *testing.T) {
 			},
 			hints: map[string]uint64{"str1": 10, "str2": 10},
 			options: []CostOption{
-				FunctionCostEstimate(overloads.Contains, overloads.ContainsString,
+				OverloadCostEstimate(overloads.ContainsString,
 					func(estimator CostEstimator, target *AstNode, args []AstNode) *CallEstimate {
 						if target != nil && len(args) == 1 {
 							strSize := estimateSize(estimator, *target).MultiplyByCostFactor(0.2)

--- a/ext/BUILD.bazel
+++ b/ext/BUILD.bazel
@@ -22,7 +22,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cel:go_default_library",
-        "//checker/decls:go_default_library",
+        "//checker:go_default_library",
         "//common/ast:go_default_library",
         "//common/overloads:go_default_library",
         "//common/types:go_default_library",

--- a/ext/sets.go
+++ b/ext/sets.go
@@ -155,10 +155,13 @@ func setsEquivalent(listA, listB ref.Val) ref.Val {
 
 func estimateSetsCost(costFactor float64) checker.FunctionEstimator {
 	return func(estimator checker.CostEstimator, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
-		arg0Size := estimateSize(estimator, args[0])
-		arg1Size := estimateSize(estimator, args[1])
-		costEstimate := arg0Size.Multiply(arg1Size).MultiplyByCostFactor(costFactor).Add(callCostEstimate)
-		return &checker.CallEstimate{CostEstimate: costEstimate}
+		if len(args) == 2 {
+			arg0Size := estimateSize(estimator, args[0])
+			arg1Size := estimateSize(estimator, args[1])
+			costEstimate := arg0Size.Multiply(arg1Size).MultiplyByCostFactor(costFactor).Add(callCostEstimate)
+			return &checker.CallEstimate{CostEstimate: costEstimate}
+		}
+		return nil
 	}
 }
 

--- a/ext/sets.go
+++ b/ext/sets.go
@@ -15,10 +15,14 @@
 package ext
 
 import (
+	"math"
+
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
+	"github.com/google/cel-go/interpreter"
 )
 
 // Sets returns a cel.EnvOption to configure namespaced set relationship
@@ -95,12 +99,24 @@ func (setsLib) CompileOptions() []cel.EnvOption {
 		cel.Function("sets.intersects",
 			cel.Overload("list_sets_intersects_list", []*cel.Type{listType, listType}, cel.BoolType,
 				cel.BinaryBinding(setsIntersects))),
+		cel.CostEstimatorOptions(
+			checker.FunctionCostEstimate("sets.contains", "list_sets_contains_list", estimateSetsCost(1)),
+			checker.FunctionCostEstimate("sets.intersects", "list_sets_intersects_list", estimateSetsCost(1)),
+			// equivalence requires potentially two m*n comparisons to ensure each list is contained by the other
+			checker.FunctionCostEstimate("sets.equivalent", "list_sets_equivalent_list", estimateSetsCost(2)),
+		),
 	}
 }
 
 // ProgramOptions implements the Library interface method.
 func (setsLib) ProgramOptions() []cel.ProgramOption {
-	return []cel.ProgramOption{}
+	return []cel.ProgramOption{
+		cel.CostTrackerOptions(
+			interpreter.FunctionCostTracker("sets.contains", "list_sets_contains_list", trackSetsCost(1)),
+			interpreter.FunctionCostTracker("sets.intersects", "list_sets_intersects_list", trackSetsCost(1)),
+			interpreter.FunctionCostTracker("sets.equivalent", "list_sets_equivalent_list", trackSetsCost(2)),
+		),
+	}
 }
 
 func setsIntersects(listA, listB ref.Val) ref.Val {
@@ -136,3 +152,43 @@ func setsEquivalent(listA, listB ref.Val) ref.Val {
 	}
 	return setsContains(listB, listA)
 }
+
+func estimateSetsCost(costFactor float64) checker.FunctionEstimator {
+	return func(estimator checker.CostEstimator, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
+		arg0Size := estimateSize(estimator, args[0])
+		arg1Size := estimateSize(estimator, args[1])
+		costEstimate := arg0Size.Multiply(arg1Size).MultiplyByCostFactor(costFactor).Add(callCostEstimate)
+		return &checker.CallEstimate{CostEstimate: costEstimate}
+	}
+}
+
+func estimateSize(estimator checker.CostEstimator, node checker.AstNode) checker.SizeEstimate {
+	if l := node.ComputedSize(); l != nil {
+		return *l
+	}
+	if l := estimator.EstimateSize(node); l != nil {
+		return *l
+	}
+	return checker.SizeEstimate{Min: 0, Max: math.MaxUint64}
+}
+
+func trackSetsCost(costFactor float64) interpreter.FunctionTracker {
+	return func(args []ref.Val, _ ref.Val) *uint64 {
+		lhsSize := actualSize(args[0])
+		rhsSize := actualSize(args[1])
+		cost := callCost + uint64(float64(lhsSize*rhsSize)*costFactor)
+		return &cost
+	}
+}
+
+func actualSize(value ref.Val) uint64 {
+	if sz, ok := value.(traits.Sizer); ok {
+		return uint64(sz.Size().(types.Int))
+	}
+	return 1
+}
+
+var (
+	callCostEstimate = checker.CostEstimate{Min: 1, Max: 1}
+	callCost         = uint64(1)
+)

--- a/ext/sets.go
+++ b/ext/sets.go
@@ -100,10 +100,10 @@ func (setsLib) CompileOptions() []cel.EnvOption {
 			cel.Overload("list_sets_intersects_list", []*cel.Type{listType, listType}, cel.BoolType,
 				cel.BinaryBinding(setsIntersects))),
 		cel.CostEstimatorOptions(
-			checker.FunctionCostEstimate("sets.contains", "list_sets_contains_list", estimateSetsCost(1)),
-			checker.FunctionCostEstimate("sets.intersects", "list_sets_intersects_list", estimateSetsCost(1)),
+			checker.OverloadCostEstimate("list_sets_contains_list", estimateSetsCost(1)),
+			checker.OverloadCostEstimate("list_sets_intersects_list", estimateSetsCost(1)),
 			// equivalence requires potentially two m*n comparisons to ensure each list is contained by the other
-			checker.FunctionCostEstimate("sets.equivalent", "list_sets_equivalent_list", estimateSetsCost(2)),
+			checker.OverloadCostEstimate("list_sets_equivalent_list", estimateSetsCost(2)),
 		),
 	}
 }
@@ -112,9 +112,9 @@ func (setsLib) CompileOptions() []cel.EnvOption {
 func (setsLib) ProgramOptions() []cel.ProgramOption {
 	return []cel.ProgramOption{
 		cel.CostTrackerOptions(
-			interpreter.FunctionCostTracker("sets.contains", "list_sets_contains_list", trackSetsCost(1)),
-			interpreter.FunctionCostTracker("sets.intersects", "list_sets_intersects_list", trackSetsCost(1)),
-			interpreter.FunctionCostTracker("sets.equivalent", "list_sets_equivalent_list", trackSetsCost(2)),
+			interpreter.OverloadCostTracker("list_sets_contains_list", trackSetsCost(1)),
+			interpreter.OverloadCostTracker("list_sets_intersects_list", trackSetsCost(1)),
+			interpreter.OverloadCostTracker("list_sets_equivalent_list", trackSetsCost(2)),
 		),
 	}
 }

--- a/ext/sets_test.go
+++ b/ext/sets_test.go
@@ -15,6 +15,7 @@
 package ext
 
 import (
+	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -50,7 +51,7 @@ func TestSets(t *testing.T) {
 			in:   map[string]any{"x": []int64{5, 4, 3, 2, 1}},
 			// min cost is input 'x' length 0, 10 for list creation, 2 for arg costs
 			// max cost is effectively infinite due to missing size hint for 'x'
-			estimatedCost: checker.CostEstimate{Min: 12, Max: 18446744073709551615},
+			estimatedCost: checker.CostEstimate{Min: 12, Max: math.MaxUint64},
 			// actual cost is 'x' length 5 * list literal length 5, 10 for list creation, 2 for arg cost
 			actualCost: 37,
 		},

--- a/ext/sets_test.go
+++ b/ext/sets_test.go
@@ -50,7 +50,7 @@ func TestSets(t *testing.T) {
 			in:   map[string]any{"x": []int64{5, 4, 3, 2, 1}},
 			// min cost is input 'x' length 0, 10 for list creation, 2 for arg costs
 			// max cost is effectively infinite due to missing size hint for 'x'
-			estimatedCost: checker.CostEstimate{Min: 12, Max: 9223372036854775820},
+			estimatedCost: checker.CostEstimate{Min: 12, Max: 18446744073709551615},
 			// actual cost is 'x' length 5 * list literal length 5, 10 for list creation, 2 for arg cost
 			actualCost: 37,
 		},

--- a/ext/sets_test.go
+++ b/ext/sets_test.go
@@ -15,67 +15,266 @@
 package ext
 
 import (
-	"fmt"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/checker"
 )
 
 func TestSets(t *testing.T) {
 	setsTests := []struct {
-		expr string
+		expr          string
+		vars          []cel.EnvOption
+		in            map[string]any
+		hints         map[string]uint64
+		estimatedCost checker.CostEstimate
+		actualCost    uint64
 	}{
 		// set containment
-		{expr: `sets.contains([], [])`},
-		{expr: `sets.contains([1], [])`},
-		{expr: `sets.contains([1], [1])`},
-		{expr: `sets.contains([1], [1, 1])`},
-		{expr: `sets.contains([1, 1], [1])`},
-		{expr: `sets.contains([2, 1], [1])`},
-		{expr: `sets.contains([1, 2, 3, 4], [2, 3])`},
-		{expr: `sets.contains([1], [1.0, 1])`},
-		{expr: `sets.contains([1, 2], [2u, 2.0])`},
-		{expr: `sets.contains([1, 2u], [2, 2.0])`},
-		{expr: `sets.contains([1, 2.0, 3u], [1.0, 2u, 3])`},
-		{expr: `sets.contains([[1], [2, 3]], [[2, 3.0]])`},
-		{expr: `!sets.contains([1], [2])`},
-		{expr: `!sets.contains([1], [1, 2])`},
-		{expr: `!sets.contains([1], ["1", 1])`},
-		{expr: `!sets.contains([1], [1.1, 1u])`},
-		// set equivalence
-		{expr: `sets.equivalent([], [])`},
-		{expr: `sets.equivalent([1], [1])`},
-		{expr: `sets.equivalent([1], [1, 1])`},
-		{expr: `sets.equivalent([1, 1], [1])`},
-		{expr: `sets.equivalent([1], [1u, 1.0])`},
-		{expr: `sets.equivalent([1], [1u, 1.0])`},
-		{expr: `sets.equivalent([1, 2, 3], [3u, 2.0, 1])`},
-		{expr: `sets.equivalent([[1.0], [2, 3]], [[1], [2, 3.0]])`},
-		{expr: `!sets.equivalent([2, 1], [1])`},
-		{expr: `!sets.equivalent([1], [1, 2])`},
-		{expr: `!sets.equivalent([1, 2], [2u, 2, 2.0])`},
-		{expr: `!sets.equivalent([1, 2], [1u, 2, 2.3])`},
+		{
+			expr:  `sets.contains(x, [1, 2, 3])`,
+			vars:  []cel.EnvOption{cel.Variable("x", cel.ListType(cel.IntType))},
+			in:    map[string]any{"x": []int64{5, 4, 3, 2, 1}},
+			hints: map[string]uint64{"x": 10},
+			// min cost is input 'x' length 0, 10 for list creation, 2 for arg costs
+			// max cost is input 'x' lenght 10, 10 for list creation, 2 for arg costs
+			estimatedCost: checker.CostEstimate{Min: 12, Max: 42},
+			// actual cost is 'x' length 5 * list literal length 3, 10 for list creation, 2 for arg cost
+			actualCost: 27,
+		},
+		{
+			expr: `sets.contains(x, [1, 1, 1, 1, 1])`,
+			vars: []cel.EnvOption{cel.Variable("x", cel.ListType(cel.IntType))},
+			in:   map[string]any{"x": []int64{5, 4, 3, 2, 1}},
+			// min cost is input 'x' length 0, 10 for list creation, 2 for arg costs
+			// max cost is effectively infinite due to missing size hint for 'x'
+			estimatedCost: checker.CostEstimate{Min: 12, Max: 9223372036854775820},
+			// actual cost is 'x' length 5 * list literal length 5, 10 for list creation, 2 for arg cost
+			actualCost: 37,
+		},
+		{
+			expr:          `sets.contains([], [])`,
+			estimatedCost: checker.CostEstimate{Min: 21, Max: 21},
+			actualCost:    21,
+		},
+		{
+			expr:          `sets.contains([1], [])`,
+			estimatedCost: checker.CostEstimate{Min: 21, Max: 21},
+			actualCost:    21,
+		},
+		{
+			expr:          `sets.contains([1], [1])`,
+			estimatedCost: checker.CostEstimate{Min: 22, Max: 22},
+			actualCost:    22,
+		},
+		{
+			expr:          `sets.contains([1], [1, 1])`,
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 23},
+			actualCost:    23,
+		},
+		{
+			expr:          `sets.contains([1, 1], [1])`,
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 23},
+			actualCost:    23,
+		},
+		{
+			expr:          `sets.contains([2, 1], [1])`,
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 23},
+			actualCost:    23,
+		},
+		{
+			expr:          `sets.contains([1, 2, 3, 4], [2, 3])`,
+			estimatedCost: checker.CostEstimate{Min: 29, Max: 29},
+			actualCost:    29,
+		},
+		{
+			expr:          `sets.contains([1], [1.0, 1])`,
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 23},
+			actualCost:    23,
+		},
+		{
+			expr:          `sets.contains([1, 2], [2u, 2.0])`,
+			estimatedCost: checker.CostEstimate{Min: 25, Max: 25},
+			actualCost:    25,
+		},
+		{
+			expr:          `sets.contains([1, 2u], [2, 2.0])`,
+			estimatedCost: checker.CostEstimate{Min: 25, Max: 25},
+			actualCost:    25,
+		},
+		{
+			expr:          `sets.contains([1, 2.0, 3u], [1.0, 2u, 3])`,
+			estimatedCost: checker.CostEstimate{Min: 30, Max: 30},
+			actualCost:    30,
+		},
+		{
+			expr: `sets.contains([[1], [2, 3]], [[2, 3.0]])`,
+			// 10 for each list creation, top-level list sizes are 2, 1
+			estimatedCost: checker.CostEstimate{Min: 53, Max: 53},
+			actualCost:    53,
+		},
+		{
+			expr:          `!sets.contains([1], [2])`,
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 23},
+			actualCost:    23,
+		},
+		{
+			expr:          `!sets.contains([1], [1, 2])`,
+			estimatedCost: checker.CostEstimate{Min: 24, Max: 24},
+			actualCost:    24,
+		},
+		{
+			expr:          `!sets.contains([1], ["1", 1])`,
+			estimatedCost: checker.CostEstimate{Min: 24, Max: 24},
+			actualCost:    24,
+		},
+		{
+			expr:          `!sets.contains([1], [1.1, 1u])`,
+			estimatedCost: checker.CostEstimate{Min: 24, Max: 24},
+			actualCost:    24,
+		},
+
+		// set equivalence (note the cost factor is higher as it's basically two contains checks)
+		{
+			expr:          `sets.equivalent([], [])`,
+			estimatedCost: checker.CostEstimate{Min: 21, Max: 21},
+			actualCost:    21,
+		},
+		{
+			expr:          `sets.equivalent([1], [1])`,
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 23},
+			actualCost:    23,
+		},
+		{
+			expr:          `sets.equivalent([1], [1, 1])`,
+			estimatedCost: checker.CostEstimate{Min: 25, Max: 25},
+			actualCost:    25,
+		},
+		{
+			expr:          `sets.equivalent([1, 1], [1])`,
+			estimatedCost: checker.CostEstimate{Min: 25, Max: 25},
+			actualCost:    25,
+		},
+		{
+			expr:          `sets.equivalent([1], [1u, 1.0])`,
+			estimatedCost: checker.CostEstimate{Min: 25, Max: 25},
+			actualCost:    25,
+		},
+		{
+			expr:          `sets.equivalent([1], [1u, 1.0])`,
+			estimatedCost: checker.CostEstimate{Min: 25, Max: 25},
+			actualCost:    25,
+		},
+		{
+			expr:          `sets.equivalent([1, 2, 3], [3u, 2.0, 1])`,
+			estimatedCost: checker.CostEstimate{Min: 39, Max: 39},
+			actualCost:    39,
+		},
+		{
+			expr:          `sets.equivalent([[1.0], [2, 3]], [[1], [2, 3.0]])`,
+			estimatedCost: checker.CostEstimate{Min: 69, Max: 69},
+			actualCost:    69,
+		},
+		{
+			expr:          `!sets.equivalent([2, 1], [1])`,
+			estimatedCost: checker.CostEstimate{Min: 26, Max: 26},
+			actualCost:    26,
+		},
+		{
+			expr:          `!sets.equivalent([1], [1, 2])`,
+			estimatedCost: checker.CostEstimate{Min: 26, Max: 26},
+			actualCost:    26,
+		},
+		{
+			expr:          `!sets.equivalent([1, 2], [2u, 2, 2.0])`,
+			estimatedCost: checker.CostEstimate{Min: 34, Max: 34},
+			actualCost:    34,
+		},
+		{
+			expr:          `!sets.equivalent([1, 2], [1u, 2, 2.3])`,
+			estimatedCost: checker.CostEstimate{Min: 34, Max: 34},
+			actualCost:    34,
+		},
+
 		// set intersection
-		{expr: `sets.intersects([1], [1])`},
-		{expr: `sets.intersects([1], [1, 1])`},
-		{expr: `sets.intersects([1, 1], [1])`},
-		{expr: `sets.intersects([2, 1], [1])`},
-		{expr: `sets.intersects([1], [1, 2])`},
-		{expr: `sets.intersects([1], [1.0, 2])`},
-		{expr: `sets.intersects([1, 2], [2u, 2, 2.0])`},
-		{expr: `sets.intersects([1, 2], [1u, 2, 2.3])`},
-		{expr: `sets.intersects([[1], [2, 3]], [[1, 2], [2, 3.0]])`},
-		{expr: `!sets.intersects([], [])`},
-		{expr: `!sets.intersects([1], [])`},
-		{expr: `!sets.intersects([1], [2])`},
-		{expr: `!sets.intersects([1], ["1", 2])`},
-		{expr: `!sets.intersects([1], [1.1, 2u])`},
+		{
+			expr:          `sets.intersects([1], [1])`,
+			estimatedCost: checker.CostEstimate{Min: 22, Max: 22},
+			actualCost:    22,
+		},
+		{
+			expr:          `sets.intersects([1], [1, 1])`,
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 23},
+			actualCost:    23,
+		},
+		{
+			expr:          `sets.intersects([1, 1], [1])`,
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 23},
+			actualCost:    23,
+		},
+		{
+			expr:          `sets.intersects([2, 1], [1])`,
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 23},
+			actualCost:    23,
+		},
+		{
+			expr:          `sets.intersects([1], [1, 2])`,
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 23},
+			actualCost:    23,
+		},
+		{
+			expr:          `sets.intersects([1], [1.0, 2])`,
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 23},
+			actualCost:    23,
+		},
+		{
+			expr:          `sets.intersects([1, 2], [2u, 2, 2.0])`,
+			estimatedCost: checker.CostEstimate{Min: 27, Max: 27},
+			actualCost:    27,
+		},
+		{
+			expr:          `sets.intersects([1, 2], [1u, 2, 2.3])`,
+			estimatedCost: checker.CostEstimate{Min: 27, Max: 27},
+			actualCost:    27,
+		},
+		{
+			expr:          `sets.intersects([[1], [2, 3]], [[1, 2], [2, 3.0]])`,
+			estimatedCost: checker.CostEstimate{Min: 65, Max: 65},
+			actualCost:    65,
+		},
+		{
+			expr:          `!sets.intersects([], [])`,
+			estimatedCost: checker.CostEstimate{Min: 22, Max: 22},
+			actualCost:    22,
+		},
+		{
+			expr:          `!sets.intersects([1], [])`,
+			estimatedCost: checker.CostEstimate{Min: 22, Max: 22},
+			actualCost:    22,
+		},
+		{
+			expr:          `!sets.intersects([1], [2])`,
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 23},
+			actualCost:    23,
+		},
+		{
+			expr:          `!sets.intersects([1], ["1", 2])`,
+			estimatedCost: checker.CostEstimate{Min: 24, Max: 24},
+			actualCost:    24,
+		},
+		{
+			expr:          `!sets.intersects([1], [1.1, 2u])`,
+			estimatedCost: checker.CostEstimate{Min: 24, Max: 24},
+			actualCost:    24,
+		},
 	}
 
-	env := testSetsEnv(t)
-	for i, tst := range setsTests {
+	for _, tst := range setsTests {
 		tc := tst
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(tc.expr, func(t *testing.T) {
+			env := testSetsEnv(t, tc.vars...)
 			var asts []*cel.Ast
 			pAst, iss := env.Parse(tc.expr)
 			if iss.Err() != nil {
@@ -86,19 +285,42 @@ func TestSets(t *testing.T) {
 			if iss.Err() != nil {
 				t.Fatalf("env.Check(%v) failed: %v", tc.expr, iss.Err())
 			}
+
+			hints := map[string]uint64{}
+			if len(tc.hints) != 0 {
+				hints = tc.hints
+			}
+			est, err := env.EstimateCost(cAst, testSetsCostEstimator{hints: hints})
+			if err != nil {
+				t.Fatalf("env.EstimateCost() failed: %v", err)
+			}
+			if !reflect.DeepEqual(est, tc.estimatedCost) {
+				t.Errorf("env.EstimateCost() got %v, wanted %v", est, tc.estimatedCost)
+			}
 			asts = append(asts, cAst)
 
 			for _, ast := range asts {
-				prg, err := env.Program(ast)
+				prgOpts := []cel.ProgramOption{}
+				if ast.IsChecked() {
+					prgOpts = append(prgOpts, cel.CostTracking(nil))
+				}
+				prg, err := env.Program(ast, prgOpts...)
 				if err != nil {
 					t.Fatalf("env.Program() failed: %v", err)
 				}
-				out, _, err := prg.Eval(cel.NoVars())
+				in := tc.in
+				if in == nil {
+					in = map[string]any{}
+				}
+				out, det, err := prg.Eval(in)
 				if err != nil {
 					t.Fatalf("prg.Eval() failed: %v", err)
 				}
 				if out.Value() != true {
 					t.Errorf("prg.Eval() got %v, wanted true for expr: %s", out.Value(), tc.expr)
+				}
+				if det.ActualCost() != nil && *det.ActualCost() != tc.actualCost {
+					t.Errorf("prg.Eval() had cost %v, wanted %v", *det.ActualCost(), tc.actualCost)
 				}
 			}
 		})
@@ -113,4 +335,19 @@ func testSetsEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
 		t.Fatalf("cel.NewEnv(Sets()) failed: %v", err)
 	}
 	return env
+}
+
+type testSetsCostEstimator struct {
+	hints map[string]uint64
+}
+
+func (tc testSetsCostEstimator) EstimateSize(element checker.AstNode) *checker.SizeEstimate {
+	if l, ok := tc.hints[strings.Join(element.Path(), ".")]; ok {
+		return &checker.SizeEstimate{Min: 0, Max: l}
+	}
+	return nil
+}
+
+func (testSetsCostEstimator) EstimateCallCost(function, overloadID string, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
+	return nil
 }

--- a/interpreter/runtimecost_test.go
+++ b/interpreter/runtimecost_test.go
@@ -737,7 +737,7 @@ func TestRuntimeCost(t *testing.T) {
 				decls.NewVariable("str2", types.StringType),
 			},
 			options: []CostTrackerOption{
-				FunctionCostTracker(overloads.Contains, overloads.ContainsString,
+				OverloadCostTracker(overloads.ContainsString,
 					func(args []ref.Val, result ref.Val) *uint64 {
 						strCost := uint64(math.Ceil(float64(actualSize(args[0])) * 0.2))
 						substrCost := uint64(math.Ceil(float64(actualSize(args[1])) * 0.2))


### PR DESCRIPTION
Introduce library-based options for cost estimation and cost tracking

*Breaking change* - This change introduced a minor shift to ensure that all instances
of the `interpreter.CostTracker` were instantiated using `interpreter.NewCostTracker()`.
This change revealed a bug where presence test, `has()`, costs were not being counted
when calling `ContextEval()` or `Eval()` with state tracking enabled. This bug has been
fixed, but revealed an inconsistency in expectations between the two method calls.

Note, these options only match against type-checked expressions. This is the 
same behavior as is used internally within estimators; however, it is probably
worth indicating the cost estimates are only accurate against type-checked
expressions at a future date.