### PR TITLE
Delete dangling source info from macro expansion

### DIFF
--- a/common/ast/ast.go
+++ b/common/ast/ast.go
@@ -310,6 +310,13 @@ func (s *SourceInfo) SetOffsetRange(id int64, o OffsetRange) {
 	s.offsetRanges[id] = o
 }
 
+// ClearMacroCall removes the OffsetRange for the given expression id.
+func (s *SourceInfo) ClearOffsetRange(id int64) {
+	if s != nil {
+		delete(s.offsetRanges, id)
+	}
+}
+
 // GetStartLocation calculates the human-readable 1-based line and 0-based column of the first character
 // of the expression node at the id.
 func (s *SourceInfo) GetStartLocation(id int64) common.Location {

--- a/common/ast/ast.go
+++ b/common/ast/ast.go
@@ -310,7 +310,7 @@ func (s *SourceInfo) SetOffsetRange(id int64, o OffsetRange) {
 	s.offsetRanges[id] = o
 }
 
-// ClearMacroCall removes the OffsetRange for the given expression id.
+// ClearOffsetRange removes the OffsetRange for the given expression id.
 func (s *SourceInfo) ClearOffsetRange(id int64) {
 	if s != nil {
 		delete(s.offsetRanges, id)

--- a/common/ast/conversion_test.go
+++ b/common/ast/conversion_test.go
@@ -285,16 +285,8 @@ func TestSourceInfoToProto(t *testing.T) {
           value: 15
         }
         positions: {
-          key: 7
-          value: 28
-        }
-        positions: {
           key: 8
           value: 29
-        }
-        positions: {
-          key: 9
-          value: 35
         }
         positions: {
           key: 10

--- a/parser/helper.go
+++ b/parser/helper.go
@@ -164,6 +164,13 @@ func (p *parserHelper) id(ctx any) int64 {
 	return id
 }
 
+func (p *parserHelper) deleteId(id int64) {
+	p.sourceInfo.ClearOffsetRange(id)
+	if id == p.nextID-1 {
+		p.nextID--
+	}
+}
+
 func (p *parserHelper) getLocation(id int64) common.Location {
 	return p.sourceInfo.GetStartLocation(id)
 }


### PR DESCRIPTION
When checking if something is a regular call or macro in the parser, we reserve an ID ahead of time and associate location information with it. When the call turns out to be a macro, the ID becomes unused but the source information is left. This change introduces logic to remove the excess information and potentially re-use the ID if we can.