### PR TITLE
Support for context proto declarations

### DIFF
--- a/policy/BUILD.bazel
+++ b/policy/BUILD.bazel
@@ -41,6 +41,9 @@ go_library(
         "//common/types/ref:go_default_library",
         "//ext:go_default_library",
         "@in_gopkg_yaml_v3//:go_default_library",
+        "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
+        "@org_golang_google_protobuf//reflect/protoregistry:go_default_library",
     ],
 )
 
@@ -58,6 +61,7 @@ go_test(
     deps = [
         "//cel:go_default_library",
         "//common/types:go_default_library",
+        "//interpreter:go_default_library",
         "//common/types/ref:go_default_library",
         "//test/proto3pb:go_default_library",
         "@in_gopkg_yaml_v3//:go_default_library",

--- a/policy/config_test.go
+++ b/policy/config_test.go
@@ -128,7 +128,7 @@ variables:
   - name: "bad_type"
     type:
       type_name: "strings"`,
-			err: "undefined type name: strings",
+			err: "invalid variable type for 'bad_type': undefined type name: strings",
 		},
 		{
 			config: `
@@ -136,7 +136,7 @@ variables:
   - name: "bad_list"
     type:
       type_name: "list"`,
-			err: "list type has unexpected param count: 0",
+			err: "invalid variable type for 'bad_list': list type has unexpected param count: 0",
 		},
 		{
 			config: `
@@ -146,7 +146,7 @@ variables:
       type_name: "map"
       params:
         - type_name: "string"`,
-			err: "map type has unexpected param count: 1",
+			err: "invalid variable type for 'bad_map': map type has unexpected param count: 1",
 		},
 		{
 			config: `
@@ -156,7 +156,7 @@ variables:
       type_name: "list"
       params:
         - type_name: "number"`,
-			err: "undefined type name: number",
+			err: "invalid variable type for 'bad_list_type_param': undefined type name: number",
 		},
 		{
 			config: `
@@ -167,8 +167,23 @@ variables:
       params:
         - type_name: "string"
         - type_name: "optional"`,
-			err: "undefined type name: optional",
+			err: "invalid variable type for 'bad_map_type_param': undefined type name: optional",
 		},
+		{
+			config: `
+variables:
+  - context_proto: "bad.proto.MessageType"
+`,
+			err: "could not find context proto type name: bad.proto.MessageType",
+		},
+		{
+			config: `
+variables:
+  - type: 
+      type_name: "no variable name"`,
+			err: "invalid variable, must set 'name' or 'context_proto' field",
+		},
+
 		{
 			config: `
 functions:

--- a/policy/conformance.go
+++ b/policy/conformance.go
@@ -38,6 +38,12 @@ type TestCase struct {
 
 // TestInput represents an input literal value or expression.
 type TestInput struct {
-	Value any    `yaml:"value"`
-	Expr  string `yaml:"expr"`
+	// Value is a simple literal value.
+	Value any `yaml:"value"`
+
+	// Expr is a CEL expression based input.
+	Expr string `yaml:"expr"`
+
+	// ContextExpr is a CEL expression which is used as cel.ContextProtoVars
+	ContextExpr string `yaml:"context_expr"`
 }

--- a/policy/helper_test.go
+++ b/policy/helper_test.go
@@ -86,6 +86,19 @@ var (
 	    ? optional.of({"banned": "unconfigured_region"}) : optional.none()))`,
 		},
 		{
+			name: "context_pb",
+			expr: `
+	(single_int32 > google.expr.proto3.test.TestAllTypes{single_int64: 10}.single_int64)
+	? optional.of("invalid spec, got single_int32=%d, wanted <= 10".format([single_int32]))
+	: ((standalone_enum == google.expr.proto3.test.TestAllTypes.NestedEnum.BAR ||
+      google.expr.proto3.test.ImportedGlobalEnum.IMPORT_BAR in imported_enums)
+	  ? optional.of("invalid spec, neither nested nor imported enums may refer to BAR or IMPORT_BAR")
+	  : optional.none())`,
+			envOpts: []cel.EnvOption{
+				cel.Types(&proto3pb.TestAllTypes{}),
+			},
+		},
+		{
 			name: "pb",
 			expr: `
 	(spec.single_int32 > google.expr.proto3.test.TestAllTypes{single_int64: 10}.single_int64)

--- a/policy/testdata/context_pb/config.yaml
+++ b/policy/testdata/context_pb/config.yaml
@@ -1,0 +1,21 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "context_pb"
+container: "google.expr.proto3"
+extensions:
+  - name: "strings"
+    version: 2
+variables:
+  - context_proto: "google.expr.proto3.test.TestAllTypes"

--- a/policy/testdata/context_pb/policy.yaml
+++ b/policy/testdata/context_pb/policy.yaml
@@ -1,0 +1,33 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "context_pb"
+
+imports:
+   - name: google.expr.proto3.test.TestAllTypes
+   - name: google.expr.proto3.test.TestAllTypes.NestedEnum
+   - name: |
+      google.expr.proto3.test.ImportedGlobalEnum
+
+rule:
+  match:
+    - condition: >
+        single_int32 > TestAllTypes{single_int64: 10}.single_int64
+      output: |
+        "invalid spec, got single_int32=%d, wanted <= 10".format([single_int32])
+    - condition: >
+        standalone_enum == NestedEnum.BAR ||
+        ImportedGlobalEnum.IMPORT_BAR in imported_enums
+      output: |
+        "invalid spec, neither nested nor imported enums may refer to BAR or IMPORT_BAR"

--- a/policy/testdata/context_pb/tests.yaml
+++ b/policy/testdata/context_pb/tests.yaml
@@ -1,0 +1,33 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: "Protobuf input tests"
+section:
+  - name: "valid"
+    tests:
+     - name: "good spec"
+       input:
+         spec:
+           context_expr: >
+             test.TestAllTypes{single_int32: 10}
+       output: "optional.none()"
+  - name: "invalid"
+    tests:
+     - name: "bad spec"
+       input:
+         spec:
+           context_expr: >
+             test.TestAllTypes{single_int32: 11}
+       output: >
+         "invalid spec, got single_int32=11, wanted <= 10"


### PR DESCRIPTION
Introduce support for using a single context declaration

Context declarations take a protobuf message as input and treat all
top-level fields as variables. Only one context declaration is supported
at this time.