### PR TITLE
Decompose the compile and compose methods

### DIFF
--- a/policy/BUILD.bazel
+++ b/policy/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     srcs = [
         "compiler.go",
         "conformance.go",
+        "composer.go",
         "config.go",
         "parser.go",
         "source.go",
@@ -33,6 +34,7 @@ go_library(
         "//cel:go_default_library",
         "//common:go_default_library",
         "//common/ast:go_default_library",
+        "//common/decls:go_default_library",
         "//common/operators:go_default_library",
         "//common/types:go_default_library",
         "//ext:go_default_library",
@@ -46,7 +48,7 @@ go_test(
     srcs = [
         "compiler_test.go",
         "config_test.go",
-        "helper_test.go",        
+        "helper_test.go",
         "parser_test.go",
     ],
     data = glob(["testdata/**"]),

--- a/policy/composer.go
+++ b/policy/composer.go
@@ -1,0 +1,109 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/operators"
+	"github.com/google/cel-go/common/types"
+)
+
+// NewRuleComposer creates a rule composer which stitches together rules within a policy into
+// a single CEL expression.
+func NewRuleComposer(env *cel.Env, p *Policy) *RuleComposer {
+	return &RuleComposer{env: env, p: p}
+}
+
+// RuleComposer optimizes a set of expressions into a single expression.
+type RuleComposer struct {
+	env *cel.Env
+	p   *Policy
+}
+
+// Compose stitches together a set of expressions within a CompiledRule into a single CEL ast.
+func (c *RuleComposer) Compose(r *CompiledRule) (*cel.Ast, *cel.Issues) {
+	ruleRoot, _ := c.env.Compile("true")
+	opt := cel.NewStaticOptimizer(&ruleComposerImpl{rule: r})
+	return opt.Optimize(c.env, ruleRoot)
+}
+
+type ruleComposerImpl struct {
+	rule *CompiledRule
+}
+
+// Optimize implements an AST optimizer for CEL which composes an expression graph into a single
+// expression value.
+func (opt *ruleComposerImpl) Optimize(ctx *cel.OptimizerContext, a *ast.AST) *ast.AST {
+	// The input to optimize is a dummy expression which is completely replaced according
+	// to the configuration of the rule composition graph.
+	ruleExpr, _ := optimizeRule(ctx, opt.rule)
+	return ctx.NewAST(ruleExpr)
+}
+
+func optimizeRule(ctx *cel.OptimizerContext, r *CompiledRule) (ast.Expr, bool) {
+	matchExpr := ctx.NewCall("optional.none")
+	matches := r.Matches()
+	optionalResult := true
+	for i := len(matches) - 1; i >= 0; i-- {
+		m := matches[i]
+		cond := ctx.CopyASTAndMetadata(m.Condition().NativeRep())
+		triviallyTrue := cond.Kind() == ast.LiteralKind && cond.AsLiteral() == types.True
+		if m.Output() != nil {
+			out := ctx.CopyASTAndMetadata(m.Output().Expr().NativeRep())
+			if triviallyTrue {
+				matchExpr = out
+				optionalResult = false
+				continue
+			}
+			if optionalResult {
+				out = ctx.NewCall("optional.of", out)
+			}
+			matchExpr = ctx.NewCall(
+				operators.Conditional,
+				cond,
+				out,
+				matchExpr)
+			continue
+		}
+		nestedRule, nestedOptional := optimizeRule(ctx, m.NestedRule())
+		if optionalResult && !nestedOptional {
+			nestedRule = ctx.NewCall("optional.of", nestedRule)
+		}
+		if !optionalResult && nestedOptional {
+			matchExpr = ctx.NewCall("optional.of", matchExpr)
+			optionalResult = true
+		}
+		if !optionalResult && !nestedOptional {
+			ctx.ReportErrorAtID(nestedRule.ID(), "subrule early terminates policy")
+			continue
+		}
+		matchExpr = ctx.NewMemberCall("or", nestedRule, matchExpr)
+	}
+
+	vars := r.Variables()
+	for i := len(vars) - 1; i >= 0; i-- {
+		v := vars[i]
+		varAST := ctx.CopyASTAndMetadata(v.Expr().NativeRep())
+		// Build up the bindings in reverse order, starting from root, all the way up to the outermost
+		// binding:
+		//    currExpr = cel.bind(outerVar, outerExpr, currExpr)
+		varName := v.Declaration().Name()
+		inlined, bindMacro := ctx.NewBindMacro(matchExpr.ID(), varName, varAST, matchExpr)
+		ctx.UpdateExpr(matchExpr, inlined)
+		ctx.SetMacroCall(matchExpr.ID(), bindMacro)
+	}
+	return matchExpr, optionalResult
+}


### PR DESCRIPTION
Decompose the compile method from the compose method.

Allow users to structure `CompileRule` calls which produce the canonical
intermediate representation for compiled policies separately from the
composition of those expressions into a single CEL expression.