### PR TITLE
Checker concurrency change

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -48,10 +48,9 @@ type checker struct {
 // registry.
 func Check(parsed *ast.AST, source common.Source, env *Env) (*ast.AST, *common.Errors) {
 	errs := common.NewErrors(source)
-	typeMap := make(map[int64]*types.Type)
-	refMap := make(map[int64]*ast.ReferenceInfo)
+	checked := ast.Copy(parsed)
 	c := checker{
-		AST:                ast.NewCheckedAST(parsed, typeMap, refMap),
+		AST:                checked,
 		ExprFactory:        ast.NewExprFactory(),
 		env:                env,
 		errors:             &typeErrors{errs: errs},

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -2413,7 +2413,7 @@ func TestCheck(t *testing.T) {
 			}
 
 			if tc.out != "" {
-				actualStr := Print(pAst.Expr(), cAst)
+				actualStr := Print(cAst.Expr(), cAst)
 				if !test.Compare(actualStr, tc.out) {
 					t.Error(test.DiffMessage("Structure error", actualStr, tc.out))
 				}
@@ -2504,7 +2504,7 @@ func BenchmarkCheck(b *testing.B) {
 				}
 
 				if tc.out != "" {
-					actualStr := Print(pAst.Expr(), cAst)
+					actualStr := Print(cAst.Expr(), cAst)
 					if !test.Compare(actualStr, tc.out) {
 						b.Error(test.DiffMessage("Structure error", actualStr, tc.out))
 					}


### PR DESCRIPTION
Copy the AST before type-checking to avoid concurrency issues

Closes #881 