### PR TITLE
Do not re-use ID twice in exists_one macro

### DIFF
--- a/parser/macro.go
+++ b/parser/macro.go
@@ -382,13 +382,11 @@ func makeQuantifier(kind quantifierKind, eh ExprHelper, target ast.Expr, args []
 		step = eh.NewCall(operators.LogicalOr, eh.NewAccuIdent(), args[1])
 		result = eh.NewAccuIdent()
 	case quantifierExistsOne:
-		zeroExpr := eh.NewLiteral(types.Int(0))
-		oneExpr := eh.NewLiteral(types.Int(1))
-		init = zeroExpr
+		init = eh.NewLiteral(types.Int(0))
 		condition = eh.NewLiteral(types.True)
 		step = eh.NewCall(operators.Conditional, args[1],
-			eh.NewCall(operators.Add, eh.NewAccuIdent(), oneExpr), eh.NewAccuIdent())
-		result = eh.NewCall(operators.Equals, eh.NewAccuIdent(), oneExpr)
+			eh.NewCall(operators.Add, eh.NewAccuIdent(), eh.NewLiteral(types.Int(1))), eh.NewAccuIdent())
+		result = eh.NewCall(operators.Equals, eh.NewAccuIdent(), eh.NewLiteral(types.Int(1)))
 	default:
 		return nil, eh.NewError(args[0].ID(), fmt.Sprintf("unrecognized quantifier '%v'", kind))
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -506,25 +506,25 @@ var testCases = []testInfo{
 			// Init
 			0^#5:*expr.Constant_Int64Value#,
 			// LoopCondition
-			true^#7:*expr.Constant_BoolValue#,
+			true^#6:*expr.Constant_BoolValue#,
 			// LoopStep
 			_?_:_(
 				f^#4:*expr.Expr_IdentExpr#,
 				_+_(
-					  __result__^#8:*expr.Expr_IdentExpr#,
-				  1^#6:*expr.Constant_Int64Value#
+					  __result__^#7:*expr.Expr_IdentExpr#,
+				  1^#8:*expr.Constant_Int64Value#
 				)^#9:*expr.Expr_CallExpr#,
 				__result__^#10:*expr.Expr_IdentExpr#
 			)^#11:*expr.Expr_CallExpr#,
 			// Result
 			_==_(
 				__result__^#12:*expr.Expr_IdentExpr#,
-				1^#6:*expr.Constant_Int64Value#
-			)^#13:*expr.Expr_CallExpr#)^#14:*expr.Expr_ComprehensionExpr#`,
+				1^#13:*expr.Constant_Int64Value#
+			)^#14:*expr.Expr_CallExpr#)^#15:*expr.Expr_ComprehensionExpr#`,
 		M: `m^#1:*expr.Expr_IdentExpr#.exists_one(
 			v^#3:*expr.Expr_IdentExpr#,
 			f^#4:*expr.Expr_IdentExpr#
-		  	)^#14:exists_one#`,
+		  	)^#15:exists_one#`,
 	},
 	{
 		I: `m.map(v, f)`,
@@ -1112,7 +1112,7 @@ var testCases = []testInfo{
 		| ..............^
 		ERROR: <input>:1:15: argument is not an identifier
 		| [1, 2, 3].map(var, var * var)
-		| ..............^		
+		| ..............^
 		ERROR: <input>:1:20: reserved identifier: var
 		| [1, 2, 3].map(var, var * var)
 		| ...................^


### PR DESCRIPTION
As it says on the tin. `exists_one` re-uses the same node twice. This is not allowed per the spec where the ID for each individual `Expr` must be unique.