### PR TITLE
Fix MaxID to consider macro keys and expressions

### DIFF
--- a/common/ast/ast.go
+++ b/common/ast/ast.go
@@ -151,6 +151,12 @@ func Copy(a *AST) *AST {
 func MaxID(a *AST) int64 {
 	visitor := &maxIDVisitor{maxID: 1}
 	PostOrderVisit(a.Expr(), visitor)
+	for id, call := range a.SourceInfo().MacroCalls() {
+		PostOrderVisit(call, visitor)
+		if id > visitor.maxID {
+			visitor.maxID = id + 1
+		}
+	}
 	return visitor.maxID + 1
 }
 

--- a/common/ast/ast_test.go
+++ b/common/ast/ast_test.go
@@ -322,6 +322,19 @@ func TestNewSourceInfoRelative(t *testing.T) {
 	}
 }
 
+func TestMaxID(t *testing.T) {
+	checked := mustTypeCheck(t, `has({'a':'key'}.key)`)
+	maxID := ast.MaxID(checked)
+	checked.SourceInfo().SetMacroCall(
+		maxID+2,
+		ast.NewExprFactory().NewIdent(maxID+1, "dummy"))
+	// Max ID always pads by 1 between invocations, and it's called twice here
+	// due to the presence of the macro which was injected after the fact.
+	if ast.MaxID(checked) != maxID+4 {
+		t.Errorf("ast.MaxID() got %v, wanted %d", ast.MaxID(checked), maxID+4)
+	}
+}
+
 func mockRelativeSource(t testing.TB, text string, lineOffsets []int32, baseLocation common.Location) common.Source {
 	t.Helper()
 	return &mockSource{


### PR DESCRIPTION
Fix MaxID to consider macro keys and expressions

During constant folding and inlining macro ids can exceed the id space present
in the actual expression body. This change ensures that `ast.MaxID` considers
these ids during its computation.
