### PR TITLE
Lists: Fix handling of go arrays

### DIFF
--- a/common/types/list.go
+++ b/common/types/list.go
@@ -190,7 +190,13 @@ func (l *baseList) ConvertToNative(typeDesc reflect.Type) (any, error) {
 	// Allow the element ConvertToNative() function to determine whether conversion is possible.
 	otherElemType := typeDesc.Elem()
 	elemCount := l.size
-	nativeList := reflect.MakeSlice(typeDesc, elemCount, elemCount)
+	var nativeList reflect.Value
+	if typeDesc.Kind() == reflect.Array {
+		nativeList = reflect.New(reflect.ArrayOf(elemCount, typeDesc)).Elem().Index(0)
+	} else {
+		nativeList = reflect.MakeSlice(typeDesc, elemCount, elemCount)
+
+	}
 	for i := 0; i < elemCount; i++ {
 		elem := l.NativeToValue(l.get(i))
 		nativeElemVal, err := elem.ConvertToNative(otherElemType)

--- a/ext/native_test.go
+++ b/ext/native_test.go
@@ -62,6 +62,12 @@ func TestNativeTypes(t *testing.T) {
 						NestedMapVal: {42: true},
 					},
 				],
+				ArrayVal: [
+					ext.TestNestedType{
+						NestedListVal:['goodbye', 'cruel', 'world'],
+						NestedMapVal: {42: true},
+					},
+				],
 				MapVal: {'map-key': ext.TestAllTypes{BoolVal: true}},
 				CustomSliceVal: [ext.TestNestedSliceType{Value: 'none'}],
 				CustomMapVal: {'even': ext.TestMapVal{Value: 'more'}},
@@ -85,6 +91,10 @@ func TestNativeTypes(t *testing.T) {
 						NestedMapVal:  map[int64]bool{42: true},
 					},
 				},
+				ArrayVal: [1]*TestNestedType{{
+					NestedListVal: []string{"goodbye", "cruel", "world"},
+					NestedMapVal:  map[int64]bool{42: true},
+				}},
 				MapVal:         map[string]TestAllTypes{"map-key": {BoolVal: true}},
 				CustomSliceVal: []TestNestedSliceType{{Value: "none"}},
 				CustomMapVal:   map[string]TestMapVal{"even": {Value: "more"}},
@@ -688,6 +698,7 @@ type TestAllTypes struct {
 	Uint32Val       uint32
 	Uint64Val       uint64
 	ListVal         []*TestNestedType
+	ArrayVal        [1]*TestNestedType
 	MapVal          map[string]TestAllTypes
 	PbVal           *proto3pb.TestAllTypes
 	CustomSliceVal  []TestNestedSliceType


### PR DESCRIPTION
Go arrays currently cause a panic, because `reflect.MakeSlice` is used to construct them which is invalid, this change fixes that.

# Pull Requests Guidelines

See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details about when to create
a GitHub [Pull Request][1] and when other kinds of contributions or
consultation might be more desirable.

When creating a new pull request, please fork the repo and work within a
development branch.

## Commit Messages

* Most changes should be accompanied by tests.
* Commit messages should explain _why_ the changes were made.
```
Summary of change in 50 characters or less

Background on why the change is being made with additional detail on
consequences of the changes elsewhere in the code or to the general
functionality of the library. Multiple paragraphs may be used, but
please keep lines to 72 characters or less.
```

## Reviews

* Perform a self-review.
* Make sure the Travis CI build passes.
* Assign a reviewer once both the above have been completed.

## Merging

* If a CEL maintaner approves the change, it may be merged by the author if
  they have write access. Otherwise, the change will be merged by a maintainer.
* Multiple commits should be squashed before merging.
* Please append the line `closes #<issue-num>: description` in the merge message,
  if applicable.

[1]:  https://help.github.com/articles/about-pull-requests