### PR TITLE
Introduce protobuf message testing to policies

### DIFF
--- a/common/decls/decls.go
+++ b/common/decls/decls.go
@@ -162,7 +162,7 @@ func (f *FunctionDecl) AddOverload(overload *OverloadDecl) error {
 		if oID == overload.ID() {
 			if o.SignatureEquals(overload) && o.IsNonStrict() == overload.IsNonStrict() {
 				// Allow redefinition of an overload implementation so long as the signatures match.
-				if !o.hasBinding() || overload.hasBinding() {
+				if overload.hasBinding() {
 					f.overloads[oID] = overload
 				}
 				return nil

--- a/common/decls/decls.go
+++ b/common/decls/decls.go
@@ -162,7 +162,9 @@ func (f *FunctionDecl) AddOverload(overload *OverloadDecl) error {
 		if oID == overload.ID() {
 			if o.SignatureEquals(overload) && o.IsNonStrict() == overload.IsNonStrict() {
 				// Allow redefinition of an overload implementation so long as the signatures match.
-				f.overloads[oID] = overload
+				if !o.hasBinding() || overload.hasBinding() {
+					f.overloads[oID] = overload
+				}
 				return nil
 			}
 			return fmt.Errorf("overload redefinition in function. %s: %s has multiple definitions", f.Name(), oID)

--- a/common/decls/decls_test.go
+++ b/common/decls/decls_test.go
@@ -413,6 +413,27 @@ func TestFunctionAddDuplicateOverloads(t *testing.T) {
 	}
 }
 
+func TestFunctionAddDuplicateOverloadsPreservesBinding(t *testing.T) {
+	f, err := NewFunction("max",
+		Overload("max_int", []*types.Type{types.IntType}, types.IntType),
+		Overload("max_int", []*types.Type{types.IntType}, types.IntType,
+			UnaryBinding(func(v ref.Val) ref.Val {
+				return v
+			})),
+		Overload("max_int", []*types.Type{types.IntType}, types.IntType),
+	)
+	if err != nil {
+		t.Fatalf("NewFunction() with duplicate overload signature failed: %v", err)
+	}
+	if len(f.overloads) != 1 {
+		t.Fatal("Duplicate overloads were not merged")
+	}
+	o := f.overloads["max_int"]
+	if o.unaryOp == nil {
+		t.Error("Duplicate overloads purged the overload binding")
+	}
+}
+
 func TestFunctionAddCollidingOverloads(t *testing.T) {
 	_, err := NewFunction("max",
 		Overload("max_int", []*types.Type{types.IntType}, types.IntType),

--- a/policy/config.go
+++ b/policy/config.go
@@ -151,7 +151,8 @@ func (td *TypeDecl) AsCELType(baseEnv *cel.Env) (*cel.Type, error) {
 			return cel.TypeParamType(td.TypeName), nil
 		}
 		if msgType, found := baseEnv.CELTypeProvider().FindStructType(td.TypeName); found {
-			return msgType, nil
+			// First parameter is the type name.
+			return msgType.Parameters()[0], nil
 		}
 		t, found := baseEnv.CELTypeProvider().FindIdent(td.TypeName)
 		if !found {

--- a/policy/conformance.go
+++ b/policy/conformance.go
@@ -31,7 +31,12 @@ type TestSection struct {
 // Note, when a test requires additional functions to be provided to execute, the test harness
 // must supply these functions.
 type TestCase struct {
-	Name   string         `yaml:"name"`
-	Input  map[string]any `yaml:"input"`
-	Output string         `yaml:"output"`
+	Name   string               `yaml:"name"`
+	Input  map[string]TestInput `yaml:"input"`
+	Output string               `yaml:"output"`
+}
+
+type TestInput struct {
+	Value any    `yaml:"value"`
+	Expr  string `yaml:"expr"`
 }

--- a/policy/helper_test.go
+++ b/policy/helper_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/test/proto3pb"
 
 	"gopkg.in/yaml.v3"
 )
@@ -57,6 +58,15 @@ var (
 		? optional.of({"banned": true}) : optional.none()).or(
 			optional.of((resource.origin in variables.permitted_regions) 
 			? {"banned": false} : {"banned": true})))`,
+		},
+		{
+			name: "pb",
+			expr: `(spec.single_int32 > 10) 
+			? optional.of("invalid spec, got single_int32=%d, wanted <= 10".format([spec.single_int32])) 
+			: optional.none()`,
+			envOpts: []cel.EnvOption{
+				cel.Types(&proto3pb.TestAllTypes{}),
+			},
 		},
 		{
 			name: "required_labels",

--- a/policy/testdata/k8s/tests.yaml
+++ b/policy/testdata/k8s/tests.yaml
@@ -18,11 +18,14 @@ section:
     tests:
       - name: "restricted_container"
         input:
-          resource.namespace: "dev.cel"
+          resource.namespace: 
+            value: "dev.cel"
           resource.labels:
-            environment: "staging"
+            value:
+              environment: "staging"
           resource.containers:
-            - staging.dev.cel.container1
-            - staging.dev.cel.container2
-            - preprod.dev.cel.container3
+            value:
+              - staging.dev.cel.container1
+              - staging.dev.cel.container2
+              - preprod.dev.cel.container3
         output: "'only staging containers are allowed in namespace dev.cel'"

--- a/policy/testdata/pb/config.yaml
+++ b/policy/testdata/pb/config.yaml
@@ -12,27 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-description: Nested rule conformance tests
-section:
-  - name: "banned"
-    tests:
-      - name: "restricted_origin"
-        input:
-          resource:
-            value:
-              origin: "ir"
-        output: "{'banned': true}"
-      - name: "by_default"
-        input:
-          resource:
-            value:
-              origin: "de"
-        output: "{'banned': true}"
-  - name: "permitted"
-    tests:
-      - name: "valid_origin"
-        input:
-          resource:
-            value:
-              origin: "uk"
-        output: "{'banned': false}"
+name: "pb"
+container: "google.expr.proto3.test"
+extensions:
+  - name: "strings"
+    version: 2
+variables:
+  - name: "spec"
+    type:
+      type_name: "google.expr.proto3.test.TestAllTypes"

--- a/policy/testdata/pb/policy.yaml
+++ b/policy/testdata/pb/policy.yaml
@@ -12,27 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-description: Nested rule conformance tests
-section:
-  - name: "banned"
-    tests:
-      - name: "restricted_origin"
-        input:
-          resource:
-            value:
-              origin: "ir"
-        output: "{'banned': true}"
-      - name: "by_default"
-        input:
-          resource:
-            value:
-              origin: "de"
-        output: "{'banned': true}"
-  - name: "permitted"
-    tests:
-      - name: "valid_origin"
-        input:
-          resource:
-            value:
-              origin: "uk"
-        output: "{'banned': false}"
+name: "pb"
+rule:
+  match:
+    - condition: spec.single_int32 > 10
+      output: |
+        "invalid spec, got single_int32=%d, wanted <= 10".format([spec.single_int32])

--- a/policy/testdata/pb/tests.yaml
+++ b/policy/testdata/pb/tests.yaml
@@ -12,27 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-description: Nested rule conformance tests
+description: "Protobuf input tests"
 section:
-  - name: "banned"
+  - name: "valid"
     tests:
-      - name: "restricted_origin"
-        input:
-          resource:
-            value:
-              origin: "ir"
-        output: "{'banned': true}"
-      - name: "by_default"
-        input:
-          resource:
-            value:
-              origin: "de"
-        output: "{'banned': true}"
-  - name: "permitted"
+     - name: "good spec"
+       input:
+         spec: 
+           expr: >
+             TestAllTypes{single_int32: 10}
+       output: "optional.none()"
+  - name: "invalid"
     tests:
-      - name: "valid_origin"
-        input:
-          resource:
-            value:
-              origin: "uk"
-        output: "{'banned': false}"
+     - name: "bad spec"
+       input:
+         spec: 
+           expr: >
+             TestAllTypes{single_int32: 11}
+       output: >
+         "invalid spec, got single_int32=11, wanted <= 10"
+       

--- a/policy/testdata/required_labels/tests.yaml
+++ b/policy/testdata/required_labels/tests.yaml
@@ -19,39 +19,45 @@ section:
      - name: "matching"
        input:
          spec:
-           labels:
-             env: prod
-             experiment: "group b"
+           value:
+             labels:
+               env: prod
+               experiment: "group b"
          resource:
-           labels:
-             env: prod
-             experiment: "group b"
-             release: "v0.1.0"
+           value:
+             labels:
+               env: prod
+               experiment: "group b"
+               release: "v0.1.0"
        output: "optional.none()"
   - name: "missing"
     tests:
      - name: "env"
        input:
          spec:
-           labels:
-             env: prod
-             experiment: "group b"
+           value:
+             labels:
+               env: prod
+               experiment: "group b"
          resource:
-           labels:
-             experiment: "group b"
-             release: "v0.1.0"
+           value:
+             labels:
+               experiment: "group b"
+               release: "v0.1.0"
        output: >
          "missing one or more required labels: [\"env\"]"
      - name: "experiment"
        input:
          spec:
-           labels:
-             env: prod
-             experiment: "group b"
+           value:
+             labels:
+               env: prod
+               experiment: "group b"
          resource:
-           labels:
-             env: staging
-             release: "v0.1.0"
+           value:
+             labels:
+               env: staging
+               release: "v0.1.0"
        output: >
          "missing one or more required labels: [\"experiment\"]"
   - name: "invalid"
@@ -59,13 +65,15 @@ section:
      - name: "env"
        input:
          spec:
-           labels:
-             env: prod
-             experiment: "group b"
+           value:
+             labels:
+               env: prod
+               experiment: "group b"
          resource:
-           labels:
-             env: staging
-             experiment: "group b"
-             release: "v0.1.0"
+           value:
+             labels:
+               env: staging
+               experiment: "group b"
+               release: "v0.1.0"
        output: >
          "invalid values provided on one or more labels: [\"env\"]"

--- a/policy/testdata/restricted_destinations/tests.yaml
+++ b/policy/testdata/restricted_destinations/tests.yaml
@@ -18,20 +18,26 @@ section:
     tests:
      - name: "allowed"
        input:
-         "spec.origin": "us"
+         "spec.origin": 
+           value: "us"
          "spec.restricted_destinations":
+           value:
              - "cu"
              - "ir"
              - "kp"
              - "sd"
              - "sy"
-         "destination.ip": "10.0.0.1"
-         "origin.ip": "10.0.0.1"
+         "destination.ip": 
+           value: "10.0.0.1"
+         "origin.ip": 
+           value: "10.0.0.1"
          request:
-           auth:
-             claims: {}
+           value:
+             auth:
+               claims: {}
          resource:
-           name: "/company/acme/secrets/doomsday-device"
-           labels:
-             location: "us"
+           value:
+             name: "/company/acme/secrets/doomsday-device"
+             labels:
+               location: "us"
        output: "true"


### PR DESCRIPTION
Cover protobuf message types in policies

Also, addresses a subtle bug where function overload implementations
were being clobbered when a duplicate function overload signature
without an implementation was introduced in a later environment.