### PR TITLE
Fixed partial variables extended bug and split PartialVarsEnvExtended test into two

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -1771,9 +1771,7 @@ func TestPartialVarsExtendedEnv(t *testing.T) {
 		Variable("y", IntType),
 	)
 
-	//To:DO
-	//then make pr to clone, repl add cmd to enable partial eval and add support for command and then add another pr
-
+	env.Compile("x == y")
 	// Now test that a sub environment is correctly copied.
 	env2, err := env.Extend(Variable("z", IntType))
 	if err != nil {

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -1733,6 +1733,81 @@ func TestResidualAstAttributeQualifiers(t *testing.T) {
 	}
 }
 
+func TestPartialVarsEnv(t *testing.T) {
+	env := testEnv(t,
+		Variable("x", IntType),
+		Variable("y", IntType),
+	)
+
+	// Use env to make sure internals are all initialized.
+	ast, iss := env.Compile("x == y")
+
+	if iss.Err() != nil {
+		t.Fatalf("env.Compile() failed: %v", iss.Err())
+	}
+	prg, err := env.Program(ast, EvalOptions(OptPartialEval))
+	if err != nil {
+		t.Fatalf("env.Program() failed: %v", err)
+	}
+
+	act, err := env.PartialVars(map[string]any{"x": 1, "y": 1})
+
+	if err != nil {
+		t.Fatalf("env.PartialVars failed: %v", err)
+	}
+	val, _, err := prg.Eval(act)
+	if err != nil {
+		t.Fatalf("Eval failed: %v", err)
+	}
+
+	if val != types.True {
+		t.Fatalf("want: %v, got: %v", types.True, val)
+	}
+}
+
+func TestPartialVarsExtendedEnv(t *testing.T) {
+	env := testEnv(t,
+		Variable("x", IntType),
+		Variable("y", IntType),
+	)
+
+	//To:DO
+	//then make pr to clone, repl add cmd to enable partial eval and add support for command and then add another pr
+
+	// Now test that a sub environment is correctly copied.
+	env2, err := env.Extend(Variable("z", IntType))
+	if err != nil {
+		t.Fatalf("env.Extend failed: %v", err)
+	}
+
+	ast, iss := env2.Compile("x == y && y == z")
+
+	if iss.Err() != nil {
+		t.Fatalf("env.Compile() failed: %v", iss.Err())
+	}
+	prg, err := env2.Program(ast, EvalOptions(OptPartialEval))
+	if err != nil {
+		t.Fatalf("env.Program() failed: %v", err)
+	}
+
+	act, err := env2.PartialVars(map[string]any{"z": 1, "y": 1})
+
+	if err != nil {
+		t.Fatalf("env.PartialVars failed: %v", err)
+	}
+	val, _, err := prg.Eval(act)
+	if err != nil {
+		t.Fatalf("Eval failed: %v", err)
+	}
+	if !types.IsUnknown(val) {
+		t.Fatalf("Wanted unknown, got %v", val)
+	}
+
+	if !reflect.DeepEqual(val, types.NewUnknown(1, types.NewAttributeTrail("x"))) {
+		t.Fatalf("Wanted Unknown(x (1)), got: %v", val)
+	}
+}
+
 func TestResidualAstModified(t *testing.T) {
 	env := testEnv(t,
 		Variable("x", MapType(StringType, IntType)),

--- a/cel/env.go
+++ b/cel/env.go
@@ -309,17 +309,14 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 	copy(chkOptsCopy, e.chkOpts)
 
 	// Copy the declarations if needed.
-	varsCopy := []*decls.VariableDecl{}
 	if chk != nil {
 		// If the type-checker has already been instantiated, then the e.declarations have been
 		// validated within the chk instance.
 		chkOptsCopy = append(chkOptsCopy, checker.ValidatedDeclarations(chk))
-	} else {
-		// If the type-checker has not been instantiated, ensure the unvalidated declarations are
-		// provided to the extended Env instance.
-		varsCopy = make([]*decls.VariableDecl, len(e.variables))
-		copy(varsCopy, e.variables)
 	}
+	//
+	varsCopy := make([]*decls.VariableDecl, len(e.variables))
+	copy(varsCopy, e.variables)
 
 	// Copy macros and program options
 	macsCopy := make([]parser.Macro, len(e.macros))

--- a/cel/env.go
+++ b/cel/env.go
@@ -314,7 +314,6 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 		// validated within the chk instance.
 		chkOptsCopy = append(chkOptsCopy, checker.ValidatedDeclarations(chk))
 	}
-	//
 	varsCopy := make([]*decls.VariableDecl, len(e.variables))
 	copy(varsCopy, e.variables)
 

--- a/repl/evaluator.go
+++ b/repl/evaluator.go
@@ -585,6 +585,7 @@ func (e *Evaluator) AddOption(opt Optioner) error {
 	return nil
 }
 
+// EnablePartialEval enables the option to allow partial evaluations.
 func (e *Evaluator) EnablePartialEval() error {
 	cpy := e.ctx.copy()
 	cpy.enablePartialEval = true

--- a/repl/evaluator.go
+++ b/repl/evaluator.go
@@ -266,9 +266,10 @@ type Optioner interface {
 // EvaluationContext context for the repl.
 // Handles maintaining state for multiple let expressions.
 type EvaluationContext struct {
-	letVars []letVariable
-	letFns  []letFunction
-	options []Optioner
+	letVars           []letVariable
+	letFns            []letFunction
+	options           []Optioner
+	enablePartialEval bool
 }
 
 func (ctx *EvaluationContext) indexLetVar(name string) int {
@@ -311,6 +312,7 @@ func (ctx *EvaluationContext) copy() *EvaluationContext {
 	copy(cpy.letVars, ctx.letVars)
 	cpy.letFns = make([]letFunction, len(ctx.letFns))
 	copy(cpy.letFns, ctx.letFns)
+	cpy.enablePartialEval = ctx.enablePartialEval
 	return &cpy
 }
 
@@ -419,12 +421,16 @@ func (ctx *EvaluationContext) addOption(opt Optioner) {
 
 // programOptions generates the program options for planning.
 // Assumes context has been planned.
-func (ctx *EvaluationContext) programOptions() cel.ProgramOption {
+func (ctx *EvaluationContext) programOptions() []cel.ProgramOption {
 	var fns = make([]*functions.Overload, len(ctx.letFns))
 	for i, fn := range ctx.letFns {
 		fns[i] = fn.generateFunction()
 	}
-	return cel.Functions(fns...)
+	result := []cel.ProgramOption{cel.Functions(fns...)}
+	if ctx.enablePartialEval {
+		result = append(result, cel.EvalOptions(cel.OptPartialEval))
+	}
+	return result
 }
 
 // Evaluator provides basic environment for evaluating an expression with
@@ -489,7 +495,7 @@ func updateContextPlans(ctx *EvaluationContext, env *cel.Env) error {
 			el.ast = ast
 			el.resultType = ast.ResultType()
 
-			plan, err := env.Program(ast, ctx.programOptions())
+			plan, err := env.Program(ast, ctx.programOptions()...)
 			if err != nil {
 				return err
 			}
@@ -571,6 +577,17 @@ func (e *Evaluator) AddDeclFn(name string, params []letFunctionParam, typeHint *
 func (e *Evaluator) AddOption(opt Optioner) error {
 	cpy := e.ctx.copy()
 	cpy.addOption(opt)
+	err := updateContextPlans(cpy, e.env)
+	if err != nil {
+		return err
+	}
+	e.ctx = *cpy
+	return nil
+}
+
+func (e *Evaluator) EnablePartialEval() error {
+	cpy := e.ctx.copy()
+	cpy.enablePartialEval = true
 	err := updateContextPlans(cpy, e.env)
 	if err != nil {
 		return err
@@ -746,6 +763,11 @@ func (e *Evaluator) setOption(args []string) error {
 			idx++
 			if err != nil {
 				issues = append(issues, fmt.Sprintf("extension: %v", err))
+			}
+		case "--enable_partial_eval":
+			err := e.EnablePartialEval()
+			if err != nil {
+				issues = append(issues, fmt.Sprintf("enable_partial_eval: %v", err))
 			}
 		default:
 			issues = append(issues, fmt.Sprintf("unsupported option '%s'", arg))
@@ -967,7 +989,12 @@ func (e *Evaluator) Process(cmd Cmder) (string, bool, error) {
 		}
 		if val != nil {
 			t := UnparseType(resultT)
+			unknown, ok := val.Value().(*types.Unknown)
+			if ok {
+				return fmt.Sprintf("Unknown %v", unknown), false, nil
+			}
 			v, err := ext.FormatString(val, "")
+
 			if err != nil {
 				// Default format if type is unsupported by ext.Strings formatter.
 				return fmt.Sprintf("%v : %s", val.Value(), t), false, nil
@@ -1039,11 +1066,12 @@ func (e *Evaluator) Evaluate(expr string) (ref.Val, *exprpb.Type, error) {
 		return nil, nil, iss.Err()
 	}
 
-	p, err := env.Program(ast, e.ctx.programOptions())
+	p, err := env.Program(ast, e.ctx.programOptions()...)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	act, _ = env.PartialVars(act)
 	val, _, err := p.Eval(act)
 	// expression can be well-formed and result in an error
 	return val, ast.ResultType(), err

--- a/repl/evaluator_test.go
+++ b/repl/evaluator_test.go
@@ -716,7 +716,81 @@ func TestProcess(t *testing.T) {
 			wantExit:  false,
 			wantError: false,
 		},
-
+		{
+			name: "OptionEnablePartialEval",
+			commands: []Cmder{
+				&simpleCmd{
+					cmd: "option",
+					args: []string{
+						"--enable_partial_eval",
+					},
+				},
+				&letVarCmd{
+					identifier: "x",
+					typeHint:   mustParseType(t, "int"),
+					src:        "",
+				},
+				&letVarCmd{
+					identifier: "y",
+					typeHint:   mustParseType(t, "int"),
+					src:        "10",
+				},
+				&evalCmd{
+					expr: "x + y > 10 || y > 10",
+				},
+			},
+			wantText:  "Unknown x (1)",
+			wantExit:  false,
+			wantError: false,
+		},
+		{
+			name: "PartialEvalDisabled",
+			commands: []Cmder{
+				&letVarCmd{
+					identifier: "x",
+					typeHint:   mustParseType(t, "int"),
+					src:        "",
+				},
+				&letVarCmd{
+					identifier: "y",
+					typeHint:   mustParseType(t, "int"),
+					src:        "10",
+				},
+				&evalCmd{
+					expr: "x + y > 10 || y > 10",
+				},
+			},
+			wantText:  "",
+			wantExit:  false,
+			wantError: true,
+		},
+		{
+			name: "PartialEvalFiltered",
+			commands: []Cmder{
+				&simpleCmd{
+					cmd: "option",
+					args: []string{
+						"--enable_partial_eval",
+					},
+				},
+				&letVarCmd{
+					identifier: "x",
+					typeHint:   mustParseType(t, "int"),
+					src:        "",
+				},
+				&letVarCmd{
+					identifier: "y",
+					typeHint:   mustParseType(t, "int"),
+					src:        "11",
+				},
+				&evalCmd{
+					expr: "x + y > 10 || y > 10",
+				},
+			},
+			wantText:  "true : bool",
+			wantExit:  false,
+			wantError: false,
+		},
 		{
 			name: "LoadDescriptorsError",
 			commands: []Cmder{

--- a/repl/main/README.md
+++ b/repl/main/README.md
@@ -161,6 +161,8 @@ may take string arguments.
 `--extension <extensionType>` enables CEL extensions. Valid options are: 
 `strings`, `protos`, `math`, `encoders`, `optional`, `bindings`, and `all`.
 
+`--enable_partial_eval` enables partial evaluations
+
 example:
 
 `%option --container 'google.protobuf'` 
@@ -168,6 +170,8 @@ example:
 `%option --extension 'strings'`
 
 `%option --extension 'all'` (Loads all extensions)
+
+`%option --enable_partial_eval`
 
 #### reset
 

--- a/test/bench/bench.go
+++ b/test/bench/bench.go
@@ -40,7 +40,7 @@ type Case struct {
 	Out ref.Val
 }
 
-// Case represents an expression compiled in a dynamic environment.
+// DynamicEnvCase represents an expression compiled in a dynamic environment.
 type DynamicEnvCase struct {
 	// Expr is a human-readable expression which is expected to compile.
 	Expr string
@@ -249,8 +249,8 @@ func RunReferenceCases(b *testing.B, env *cel.Env) {
 	}
 }
 
-// RunReferenceCheckerCases evaluates the set of ReferenceDynamicEnvCases.
-func RunReferenceCheckerCases(b *testing.B) {
+// RunReferenceDynamicEnvCases evaluates the set of ReferenceDynamicEnvCases.
+func RunReferenceDynamicEnvCases(b *testing.B) {
 	b.Helper()
 	for _, rc := range ReferenceDynamicEnvCases {
 		RunDynamicEnvCase(b, rc)

--- a/test/bench/bench.go
+++ b/test/bench/bench.go
@@ -40,7 +40,8 @@ type Case struct {
 	Out ref.Val
 }
 
-type EvalCase struct {
+// Case represents an expression compiled in a dynamic environment.
+type DynamicEnvCase struct {
 	// Expr is a human-readable expression which is expected to compile.
 	Expr string
 
@@ -190,10 +191,9 @@ var (
 			Out: types.String(`formatted list: ["abc", "cde"], size: 2`),
 		},
 	}
-)
-
-var (
-	ReferenceCheckerCases = []*EvalCase{
+	// ReferenceDynamicEnvCases represent CEL expressions compiled in an extended environment.
+	ReferenceDynamicEnvCases = []*DynamicEnvCase{
+		// Base case without extended environment.
 		{
 			Expr: `a+b`,
 			Options: func(b *testing.B) *cel.Env {
@@ -249,10 +249,11 @@ func RunReferenceCases(b *testing.B, env *cel.Env) {
 	}
 }
 
+// RunReferenceCheckerCases evaluates the set of ReferenceDynamicEnvCases.
 func RunReferenceCheckerCases(b *testing.B) {
 	b.Helper()
-	for _, rc := range ReferenceCheckerCases {
-		RunEvalCase(b, rc)
+	for _, rc := range ReferenceDynamicEnvCases {
+		RunDynamicEnvCase(b, rc)
 	}
 }
 
@@ -310,7 +311,8 @@ func RunCase(b *testing.B, env *cel.Env, bc *Case) {
 	}
 }
 
-func RunEvalCase(b *testing.B, bc *EvalCase) {
+// RunDynamicEnvCase runs a singular DynamicEnvCase.
+func RunDynamicEnvCase(b *testing.B, bc *DynamicEnvCase) {
 	b.Helper()
 	b.Run(bc.Expr, func(b *testing.B) {
 		env := bc.Options(b)

--- a/test/bench/bench_test.go
+++ b/test/bench/bench_test.go
@@ -27,3 +27,7 @@ func BenchmarkReferenceCases(b *testing.B) {
 	}
 	RunReferenceCases(b, stdenv)
 }
+
+func BenchmarkReferenceCheckerCases(b *testing.B) {
+	RunReferenceCheckerCases(b)
+}

--- a/test/bench/bench_test.go
+++ b/test/bench/bench_test.go
@@ -29,5 +29,5 @@ func BenchmarkReferenceCases(b *testing.B) {
 }
 
 func BenchmarkReferenceCheckerCases(b *testing.B) {
-	RunReferenceCheckerCases(b)
+	RunReferenceDynamicEnvCases(b)
 }


### PR DESCRIPTION
Changed the varsCopy variable to unconditionally copy e.variables. Split the partial variables extended test into TestPartialVarsEnv and TestPartialVarsExtendedEnv which tests, respectively, if internals are initialized and if sub environment is correctly copied. 

Fixes an edge case with env.PartialVars on an extended environment if the base was used for type checking already.