### PR TITLE
Variable and nested rule limits

### DIFF
--- a/policy/composer.go
+++ b/policy/composer.go
@@ -63,7 +63,7 @@ func (opt *ruleComposerImpl) optimizeRule(ctx *cel.OptimizerContext, r *Compiled
 	vars := r.Variables()
 	optionalResult := true
 
-	// Build the rule sub-graph.
+	// Build the rule subgraph.
 	for i := len(matches) - 1; i >= 0; i-- {
 		m := matches[i]
 		cond := ctx.CopyASTAndMetadata(m.Condition().NativeRep())
@@ -109,7 +109,7 @@ func (opt *ruleComposerImpl) optimizeRule(ctx *cel.OptimizerContext, r *Compiled
 		}
 	}
 
-	// Bind variables in reverse order to declaration on top of rule-subgrap
+	// Bind variables in reverse order to declaration on top of rule-subgraph.
 	for i := len(vars) - 1; i >= 0; i-- {
 		v := vars[i]
 		varAST := ctx.CopyASTAndMetadata(v.Expr().NativeRep())

--- a/policy/composer.go
+++ b/policy/composer.go
@@ -24,7 +24,10 @@ import (
 // NewRuleComposer creates a rule composer which stitches together rules within a policy into
 // a single CEL expression.
 func NewRuleComposer(env *cel.Env, p *Policy) *RuleComposer {
-	return &RuleComposer{env: env, p: p}
+	return &RuleComposer{
+		env: env,
+		p:   p,
+	}
 }
 
 // RuleComposer optimizes a set of expressions into a single expression.
@@ -41,7 +44,8 @@ func (c *RuleComposer) Compose(r *CompiledRule) (*cel.Ast, *cel.Issues) {
 }
 
 type ruleComposerImpl struct {
-	rule *CompiledRule
+	rule                     *CompiledRule
+	maxNestedExpressionLimit int
 }
 
 // Optimize implements an AST optimizer for CEL which composes an expression graph into a single
@@ -49,14 +53,17 @@ type ruleComposerImpl struct {
 func (opt *ruleComposerImpl) Optimize(ctx *cel.OptimizerContext, a *ast.AST) *ast.AST {
 	// The input to optimize is a dummy expression which is completely replaced according
 	// to the configuration of the rule composition graph.
-	ruleExpr, _ := optimizeRule(ctx, opt.rule)
+	ruleExpr, _ := opt.optimizeRule(ctx, opt.rule)
 	return ctx.NewAST(ruleExpr)
 }
 
-func optimizeRule(ctx *cel.OptimizerContext, r *CompiledRule) (ast.Expr, bool) {
+func (opt *ruleComposerImpl) optimizeRule(ctx *cel.OptimizerContext, r *CompiledRule) (ast.Expr, bool) {
 	matchExpr := ctx.NewCall("optional.none")
 	matches := r.Matches()
+	vars := r.Variables()
 	optionalResult := true
+
+	// Build the rule sub-graph.
 	for i := len(matches) - 1; i >= 0; i-- {
 		m := matches[i]
 		cond := ctx.CopyASTAndMetadata(m.Condition().NativeRep())
@@ -78,7 +85,7 @@ func optimizeRule(ctx *cel.OptimizerContext, r *CompiledRule) (ast.Expr, bool) {
 				matchExpr)
 			continue
 		}
-		nestedRule, nestedOptional := optimizeRule(ctx, m.NestedRule())
+		nestedRule, nestedOptional := opt.optimizeRule(ctx, m.NestedRule())
 		if optionalResult && !nestedOptional {
 			nestedRule = ctx.NewCall("optional.of", nestedRule)
 		}
@@ -90,10 +97,19 @@ func optimizeRule(ctx *cel.OptimizerContext, r *CompiledRule) (ast.Expr, bool) {
 			ctx.ReportErrorAtID(nestedRule.ID(), "subrule early terminates policy")
 			continue
 		}
-		matchExpr = ctx.NewMemberCall("or", nestedRule, matchExpr)
+		if triviallyTrue {
+			matchExpr = ctx.NewMemberCall("or", nestedRule, matchExpr)
+		} else {
+			matchExpr = ctx.NewCall(
+				operators.Conditional,
+				cond,
+				nestedRule,
+				matchExpr,
+			)
+		}
 	}
 
-	vars := r.Variables()
+	// Bind variables in reverse order to declaration on top of rule-subgrap
 	for i := len(vars) - 1; i >= 0; i-- {
 		v := vars[i]
 		varAST := ctx.CopyASTAndMetadata(v.Expr().NativeRep())

--- a/policy/config.go
+++ b/policy/config.go
@@ -16,6 +16,7 @@ package policy
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/ext"
@@ -87,7 +88,12 @@ func (ec *ExtensionConfig) AsEnvOption(baseEnv *cel.Env) (cel.EnvOption, error) 
 	if !found {
 		return nil, fmt.Errorf("unrecognized extension: %s", ec.Name)
 	}
-	return fac(uint32(ec.Version)), nil
+	// If the version is less than or equal to zero set the version to the max value.
+	ver := ec.Version
+	if ver < 0 {
+		ver = math.MaxUint32
+	}
+	return fac(uint32(ver)), nil
 }
 
 // VariableDecl represents a YAML serializable CEL variable declaration.

--- a/policy/conformance.go
+++ b/policy/conformance.go
@@ -36,6 +36,7 @@ type TestCase struct {
 	Output string               `yaml:"output"`
 }
 
+// TestInput represents an input literal value or expression.
 type TestInput struct {
 	Value any    `yaml:"value"`
 	Expr  string `yaml:"expr"`

--- a/policy/testdata/errors/config.yaml
+++ b/policy/testdata/errors/config.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "labels"
+name: "errors"
 extensions:
   - name: "lists"
   - name: "sets"

--- a/policy/testdata/limits/config.yaml
+++ b/policy/testdata/limits/config.yaml
@@ -15,7 +15,7 @@
 name: "limits"
 extensions:
   - name: "strings"
-    version: -1
+    version: latest
 variables:
   - name: "now"
     type:

--- a/policy/testdata/limits/config.yaml
+++ b/policy/testdata/limits/config.yaml
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "limits"
+extensions:
+  - name: "strings"
+    version: -1
+variables:
+  - name: "now"
+    type:
+      type_name: "google.protobuf.Timestamp"

--- a/policy/testdata/limits/policy.yaml
+++ b/policy/testdata/limits/policy.yaml
@@ -1,0 +1,47 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "limits"
+rule:
+  variables:
+    - name: "greeting"
+      expression: "'hello'"
+    - name: "farewell"
+      expression: "'goodbye'"
+    - name: "person"
+      expression: "'me'"
+    - name: "message_fmt"
+      expression: "'%s, %s'"
+  match:
+    - condition: |
+        now.getHours() >= 20
+      rule:
+        id: "farewells"
+        variables:
+          - name: "message"
+            expression: >
+              variables.message_fmt.format([variables.farewell,
+                                            variables.person])
+        match:
+          - condition: >
+              now.getHours() < 21
+            output: variables.message + "!"
+          - condition: >
+              now.getHours() < 22
+            output: variables.message + "!!"
+          - condition: >
+              now.getHours() < 24
+            output: variables.message + "!!!"
+    - output: >
+        variables.message_fmt.format([variables.greeting, variables.person])

--- a/policy/testdata/limits/tests.yaml
+++ b/policy/testdata/limits/tests.yaml
@@ -1,0 +1,38 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: Limits related tests
+section:
+  - name: "now_after_hours"
+    tests:
+      - name: "7pm"
+        input:
+          now:
+            expr: "timestamp('2024-07-30T00:30:00Z')"
+        output: "'hello, me'"
+      - name: "8pm"
+        input:
+          now:
+            expr: "timestamp('2024-07-30T20:30:00Z')"
+        output: "'goodbye, me!'"
+      - name: "9pm"
+        input:
+          now:
+            expr: "timestamp('2024-07-30T21:30:00Z')"
+        output: "'goodbye, me!!'"
+      - name: "11pm"
+        input:
+          now:
+            expr: "timestamp('2024-07-30T23:30:00Z')"
+        output: "'goodbye, me!!!'"


### PR DESCRIPTION
Provide a configurable limit for variable and nested rules

Ensure that policies are no so expressive that they cause problems
for stacks with limited recursion depths. The limit defaults to 100.
This change also makes a critical fix to support conditionally nested
rules. Previously the condition was being omitted during composition.

Closes  #972