### PR TITLE
Ensure error typed variables are returned as errors from Resolve

### DIFF
--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -287,6 +287,9 @@ func (a *absoluteAttribute) Resolve(vars Activation) (any, error) {
 		// determine whether the type is unknown before returning.
 		obj, found := vars.ResolveName(nm)
 		if found {
+			if celErr, ok := obj.(*types.Err); ok {
+				return nil, celErr.Unwrap()
+			}
 			obj, isOpt, err := applyQualifiers(vars, obj, a.qualifiers)
 			if err != nil {
 				return nil, err

--- a/interpreter/attributes_test.go
+++ b/interpreter/attributes_test.go
@@ -84,6 +84,26 @@ func TestAttributesAbsoluteAttrType(t *testing.T) {
 	}
 }
 
+func TestAttributesAbsoluteAttrError(t *testing.T) {
+	reg := newTestRegistry(t)
+	attrs := NewAttributeFactory(containers.DefaultContainer, reg, reg)
+	vars, err := NewActivation(map[string]any{
+		"err": types.NewErr("invalid variable computation"),
+	})
+	if err != nil {
+		t.Fatalf("NewActivation() failed: %v", err)
+	}
+
+	// acme.a.b[4][false]
+	attr := attrs.AbsoluteAttribute(1, "err")
+	qualMsg := makeQualifier(t, attrs, nil, 2, "message")
+	attr.AddQualifier(qualMsg)
+	out, err := attr.Resolve(vars)
+	if err == nil {
+		t.Errorf("attr.Resolve('err') got %v, wanted error", out)
+	}
+}
+
 func TestAttributesRelativeAttr(t *testing.T) {
 	reg := newTestRegistry(t)
 	attrs := NewAttributeFactory(containers.DefaultContainer, reg, reg)


### PR DESCRIPTION
The following change verifies that if a variable is found, but of `types.Err` type,
then it will be returned as an error rather than as a potential source of further
attribute resolution.