### PR TITLE
Add function accessor to Env

### DIFF
--- a/cel/env.go
+++ b/cel/env.go
@@ -412,6 +412,17 @@ func (e *Env) Libraries() []string {
 	return libraries
 }
 
+// HasFunction returns whether a specific function has been configured in the environment
+func (e *Env) HasFunction(functionName string) bool {
+	_, ok := e.functions[functionName]
+	return ok
+}
+
+// Functions returns map of Functions, keyed by function name, that have been configured in the environment.
+func (e *Env) Functions() map[string]*decls.FunctionDecl {
+	return e.functions
+}
+
 // HasValidator returns whether a specific ASTValidator has been configured in the environment.
 func (e *Env) HasValidator(name string) bool {
 	for _, v := range e.validators {

--- a/cel/env_test.go
+++ b/cel/env_test.go
@@ -271,6 +271,22 @@ func TestLibraries(t *testing.T) {
 	}
 }
 
+func TestFunctions(t *testing.T) {
+	e, err := NewEnv(OptionalTypes())
+	if err != nil {
+		t.Fatalf("NewEnv() failed: %v", err)
+	}
+	for _, expected := range []string{"optional.of", "or"} {
+		if !e.HasFunction(expected) {
+			t.Errorf("Expected HasFunction() to return true for '%s'", expected)
+		}
+
+		if _, ok := e.Functions()[expected]; !ok {
+			t.Errorf("Expected Functions() to include '%s'", expected)
+		}
+	}
+}
+
 func BenchmarkNewCustomEnvLazy(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
We're working on improving our backward compatibility linting to ensure that we never accidentally remove library functions once they are added. This would make it a lot easier for us to inspect the environments we actually build and use when linting. 