### PR TITLE
Introduce a flag for supporting 'null' as absent on optional field selection

### DIFF
--- a/cel/library.go
+++ b/cel/library.go
@@ -446,6 +446,10 @@ func enableOptionalSyntax() EnvOption {
 	}
 }
 
+func OptionalFieldSelectionNoneIfNull(value bool) EnvOption {
+	return features(featureOptionalFieldSelectionNoneIfNull, value)
+}
+
 func decorateOptionalOr(i interpreter.Interpretable) (interpreter.Interpretable, error) {
 	call, ok := i.(interpreter.InterpretableCall)
 	if !ok {

--- a/cel/options.go
+++ b/cel/options.go
@@ -61,6 +61,9 @@ const (
 	// compressing the logic graph to a single call when multiple like-operator
 	// expressions occur: e.g. a && b && c && d -> call(_&&_, [a, b, c, d])
 	featureVariadicLogicalASTs
+
+	// Enable optional field selection to treat null values as optional.none()
+	featureOptionalFieldSelectionNoneIfNull
 )
 
 // EnvOption is a functional interface for configuring the environment.

--- a/cel/program.go
+++ b/cel/program.go
@@ -187,10 +187,13 @@ func newProgram(e *Env, a *Ast, opts []ProgramOption) (Program, error) {
 
 	// Set the attribute factory after the options have been set.
 	var attrFactory interpreter.AttributeFactory
+	attrFactorOpts := []interpreter.AttrFactoryOption{
+		interpreter.OptionalFieldSelectionNoneIfNull(p.HasFeature(featureOptionalFieldSelectionNoneIfNull)),
+	}
 	if p.evalOpts&OptPartialEval == OptPartialEval {
-		attrFactory = interpreter.NewPartialAttributeFactory(e.Container, e.adapter, e.provider)
+		attrFactory = interpreter.NewPartialAttributeFactory(e.Container, e.adapter, e.provider, attrFactorOpts...)
 	} else {
-		attrFactory = interpreter.NewAttributeFactory(e.Container, e.adapter, e.provider)
+		attrFactory = interpreter.NewAttributeFactory(e.Container, e.adapter, e.provider, attrFactorOpts...)
 	}
 	interp := interpreter.NewInterpreter(disp, e.Container, e.provider, e.adapter, attrFactory)
 	p.interpreter = interp

--- a/interpreter/attribute_patterns.go
+++ b/interpreter/attribute_patterns.go
@@ -178,10 +178,8 @@ func numericValueEquals(value any, celValue ref.Val) bool {
 
 // NewPartialAttributeFactory returns an AttributeFactory implementation capable of performing
 // AttributePattern matches with PartialActivation inputs.
-func NewPartialAttributeFactory(container *containers.Container,
-	adapter types.Adapter,
-	provider types.Provider) AttributeFactory {
-	fac := NewAttributeFactory(container, adapter, provider)
+func NewPartialAttributeFactory(container *containers.Container, adapter types.Adapter, provider types.Provider, opts ...AttrFactoryOption) AttributeFactory {
+	fac := NewAttributeFactory(container, adapter, provider, opts...)
 	return &partialAttributeFactory{
 		AttributeFactory: fac,
 		container:        container,

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -1455,6 +1455,20 @@ func testData(t testing.TB) []testCase {
 			expr: `has(dyn([]).invalid)`,
 			err:  "unsupported index type 'string' in list",
 		},
+
+		{
+			name: "optional_select_on_undefined",
+			expr: `{}.?invalid`,
+
+			out: types.OptionalNone,
+		},
+		{
+			name: "optional_select_on_null_literal",
+			expr: `{"invalid": dyn(null)}.?invalid.?nested`,
+			out:  types.OptionalNone,
+			attrs: NewAttributeFactory(testContainer(""), types.DefaultTypeAdapter, types.NewEmptyRegistry(),
+				OptionalFieldSelectionNoneIfNull(true)),
+		},
 	}
 }
 


### PR DESCRIPTION
Due to a bug in the original implementation of optional values, a field selection
on a `null` value would produce `optional.none()` rather than an error. This
bug was fixed in #922; however, the bug has been relied upon as a feature
within upstream software.

To preserve the legacy behavior, configure the following option:

```
cel.NewEnv(cel.OptionalTypes(), cel.OptionalFieldSelectionNoneIfNull(true)))
```

Closes #937 