### PR TITLE
ext.NativeTypes: Recursively add sub-types

### DIFF
--- a/ext/native_test.go
+++ b/ext/native_test.go
@@ -63,6 +63,8 @@ func TestNativeTypes(t *testing.T) {
 					},
 				],
 				MapVal: {'map-key': ext.TestAllTypes{BoolVal: true}},
+				CustomSliceVal: [ext.TestNestedSliceType{Value: 'none'}],
+				CustomMapVal: {'even': ext.TestMapVal{Value: 'more'}},
 			}`,
 			out: &TestAllTypes{
 				NestedVal:    &TestNestedType{NestedMapVal: map[int64]bool{1: false}},
@@ -83,7 +85,9 @@ func TestNativeTypes(t *testing.T) {
 						NestedMapVal:  map[int64]bool{42: true},
 					},
 				},
-				MapVal: map[string]TestAllTypes{"map-key": {BoolVal: true}},
+				MapVal:         map[string]TestAllTypes{"map-key": {BoolVal: true}},
+				CustomSliceVal: []TestNestedSliceType{{Value: "none"}},
+				CustomMapVal:   map[string]TestMapVal{"even": {Value: "more"}},
 			},
 		},
 		{
@@ -645,7 +649,6 @@ func testNativeEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
 	envOpts = append(envOpts, opts...)
 	envOpts = append(envOpts,
 		NativeTypes(
-			reflect.TypeOf(&TestNestedType{}),
 			reflect.ValueOf(&TestAllTypes{}),
 		),
 	)
@@ -687,6 +690,8 @@ type TestAllTypes struct {
 	ListVal         []*TestNestedType
 	MapVal          map[string]TestAllTypes
 	PbVal           *proto3pb.TestAllTypes
+	CustomSliceVal  []TestNestedSliceType
+	CustomMapVal    map[string]TestMapVal
 
 	// channel types are not supported
 	UnsupportedVal     chan string
@@ -695,4 +700,12 @@ type TestAllTypes struct {
 
 	// unexported types can be found but not set or accessed
 	privateVal map[string]string
+}
+
+type TestNestedSliceType struct {
+	Value string
+}
+
+type TestMapVal struct {
+	Value string
 }


### PR DESCRIPTION
This change extends the `NativeTypes` provider to not only add the passed-in type but also all of its sub-types in order to simplify using it in the context of nested structs.

Fixes https://github.com/google/cel-go/issues/885

# Pull Requests Guidelines

See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details about when to create
a GitHub [Pull Request][1] and when other kinds of contributions or
consultation might be more desirable.

When creating a new pull request, please fork the repo and work within a
development branch.

## Commit Messages

* Most changes should be accompanied by tests.
* Commit messages should explain _why_ the changes were made.
```
Summary of change in 50 characters or less

Background on why the change is being made with additional detail on
consequences of the changes elsewhere in the code or to the general
functionality of the library. Multiple paragraphs may be used, but
please keep lines to 72 characters or less.
```

## Reviews

* Perform a self-review.
* Make sure the Travis CI build passes.
* Assign a reviewer once both the above have been completed.

## Merging

* If a CEL maintaner approves the change, it may be merged by the author if
  they have write access. Otherwise, the change will be merged by a maintainer.
* Multiple commits should be squashed before merging.
* Please append the line `closes #<issue-num>: description` in the merge message,
  if applicable.

[1]:  https://help.github.com/articles/about-pull-requests