### PR TITLE
ext: support member overloads for map-like custom types

### DIFF
--- a/checker/types.go
+++ b/checker/types.go
@@ -144,9 +144,11 @@ func internalIsAssignable(m *mapping, t1, t2 *types.Type) bool {
 		return t2.IsAssignableType(t1)
 	case types.TypeKind:
 		return kind2 == types.TypeKind
-	case types.OpaqueKind, types.ListKind, types.MapKind:
+	case types.OpaqueKind, types.ListKind:
 		return t1.Kind() == t2.Kind() && t1.TypeName() == t2.TypeName() &&
 			internalIsAssignableList(m, t1.Parameters(), t2.Parameters())
+	case types.MapKind:
+		return t1.Kind() == t2.Kind() && internalIsAssignableList(m, t1.Parameters(), t2.Parameters())
 	default:
 		return false
 	}

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -33,12 +33,17 @@ import (
 
 // NewDynamicMap returns a traits.Mapper value with dynamic key, value pairs.
 func NewDynamicMap(adapter Adapter, value any) traits.Mapper {
+	return NewDynamicMapWithType(adapter, value, MapType)
+}
+
+func NewDynamicMapWithType(adapter Adapter, value any, valueType ref.Type) traits.Mapper {
 	refValue := reflect.ValueOf(value)
 	return &baseMap{
 		Adapter:     adapter,
 		mapAccessor: newReflectMapAccessor(adapter, refValue),
 		value:       value,
 		size:        refValue.Len(),
+		valueType:   valueType,
 	}
 }
 
@@ -53,6 +58,7 @@ func NewJSONStruct(adapter Adapter, value *structpb.Struct) traits.Mapper {
 		mapAccessor: newJSONStructAccessor(adapter, fields),
 		value:       value,
 		size:        len(fields),
+		valueType:   MapType,
 	}
 }
 
@@ -63,6 +69,7 @@ func NewRefValMap(adapter Adapter, value map[ref.Val]ref.Val) traits.Mapper {
 		mapAccessor: newRefValMapAccessor(value),
 		value:       value,
 		size:        len(value),
+		valueType:   MapType,
 	}
 }
 
@@ -73,6 +80,7 @@ func NewStringInterfaceMap(adapter Adapter, value map[string]any) traits.Mapper 
 		mapAccessor: newStringIfaceMapAccessor(adapter, value),
 		value:       value,
 		size:        len(value),
+		valueType:   MapType,
 	}
 }
 
@@ -83,6 +91,7 @@ func NewStringStringMap(adapter Adapter, value map[string]string) traits.Mapper 
 		mapAccessor: newStringMapAccessor(value),
 		value:       value,
 		size:        len(value),
+		valueType:   MapType,
 	}
 }
 
@@ -122,6 +131,8 @@ type baseMap struct {
 
 	// size is the number of entries in the map.
 	size int
+
+	valueType ref.Type
 }
 
 // Contains implements the traits.Container interface method.
@@ -299,7 +310,7 @@ func (m *baseMap) String() string {
 
 // Type implements the ref.Val interface method.
 func (m *baseMap) Type() ref.Type {
-	return MapType
+	return m.valueType
 }
 
 // Value implements the ref.Val interface method.

--- a/common/types/types.go
+++ b/common/types/types.go
@@ -390,6 +390,21 @@ func (t *Type) WithTraits(traits int) *Type {
 	}
 }
 
+// WithRuntimeTypeName creates a copy of the current Type and sets its runtime type name.
+func (t *Type) WithRuntimeTypeName(runtimeTypeName string) *Type {
+	if t == nil {
+		return nil
+	}
+	return &Type{
+		kind:                    t.kind,
+		parameters:              t.parameters,
+		runtimeTypeName:         runtimeTypeName,
+		isAssignableType:        t.isAssignableType,
+		isAssignableRuntimeType: t.isAssignableRuntimeType,
+		traitMask:               t.traitMask,
+	}
+}
+
 // String returns a human-readable definition of the type name.
 func (t *Type) String() string {
 	if len(t.Parameters()) == 0 {


### PR DESCRIPTION
If this change is accepted the same could be implemented for slice-like types.

Example usecase is to access http.Request properties like:
```go
	expr := `
		request.Method == "GET"
		&& "q" in request.URL.Query()
		&& request.URL.Query().Has("q")
		&& request.URL.Query().Get("q") == "t"
		&& request.URL.Host == "foo.test:1234"
		&& request.URL.Hostname() == "foo.test"
		&& request.URL.Port() == "1234"
		&& request.URL.RequestURI() == "/foo?q=t"
		&& "X-Foo" in request.Header
		&& "bar" in request.Header["X-Foo"]
		&& "baz" in request.Header["X-Foo"]
		&& request.Header.Get("x-foo") == "bar"
		&& "baz" in request.Header.Values("x-foo")
	`

	urlType := cel.ObjectType("url.URL")
	urlValuesType := cel.MapType(cel.StringType, cel.ListType(cel.StringType)).WithRuntimeTypeName("url.Values")
	httpHeaderType := cel.MapType(cel.StringType, cel.ListType(cel.StringType)).WithRuntimeTypeName("http.Header")

	var env *cel.Env

	makeGetter := func(typ *cel.Type, getter string, argsAndResultTypes ...*cel.Type) cel.EnvOption {
		if len(argsAndResultTypes) == 0 {
			panic("missing return type")
		}
		argTypes := argsAndResultTypes[:len(argsAndResultTypes)-1]
		retType := argsAndResultTypes[len(argsAndResultTypes)-1]
		return cel.Function(getter,
			cel.MemberOverload(
				strings.ReplaceAll(typ.TypeName(), ".", "_")+"_"+getter,
				append([]*cel.Type{typ}, argTypes...),
				retType,
				cel.FunctionBinding(func(args ...ref.Val) ref.Val {
					method := reflect.ValueOf(args[0].Value()).MethodByName(getter)
					var callArgs []reflect.Value
					for _, arg := range args[1:] {
						callArgs = append(callArgs, reflect.ValueOf(arg.Value()))
					}
					result := method.Call(callArgs)[0].Interface()
					return env.CELTypeAdapter().NativeToValue(result)
				}),
			),
		)
	}

	env, err := cel.NewEnv(
		cel.Variable("request", cel.ObjectType("http.Request")),
		ext.NativeTypes(reflect.TypeOf(http.Request{}), reflect.TypeOf(url.URL{})),
		ext.Strings(),

		makeGetter(urlType, "Hostname", cel.StringType),
		makeGetter(urlType, "Port", cel.StringType),
		makeGetter(urlType, "RequestURI", cel.StringType),
		makeGetter(urlType, "Query", urlValuesType),
		makeGetter(urlValuesType, "Get", cel.StringType, cel.StringType),
		makeGetter(urlValuesType, "Has", cel.StringType, cel.BoolType),
		makeGetter(httpHeaderType, "Get", cel.StringType, cel.StringType),
		makeGetter(httpHeaderType, "Values", cel.StringType, cel.ListType(cel.StringType)),
	)
	...
```