### PR TITLE
Update the presence testing fix to be opt-out

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -119,7 +119,7 @@ go_repository(
 # CEL Spec deps
 go_repository(
     name = "com_google_cel_spec",
-    commit = "91f3cb1a7590f594a392b607ae9cab5e969b4cf3",
+    commit = "8958834564cfc6a4764f76238d03cdbe772665bb",
     importpath = "github.com/google/cel-spec",
 )
 

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -2254,6 +2254,34 @@ func TestOptionalValuesEval(t *testing.T) {
 		out  any
 	}{
 		{
+			expr: `{}.?invalid`,
+			out:  types.OptionalNone,
+		},
+		{
+			expr: `{'null_field': dyn(null)}.?null_field`,
+			out:  types.OptionalOf(types.NullValue),
+		},
+		{
+			expr: `{'null_field': dyn(null)}.?null_field.?nested`,
+			out:  types.OptionalNone,
+		},
+		{
+			expr: `{'zero_field': dyn(0)}.?zero_field.?invalid`,
+			out:  types.OptionalNone,
+		},
+		{
+			expr: `{0: dyn(0)}[?0].?invalid`,
+			out:  types.OptionalNone,
+		},
+		{
+			expr: `{true: dyn(0)}[?false].?invalid`,
+			out:  types.OptionalNone,
+		},
+		{
+			expr: `{true: dyn(0)}[?true].?invalid`,
+			out:  types.OptionalNone,
+		},
+		{
 			expr: `x.or(y).orValue(z)`,
 			in: map[string]any{
 				"x": types.OptionalNone,
@@ -2659,10 +2687,10 @@ func TestOptionalValuesEval(t *testing.T) {
 	}
 }
 
-func TestOptionalValuesEvalNoneIfNull(t *testing.T) {
+func TestEnableErrorOnBadPresenceTest(t *testing.T) {
 	env := testEnv(t,
 		OptionalTypes(),
-		OptionalFieldSelectionNoneIfNull(true),
+		EnableErrorOnBadPresenceTest(true),
 	)
 	adapter := env.TypeAdapter()
 	tests := []struct {
@@ -2676,11 +2704,11 @@ func TestOptionalValuesEvalNoneIfNull(t *testing.T) {
 		},
 		{
 			expr: `{'null_field': dyn(null)}.?null_field`,
-			out:  types.OptionalNone,
+			out:  types.OptionalOf(types.NullValue),
 		},
 		{
 			expr: `{'null_field': dyn(null)}.?null_field.?nested`,
-			out:  types.OptionalNone,
+			out:  "no such key: nested",
 		},
 		{
 			expr: `{'zero_field': dyn(0)}.?zero_field.?invalid`,

--- a/cel/library.go
+++ b/cel/library.go
@@ -446,8 +446,8 @@ func enableOptionalSyntax() EnvOption {
 	}
 }
 
-func OptionalFieldSelectionNoneIfNull(value bool) EnvOption {
-	return features(featureOptionalFieldSelectionNoneIfNull, value)
+func EnableErrorOnBadPresenceTest(value bool) EnvOption {
+	return features(featureEnableErrorOnBadPresenceTest, value)
 }
 
 func decorateOptionalOr(i interpreter.Interpretable) (interpreter.Interpretable, error) {

--- a/cel/library.go
+++ b/cel/library.go
@@ -446,6 +446,8 @@ func enableOptionalSyntax() EnvOption {
 	}
 }
 
+// EnableErrorOnBadPresenceTest enables error generation when a presence test or optional field
+// selection is performed on a primitive type.
 func EnableErrorOnBadPresenceTest(value bool) EnvOption {
 	return features(featureEnableErrorOnBadPresenceTest, value)
 }

--- a/cel/options.go
+++ b/cel/options.go
@@ -63,7 +63,7 @@ const (
 	featureVariadicLogicalASTs
 
 	// Enable optional field selection to treat null values as optional.none()
-	featureOptionalFieldSelectionNoneIfNull
+	featureEnableErrorOnBadPresenceTest
 )
 
 // EnvOption is a functional interface for configuring the environment.

--- a/cel/options.go
+++ b/cel/options.go
@@ -62,7 +62,8 @@ const (
 	// expressions occur: e.g. a && b && c && d -> call(_&&_, [a, b, c, d])
 	featureVariadicLogicalASTs
 
-	// Enable optional field selection to treat null values as optional.none()
+	// Enable error generation when a presence test or optional field selection is
+	// performed on a primitive type.
 	featureEnableErrorOnBadPresenceTest
 )
 

--- a/cel/program.go
+++ b/cel/program.go
@@ -188,7 +188,7 @@ func newProgram(e *Env, a *Ast, opts []ProgramOption) (Program, error) {
 	// Set the attribute factory after the options have been set.
 	var attrFactory interpreter.AttributeFactory
 	attrFactorOpts := []interpreter.AttrFactoryOption{
-		interpreter.OptionalFieldSelectionNoneIfNull(p.HasFeature(featureOptionalFieldSelectionNoneIfNull)),
+		interpreter.EnableErrorOnBadPresenceTest(p.HasFeature(featureEnableErrorOnBadPresenceTest)),
 	}
 	if p.evalOpts&OptPartialEval == OptPartialEval {
 		attrFactory = interpreter.NewPartialAttributeFactory(e.Container, e.adapter, e.provider, attrFactorOpts...)

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -129,8 +129,8 @@ type NamespacedAttribute interface {
 // AttrFactoryOption specifies a functional option for configuring an attribute factory.
 type AttrFactoryOption func(*attrFactory) *attrFactory
 
-// EnableErrorOnBadPresenceTest indicates that when a null value is encountered during
-// optional field selection that it is treated as optional.none() rather than as optional.of(null).
+// EnableErrorOnBadPresenceTest error generation when a presence test or optional field selection
+// is performed on a primitive type.
 func EnableErrorOnBadPresenceTest(value bool) AttrFactoryOption {
 	return func(fac *attrFactory) *attrFactory {
 		fac.errorOnBadPresenceTest = value

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -129,11 +129,11 @@ type NamespacedAttribute interface {
 // AttrFactoryOption specifies a functional option for configuring an attribute factory.
 type AttrFactoryOption func(*attrFactory) *attrFactory
 
-// OptionalFieldSelectionNoneIfNull indicates that when a null value is encountered during
+// EnableErrorOnBadPresenceTest indicates that when a null value is encountered during
 // optional field selection that it is treated as optional.none() rather than as optional.of(null).
-func OptionalFieldSelectionNoneIfNull(value bool) AttrFactoryOption {
+func EnableErrorOnBadPresenceTest(value bool) AttrFactoryOption {
 	return func(fac *attrFactory) *attrFactory {
-		fac.optionalFieldSelectionNoneIfNull = value
+		fac.errorOnBadPresenceTest = value
 		return fac
 	}
 }
@@ -158,7 +158,7 @@ type attrFactory struct {
 	adapter   types.Adapter
 	provider  types.Provider
 
-	optionalFieldSelectionNoneIfNull bool
+	errorOnBadPresenceTest bool
 }
 
 // AbsoluteAttribute refers to a variable value and an optional qualifier path.
@@ -167,13 +167,13 @@ type attrFactory struct {
 // resolution rules.
 func (r *attrFactory) AbsoluteAttribute(id int64, names ...string) NamespacedAttribute {
 	return &absoluteAttribute{
-		id:                               id,
-		namespaceNames:                   names,
-		qualifiers:                       []Qualifier{},
-		adapter:                          r.adapter,
-		provider:                         r.provider,
-		fac:                              r,
-		optionalFieldSelectionNoneIfNull: r.optionalFieldSelectionNoneIfNull,
+		id:                     id,
+		namespaceNames:         names,
+		qualifiers:             []Qualifier{},
+		adapter:                r.adapter,
+		provider:               r.provider,
+		fac:                    r,
+		errorOnBadPresenceTest: r.errorOnBadPresenceTest,
 	}
 }
 
@@ -207,12 +207,12 @@ func (r *attrFactory) MaybeAttribute(id int64, name string) Attribute {
 // RelativeAttribute refers to an expression and an optional qualifier path.
 func (r *attrFactory) RelativeAttribute(id int64, operand Interpretable) Attribute {
 	return &relativeAttribute{
-		id:                               id,
-		operand:                          operand,
-		qualifiers:                       []Qualifier{},
-		adapter:                          r.adapter,
-		fac:                              r,
-		optionalFieldSelectionNoneIfNull: r.optionalFieldSelectionNoneIfNull,
+		id:                     id,
+		operand:                operand,
+		qualifiers:             []Qualifier{},
+		adapter:                r.adapter,
+		fac:                    r,
+		errorOnBadPresenceTest: r.errorOnBadPresenceTest,
 	}
 }
 
@@ -234,7 +234,7 @@ func (r *attrFactory) NewQualifier(objType *types.Type, qualID int64, val any, o
 			}, nil
 		}
 	}
-	return newQualifier(r.adapter, qualID, val, opt)
+	return newQualifier(r.adapter, qualID, val, opt, r.errorOnBadPresenceTest)
 }
 
 type absoluteAttribute struct {
@@ -247,7 +247,7 @@ type absoluteAttribute struct {
 	provider       types.Provider
 	fac            AttributeFactory
 
-	optionalFieldSelectionNoneIfNull bool
+	errorOnBadPresenceTest bool
 }
 
 // ID implements the Attribute interface method.
@@ -312,7 +312,7 @@ func (a *absoluteAttribute) Resolve(vars Activation) (any, error) {
 			if celErr, ok := obj.(*types.Err); ok {
 				return nil, celErr.Unwrap()
 			}
-			obj, isOpt, err := applyQualifiers(vars, obj, a.qualifiers, a.optionalFieldSelectionNoneIfNull)
+			obj, isOpt, err := applyQualifiers(vars, obj, a.qualifiers)
 			if err != nil {
 				return nil, err
 			}
@@ -537,7 +537,7 @@ type relativeAttribute struct {
 	adapter    types.Adapter
 	fac        AttributeFactory
 
-	optionalFieldSelectionNoneIfNull bool
+	errorOnBadPresenceTest bool
 }
 
 // ID is an implementation of the Attribute interface method.
@@ -582,7 +582,7 @@ func (a *relativeAttribute) Resolve(vars Activation) (any, error) {
 	if types.IsUnknown(v) {
 		return v, nil
 	}
-	obj, isOpt, err := applyQualifiers(vars, v, a.qualifiers, a.optionalFieldSelectionNoneIfNull)
+	obj, isOpt, err := applyQualifiers(vars, v, a.qualifiers)
 	if err != nil {
 		return nil, err
 	}
@@ -601,7 +601,7 @@ func (a *relativeAttribute) String() string {
 	return fmt.Sprintf("id: %v, operand: %v", a.id, a.operand)
 }
 
-func newQualifier(adapter types.Adapter, id int64, v any, opt bool) (Qualifier, error) {
+func newQualifier(adapter types.Adapter, id int64, v any, opt, errorOnBadPresenceTest bool) (Qualifier, error) {
 	var qual Qualifier
 	switch val := v.(type) {
 	case Attribute:
@@ -616,71 +616,138 @@ func newQualifier(adapter types.Adapter, id int64, v any, opt bool) (Qualifier, 
 		}, nil
 	case string:
 		qual = &stringQualifier{
-			id:       id,
-			value:    val,
-			celValue: types.String(val),
-			adapter:  adapter,
-			optional: opt,
+			id:                     id,
+			value:                  val,
+			celValue:               types.String(val),
+			adapter:                adapter,
+			optional:               opt,
+			errorOnBadPresenceTest: errorOnBadPresenceTest,
 		}
 	case int:
 		qual = &intQualifier{
-			id: id, value: int64(val), celValue: types.Int(val), adapter: adapter, optional: opt,
+			id:                     id,
+			value:                  int64(val),
+			celValue:               types.Int(val),
+			adapter:                adapter,
+			optional:               opt,
+			errorOnBadPresenceTest: errorOnBadPresenceTest,
 		}
 	case int32:
 		qual = &intQualifier{
-			id: id, value: int64(val), celValue: types.Int(val), adapter: adapter, optional: opt,
+			id:                     id,
+			value:                  int64(val),
+			celValue:               types.Int(val),
+			adapter:                adapter,
+			optional:               opt,
+			errorOnBadPresenceTest: errorOnBadPresenceTest,
 		}
 	case int64:
 		qual = &intQualifier{
-			id: id, value: val, celValue: types.Int(val), adapter: adapter, optional: opt,
+			id:                     id,
+			value:                  val,
+			celValue:               types.Int(val),
+			adapter:                adapter,
+			optional:               opt,
+			errorOnBadPresenceTest: errorOnBadPresenceTest,
 		}
 	case uint:
 		qual = &uintQualifier{
-			id: id, value: uint64(val), celValue: types.Uint(val), adapter: adapter, optional: opt,
+			id:                     id,
+			value:                  uint64(val),
+			celValue:               types.Uint(val),
+			adapter:                adapter,
+			optional:               opt,
+			errorOnBadPresenceTest: errorOnBadPresenceTest,
 		}
 	case uint32:
 		qual = &uintQualifier{
-			id: id, value: uint64(val), celValue: types.Uint(val), adapter: adapter, optional: opt,
+			id:                     id,
+			value:                  uint64(val),
+			celValue:               types.Uint(val),
+			adapter:                adapter,
+			optional:               opt,
+			errorOnBadPresenceTest: errorOnBadPresenceTest,
 		}
 	case uint64:
 		qual = &uintQualifier{
-			id: id, value: val, celValue: types.Uint(val), adapter: adapter, optional: opt,
+			id:                     id,
+			value:                  val,
+			celValue:               types.Uint(val),
+			adapter:                adapter,
+			optional:               opt,
+			errorOnBadPresenceTest: errorOnBadPresenceTest,
 		}
 	case bool:
 		qual = &boolQualifier{
-			id: id, value: val, celValue: types.Bool(val), adapter: adapter, optional: opt,
+			id:                     id,
+			value:                  val,
+			celValue:               types.Bool(val),
+			adapter:                adapter,
+			optional:               opt,
+			errorOnBadPresenceTest: errorOnBadPresenceTest,
 		}
 	case float32:
 		qual = &doubleQualifier{
-			id:       id,
-			value:    float64(val),
-			celValue: types.Double(val),
-			adapter:  adapter,
-			optional: opt,
+			id:                     id,
+			value:                  float64(val),
+			celValue:               types.Double(val),
+			adapter:                adapter,
+			optional:               opt,
+			errorOnBadPresenceTest: errorOnBadPresenceTest,
 		}
 	case float64:
 		qual = &doubleQualifier{
-			id: id, value: val, celValue: types.Double(val), adapter: adapter, optional: opt,
+			id:                     id,
+			value:                  val,
+			celValue:               types.Double(val),
+			adapter:                adapter,
+			optional:               opt,
+			errorOnBadPresenceTest: errorOnBadPresenceTest,
 		}
 	case types.String:
 		qual = &stringQualifier{
-			id: id, value: string(val), celValue: val, adapter: adapter, optional: opt,
+			id:                     id,
+			value:                  string(val),
+			celValue:               val,
+			adapter:                adapter,
+			optional:               opt,
+			errorOnBadPresenceTest: errorOnBadPresenceTest,
 		}
 	case types.Int:
 		qual = &intQualifier{
-			id: id, value: int64(val), celValue: val, adapter: adapter, optional: opt,
+			id:                     id,
+			value:                  int64(val),
+			celValue:               val,
+			adapter:                adapter,
+			optional:               opt,
+			errorOnBadPresenceTest: errorOnBadPresenceTest,
 		}
 	case types.Uint:
 		qual = &uintQualifier{
-			id: id, value: uint64(val), celValue: val, adapter: adapter, optional: opt,
+			id:                     id,
+			value:                  uint64(val),
+			celValue:               val,
+			adapter:                adapter,
+			optional:               opt,
+			errorOnBadPresenceTest: errorOnBadPresenceTest,
 		}
 	case types.Bool:
 		qual = &boolQualifier{
-			id: id, value: bool(val), celValue: val, adapter: adapter, optional: opt,
+			id:                     id,
+			value:                  bool(val),
+			celValue:               val,
+			adapter:                adapter,
+			optional:               opt,
+			errorOnBadPresenceTest: errorOnBadPresenceTest,
 		}
 	case types.Double:
 		qual = &doubleQualifier{
-			id: id, value: float64(val), celValue: val, adapter: adapter, optional: opt,
+			id:                     id,
+			value:                  float64(val),
+			celValue:               val,
+			adapter:                adapter,
+			optional:               opt,
+			errorOnBadPresenceTest: errorOnBadPresenceTest,
 		}
 	case *types.Unknown:
 		qual = &unknownQualifier{id: id, value: val}
@@ -711,11 +778,12 @@ func (q *attrQualifier) IsOptional() bool {
 }
 
 type stringQualifier struct {
-	id       int64
-	value    string
-	celValue ref.Val
-	adapter  types.Adapter
-	optional bool
+	id                     int64
+	value                  string
+	celValue               ref.Val
+	adapter                types.Adapter
+	optional               bool
+	errorOnBadPresenceTest bool
 }
 
 // ID is an implementation of the Qualifier interface method.
@@ -798,7 +866,7 @@ func (q *stringQualifier) qualifyInternal(vars Activation, obj any, presenceTest
 			return obj, true, nil
 		}
 	default:
-		return refQualify(q.adapter, obj, q.celValue, presenceTest, presenceOnly)
+		return refQualify(q.adapter, obj, q.celValue, presenceTest, presenceOnly, q.errorOnBadPresenceTest)
 	}
 	if presenceTest {
 		return nil, false, nil
@@ -812,11 +880,12 @@ func (q *stringQualifier) Value() ref.Val {
 }
 
 type intQualifier struct {
-	id       int64
-	value    int64
-	celValue ref.Val
-	adapter  types.Adapter
-	optional bool
+	id                     int64
+	value                  int64
+	celValue               ref.Val
+	adapter                types.Adapter
+	optional               bool
+	errorOnBadPresenceTest bool
 }
 
 // ID is an implementation of the Qualifier interface method.
@@ -922,7 +991,7 @@ func (q *intQualifier) qualifyInternal(vars Activation, obj any, presenceTest, p
 			return o[i], true, nil
 		}
 	default:
-		return refQualify(q.adapter, obj, q.celValue, presenceTest, presenceOnly)
+		return refQualify(q.adapter, obj, q.celValue, presenceTest, presenceOnly, q.errorOnBadPresenceTest)
 	}
 	if presenceTest {
 		return nil, false, nil
@@ -939,11 +1008,12 @@ func (q *intQualifier) Value() ref.Val {
 }
 
 type uintQualifier struct {
-	id       int64
-	value    uint64
-	celValue ref.Val
-	adapter  types.Adapter
-	optional bool
+	id                     int64
+	value                  uint64
+	celValue               ref.Val
+	adapter                types.Adapter
+	optional               bool
+	errorOnBadPresenceTest bool
 }
 
 // ID is an implementation of the Qualifier interface method.
@@ -990,7 +1060,7 @@ func (q *uintQualifier) qualifyInternal(vars Activation, obj any, presenceTest, 
 			return obj, true, nil
 		}
 	default:
-		return refQualify(q.adapter, obj, q.celValue, presenceTest, presenceOnly)
+		return refQualify(q.adapter, obj, q.celValue, presenceTest, presenceOnly, q.errorOnBadPresenceTest)
 	}
 	if presenceTest {
 		return nil, false, nil
@@ -1004,11 +1074,12 @@ func (q *uintQualifier) Value() ref.Val {
 }
 
 type boolQualifier struct {
-	id       int64
-	value    bool
-	celValue ref.Val
-	adapter  types.Adapter
-	optional bool
+	id                     int64
+	value                  bool
+	celValue               ref.Val
+	adapter                types.Adapter
+	optional               bool
+	errorOnBadPresenceTest bool
 }
 
 // ID is an implementation of the Qualifier interface method.
@@ -1041,7 +1112,7 @@ func (q *boolQualifier) qualifyInternal(vars Activation, obj any, presenceTest, 
 			return obj, true, nil
 		}
 	default:
-		return refQualify(q.adapter, obj, q.celValue, presenceTest, presenceOnly)
+		return refQualify(q.adapter, obj, q.celValue, presenceTest, presenceOnly, q.errorOnBadPresenceTest)
 	}
 	if presenceTest {
 		return nil, false, nil
@@ -1116,11 +1187,12 @@ func (q *fieldQualifier) Value() ref.Val {
 // type may not be known ahead of time and may not conform to the standard types supported as valid
 // protobuf map key types.
 type doubleQualifier struct {
-	id       int64
-	value    float64
-	celValue ref.Val
-	adapter  types.Adapter
-	optional bool
+	id                     int64
+	value                  float64
+	celValue               ref.Val
+	adapter                types.Adapter
+	optional               bool
+	errorOnBadPresenceTest bool
 }
 
 // ID is an implementation of the Qualifier interface method.
@@ -1144,7 +1216,7 @@ func (q *doubleQualifier) QualifyIfPresent(vars Activation, obj any, presenceOnl
 }
 
 func (q *doubleQualifier) qualifyInternal(vars Activation, obj any, presenceTest, presenceOnly bool) (any, bool, error) {
-	return refQualify(q.adapter, obj, q.celValue, presenceTest, presenceOnly)
+	return refQualify(q.adapter, obj, q.celValue, presenceTest, presenceOnly, q.errorOnBadPresenceTest)
 }
 
 // Value implements the ConstantQualifier interface
@@ -1184,7 +1256,7 @@ func (q *unknownQualifier) Value() ref.Val {
 	return q.value
 }
 
-func applyQualifiers(vars Activation, obj any, qualifiers []Qualifier, noneIfNull bool) (any, bool, error) {
+func applyQualifiers(vars Activation, obj any, qualifiers []Qualifier) (any, bool, error) {
 	optObj, isOpt := obj.(*types.Optional)
 	if isOpt {
 		if !optObj.HasValue() {
@@ -1207,9 +1279,6 @@ func applyQualifiers(vars Activation, obj any, qualifiers []Qualifier, noneIfNul
 				// We return optional none here with a presence of 'false' as the layers
 				// above will attempt to call types.OptionalOf() on a present value if any
 				// of the qualifiers is optional.
-				return types.OptionalNone, false, nil
-			}
-			if noneIfNull && qualObj == types.NullValue {
 				return types.OptionalNone, false, nil
 			}
 		} else {
@@ -1253,7 +1322,7 @@ func attrQualifyIfPresent(fac AttributeFactory, vars Activation, obj any, qualAt
 
 // refQualify attempts to convert the value to a CEL value and then uses reflection methods to try and
 // apply the qualifier with the option to presence test field accesses before retrieving field values.
-func refQualify(adapter types.Adapter, obj any, idx ref.Val, presenceTest, presenceOnly bool) (ref.Val, bool, error) {
+func refQualify(adapter types.Adapter, obj any, idx ref.Val, presenceTest, presenceOnly, errorOnBadPresenceTest bool) (ref.Val, bool, error) {
 	celVal := adapter.NativeToValue(obj)
 	switch v := celVal.(type) {
 	case *types.Unknown:
@@ -1310,6 +1379,9 @@ func refQualify(adapter types.Adapter, obj any, idx ref.Val, presenceTest, prese
 		}
 		return val, true, nil
 	default:
+		if presenceTest && !errorOnBadPresenceTest {
+			return nil, false, nil
+		}
 		return nil, false, missingKey(idx)
 	}
 }

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -1449,25 +1449,26 @@ func testData(t testing.TB) []testCase {
 			name: "invalid_presence_test_on_int_literal",
 			expr: `has(dyn(1).invalid)`,
 			err:  "no such key: invalid",
+			attrs: NewAttributeFactory(testContainer(""), types.DefaultTypeAdapter, types.NewEmptyRegistry(),
+				EnableErrorOnBadPresenceTest(true)),
 		},
 		{
 			name: "invalid_presence_test_on_list_literal",
 			expr: `has(dyn([]).invalid)`,
 			err:  "unsupported index type 'string' in list",
+			attrs: NewAttributeFactory(testContainer(""), types.DefaultTypeAdapter, types.NewEmptyRegistry(),
+				EnableErrorOnBadPresenceTest(true)),
 		},
 
 		{
 			name: "optional_select_on_undefined",
 			expr: `{}.?invalid`,
-
-			out: types.OptionalNone,
+			out:  types.OptionalNone,
 		},
 		{
 			name: "optional_select_on_null_literal",
 			expr: `{"invalid": dyn(null)}.?invalid.?nested`,
 			out:  types.OptionalNone,
-			attrs: NewAttributeFactory(testContainer(""), types.DefaultTypeAdapter, types.NewEmptyRegistry(),
-				OptionalFieldSelectionNoneIfNull(true)),
 		},
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -270,5 +270,6 @@ func init() {
 		ext.Encoders(),
 		cel.Types(&test2pb.TestAllTypes{}, &test3pb.TestAllTypes{}),
 		cel.EagerlyValidateDeclarations(true),
+		cel.EnableErrorOnBadPresenceTest(true),
 		cel.OptionalTypes())
 }


### PR DESCRIPTION
In conversation with @mtaufen regarding issue #937, it seems the safer fix
is to revert to the old behavior unless the error behavior has been opted-out
of by the CEL integrator.

This is in line with CEL team's policy to ensure that all non-error -> error fixes
be flag guarded.