### PR TITLE
Minor adjustment to inlining to fix a bad bind

### DIFF
--- a/cel/inlining.go
+++ b/cel/inlining.go
@@ -201,8 +201,7 @@ func (opt *inliningOptimizer) rewritePresenceExpr(ctx *OptimizerContext, prev, i
 // in most cases.
 func isBindable(matches []ast.NavigableExpr, inlined ast.Expr, inlinedType *Type) bool {
 	if inlinedType.IsAssignableType(NullType) ||
-		inlinedType.HasTrait(traits.SizerType) ||
-		inlinedType.HasTrait(traits.FieldTesterType) {
+		inlinedType.HasTrait(traits.SizerType) {
 		return true
 	}
 	for _, m := range matches {

--- a/cel/inlining_test.go
+++ b/cel/inlining_test.go
@@ -666,6 +666,29 @@ func TestInliningOptimizerMultiStage(t *testing.T) {
 			inlined: "cel.bind(listA, [1, 1], cel.bind(listB, [1, 1, 1], listB.all(b, b == listA[0]) &&\nlistA.all(a, a == listB[0])) || listA.size() == 0) || false",
 			folded:  `true`,
 		},
+		{
+			expr: `has(m.child) && has(m.child.payload)`,
+			vars: []varDecl{
+				{
+					name: "m",
+					t:    cel.ObjectType("google.expr.proto3.test.NestedTestAllTypes"),
+				},
+				{
+					name: "m_view",
+					t:    cel.MapType(cel.StringType, cel.ObjectType("google.expr.proto3.test.NestedTestAllTypes")),
+				},
+			},
+			inlineVars: []inlineVarExpr{
+				{
+					name:  "m.child",
+					t:     cel.ObjectType("google.expr.proto3.test.NestedTestAllTypes"),
+					alias: "child",
+					expr:  "m_view.nested.child",
+				},
+			},
+			inlined: "has(m_view.nested.child) && has(m_view.nested.child.payload)",
+			folded:  "has(m_view.nested.child) && has(m_view.nested.child.payload)",
+		},
 	}
 	for _, tst := range tests {
 		tc := tst


### PR DESCRIPTION
Inlining attempted a `bind` where one was not valid.

Whether or not the inlined type would support field tests was not relevant
to whether it could be used in a bind within a presence test. Removed this
single condition which triggers failures as well as a test case to reproduce
 the issue.