### PR TITLE
Make the CEL ast package public.

### DIFF
--- a/common/ast/BUILD.bazel
+++ b/common/ast/BUILD.bazel
@@ -1,14 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(
-    default_visibility = [
-        "//cel:__subpackages__",
-        "//checker:__subpackages__",
-        "//common:__subpackages__",
-        "//ext:__subpackages__",
-        "//interpreter:__subpackages__",
-        "//parser:__subpackages__",
-    ],
+    default_visibility = ["//visibility:public"],
     licenses = ["notice"],  # Apache 2.0
 )
 


### PR DESCRIPTION
Make the CEL ast package public.

This allows the usage of the new [GlobalMacro](https://github.com/google/cel-go/blob/master/cel/macro.go#L146) as the [MacroFactory](https://github.com/google/cel-go/blob/master/parser/macro.go#L146) depends on the ast package.