### PR TITLE
Fix issue related to native byte arrays in type system

### DIFF
--- a/common/overloads/overloads.go
+++ b/common/overloads/overloads.go
@@ -265,6 +265,7 @@ const (
 // Bytes conversion functions.
 const (
 	BytesToBytes  = "bytes_to_bytes"
+	IntsToBytes  = "ints_to_bytes"
 	StringToBytes = "string_to_bytes"
 )
 

--- a/ext/native.go
+++ b/ext/native.go
@@ -325,7 +325,16 @@ func (tp *nativeTypeProvider) NativeToValue(val any) ref.Val {
 	// This isn't quite right if you're also supporting proto,
 	// but maybe an acceptable limitation.
 	switch refVal.Kind() {
-	case reflect.Array, reflect.Slice:
+	case reflect.Array:
+		refElem := refVal.Type().Elem()
+		if refElem == reflect.TypeOf(byte(0)) {
+			tmp := reflect.New(refVal.Type())
+			tmp.Elem().Set(refVal)
+
+			return types.Bytes(tmp.Elem().Bytes())
+		}
+		return types.NewDynamicList(tp, val)
+	case reflect.Slice:
 		switch val := val.(type) {
 		case []byte:
 			return tp.baseAdapter.NativeToValue(val)


### PR DESCRIPTION
Byte arrays are now always considered bytes by both the type checker and the runtime. This fixes a bug, when there was a native struct containing an byte array and a function that takes the byte arrays as input, the program would fail at runtime, as it would expect a dynamic list instead of bytes.

For an concrete example see the TestFunctionOverloadForNative test in the native tests.

Fixes #953