### PR TITLE
Prevent self-append for Issues

### DIFF
--- a/cel/env.go
+++ b/cel/env.go
@@ -760,10 +760,10 @@ func (i *Issues) Append(other *Issues) *Issues {
 	if i == nil {
 		return other
 	}
-	if other == nil {
+	if other == nil || i == other {
 		return i
 	}
-	return NewIssues(i.errs.Append(other.errs.GetErrors()))
+	return NewIssuesWithSourceInfo(i.errs.Append(other.errs.GetErrors()), i.info)
 }
 
 // String converts the issues to a suitable display string.

--- a/cel/env_test.go
+++ b/cel/env_test.go
@@ -81,6 +81,21 @@ func TestIssuesEmpty(t *testing.T) {
 	}
 }
 
+func TestIssuesAppendSelf(t *testing.T) {
+	e, err := NewEnv()
+	if err != nil {
+		t.Fatalf("NewEnv() failed: %v", err)
+	}
+	_, iss := e.Compile("a")
+	if len(iss.Errors()) != 1 {
+		t.Errorf("iss.Errors() got %v, wanted 1 error", iss.Errors())
+	}
+	iss = iss.Append(iss)
+	if len(iss.Errors()) != 1 {
+		t.Errorf("iss.Errors() got %v, wanted 1 error", iss.Errors())
+	}
+}
+
 func TestIssues(t *testing.T) {
 	e, err := NewEnv()
 	if err != nil {


### PR DESCRIPTION
Prevent self-append for Issues

Previously it was possible for Issues to double report as a result of a self-append.