### PR TITLE
Stabilize macro id generation

### DIFF
--- a/cel/optimizer.go
+++ b/cel/optimizer.go
@@ -15,6 +15,8 @@
 package cel
 
 import (
+	"sort"
+
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/types"
@@ -98,14 +100,21 @@ func (opt *StaticOptimizer) Optimize(env *Env, a *Ast) (*Ast, *Issues) {
 // that the ids within the expression correspond to the ids within macros.
 func normalizeIDs(idGen ast.IDGenerator, optimized ast.Expr, info *ast.SourceInfo) {
 	optimized.RenumberIDs(idGen)
-
 	if len(info.MacroCalls()) == 0 {
 		return
 	}
 
+	// Sort the macro ids to make sure that the renumbering of macro-specific variables
+	// is stable across normalization calls.
+	sortedMacroIDs := []int64{}
+	for id := range info.MacroCalls() {
+		sortedMacroIDs = append(sortedMacroIDs, id)
+	}
+	sort.Slice(sortedMacroIDs, func(i, j int) bool { return sortedMacroIDs[i] < sortedMacroIDs[j] })
+
 	// First, update the macro call ids themselves.
 	callIDMap := map[int64]int64{}
-	for id := range info.MacroCalls() {
+	for _, id := range sortedMacroIDs {
 		callIDMap[id] = idGen(id)
 	}
 	// Then update the macro call definitions which refer to these ids, but
@@ -116,7 +125,8 @@ func normalizeIDs(idGen ast.IDGenerator, optimized ast.Expr, info *ast.SourceInf
 		call ast.Expr
 	}
 	macroUpdates := []macroUpdate{}
-	for oldID, newID := range callIDMap {
+	for _, oldID := range sortedMacroIDs {
+		newID := callIDMap[oldID]
 		call, found := info.GetMacroCall(oldID)
 		if !found {
 			continue
@@ -134,6 +144,7 @@ func cleanupMacroRefs(expr ast.Expr, info *ast.SourceInfo) {
 	if len(info.MacroCalls()) == 0 {
 		return
 	}
+
 	// Sanitize the macro call references once the optimized expression has been computed
 	// and the ids normalized between the expression and the macros.
 	exprRefMap := make(map[int64]struct{})
@@ -251,6 +262,11 @@ func (opt *optimizerExprFactory) ClearMacroCall(id int64) {
 // metadata.
 func (opt *optimizerExprFactory) SetMacroCall(id int64, expr ast.Expr) {
 	opt.sourceInfo.SetMacroCall(id, expr)
+}
+
+// MacroCalls returns the map of macro calls currently in the context.
+func (opt *optimizerExprFactory) MacroCalls() map[int64]ast.Expr {
+	return opt.sourceInfo.MacroCalls()
 }
 
 // NewBindMacro creates an AST expression representing the expanded bind() macro, and a macro expression


### PR DESCRIPTION
Update the macro id generation to occur in sorted order.

This issue is somewhat difficult to trigger, but any expression
with two macros present within it should eventually trip the issue.

The test has been updated to removed some redundant conditions
which were extant once the macro tracking in the test optimizer
was fixed to reflect how macro id tracking works within the production
optimizers.