### PR TITLE
Update the Go AST representation to handle a second iteration variable

### DIFF
--- a/common/ast/BUILD.bazel
+++ b/common/ast/BUILD.bazel
@@ -15,7 +15,7 @@ go_library(
         "navigable.go",
     ],
     importpath = "github.com/google/cel-go/common/ast",
-    deps = [    
+    deps = [
         "//common:go_default_library",
         "//common/types:go_default_library",
         "//common/types/ref:go_default_library",
@@ -35,12 +35,13 @@ go_test(
     embed = [
         ":go_default_library",
     ],
-    deps = [    
+    deps = [
         "//checker:go_default_library",
         "//checker/decls:go_default_library",
         "//common:go_default_library",
         "//common/containers:go_default_library",
         "//common/decls:go_default_library",
+        "//common/operators:go_default_library",
         "//common/overloads:go_default_library",
         "//common/stdlib:go_default_library",
         "//common/types:go_default_library",

--- a/common/ast/conversion.go
+++ b/common/ast/conversion.go
@@ -173,9 +173,10 @@ func exprComprehension(factory ExprFactory, id int64, comp *exprpb.Expr_Comprehe
 	if err != nil {
 		return nil, err
 	}
-	return factory.NewComprehension(id,
+	return factory.NewComprehensionTwoVar(id,
 		iterRange,
 		comp.GetIterVar(),
+		comp.GetIterVar2(),
 		comp.GetAccuVar(),
 		accuInit,
 		loopCond,
@@ -363,6 +364,7 @@ func protoComprehension(id int64, comp ComprehensionExpr) (*exprpb.Expr, error) 
 		ExprKind: &exprpb.Expr_ComprehensionExpr{
 			ComprehensionExpr: &exprpb.Expr_Comprehension{
 				IterVar:       comp.IterVar(),
+				IterVar2:      comp.IterVar2(),
 				IterRange:     iterRange,
 				AccuVar:       comp.AccuVar(),
 				AccuInit:      accuInit,

--- a/common/ast/expr.go
+++ b/common/ast/expr.go
@@ -269,7 +269,21 @@ type ComprehensionExpr interface {
 	IterRange() Expr
 
 	// IterVar returns the iteration variable name.
+	//
+	// For one-variable comprehensions, the iter var refers to the element value
+	// when iterating over a list, or the map key when iterating over a map.
+	//
+	// For two-variable comprehneions, the iter var refers to the list index or the
+	// map key.
 	IterVar() string
+
+	// IterVar2 returns the second iteration variable name.
+	//
+	// When the value is non-empty, the comprehension is a two-variable comprehension.
+	IterVar2() string
+
+	// HasIterVar2 returns true if the second iteration variable is non-empty.
+	HasIterVar2() bool
 
 	// AccuVar returns the accumulation variable name.
 	AccuVar() string
@@ -397,6 +411,7 @@ func (e *expr) SetKindCase(other Expr) {
 		e.exprKindCase = &baseComprehensionExpr{
 			iterRange: c.IterRange(),
 			iterVar:   c.IterVar(),
+			iterVar2:  c.IterVar2(),
 			accuVar:   c.AccuVar(),
 			accuInit:  c.AccuInit(),
 			loopCond:  c.LoopCondition(),
@@ -505,6 +520,7 @@ var _ ComprehensionExpr = &baseComprehensionExpr{}
 type baseComprehensionExpr struct {
 	iterRange Expr
 	iterVar   string
+	iterVar2  string
 	accuVar   string
 	accuInit  Expr
 	loopCond  Expr
@@ -525,6 +541,14 @@ func (e *baseComprehensionExpr) IterRange() Expr {
 
 func (e *baseComprehensionExpr) IterVar() string {
 	return e.iterVar
+}
+
+func (e *baseComprehensionExpr) IterVar2() string {
+	return e.iterVar2
+}
+
+func (e *baseComprehensionExpr) HasIterVar2() bool {
+	return e.iterVar2 != ""
 }
 
 func (e *baseComprehensionExpr) AccuVar() string {

--- a/common/ast/navigable.go
+++ b/common/ast/navigable.go
@@ -390,6 +390,14 @@ func (comp navigableComprehensionImpl) IterVar() string {
 	return comp.Expr.AsComprehension().IterVar()
 }
 
+func (comp navigableComprehensionImpl) IterVar2() string {
+	return comp.Expr.AsComprehension().IterVar2()
+}
+
+func (comp navigableComprehensionImpl) HasIterVar2() bool {
+	return comp.Expr.AsComprehension().HasIterVar2()
+}
+
 func (comp navigableComprehensionImpl) AccuVar() string {
 	return comp.Expr.AsComprehension().AccuVar()
 }

--- a/common/ast/navigable_test.go
+++ b/common/ast/navigable_test.go
@@ -488,6 +488,12 @@ func TestNavigableComprehensionExpr(t *testing.T) {
 	if comp.IterVar() != "i" {
 		t.Errorf("IterVar() got %s, wanted 'i'", comp.IterVar())
 	}
+	if comp.HasIterVar2() {
+		t.Error("HasIterVar2() returned true, wanted false")
+	}
+	if comp.IterVar2() != "" {
+		t.Errorf("IterVar2() returned %s, wanted empty string", comp.IterVar2())
+	}
 	if comp.AccuVar() != "__result__" {
 		t.Errorf("AccuVar() got %s, wanted '__result__'", comp.AccuVar())
 	}

--- a/common/debug/debug.go
+++ b/common/debug/debug.go
@@ -215,6 +215,11 @@ func (w *debugWriter) appendComprehension(comprehension ast.ComprehensionExpr) {
 	w.append(comprehension.IterVar())
 	w.append(",")
 	w.appendLine()
+	if comprehension.HasIterVar2() {
+		w.append(comprehension.IterVar2())
+		w.append(",")
+		w.appendLine()
+	}
 	w.append("// Target")
 	w.appendLine()
 	w.Buffer(comprehension.IterRange())


### PR DESCRIPTION
Update the Go AST representation to handle a second iteration variable