### PR TITLE
policy: parse explanations in match blocks

### DIFF
--- a/policy/parser_test.go
+++ b/policy/parser_test.go
@@ -123,6 +123,32 @@ rule:
  |       output: "world"
  | ......^`,
 		},
+		{
+			txt: `
+rule:
+  match:
+    - condition: "true"
+      explanation: "hi"
+      rule:
+        match:
+          - output: "hello"`,
+			err: `ERROR: <input>:6:7: explanation can only be set on output match cases, not nested rules
+ |       rule:
+ | ......^`,
+		},
+		{
+			txt: `
+rule:
+  match:
+    - condition: "true"
+      rule:
+        match:
+          - output: "hello"
+      explanation: "hi"`,
+			err: `ERROR: <input>:8:7: explanation can only be set on output match cases, not nested rules
+ |       explanation: "hi"
+ | ......^`,
+		},
 	}
 
 	for _, tst := range tests {

--- a/policy/testdata/nested_rule/policy.yaml
+++ b/policy/testdata/nested_rule/policy.yaml
@@ -32,6 +32,7 @@ rule:
               resource.origin in variables.banned_regions &&
               !(resource.origin in variables.permitted_regions)
             output: "{'banned': true}"
+            explanation: "'resource is in the banned region ' + resource.origin"
     - condition: resource.origin in variables.permitted_regions
       output: "{'banned': false}"
     - output: "{'banned': true}"


### PR DESCRIPTION
This adds a secondary output to every block, an "explanation" of why a value was returned. This can be structured or non-structured text. For now the parser is simply storing the value, but the compiler cannot process it yet.