### PR TITLE
ext: add list.sort()

### DIFF
--- a/ext/README.md
+++ b/ext/README.md
@@ -405,6 +405,19 @@ Examples:
     [1,2,3,4].slice(1, 3) // return [2, 3]
     [1,2,3,4].slice(2, 4) // return [3 ,4]
 
+### Sort
+
+Sorts a list with comparable elements. If the element type is not comparable
+
+    <list(T)>.sort() -> <list(T)>
+
+Examples:
+
+    [3, 2, 1].sort() // return [1, 2, 3]
+    ["b", "c", "a"].sort() // return ["a", "b", "c"]
+    [1, "b"].sort() // error
+    [[1, 2, 3]].sort() // error
+
 ## Sets
 
 Sets provides set relationship tests.

--- a/ext/README.md
+++ b/ext/README.md
@@ -408,8 +408,10 @@ Examples:
 ### Sort
 
 Sorts a list with comparable elements. If the element type is not comparable
+or the element types are not the same, the function will produce an error.
 
     <list(T)>.sort() -> <list(T)>
+    T in {int, uint, double, bool, duration, timestamp, string, bytes}
 
 Examples:
 

--- a/ext/README.md
+++ b/ext/README.md
@@ -407,6 +407,8 @@ Examples:
 
 ### Sort
 
+**Introduced in version 2**
+
 Sorts a list with comparable elements. If the element type is not comparable
 or the element types are not the same, the function will produce an error.
 

--- a/ext/lists.go
+++ b/ext/lists.go
@@ -17,7 +17,7 @@ package ext
 import (
 	"fmt"
 	"math"
-	"slices"
+	"sort"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/decls"
@@ -286,8 +286,8 @@ func sortList(list traits.Lister) (ref.Val, error) {
 		sorted = append(sorted, val)
 	}
 
-	slices.SortFunc(sorted, func(a, b ref.Val) int {
-		return int(a.(traits.Comparer).Compare(b).Value().(int64))
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].(traits.Comparer).Compare(sorted[j]) == types.IntNegOne
 	})
 
 	return types.DefaultTypeAdapter.NativeToValue(sorted), nil

--- a/ext/lists.go
+++ b/ext/lists.go
@@ -210,11 +210,7 @@ func (lib listsLib) CompileOptions() []cel.EnvOption {
 						return sorted
 					},
 					// List traits
-					traits.AdderType,
-					traits.ContainerType,
-					traits.IndexerType,
-					traits.IterableType,
-					traits.SizerType,
+					traits.ListerType,
 				),
 			)...,
 		)

--- a/ext/lists.go
+++ b/ext/lists.go
@@ -69,6 +69,8 @@ var comparableTypes = []*cel.Type{
 //
 // # Sort
 //
+// Introduced in version: 2
+//
 // Sorts a list with comparable elements. If the element type is not comparable
 // or the element types are not the same, the function will produce an error.
 //

--- a/ext/lists_test.go
+++ b/ext/lists_test.go
@@ -42,6 +42,11 @@ func TestLists(t *testing.T) {
 		{expr: `[1,2,[],[],[3,4]].flatten() == [1,2,3,4]`},
 		{expr: `[1,[2,[3,4]]].flatten(2) == [1,2,3,4]`},
 		{expr: `[1,[2,[3,[4]]]].flatten(-1) == [1,2,3,4]`, err: "level must be non-negative"},
+		{expr: `[4, 3, 2, 1].sort() == [1, 2, 3, 4]`},
+		{expr: `["d", "a", "b", "c"].sort() == ["a", "b", "c", "d"]`},
+		{expr: `["d", 3, 2, "c"].sort() == ["a", "b", "c", "d"]`, err: "list elements must have the same type"},
+		{expr: `[[1, 2, 3], [3, 2, 1]].sort()`, err: "list elements must be comparable"},
+		{expr: `[[1, 2, 3]].sort()`, err: "list elements must be comparable"},
 	}
 
 	env := testListsEnv(t)

--- a/ext/lists_test.go
+++ b/ext/lists_test.go
@@ -45,8 +45,6 @@ func TestLists(t *testing.T) {
 		{expr: `[4, 3, 2, 1].sort() == [1, 2, 3, 4]`},
 		{expr: `["d", "a", "b", "c"].sort() == ["a", "b", "c", "d"]`},
 		{expr: `["d", 3, 2, "c"].sort() == ["a", "b", "c", "d"]`, err: "list elements must have the same type"},
-		{expr: `[[1, 2, 3], [3, 2, 1]].sort()`, err: "list elements must be comparable"},
-		{expr: `[[1, 2, 3]].sort()`, err: "list elements must be comparable"},
 	}
 
 	env := testListsEnv(t)


### PR DESCRIPTION
I skipped creating an issue because this seemed like a small enough change to me, but please let me know if an issue is preferable.

This PR adds a `<list(T)>.sort() -> <list(T)>` member. T must implement `(traits.Comparer)`.

I believe that the check if the element type implements `traits.Comparer` only happens at runtime (how can I write tests for this?). An alternative implementation would create separate member overloads for `list(T), T in {set of comparable types}` similar to kube [apiserver list extensions](https://github.com/kubernetes/apiextensions-apiserver/blob/v0.25.16/pkg/apiserver/schema/cel/library/lists.go#L135)

Let me know if I should update the PR to create separate overloads.

