### PR TITLE
Custom Tag Handler support for CEL Policy Compilation

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -138,6 +138,15 @@ go_repository(
     importpath = "github.com/chzyer/readline",
 )
 
+# gopkg.in/yaml.v3 for policy module
+go_repository(
+    name = "in_gopkg_yaml_v3",
+    build_file_proto_mode = "disable_global",
+    importpath = "gopkg.in/yaml.v3",
+    sum = "h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=",
+    version = "v3.0.1",
+)
+
 # golang.org/x/exp deps
 go_repository(
     name = "org_golang_x_exp",

--- a/common/ast/ast.go
+++ b/common/ast/ast.go
@@ -343,12 +343,11 @@ func (s *SourceInfo) GetLocationByOffset(offset int32) common.Location {
 	line := 1
 	col := int(offset)
 	for _, lineOffset := range s.LineOffsets() {
-		if lineOffset <= offset {
-			line++
-			col = int(offset - lineOffset)
-		} else {
+		if lineOffset > offset {
 			break
 		}
+		line++
+		col = int(offset - lineOffset)
 	}
 	return common.NewLocation(line, col)
 }

--- a/common/ast/ast.go
+++ b/common/ast/ast.go
@@ -321,17 +321,7 @@ func (s *SourceInfo) ClearOffsetRange(id int64) {
 // of the expression node at the id.
 func (s *SourceInfo) GetStartLocation(id int64) common.Location {
 	if o, found := s.GetOffsetRange(id); found {
-		line := 1
-		col := int(o.Start)
-		for _, lineOffset := range s.LineOffsets() {
-			if lineOffset < o.Start {
-				line++
-				col = int(o.Start - lineOffset)
-			} else {
-				break
-			}
-		}
-		return common.NewLocation(line, col)
+		return s.GetLocationByOffset(o.Start)
 	}
 	return common.NoLocation
 }
@@ -343,19 +333,24 @@ func (s *SourceInfo) GetStartLocation(id int64) common.Location {
 // be identical to the start location for the expression.
 func (s *SourceInfo) GetStopLocation(id int64) common.Location {
 	if o, found := s.GetOffsetRange(id); found {
-		line := 1
-		col := int(o.Stop)
-		for _, lineOffset := range s.LineOffsets() {
-			if lineOffset < o.Stop {
-				line++
-				col = int(o.Stop - lineOffset)
-			} else {
-				break
-			}
-		}
-		return common.NewLocation(line, col)
+		return s.GetLocationByOffset(o.Stop)
 	}
 	return common.NoLocation
+}
+
+// GetLocationByOffset returns the line and column information for a given character offset.
+func (s *SourceInfo) GetLocationByOffset(offset int32) common.Location {
+	line := 1
+	col := int(offset)
+	for _, lineOffset := range s.LineOffsets() {
+		if lineOffset <= offset {
+			line++
+			col = int(offset - lineOffset)
+		} else {
+			break
+		}
+	}
+	return common.NewLocation(line, col)
 }
 
 // ComputeOffset calculates the 0-based character offset from a 1-based line and 0-based column.

--- a/common/source.go
+++ b/common/source.go
@@ -163,9 +163,8 @@ func (s *sourceImpl) findLine(characterOffset int32) (int32, int32) {
 	for _, lineOffset := range s.lineOffsets {
 		if lineOffset > characterOffset {
 			break
-		} else {
-			line++
 		}
+		line++
 	}
 	if line == 1 {
 		return line, 0

--- a/parser/helper.go
+++ b/parser/helper.go
@@ -172,6 +172,10 @@ func (p *parserHelper) getLocation(id int64) common.Location {
 	return p.sourceInfo.GetStartLocation(id)
 }
 
+func (p *parserHelper) getLocationByOffset(offset int32) common.Location {
+	return p.getSourceInfo().GetLocationByOffset(offset)
+}
+
 // buildMacroCallArg iterates the expression and returns a new expression
 // where all macros have been replaced by their IDs in MacroCalls
 func (p *parserHelper) buildMacroCallArg(expr ast.Expr) ast.Expr {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -856,7 +856,8 @@ func (p *parser) reportError(ctx any, format string, args ...any) ast.Expr {
 
 // ANTLR Parse listener implementations
 func (p *parser) SyntaxError(recognizer antlr.Recognizer, offendingSymbol any, line, column int, msg string, e antlr.RecognitionException) {
-	l := p.helper.source.NewLocation(line, column)
+	offset := p.helper.sourceInfo.ComputeOffset(int32(line), int32(column))
+	l := p.helper.getLocationByOffset(offset)
 	// Hack to keep existing error messages consistent with previous versions of CEL when a reserved word
 	// is used as an identifier. This behavior needs to be overhauled to provide consistent, normalized error
 	// messages out of ANTLR to prevent future breaking changes related to error message content.

--- a/policy/BUILD.bazel
+++ b/policy/BUILD.bazel
@@ -1,0 +1,61 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(
+    default_visibility = ["//policy:__subpackages__"],
+    licenses = ["notice"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "compiler.go",
+        "conformance.go",
+        "config.go",
+        "parser.go",
+        "source.go",
+    ],
+    importpath = "github.com/google/cel-go/policy",
+    deps = [
+        "//cel:go_default_library",
+        "//common:go_default_library",
+        "//common/ast:go_default_library",
+        "//common/operators:go_default_library",
+        "//common/types:go_default_library",
+        "//ext:go_default_library",
+        "@in_gopkg_yaml_v3//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = [
+        "compiler_test.go",
+        "config_test.go",
+        "parser_test.go",
+        "test.go",
+    ],
+    data = glob(["testdata/**"]),
+    embed = [":go_default_library"],
+    deps = [
+        "//cel:go_default_library",
+        "//common/types:go_default_library",
+        "//common/types/ref:go_default_library",
+        "//test/proto3pb:go_default_library",
+        "@in_gopkg_yaml_v3//:go_default_library",
+    ],
+)

--- a/policy/config_test.go
+++ b/policy/config_test.go
@@ -20,8 +20,9 @@ import (
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/ext"
-	"google.golang.org/genproto/googleapis/rpc/context/attribute_context"
 	"gopkg.in/yaml.v3"
+
+	acpb "google.golang.org/genproto/googleapis/rpc/context/attribute_context"
 )
 
 func TestConfig(t *testing.T) {
@@ -95,7 +96,7 @@ variables:
 	}
 	baseEnv, err := cel.NewEnv(
 		cel.OptionalTypes(),
-		cel.Types(&attribute_context.AttributeContext_Request{}),
+		cel.Types(&acpb.AttributeContext_Request{}),
 	)
 	if err != nil {
 		t.Fatalf("cel.NewEnv() failed: %v", err)
@@ -204,7 +205,7 @@ functions:
 	}
 	baseEnv, err := cel.NewEnv(
 		cel.OptionalTypes(),
-		cel.Types(&attribute_context.AttributeContext_Request{}),
+		cel.Types(&acpb.AttributeContext_Request{}),
 	)
 	if err != nil {
 		t.Fatalf("cel.NewEnv() failed: %v", err)

--- a/policy/config_test.go
+++ b/policy/config_test.go
@@ -20,9 +20,10 @@ import (
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/ext"
+
 	"gopkg.in/yaml.v3"
 
-	acpb "google.golang.org/genproto/googleapis/rpc/context/attribute_context"
+	proto3pb "github.com/google/cel-go/test/proto3pb"
 )
 
 func TestConfig(t *testing.T) {
@@ -91,12 +92,12 @@ variables:
 variables:
 - name: "request"
   type:
-    type_name: "google.rpc.context.AttributeContext.Request"
+    type_name: "google.expr.proto3.test.TestAllTypes"
 `,
 	}
 	baseEnv, err := cel.NewEnv(
 		cel.OptionalTypes(),
-		cel.Types(&acpb.AttributeContext_Request{}),
+		cel.Types(&proto3pb.TestAllTypes{}),
 	)
 	if err != nil {
 		t.Fatalf("cel.NewEnv() failed: %v", err)
@@ -203,10 +204,7 @@ functions:
 			err: "undefined type name: unknown",
 		},
 	}
-	baseEnv, err := cel.NewEnv(
-		cel.OptionalTypes(),
-		cel.Types(&acpb.AttributeContext_Request{}),
-	)
+	baseEnv, err := cel.NewEnv(cel.OptionalTypes())
 	if err != nil {
 		t.Fatalf("cel.NewEnv() failed: %v", err)
 	}

--- a/policy/conformance.go
+++ b/policy/conformance.go
@@ -1,0 +1,37 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+// TestSuite describes a set of tests divided by section.
+type TestSuite struct {
+	Description string         `yaml:"description"`
+	Sections    []*TestSection `yaml:"section"`
+}
+
+// TestSection describes a related set of tests associated with a behavior.
+type TestSection struct {
+	Name  string      `yaml:"name"`
+	Tests []*TestCase `yaml:"tests"`
+}
+
+// TestCase describes a named test scenario with a set of inputs and expected outputs.
+//
+// Note, when a test requires additional functions to be provided to execute, the test harness
+// must supply these functions.
+type TestCase struct {
+	Name   string         `yaml:"name"`
+	Input  map[string]any `yaml:"input"`
+	Output string         `yaml:"output"`
+}

--- a/policy/parser.go
+++ b/policy/parser.go
@@ -79,6 +79,15 @@ func (p *Policy) Metadata(name string) (any, bool) {
 	return value, found
 }
 
+// MetadataKeys returns a list of metadata keys set on the policy.
+func (p *Policy) MetadataKeys() []string {
+	keys := make([]string, 0, len(p.metadata))
+	for k := range p.metadata {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 // SetName configures the policy name.
 func (p *Policy) SetName(name ValueString) {
 	p.name = name
@@ -309,6 +318,10 @@ type TagVisitor interface {
 	// VariableTag accepts a parser context, field id, tag name, yaml node, as well as the parent policy and
 	// current variable to allow for continued parsing within custom tags.
 	VariableTag(ParserContext, int64, string, *yaml.Node, *Policy, *Variable)
+}
+
+func DefaultTagVisitor() TagVisitor {
+	return defaultTagVisitor{}
 }
 
 type defaultTagVisitor struct{}

--- a/policy/parser.go
+++ b/policy/parser.go
@@ -419,35 +419,42 @@ type parserImpl struct {
 	iss     *cel.Issues
 }
 
+// NextID returns a monotonically increasing identifier for a source fragment.
+// This ID is implicitly created and tracked within the CollectMetadata method.
 func (p *parserImpl) NextID() int64 {
 	p.id++
 	return p.id
 }
 
+// NewPolicy creates a new Policy instance with an ID associated with the YAML node.
 func (p *parserImpl) NewPolicy(node *yaml.Node) (*Policy, int64) {
 	policy := NewPolicy(p.src, p.info)
 	id := p.CollectMetadata(node)
 	return policy, id
 }
 
+// NewRule creates a new Rule instance with an ID associated with the YAML node.
 func (p *parserImpl) NewRule(node *yaml.Node) (*Rule, int64) {
 	r := NewRule()
 	id := p.CollectMetadata(node)
 	return r, id
 }
 
+// NewVariable creates a new Variable instance with an ID associated with the YAML node.
 func (p *parserImpl) NewVariable(node *yaml.Node) (*Variable, int64) {
 	v := NewVariable()
 	id := p.CollectMetadata(node)
 	return v, id
 }
 
+// NewMatch creates a new Match instance with an ID associated with the YAML node.
 func (p *parserImpl) NewMatch(node *yaml.Node) (*Match, int64) {
 	m := NewMatch()
 	id := p.CollectMetadata(node)
 	return m, id
 }
 
+// NewString creates a new ValueString from the YAML node.
 func (p *parserImpl) NewString(node *yaml.Node) ValueString {
 	id := p.CollectMetadata(node)
 	nodeType := p.assertYamlType(id, node, yamlString, yamlText)
@@ -482,6 +489,8 @@ func (p *parserImpl) NewString(node *yaml.Node) ValueString {
 	return ValueString{ID: id, Value: node.Value}
 }
 
+// CollectMetadata records the source position information of a given YAML node, and returns
+// the id associated with the source metadata which is returned in the Policy SourceInfo object.
 func (p *parserImpl) CollectMetadata(node *yaml.Node) int64 {
 	id := p.NextID()
 	line := node.Line
@@ -498,6 +507,7 @@ func (p *parserImpl) CollectMetadata(node *yaml.Node) int64 {
 	return id
 }
 
+// ParsePolicy will parse the target yaml node as though it is the top-level policy.
 func (p *parserImpl) ParsePolicy(ctx ParserContext, node *yaml.Node) *Policy {
 	ctx.CollectMetadata(node)
 	policy, id := ctx.NewPolicy(node)
@@ -521,6 +531,7 @@ func (p *parserImpl) ParsePolicy(ctx ParserContext, node *yaml.Node) *Policy {
 	return policy
 }
 
+// ParseRule will parse the current yaml node as though it is the entry point to a rule.
 func (p *parserImpl) ParseRule(ctx ParserContext, policy *Policy, node *yaml.Node) *Rule {
 	r, id := ctx.NewRule(node)
 	if p.assertYamlType(id, node, yamlMap) == nil || !p.checkMapValid(ctx, id, node) {
@@ -561,6 +572,7 @@ func (p *parserImpl) parseVariables(ctx ParserContext, policy *Policy, r *Rule, 
 	}
 }
 
+// ParseVariable will parse the current yaml node as though it is the entry point to a variable.
 func (p *parserImpl) ParseVariable(ctx ParserContext, policy *Policy, node *yaml.Node) *Variable {
 	v, id := ctx.NewVariable(node)
 	if p.assertYamlType(id, node, yamlMap) == nil || !p.checkMapValid(ctx, id, node) {
@@ -597,6 +609,7 @@ func (p *parserImpl) parseMatches(ctx ParserContext, policy *Policy, r *Rule, no
 	}
 }
 
+// ParseMatch  will parse the current yaml node as though it is the entry point to a match.
 func (p *parserImpl) ParseMatch(ctx ParserContext, policy *Policy, node *yaml.Node) *Match {
 	m, id := ctx.NewMatch(node)
 	if p.assertYamlType(id, node, yamlMap) == nil || !p.checkMapValid(ctx, id, node) {
@@ -647,6 +660,8 @@ func (p *parserImpl) assertYamlType(id int64, node *yaml.Node, nodeTypes ...yaml
 	return nil
 }
 
+// ReportErrorAtID logs an error during parsing which is included in the issue set returned from
+// a failed parse.
 func (p *parserImpl) ReportErrorAtID(id int64, format string, args ...any) {
 	p.iss.ReportErrorAtID(id, format, args...)
 }

--- a/policy/parser_test.go
+++ b/policy/parser_test.go
@@ -20,12 +20,12 @@ import (
 )
 
 func TestParse(t *testing.T) {
-	parser, err := NewParser()
-	if err != nil {
-		t.Fatalf("NewParser() failed: %v", err)
-	}
 	for _, tst := range policyTests {
 		srcFile := readPolicy(t, fmt.Sprintf("testdata/%s/policy.yaml", tst.name))
+		parser, err := NewParser(tst.parseOpts...)
+		if err != nil {
+			t.Fatalf("NewParser() failed: %v", err)
+		}
 		p, iss := parser.Parse(srcFile)
 		if iss.Err() != nil {
 			t.Fatalf("parse() failed: %v", iss.Err())

--- a/policy/parser_test.go
+++ b/policy/parser_test.go
@@ -28,10 +28,10 @@ func TestParse(t *testing.T) {
 		}
 		p, iss := parser.Parse(srcFile)
 		if iss.Err() != nil {
-			t.Fatalf("parse() failed: %v", iss.Err())
+			t.Fatalf("parser.Parse() failed: %v", iss.Err())
 		}
 		if p.Name().Value != tst.name {
-			t.Errorf("policy name is %v, wanted 'required_labels'", p.name)
+			t.Errorf("policy name is %v, wanted %q", p.name, tst.name)
 		}
 	}
 }

--- a/policy/parser_test.go
+++ b/policy/parser_test.go
@@ -62,8 +62,8 @@ rule:
 inputs:
   - name: a
   - name: b`,
-			err: `ERROR: <input>:1:2: unsupported policy tag: inputs
- | 
+			err: `ERROR: <input>:2:1: unsupported policy tag: inputs
+ | inputs:
  | ^`,
 		},
 		{
@@ -93,8 +93,8 @@ ERROR: <input>:5:7: unsupported match tag: alt_name
 			txt: `
 - rule:
     id: a`,
-			err: `ERROR: <input>:1:2: got yaml node type tag:yaml.org,2002:seq, wanted type(s) [tag:yaml.org,2002:map]
- | 
+			err: `ERROR: <input>:2:1: got yaml node type tag:yaml.org,2002:seq, wanted type(s) [tag:yaml.org,2002:map]
+ | - rule:
  | ^`,
 		},
 		{

--- a/policy/test.go
+++ b/policy/test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
-	"github.com/google/cel-go/ext"
 
 	"gopkg.in/yaml.v3"
 )
@@ -40,9 +39,6 @@ var (
 				p.TagVisitor = k8sTagHandler()
 				return p, nil
 			}},
-			envOpts: []cel.EnvOption{
-				ext.Strings(),
-			},
 			expr: `
     cel.bind(variables.env, resource.labels.?environment.orValue("prod"),
 	  cel.bind(variables.break_glass, resource.labels.?break_glass.orValue("false") == "true",
@@ -107,6 +103,33 @@ var (
 							}
 						}))),
 			}},
+	}
+
+	policyErrorTests = []struct {
+		name string
+		err  string
+	}{
+		{
+			name: "errors",
+			err: `ERROR: testdata/errors/policy.yaml:19:19: undeclared reference to 'spec' (in container '')
+ |       expression: spec.labels
+ | ..................^
+ERROR: testdata/errors/policy.yaml:21:50: Syntax error: mismatched input 'resource' expecting ')'
+ |       expression: variables.want.filter(l, !(lin resource.labels))
+ | .................................................^
+ERROR: testdata/errors/policy.yaml:21:66: Syntax error: extraneous input ')' expecting <EOF>
+ |       expression: variables.want.filter(l, !(lin resource.labels))
+ | .................................................................^
+ERROR: testdata/errors/policy.yaml:23:27: Syntax error: mismatched input '2' expecting {'}', ','}
+ |       expression: "{1:305 2:569}"
+ | ..........................^
+ERROR: testdata/errors/policy.yaml:31:75: Syntax error: extraneous input ']' expecting ')'
+ |         "missing one or more required labels: %s".format(variables.missing])
+ | ..........................................................................^
+ERROR: testdata/errors/policy.yaml:34:67: undeclared reference to 'format' (in container '')
+ |         "invalid values provided on one or more labels: %s".format([variables.invalid])
+ | ..................................................................^`,
+		},
 	}
 )
 

--- a/policy/test.go
+++ b/policy/test.go
@@ -37,7 +37,7 @@ var (
 		{
 			name: "k8s",
 			parseOpts: []ParserOption{func(p *Parser) (*Parser, error) {
-				p.TagVisitor = k8sAdmissionTagHandler{}
+				p.TagVisitor = k8sTagHandler()
 				return p, nil
 			}},
 			envOpts: []cel.EnvOption{
@@ -110,8 +110,12 @@ var (
 	}
 )
 
+func k8sTagHandler() TagVisitor {
+	return k8sAdmissionTagHandler{TagVisitor: DefaultTagVisitor()}
+}
+
 type k8sAdmissionTagHandler struct {
-	defaultTagVisitor
+	TagVisitor
 }
 
 func (k8sAdmissionTagHandler) PolicyTag(ctx ParserContext, id int64, tagName string, node *yaml.Node, policy *Policy) {

--- a/policy/test.go
+++ b/policy/test.go
@@ -145,7 +145,7 @@ type TestSection struct {
 // Note, when a test requires additional functions to be provided to execute, the test harness
 // must supply these functions.
 type TestCase struct {
-	Name   string                 `yaml:"name"`
-	Input  map[string]interface{} `yaml:"input"`
-	Output string                 `yaml:"output"`
+	Name   string         `yaml:"name"`
+	Input  map[string]any `yaml:"input"`
+	Output string         `yaml:"output"`
 }

--- a/policy/testdata/errors/config.yaml
+++ b/policy/testdata/errors/config.yaml
@@ -12,22 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: k8s
+name: "labels"
 extensions:
-  - name: "strings"
-    version: 2
+  - name: "lists"
+  - name: "sets"
 variables:
-  - name: "resource.labels"
+  - name: "destination.ip"
     type:
-      type_name: "map"
-      params:
-        - type_name: "string"
-        - type_name: "string"
-  - name: "resource.containers"
+      type_name: "string"
+  - name: "origin.ip"
+    type:
+      type_name: "string"
+  - name: "spec.restricted_destinations"
     type:
       type_name: "list"
       params:
         - type_name: "string"
-  - name: "resource.namespace"
+  - name: "spec.origin"
     type:
       type_name: "string"
+  - name: "request"
+    type:
+      type_name: "map"
+      params:
+        - type_name: "string"
+        - type_name: "dyn"
+  - name: "resource"
+    type:
+      type_name: "map"
+      params:
+        - type_name: "string"
+        - type_name: "dyn"
+functions:
+  - name: "locationCode"
+    overloads:
+      - id: "locationCode_string"
+        args:
+          - type_name: "string"
+        return:
+          type_name: "string"

--- a/policy/testdata/errors/policy.yaml
+++ b/policy/testdata/errors/policy.yaml
@@ -1,0 +1,34 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "errors"
+rule:
+  variables:
+    - name: want
+      expression: spec.labels
+    - name: missing
+      expression: variables.want.filter(l, !(lin resource.labels))
+    - name: bad_data
+      expression: "{1:305 2:569}"
+    - name: invalid
+      expression: >
+        resource.labels.filter(l,
+          l in variables.want && variables.want[l] != resource.labels[l])
+  match:
+    - condition: variables.missing.size() > 0
+      output: |
+        "missing one or more required labels: %s".format(variables.missing])
+    - condition: variables.invalid.size() > 0
+      output: |
+        "invalid values provided on one or more labels: %s".format([variables.invalid])

--- a/policy/testdata/k8s/config.yaml
+++ b/policy/testdata/k8s/config.yaml
@@ -12,24 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-description: Nested rule conformance tests
-section:
-  - name: "banned"
-    tests:
-      - name: "restricted_origin"
-        input:
-          resource:
-            origin: "ir"
-        output: "{'banned': true}"
-      - name: "by_default"
-        input:
-          resource:
-            origin: "de"
-        output: "{'banned': true}"
-  - name: "permitted"
-    tests:
-      - name: "valid_origin"
-        input:
-          resource:
-            origin: "uk"
-        output: "{'banned': false}"
+name: k8s
+variables:
+  - name: "resource.labels"
+    type:
+      type_name: "map"
+      params:
+        - type_name: "string"
+        - type_name: "string"
+  - name: "resource.containers"
+    type:
+      type_name: "list"
+      params:
+        - type_name: "string"
+  - name: "resource.namespace"
+    type:
+      type_name: "string"

--- a/policy/testdata/k8s/policy.yaml
+++ b/policy/testdata/k8s/policy.yaml
@@ -1,0 +1,33 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: k8s
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "policy.cel.dev"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["services"]
+      apiVersions: ["v2"]
+      operations:  ["CREATE", "UPDATE"]
+  variables:
+  - name: env
+    expression: "resource.labels.?environment.orValue('prod')"
+  - name: break_glass
+    expression: "resource.labels.?break_glass.orValue('false') == 'true'"
+  validations:
+  - expression: "variables.break_glass || resource.containers.all(c, c.startsWith(variables.env + '.'))"
+    messageExpression: "'only %s containers are allowed in namespace %s".format([variables.env, resource.namespace])

--- a/policy/testdata/k8s/policy.yaml
+++ b/policy/testdata/k8s/policy.yaml
@@ -21,7 +21,7 @@ spec:
   matchConstraints:
     resourceRules:
     - apiGroups:   ["services"]
-      apiVersions: ["v2"]
+      apiVersions: ["v3"]
       operations:  ["CREATE", "UPDATE"]
   variables:
   - name: env
@@ -29,5 +29,9 @@ spec:
   - name: break_glass
     expression: "resource.labels.?break_glass.orValue('false') == 'true'"
   validations:
-  - expression: "variables.break_glass || resource.containers.all(c, c.startsWith(variables.env + '.'))"
-    messageExpression: "'only %s containers are allowed in namespace %s".format([variables.env, resource.namespace])
+  - expression: >
+      variables.break_glass || 
+        resource.containers.all(c, c.startsWith(variables.env + '.'))
+    messageExpression: >
+      'only %s containers are allowed in namespace %s'
+        .format([variables.env, resource.namespace])

--- a/policy/testdata/k8s/tests.yaml
+++ b/policy/testdata/k8s/tests.yaml
@@ -12,24 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-description: Nested rule conformance tests
-section:
-  - name: "banned"
-    tests:
-      - name: "restricted_origin"
-        input:
-          resource:
-            origin: "ir"
-        output: "{'banned': true}"
-      - name: "by_default"
-        input:
-          resource:
-            origin: "de"
-        output: "{'banned': true}"
-  - name: "permitted"
-    tests:
-      - name: "valid_origin"
-        input:
-          resource:
-            origin: "uk"
-        output: "{'banned': false}"

--- a/policy/testdata/k8s/tests.yaml
+++ b/policy/testdata/k8s/tests.yaml
@@ -12,3 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+description: K8s admission control tests
+section:
+  - name: "invalid"
+    tests:
+      - name: "restricted_container"
+        input:
+          resource.namespace: "dev.cel"
+          resource.labels:
+            environment: "staging"
+          resource.containers:
+            - staging.dev.cel.container1
+            - staging.dev.cel.container2
+            - preprod.dev.cel.container3
+        output: "'only staging containers are allowed in namespace dev.cel'"

--- a/policy/testdata/nested_rule/policy.yaml
+++ b/policy/testdata/nested_rule/policy.yaml
@@ -35,5 +35,3 @@ rule:
     - condition: resource.origin in variables.permitted_regions
       output: "{'banned': false}"
     - output: "{'banned': true}"
-    
-

--- a/policy/testdata/required_labels/policy.yaml
+++ b/policy/testdata/required_labels/policy.yaml
@@ -27,6 +27,6 @@ rule:
     - condition: variables.missing.size() > 0
       output: |
         "missing one or more required labels: %s".format([variables.missing])
-    - condition: variables.invalid.size() > 0    
+    - condition: variables.invalid.size() > 0
       output: |
         "invalid values provided on one or more labels: %s".format([variables.invalid])

--- a/policy/testdata/required_labels/tests.yaml
+++ b/policy/testdata/required_labels/tests.yaml
@@ -17,7 +17,7 @@ section:
   - name: "valid"
     tests:
      - name: "matching"
-       input: 
+       input:
          spec:
            labels:
              env: prod
@@ -31,7 +31,7 @@ section:
   - name: "missing"
     tests:
      - name: "env"
-       input: 
+       input:
          spec:
            labels:
              env: prod
@@ -43,7 +43,7 @@ section:
        output: >
          "missing one or more required labels: [\"env\"]"
      - name: "experiment"
-       input: 
+       input:
          spec:
            labels:
              env: prod
@@ -57,7 +57,7 @@ section:
   - name: "invalid"
     tests:
      - name: "env"
-       input: 
+       input:
          spec:
            labels:
              env: prod

--- a/policy/testdata/restricted_destinations/tests.yaml
+++ b/policy/testdata/restricted_destinations/tests.yaml
@@ -17,7 +17,7 @@ section:
   - name: "valid"
     tests:
      - name: "allowed"
-       input: 
+       input:
          "spec.origin": "us"
          "spec.restricted_destinations":
              - "cu"

--- a/test/proto3pb/BUILD.bazel
+++ b/test/proto3pb/BUILD.bazel
@@ -9,6 +9,7 @@ package(
         "//ext:__subpackages__",
         "//interpreter:__subpackages__",
         "//parser:__subpackages__",
+        "//policy:__subpackages__",
         "//server:__subpackages__",
         "//test:__subpackages__",
     ],


### PR DESCRIPTION
The example content demonstrates how to map K8s Admission Policy
into the CEL Policy compilation.