### PR TITLE
Fix type substitution within parameterized type names

### DIFF
--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -2233,6 +2233,35 @@ _&&_(_==_(list~type(list(dyn))^list,
 			| NotAMessage{}
 			| ...........^`,
 		},
+		{
+			in: `{}.map(c,[c,type(c)])`,
+			out: `__comprehension__(
+				// Variable
+				c,
+				// Target
+				{}~map(dyn, dyn),
+				// Accumulator
+				__result__,
+				// Init
+				[]~list(list(dyn)),
+				// LoopCondition
+				true~bool,
+				// LoopStep
+				_+_(
+				  __result__~list(list(dyn))^__result__,
+				  [
+					[
+					  c~dyn^c,
+					  type(
+						c~dyn^c
+					  )~type(dyn)^type
+					]~list(dyn)
+				  ]~list(list(dyn))
+				)~list(list(dyn))^add_list,
+				// Result
+				__result__~list(list(dyn))^__result__)~list(list(dyn))`,
+			outType: types.NewListType(types.NewListType(types.DynType)),
+		},
 	}
 }
 

--- a/checker/types.go
+++ b/checker/types.go
@@ -260,7 +260,7 @@ func notReferencedIn(m *mapping, t, withinType *types.Type) bool {
 			return true
 		}
 		return notReferencedIn(m, t, wtSub)
-	case types.OpaqueKind, types.ListKind, types.MapKind:
+	case types.OpaqueKind, types.ListKind, types.MapKind, types.TypeKind:
 		for _, pt := range withinType.Parameters() {
 			if !notReferencedIn(m, t, pt) {
 				return false
@@ -292,7 +292,8 @@ func substitute(m *mapping, t *types.Type, typeParamToDyn bool) *types.Type {
 			substitute(m, t.Parameters()[1], typeParamToDyn))
 	case types.TypeKind:
 		if len(t.Parameters()) > 0 {
-			return types.NewTypeTypeWithParam(substitute(m, t.Parameters()[0], typeParamToDyn))
+			tParam := t.Parameters()[0]
+			return types.NewTypeTypeWithParam(substitute(m, tParam, typeParamToDyn))
 		}
 		return t
 	default:


### PR DESCRIPTION
Fix parameterized type substitutions for results from `type()` calls