### PR TITLE
Allow custom field name resolving for native types

### DIFF
--- a/ext/native.go
+++ b/ext/native.go
@@ -188,16 +188,17 @@ func (tp *nativeTypeProvider) FindStructFieldType(typeName, fieldName string) (*
 	if !ok {
 		return nil, false
 	}
+	refFieldName := refField.Name
 	return &types.FieldType{
 		Type: celType,
 		IsSet: func(obj any) bool {
 			refVal := reflect.Indirect(reflect.ValueOf(obj))
-			refField := refVal.FieldByName(fieldName)
+			refField := refVal.FieldByName(refFieldName)
 			return !refField.IsZero()
 		},
 		GetFrom: func(obj any) (any, error) {
 			refVal := reflect.Indirect(reflect.ValueOf(obj))
-			refField := refVal.FieldByName(fieldName)
+			refField := refVal.FieldByName(refFieldName)
 			return getFieldValue(tp, refField), nil
 		},
 	}, true


### PR DESCRIPTION
My use-case:
```go
type CustomNativeType struct {
	reflect.Type
}

func (t *CustomNativeType) FieldByName(name string) (reflect.StructField, bool) {
	name = strcase.ToPascal(name)
	return t.Type.FieldByName(name)
}

type Foo struct {
	MyField string
}

func main() {
	fooType := &CustomNativeType{Type: reflect.TypeOf(Foo{})}

	env, err := cel.NewEnv(
		ext.NativeTypes(fooType),
		cel.Variable("foo", cel.ObjectType("package.Foo")),
	)
	if err != nil {
		panic(err)
	}

	// Evaluate "foo.my_field"
}
```