### PR TITLE
Update REPL examples

### DIFF
--- a/repl/appengine/web/src/app/reference_panel/reference-panel-component.html
+++ b/repl/appengine/web/src/app/reference_panel/reference-panel-component.html
@@ -59,5 +59,9 @@
             <button mat-list-item (click)="startExample('math')">Math</button>
             <button mat-list-item (click)="startExample('bind')">Bind</button>
         </mat-action-list>
+        <p>CEL Spec</p>
+        <mat-action-list>
+            <button mat-list-item (click)="startExample('cel-spec-test')">CEL Spec Test Types</button>
+        </mat-action-list>
     </mat-expansion-panel>
 </mat-accordion>

--- a/repl/appengine/web/src/app/reference_panel/reference-panel-component.ts
+++ b/repl/appengine/web/src/app/reference_panel/reference-panel-component.ts
@@ -112,9 +112,20 @@ const examples = new Map<string, Example>([
     "request": {
       commands: [
         `%option --enable_partial_eval`,
-        `%declare x : int`,
-        `%let y : int = 10`,
-        `x > y || y > 10`,
+        `%declare unk_a : bool`,
+        `%declare unk_b : bool`,
+        `%let err = 1 / 0 > 2`,
+        `true || false`,
+        `true || unk_a`,
+        `true || err`,
+        `false || unk_a`,
+        `false || err`,
+        `unk_a || true`,
+        `unk_a || false`,
+        `unk_a || err`,
+        `unk_a || unk_a`,
+        `unk_a || unk_b`,
+        `unk_a || true || err`,
       ]
     }
   }],
@@ -168,6 +179,19 @@ const examples = new Map<string, Example>([
         `%option --extension "bindings"`,
         `cel.bind(x, 20, x * x)`,
         `cel.bind(allow, [1, 2, 3, 4], [3, 2, 1, 1, 4].all(x, x in allow))`
+      ]
+    }
+  }],
+  [
+    "cel-spec-test",
+  {
+    request: {
+      commands: [
+        `%load_descriptors --pkg 'cel-spec-test-types'`,
+        `%option --container "google.api.expr.test.v1"`,
+        `%let pb3 = proto3.TestAllTypes{}`,
+        `%let pb2 = proto2.TestAllTypes`,
+        `pb3 == proto3.TestAllTypes{}`
       ]
     }
   }],

--- a/repl/appengine/web/src/theme.scss
+++ b/repl/appengine/web/src/theme.scss
@@ -38,15 +38,17 @@ $theme: mat.m2-define-light-theme(
   )
 );
 
-// Include theme styles for "core" features like ripples and elevation.
-@include mat.core-theme($theme);
+html {
+  // Include theme styles for "core" features like ripples and elevation.
+  @include mat.core-theme($theme);
 
-// Include theme styles for each component used in the application.
-@include mat.button-theme($theme);
-@include mat.fab-theme($theme);
-@include mat.icon-theme($theme);
-@include mat.form-field-theme($theme);
-@include mat.input-theme($theme);
-@include mat.sidenav-theme($theme);
-@include mat.expansion-theme($theme);
-@include mat.list-theme($theme);
+  // Include theme styles for each component used in the application.
+  @include mat.button-theme($theme);
+  @include mat.fab-theme($theme);
+  @include mat.icon-theme($theme);
+  @include mat.form-field-theme($theme);
+  @include mat.input-theme($theme);
+  @include mat.sidenav-theme($theme);
+  @include mat.expansion-theme($theme);
+  @include mat.list-theme($theme);
+}


### PR DESCRIPTION
- update partial eval with a simple value table for or
- add example for loading cel-spec test types
- update theme.scss to apply the theme to html selector explicitly

![image](https://github.com/user-attachments/assets/9abf3cf0-81c2-4610-86a3-be1ff9f70f6b)
![image](https://github.com/user-attachments/assets/f813bad6-5c40-4aa3-a8a2-5e7f97fc68e0)

