### PR TITLE
Fix incorrect example in string formatting docs.

### DIFF
--- a/ext/strings.go
+++ b/ext/strings.go
@@ -96,7 +96,7 @@ const (
 //	"a map inside a list: %s".format([[1, 2, 3, {"a": "x", "b": "y", "c": "z"}]]) // returns "a map inside a list: [1, 2, 3, {"a":"x", "b":"y", "c":"d"}]"
 //	"true bool: %s - false bool: %s\nbinary bool: %b".format([true, false, true]) // returns "true bool: true - false bool: false\nbinary bool: 1"
 //
-// Passing an incorrect type (an integer to `%s`) is considered an error, as well as attempting
+// Passing an incorrect type (a string to `%b`) is considered an error, as well as attempting
 // to use more formatting clauses than there are arguments (`%d %d %d` while passing two ints, for instance).
 // If compile-time checking is enabled, and the formatting string is a constant, and the argument list is a literal,
 // then letting any arguments go unused/unformatted is also considered an error.

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -714,6 +714,14 @@ func TestStringFormat(t *testing.T) {
 			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
 		},
 		{
+			name:                  "int support for string",
+			format:                "%s",
+			formatArgs:            `999999999999`,
+			expectedOutput:        "999999999999",
+			expectedRuntimeCost:   11,
+			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+		},
+		{
 			name:                  "bytes support for string",
 			format:                "some bytes: %s",
 			formatArgs:            `b"xyz"`,


### PR DESCRIPTION
%s is defined to support "all numerical types (int, uint, and double)." but later the docs also say:
"Passing an incorrect type (an integer to `%s`) is considered an error"

The example in the parenthetical contradicts the definition of %s.

This change replaces the parenthetical example with one that is accurate and verified by an existing test case. This change also adds an explicit test case to verify that it is valid to pass an int to %s.