### PR TITLE
Add AST node IDs to types.Err for errorable expressions

### DIFF
--- a/common/types/err.go
+++ b/common/types/err.go
@@ -31,6 +31,7 @@ type Error interface {
 // Err type which extends the built-in go error and implements ref.Val.
 type Err struct {
 	error
+	id int64
 }
 
 var (
@@ -58,7 +59,24 @@ var (
 // NewErr creates a new Err described by the format string and args.
 // TODO: Audit the use of this function and standardize the error messages and codes.
 func NewErr(format string, args ...any) ref.Val {
-	return &Err{fmt.Errorf(format, args...)}
+	return &Err{error: fmt.Errorf(format, args...)}
+}
+
+// NewErrWithNodeID creates a new Err described by the format string and args.
+// TODO: Audit the use of this function and standardize the error messages and codes.
+func NewErrWithNodeID(id int64, format string, args ...any) ref.Val {
+	return &Err{error: fmt.Errorf(format, args...), id: id}
+}
+
+// LabelErrNode returns val unaltered it is not an Err or if the error has a non-zero
+// AST node ID already present. Otherwise the id is added to the error for
+// recovery with the Err.NodeID method.
+func LabelErrNode(id int64, val ref.Val) ref.Val {
+	if err, ok := val.(*Err); ok && err.id == 0 {
+		err.id = id
+		return err
+	}
+	return val
 }
 
 // NoSuchOverloadErr returns a new types.Err instance with a no such overload message.
@@ -122,6 +140,11 @@ func (e *Err) Type() ref.Type {
 // Value implements ref.Val.Value.
 func (e *Err) Value() any {
 	return e.error
+}
+
+// NodeID returns the AST node ID of the expression that returned the error.
+func (e *Err) NodeID() int64 {
+	return e.id
 }
 
 // Is implements errors.Is.

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -276,7 +276,7 @@ func (p *Registry) NewValue(structType string, fields map[string]ref.Val) ref.Va
 		}
 		err := msgSetField(msg, field, value)
 		if err != nil {
-			return &Err{err}
+			return &Err{error: err}
 		}
 	}
 	return p.NativeToValue(msg.Interface())

--- a/common/types/string.go
+++ b/common/types/string.go
@@ -158,7 +158,7 @@ func (s String) Match(pattern ref.Val) ref.Val {
 	}
 	matched, err := regexp.MatchString(pat.Value().(string), s.Value().(string))
 	if err != nil {
-		return &Err{err}
+		return &Err{error: err}
 	}
 	return Bool(matched)
 }

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -1549,6 +1549,13 @@ func TestInterpreter(t *testing.T) {
 						if !types.IsError(got) || !strings.Contains(got.(*types.Err).String(), tc.err) {
 							t.Errorf("Got %v (%T), wanted error: %s", got, got, tc.err)
 						}
+						type nodeIDer interface {
+							NodeID() int64
+						}
+						nodeErr, ok := got.(nodeIDer)
+						if !ok || nodeErr.NodeID() == 0 {
+							t.Errorf("Did not get AST node ID from error: %#v", got)
+						}
 					} else if got.Equal(want) != types.True {
 						t.Errorf("Got %v, wanted %v", got, want)
 					}

--- a/server/server.go
+++ b/server/server.go
@@ -123,7 +123,7 @@ func (s *ConformanceServer) Eval(ctx context.Context, in *confpb.EvalRequest) (*
 	res, _, err := prg.Eval(args)
 	resultExprVal, err := RefValueToExprValue(res, err)
 	if err != nil {
-		return nil, fmt.Errorf("con't convert result: %s", err)
+		return nil, fmt.Errorf("can't convert result: %s", err)
 	}
 	return &confpb.EvalResponse{Result: resultExprVal}, nil
 }


### PR DESCRIPTION
I have tried to make this as minimally invasive as possible and hopefully the naming is within project style.

Please take a look.

# Pull Requests Guidelines

See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details about when to create
a GitHub [Pull Request][1] and when other kinds of contributions or
consultation might be more desirable.

When creating a new pull request, please fork the repo and work within a
development branch.

## Commit Messages

* Most changes should be accompanied by tests.
* Commit messages should explain _why_ the changes were made.
```
Add AST node IDs to types.Err for errorable expressions

Currently, it is not possible to obtain the source location of a runtime
error making it difficult sometimes to identify the cause of an issue.
If an AST node ID is available, the source location can be obtained, so
add this information to runtime errors.

ref.Val values returned by the following types are examined for error
state and if an error and no AST node has been set, the node ID of the
Interpretable is added to the error.

* evalAnd
* evalAttr
* evalBinary
* evalExhaustiveConditional
* evalList
* evalMap
* evalMap
* evalObj
* evalOr
* evalTestOnly
* evalUnary
* evalVarArgs
* evalWatchAttrQual
* evalWatchConstQual
* evalWatchQual
* evalZeroArity
```

## Reviews

* Perform a self-review. ✔️
* Make sure the Travis CI build passes. ✔️
* Assign a reviewer once both the above have been completed.

## Merging

* If a CEL maintaner approves the change, it may be merged by the author if
  they have write access. Otherwise, the change will be merged by a maintainer.
* Multiple commits should be squashed before merging.
* Please append the line `closes #<issue-num>: description` in the merge message,
  if applicable.

[1]:  https://help.github.com/articles/about-pull-requests