### PR TITLE
String formatting panic fix

### DIFF
--- a/ext/formatting.go
+++ b/ext/formatting.go
@@ -484,7 +484,7 @@ func matchConstantFormatStringWithListLiteralArgs(a *ast.AST) ast.ExprMatcher {
 			}
 		}
 		formatString := call.Target()
-		if formatString.Kind() != ast.LiteralKind && formatString.AsLiteral().Type() != cel.StringType {
+		if formatString.Kind() != ast.LiteralKind || formatString.AsLiteral().Type() != cel.StringType {
 			return false
 		}
 		args := call.Args()

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -141,6 +141,10 @@ var stringTests = []struct {
 	{expr: `strings.quote("\U0001F431\U0001F600\U0001F61B") == "\"\U0001F431\U0001F600\U0001F61B\""`},
 	{expr: `strings.quote("ta©o©αT") == "\"ta©o©αT\""`},
 	{expr: `strings.quote("") == "\"\""`},
+	// Format tests with a non-literal as the format string
+	{
+		expr: `strings.quote('%s %s').format(['hello', 'world']) == "\"hello world\""`,
+	},
 	// Error test cases based on checked expression usage.
 	{
 		expr: `'tacocat'.charAt(30) == ''`,


### PR DESCRIPTION
String formatting panic fix

If the string format is not a literal, the formatting validation will panic
as it incorrectly used an `&&` rather than an `||` on the validation
condition.