### PR TITLE
Track sizes of comprehension results

### DIFF
--- a/checker/cost.go
+++ b/checker/cost.go
@@ -506,6 +506,9 @@ func (c *coster) costComprehension(e ast.Expr) CostEstimate {
 	c.iterRanges.pop(comp.IterVar())
 	sum = sum.Add(c.cost(comp.Result()))
 	rangeCnt := c.sizeEstimate(c.newAstNode(comp.IterRange()))
+
+	c.computedSizes[e.ID()] = rangeCnt
+
 	rangeCost := rangeCnt.MultiplyByCost(stepCost.Add(loopCost))
 	sum = sum.Add(rangeCost)
 

--- a/interpreter/runtimecost_test.go
+++ b/interpreter/runtimecost_test.go
@@ -791,6 +791,70 @@ func TestRuntimeCost(t *testing.T) {
 			in:   map[string]any{},
 			want: 77,
 		},
+		{
+			name: "list map literal",
+			expr: `[{'k1': 1}, {'k2': 2}].all(x, true)`,
+			vars: []*decls.VariableDecl{},
+			in:   map[string]any{},
+			want: 77,
+		},
+		{
+			name: ".filter list literal",
+			expr: `[1,2,3,4,5].filter(x, x % 2 == 0)`,
+			vars: []*decls.VariableDecl{},
+			in:   map[string]any{},
+			want: 62,
+		},
+		{
+			name: ".map list literal",
+			expr: `[1,2,3,4,5].map(x, x)`,
+			vars: []*decls.VariableDecl{},
+			in:   map[string]any{},
+			want: 86,
+		},
+		{
+			name: ".map.filter list literal",
+			expr: `[1,2,3,4,5].map(x, x).filter(x, x % 2 == 0)`,
+			vars: []*decls.VariableDecl{},
+			in:   map[string]any{},
+			want: 138,
+		},
+		{
+			name: ".map.exists list literal",
+			expr: `[1,2,3,4,5].map(x, x).exists(x, x == 5) == true`,
+			vars: []*decls.VariableDecl{},
+			in:   map[string]any{},
+			want: 118,
+		},
+		{
+			name: ".map.map list literal",
+			expr: `[1,2,3,4,5].map(x, x).map(x, x)`,
+			vars: []*decls.VariableDecl{},
+			in:   map[string]any{},
+			want: 162,
+		},
+		{
+			name: ".map.map list literal",
+			expr: `[1,2,3,4,5].map(x, [x, x]).filter(z, z.size() == 2)`,
+			vars: []*decls.VariableDecl{},
+			in:   map[string]any{},
+			want: 232,
+		},
+		{
+			name: "comprehension on nested list",
+			expr: `[1,2,3,4,5].map(x, [x, x]).all(y, y.all(y, y == 1))`,
+			want: 171,
+		},
+		{
+			name: "comprehension size",
+			expr: `[1,2,3,4,5].map(x, x).map(x, x) + [1]`,
+			want: 173,
+		},
+		{
+			name: "nested comprehension",
+			expr: `[1,2,3].all(i, i in [1,2,3].map(j, j + j))`,
+			want: 86,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Setting this as draft because I'm not convinced it's entirely correct.  It's assuming that the result size of a comprehension matches the iteration. Does this miscount break `.filter()`, `.exists()` ...?

Fixes https://github.com/google/cel-go/issues/900