### PR TITLE
Support for typename import aliases

### DIFF
--- a/common/containers/container.go
+++ b/common/containers/container.go
@@ -19,6 +19,7 @@ package containers
 import (
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/google/cel-go/common/ast"
 )
@@ -212,6 +213,13 @@ type ContainerOption func(*Container) (*Container, error)
 func Abbrevs(qualifiedNames ...string) ContainerOption {
 	return func(c *Container) (*Container, error) {
 		for _, qn := range qualifiedNames {
+			qn = strings.TrimSpace(qn)
+			for _, r := range []rune(qn) {
+				if !isIdentifierChar(r) {
+					return nil, fmt.Errorf(
+						"invalid qualified name: %s, wanted name of the form 'qualified.name'", qn)
+				}
+			}
 			ind := strings.LastIndex(qn, ".")
 			if ind <= 0 || ind >= len(qn)-1 {
 				return nil, fmt.Errorf(
@@ -276,6 +284,10 @@ func aliasAs(kind, qualifiedName, alias string) ContainerOption {
 		c.aliases[alias] = qualifiedName
 		return c, nil
 	}
+}
+
+func isIdentifierChar(r rune) bool {
+	return r <= unicode.MaxASCII && (r == '.' || r == '_' || unicode.IsLetter(r) || unicode.IsNumber(r))
 }
 
 // Name sets the fully-qualified name of the Container.

--- a/policy/BUILD.bazel
+++ b/policy/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//cel:go_default_library",
         "//common:go_default_library",
         "//common/ast:go_default_library",
+        "//common/containers:go_default_library",
         "//common/decls:go_default_library",
         "//common/operators:go_default_library",
         "//common/types:go_default_library",

--- a/policy/compiler_test.go
+++ b/policy/compiler_test.go
@@ -86,6 +86,20 @@ func TestCompiledRuleHasOptionalOutput(t *testing.T) {
 	}
 }
 
+func TestMaxNestedExpressions_Error(t *testing.T) {
+	policyName := "required_labels"
+	wantError := `ERROR: testdata/required_labels/policy.yaml:15:8: error configuring compiler option: nested expression limit must be non-negative, non-zero value: -1
+ | name: "required_labels"
+ | .......^`
+	_, _, iss := compile(t, policyName, []ParserOption{}, []cel.EnvOption{}, []CompilerOption{MaxNestedExpressions(-1)})
+	if iss.Err() == nil {
+		t.Fatalf("compile(%s) did not error, wanted %s", policyName, wantError)
+	}
+	if iss.Err().Error() != wantError {
+		t.Errorf("compile(%s) got error %s, wanted %s", policyName, iss.Err().Error(), wantError)
+	}
+}
+
 func BenchmarkCompile(b *testing.B) {
 	for _, tst := range policyTests {
 		r := newRunner(b, tst.name, tst.expr, tst.parseOpts, tst.envOpts...)

--- a/policy/helper_test.go
+++ b/policy/helper_test.go
@@ -63,26 +63,26 @@ var (
 		{
 			name: "nested_rule2",
 			expr: `
-	cel.bind(variables.permitted_regions, ["us", "uk", "es"], 
-	  resource.?user.orValue("").startsWith("bad") 
-	  ? cel.bind(variables.banned_regions, {"us": false, "ru": false, "ir": false}, 
+	cel.bind(variables.permitted_regions, ["us", "uk", "es"],
+	  resource.?user.orValue("").startsWith("bad")
+	  ? cel.bind(variables.banned_regions, {"us": false, "ru": false, "ir": false},
 	    (resource.origin in variables.banned_regions &&
-        !(resource.origin in variables.permitted_regions)) 
-		? {"banned": "restricted_region"} : {"banned": "bad_actor"}) 
-	  : (!(resource.origin in variables.permitted_regions) 
+        !(resource.origin in variables.permitted_regions))
+		? {"banned": "restricted_region"} : {"banned": "bad_actor"})
+	  : (!(resource.origin in variables.permitted_regions)
 	    ? {"banned": "unconfigured_region"} : {}))`,
 		},
 		{
 			name: "nested_rule3",
 			expr: `
-	cel.bind(variables.permitted_regions, ["us", "uk", "es"], 
-	  resource.?user.orValue("").startsWith("bad") 
+	cel.bind(variables.permitted_regions, ["us", "uk", "es"],
+	  resource.?user.orValue("").startsWith("bad")
 	  ? optional.of(
 	      cel.bind(variables.banned_regions, {"us": false, "ru": false, "ir": false},
 		  (resource.origin in variables.banned_regions &&
-          !(resource.origin in variables.permitted_regions)) 
-		  ? {"banned": "restricted_region"} : {"banned": "bad_actor"})) 
-	  : (!(resource.origin in variables.permitted_regions) 
+          !(resource.origin in variables.permitted_regions))
+		  ? {"banned": "restricted_region"} : {"banned": "bad_actor"}))
+	  : (!(resource.origin in variables.permitted_regions)
 	    ? optional.of({"banned": "unconfigured_region"}) : optional.none()))`,
 		},
 		{
@@ -172,31 +172,34 @@ var (
 	}{
 		{
 			name: "errors",
-			err: `ERROR: testdata/errors/policy.yaml:17:12: error configuring imports: invalid qualified name: bad import, wanted name of the form 'qualified.name'
+			err: `ERROR: testdata/errors/policy.yaml:19:1: error configuring import: invalid qualified name: punc.Import!, wanted name of the form 'qualified.name'
+ |       punc.Import!
+ | ^
+ERROR: testdata/errors/policy.yaml:20:12: error configuring import: invalid qualified name: bad import, wanted name of the form 'qualified.name'
  |   - name: "bad import"
  | ...........^
-ERROR: testdata/errors/policy.yaml:21:19: undeclared reference to 'spec' (in container '')
+ERROR: testdata/errors/policy.yaml:24:19: undeclared reference to 'spec' (in container '')
  |       expression: spec.labels
  | ..................^
-ERROR: testdata/errors/policy.yaml:22:7: invalid variable declaration: overlapping identifier for name 'variables.want'
+ERROR: testdata/errors/policy.yaml:25:7: invalid variable declaration: overlapping identifier for name 'variables.want'
  |     - name: want
  | ......^
-ERROR: testdata/errors/policy.yaml:25:50: Syntax error: mismatched input 'resource' expecting ')'
+ERROR: testdata/errors/policy.yaml:28:50: Syntax error: mismatched input 'resource' expecting ')'
  |       expression: variables.want.filter(l, !(lin resource.labels))
  | .................................................^
-ERROR: testdata/errors/policy.yaml:25:66: Syntax error: extraneous input ')' expecting <EOF>
+ERROR: testdata/errors/policy.yaml:28:66: Syntax error: extraneous input ')' expecting <EOF>
  |       expression: variables.want.filter(l, !(lin resource.labels))
  | .................................................................^
-ERROR: testdata/errors/policy.yaml:27:27: Syntax error: mismatched input '2' expecting {'}', ','}
+ERROR: testdata/errors/policy.yaml:30:27: Syntax error: mismatched input '2' expecting {'}', ','}
  |       expression: "{1:305 2:569}"
  | ..........................^
-ERROR: testdata/errors/policy.yaml:35:75: Syntax error: extraneous input ']' expecting ')'
+ERROR: testdata/errors/policy.yaml:38:75: Syntax error: extraneous input ']' expecting ')'
  |         "missing one or more required labels: %s".format(variables.missing])
  | ..........................................................................^
-ERROR: testdata/errors/policy.yaml:38:67: undeclared reference to 'format' (in container '')
+ERROR: testdata/errors/policy.yaml:41:67: undeclared reference to 'format' (in container '')
  |         "invalid values provided on one or more labels: %s".format([variables.invalid])
  | ..................................................................^
-ERROR: testdata/errors/policy.yaml:38:16: incompatible output types: bool not assignable to string
+ERROR: testdata/errors/policy.yaml:45:16: incompatible output types: bool not assignable to string
  |       output: "'false'"
  | ...............^`,
 		},

--- a/policy/parser_test.go
+++ b/policy/parser_test.go
@@ -149,6 +149,65 @@ rule:
  |       explanation: "hi"
  | ......^`,
 		},
+		{
+			txt: `
+imports:
+  - first`,
+			err: `ERROR: <input>:3:5: got yaml node type tag:yaml.org,2002:str, wanted type(s) [tag:yaml.org,2002:map]
+ |   - first
+ | ....^`,
+		},
+		{
+			txt: `
+imports:
+  first: name`,
+			err: `ERROR: <input>:3:3: got yaml node type tag:yaml.org,2002:map, wanted type(s) [tag:yaml.org,2002:seq]
+ |   first: name
+ | ..^`,
+		},
+		{
+			txt: `
+rule:
+  - variables: name`,
+			err: `ERROR: <input>:3:3: got yaml node type tag:yaml.org,2002:seq, wanted type(s) [tag:yaml.org,2002:map]
+ |   - variables: name
+ | ..^`,
+		},
+		{
+			txt: `
+rule:
+  variables: name`,
+			err: `ERROR: <input>:3:14: got yaml node type tag:yaml.org,2002:str, wanted type(s) [tag:yaml.org,2002:seq]
+ |   variables: name
+ | .............^`,
+		},
+		{
+			txt: `
+rule:
+  variables: 
+    - name`,
+			err: `ERROR: <input>:4:7: got yaml node type tag:yaml.org,2002:str, wanted type(s) [tag:yaml.org,2002:map]
+ |     - name
+ | ......^`,
+		},
+		{
+			txt: `
+rule:
+  match: 
+    name: value`,
+			err: `ERROR: <input>:4:5: got yaml node type tag:yaml.org,2002:map, wanted type(s) [tag:yaml.org,2002:seq]
+ |     name: value
+ | ....^`,
+		},
+		{
+			txt: `
+rule:
+  match: 
+    - name`,
+			err: `ERROR: <input>:4:7: got yaml node type tag:yaml.org,2002:str, wanted type(s) [tag:yaml.org,2002:map]
+ |     - name
+ | ......^`,
+		},
 	}
 
 	for _, tst := range tests {

--- a/policy/testdata/errors/policy.yaml
+++ b/policy/testdata/errors/policy.yaml
@@ -14,6 +14,9 @@
 
 name: "errors"
 imports:
+  - name: " untrimmed.Import1  "
+  - name: >
+      punc.Import!
   - name: "bad import"
 rule:
   variables:

--- a/policy/testdata/errors/policy.yaml
+++ b/policy/testdata/errors/policy.yaml
@@ -13,10 +13,14 @@
 # limitations under the License.
 
 name: "errors"
+imports:
+  - name: "bad import"
 rule:
   variables:
     - name: want
       expression: spec.labels
+    - name: want
+      expression: "2"
     - name: missing
       expression: variables.want.filter(l, !(lin resource.labels))
     - name: bad_data

--- a/policy/testdata/pb/config.yaml
+++ b/policy/testdata/pb/config.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: "pb"
-container: "google.expr.proto3.test"
+container: "google.expr.proto3"
 extensions:
   - name: "strings"
     version: 2

--- a/policy/testdata/pb/policy.yaml
+++ b/policy/testdata/pb/policy.yaml
@@ -15,8 +15,10 @@
 name: "pb"
 
 imports:
+   - name: google.expr.proto3.test.TestAllTypes
    - name: google.expr.proto3.test.TestAllTypes.NestedEnum
-   - name: google.expr.proto3.test.ImportedGlobalEnum
+   - name: |
+      google.expr.proto3.test.ImportedGlobalEnum
 
 rule:
   match:

--- a/policy/testdata/pb/policy.yaml
+++ b/policy/testdata/pb/policy.yaml
@@ -13,8 +13,19 @@
 # limitations under the License.
 
 name: "pb"
+
+imports:
+   - name: google.expr.proto3.test.TestAllTypes.NestedEnum
+   - name: google.expr.proto3.test.ImportedGlobalEnum
+
 rule:
   match:
-    - condition: spec.single_int32 > 10
+    - condition: >
+        spec.single_int32 > TestAllTypes{single_int64: 10}.single_int64
       output: |
         "invalid spec, got single_int32=%d, wanted <= 10".format([spec.single_int32])
+    - condition: >
+        spec.standalone_enum == NestedEnum.BAR ||
+        ImportedGlobalEnum.IMPORT_BAR in spec.imported_enums
+      output: |
+        "invalid spec, neither nested nor imported enums may refer to BAR or IMPORT_BAR"

--- a/policy/testdata/pb/tests.yaml
+++ b/policy/testdata/pb/tests.yaml
@@ -18,17 +18,16 @@ section:
     tests:
      - name: "good spec"
        input:
-         spec: 
+         spec:
            expr: >
-             TestAllTypes{single_int32: 10}
+             test.TestAllTypes{single_int32: 10}
        output: "optional.none()"
   - name: "invalid"
     tests:
      - name: "bad spec"
        input:
-         spec: 
+         spec:
            expr: >
-             TestAllTypes{single_int32: 11}
+             test.TestAllTypes{single_int32: 11}
        output: >
          "invalid spec, got single_int32=11, wanted <= 10"
-       


### PR DESCRIPTION
Allow users to specify type name imports in policies.

Imported types are aliased by the simple type name:

```yaml
# Create an import alias to `TypeName`
imports:
  - name: my.custom.really.ridiculously.long.package.TypeName

rule:
  match:
    - output: "TypeName{}"
```
 
As a future refinement, the imports will support a custom `alias` to allow
for alias disambiguation between types which come from different packages
but have the same simple name.