### PR TITLE
Revert the AST copy as some users were relying on Check to be mutable

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -48,9 +48,10 @@ type checker struct {
 // registry.
 func Check(parsed *ast.AST, source common.Source, env *Env) (*ast.AST, *common.Errors) {
 	errs := common.NewErrors(source)
-	checked := ast.Copy(parsed)
+	typeMap := make(map[int64]*types.Type)
+	refMap := make(map[int64]*ast.ReferenceInfo)
 	c := checker{
-		AST:                checked,
+		AST:                ast.NewCheckedAST(parsed, typeMap, refMap),
 		ExprFactory:        ast.NewExprFactory(),
 		env:                env,
 		errors:             &typeErrors{errs: errs},


### PR DESCRIPTION
Re-opens #881 