### PR TITLE
Do not permit unbounded recursive flattening in lists

### DIFF
--- a/ext/lists_test.go
+++ b/ext/lists_test.go
@@ -41,7 +41,7 @@ func TestLists(t *testing.T) {
 		{expr: `[1,[2,[3,4]]].flatten() == [1,2,[3,4]]`},
 		{expr: `[1,2,[],[],[3,4]].flatten() == [1,2,3,4]`},
 		{expr: `[1,[2,[3,4]]].flatten(2) == [1,2,3,4]`},
-		{expr: `[1,[2,[3,[4]]]].flatten(-1) == [1,2,3,4]`},
+		{expr: `[1,[2,[3,[4]]]].flatten(-1) == [1,2,3,4]`, err: "level must be non-negative"},
 	}
 
 	env := testListsEnv(t)


### PR DESCRIPTION
Cyclic lists will lead to an infinite recursion. For safety, we want to disallow accepting negative depth level to `flatten` function.