### PR TITLE
Two-variable comprehension support

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -496,16 +496,32 @@ func (c *checker) checkComprehension(e ast.Expr) {
 	comp := e.AsComprehension()
 	c.check(comp.IterRange())
 	c.check(comp.AccuInit())
-	accuType := c.getType(comp.AccuInit())
 	rangeType := substitute(c.mappings, c.getType(comp.IterRange()), false)
-	var varType *types.Type
 
+	// Create a scope for the comprehension since it has a local accumulation variable.
+	// This scope will contain the accumulation variable used to compute the result.
+	accuType := c.getType(comp.AccuInit())
+	c.env = c.env.enterScope()
+	c.env.AddIdents(decls.NewVariable(comp.AccuVar(), accuType))
+
+	var varType, var2Type *types.Type
 	switch rangeType.Kind() {
 	case types.ListKind:
+		// varType represents the list element type for oen-variable comprehensions.
 		varType = rangeType.Parameters()[0]
+		if comp.HasIterVar2() {
+			// varType represents the list index (int) for two-variable comprehensions,
+			// and var2Type represents the list element type.
+			varType = types.IntType
+			var2Type = rangeType.Parameters()[0]
+		}
 	case types.MapKind:
-		// Ranges over the keys.
+		// varType represents the map entry key for all comprehension types.
 		varType = rangeType.Parameters()[0]
+		if comp.HasIterVar2() {
+			// var2Type represents the map entry value for two-variable comprehensions.
+			var2Type = rangeType.Parameters()[1]
+		}
 	case types.DynKind, types.ErrorKind, types.TypeParamKind:
 		// Set the range type to DYN to prevent assignment to a potentially incorrect type
 		// at a later point in type-checking. The isAssignable call will update the type
@@ -518,13 +534,12 @@ func (c *checker) checkComprehension(e ast.Expr) {
 		varType = types.ErrorType
 	}
 
-	// Create a scope for the comprehension since it has a local accumulation variable.
-	// This scope will contain the accumulation variable used to compute the result.
-	c.env = c.env.enterScope()
-	c.env.AddIdents(decls.NewVariable(comp.AccuVar(), accuType))
 	// Create a block scope for the loop.
 	c.env = c.env.enterScope()
 	c.env.AddIdents(decls.NewVariable(comp.IterVar(), varType))
+	if comp.HasIterVar2() {
+		c.env.AddIdents(decls.NewVariable(comp.IterVar2(), var2Type))
+	}
 	// Check the variable references in the condition and step.
 	c.check(comp.LoopCondition())
 	c.assertType(comp.LoopCondition(), types.BoolType)

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -507,13 +507,13 @@ func (c *checker) checkComprehension(e ast.Expr) {
 	var varType, var2Type *types.Type
 	switch rangeType.Kind() {
 	case types.ListKind:
-		// varType represents the list element type for oen-variable comprehensions.
+		// varType represents the list element type for one-variable comprehensions.
 		varType = rangeType.Parameters()[0]
 		if comp.HasIterVar2() {
 			// varType represents the list index (int) for two-variable comprehensions,
 			// and var2Type represents the list element type.
+			var2Type = varType
 			varType = types.IntType
-			var2Type = rangeType.Parameters()[0]
 		}
 	case types.MapKind:
 		// varType represents the map entry key for all comprehension types.

--- a/ext/README.md
+++ b/ext/README.md
@@ -3,12 +3,12 @@
 CEL extensions are a related set of constants, functions, macros, or other
 features which may not be covered by the core CEL spec.
 
-## Bindings 
+## Bindings
 
 Returns a cel.EnvOption to configure support for local variable bindings
 in expressions.
 
-# Cel.Bind
+### Cel.Bind
 
 Binds a simple identifier to an initialization expression which may be used
 in a subsequenct result expression. Bindings may also be nested within each
@@ -19,11 +19,11 @@ other.
 Examples:
 
     cel.bind(a, 'hello',
-     cel.bind(b, 'world', a + b + b + a)) // "helloworldworldhello"
+    cel.bind(b, 'world', a + b + b + a)) // "helloworldworldhello"
 
     // Avoid a list allocation within the exists comprehension.
     cel.bind(valid_values, [a, b, c],
-     [d, e, f].exists(elem, elem in valid_values))
+    [d, e, f].exists(elem, elem in valid_values))
 
 Local bindings are not guaranteed to be evaluated before use.
 
@@ -684,3 +684,134 @@ Examples:
 
     'gums'.reverse() // returns 'smug'
     'John Smith'.reverse() // returns 'htimS nhoJ'
+
+## TwoVarComprehensions
+
+TwoVarComprehensions introduces support for two-variable comprehensions.
+
+The two-variable form of comprehensions looks similar to the one-variable
+counterparts. Where possible, the same macro names were used and additional
+macro signatures added. The notable distinction for two-variable comprehensions
+is the introduction of `transformList`, `transformMap`, and `transformMapEntry`
+support for list and map types rather than the more traditional `map` and
+`filter` macros.
+
+### All
+
+Comprehension which tests whether all elements in the list or map satisfy a
+given predicate. The `all` macro evaluates in a manner consistent with logical
+AND and will short-circuit when encountering a `false` value.
+
+    <list>.all(indexVar, valueVar, <predicate>) -> bool
+    <map>.all(keyVar, valueVar, <predicate>) -> bool
+
+Examples:
+
+    [1, 2, 3].all(i, j, i < j) // returns true
+    {'hello': 'world', 'taco': 'taco'}.all(k, v, k != v) // returns false
+
+    // Combines two-variable comprehension with single variable
+    {'h': ['hello', 'hi'], 'j': ['joke', 'jog']}
+      .all(k, vals, vals.all(v, v.startsWith(k))) // returns true
+
+### Exists
+
+Comprehension which tests whether any element in a list or map exists which
+satisfies a given predicate. The `exists` macro evaluates in a manner consistent
+with logical OR and will short-circuit when encountering a `true` value.
+
+    <list>.exists(indexVar, valueVar, <predicate>) -> bool
+    <map>.exists(keyVar, valueVar, <predicate>) -> bool
+
+Examples:
+
+    {'greeting': 'hello', 'farewell': 'goodbye'}
+      .exists(k, v, k.startsWith('good') || v.endsWith('bye')) // returns true
+    [1, 2, 4, 8, 16].exists(i, v, v == 1024 && i == 10) // returns false
+
+### ExistsOne
+
+Comprehension which tests whether exactly one element in a list or map exists
+which satisfies a given predicate expression. This comprehension does not
+short-circuit in keeping with the one-variable exists one macro semantics.
+
+    <list>.existsOne(indexVar, valueVar, <predicate>)
+    <map>.existsOne(keyVar, valueVar, <predicate>)
+
+This macro may also be used with the `exists_one` function name, for
+compatibility with the one-variable macro of the same name.
+
+Examples:
+
+    [1, 2, 1, 3, 1, 4].existsOne(i, v, i == 1 || v == 1) // returns false
+    [1, 1, 2, 2, 3, 3].existsOne(i, v, i == 2 && v == 2) // returns true
+    {'i': 0, 'j': 1, 'k': 2}.existsOne(i, v, i == 'l' || v == 1) // returns true
+
+### TransformList
+
+Comprehension which converts a map or a list into a list value. The output
+expression of the comprehension determines the contents of the output list.
+Elements in the list may optionally be filtered according to a predicate
+expression, where elements that satisfy the predicate are transformed.
+
+    <list>.transformList(indexVar, valueVar, <transform>)
+    <list>.transformList(indexVar, valueVar, <filter>, <transform>)
+    <map>.transformList(keyVar, valueVar, <transform>)
+    <map>.transformList(keyVar, valueVar, <filter>, <transform>)
+
+Examples:
+
+    [1, 2, 3].transformList(indexVar, valueVar,
+      (indexVar * valueVar) + valueVar) // returns [1, 4, 9]
+    [1, 2, 3].transformList(indexVar, valueVar, indexVar % 2 == 0
+      (indexVar * valueVar) + valueVar) // returns [1, 9]
+    {'greeting': 'hello', 'farewell': 'goodbye'}
+      .transformList(k, _, k) // returns ['greeting', 'farewell']
+    {'greeting': 'hello', 'farewell': 'goodbye'}
+      .transformList(_, v, v) // returns ['hello', 'goodbye']
+
+### TransformMap
+
+Comprehension which converts a map or a list into a map value. The output
+expression of the comprehension determines the value of the output map entry;
+however, the key remains fixed. Elements in the map may optionally be filtered
+according to a predicate expression, where elements that satisfy the predicate
+are transformed.
+
+    <list>.transformMap(indexVar, valueVar, <transform>)
+    <list>.transformMap(indexVar, valueVar, <filter>, <transform>)
+    <map>.transformMap(keyVar, valueVar, <transform>)
+    <map>.transformMap(keyVar, valueVar, <filter>, <transform>)
+
+Examples:
+
+    [1, 2, 3].transformMap(indexVar, valueVar,
+      (indexVar * valueVar) + valueVar) // returns {0: 1, 1: 4, 2: 9}
+    [1, 2, 3].transformMap(indexVar, valueVar, indexVar % 2 == 0
+      (indexVar * valueVar) + valueVar) // returns {0: 1, 2: 9}
+    {'greeting': 'hello'}.transformMap(k, v, v + '!') // returns {'greeting': 'hello!'}
+
+### TransformMapEntry
+
+Comprehension which converts a map or a list into a map value; however, this
+transform expects the entry expression be a map literal. If the transform
+produces an entry which duplicates a key in the target map, the comprehension
+will error.
+
+Elements in the map may optionally be filtered according to a predicate
+expression, where elements that satisfy the predicate are transformed.
+
+    <list>.transformMap(indexVar, valueVar, <transform>)
+    <list>.transformMap(indexVar, valueVar, <filter>, <transform>)
+    <map>.transformMap(keyVar, valueVar, <transform>)
+    <map>.transformMap(keyVar, valueVar, <filter>, <transform>)
+
+Examples:
+
+    // returns {'hello': 'greeting'}
+    {'greeting': 'hello'}.transformMapEntry(keyVar, valueVar, {valueVar: keyVar})
+    // reverse lookup, require all values in list be unique
+    [1, 2, 3].transformMapEntry(indexVar, valueVar, {valueVar: indexVar})
+
+    {'greeting': 'aloha', 'farewell': 'aloha'}
+      .transformMapEntry(keyVar, valueVar, {valueVar: keyVar}) // error, duplicate key

--- a/ext/comprehensions.go
+++ b/ext/comprehensions.go
@@ -1,0 +1,210 @@
+package ext
+
+import (
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/operators"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+	"github.com/google/cel-go/parser"
+)
+
+const (
+	mapInsert         = "cel.@mapInsert"
+	mapInsertOverload = "@mapInsert_map_key_value"
+)
+
+func TwoVarComprehensions() cel.EnvOption {
+	return cel.Lib(compreV2Lib{})
+}
+
+type compreV2Lib struct{}
+
+func (compreV2Lib) LibraryName() string {
+	return "cel.lib.ext.comprev2"
+}
+
+func (compreV2Lib) CompileOptions() []cel.EnvOption {
+	kType := cel.TypeParamType("K")
+	vType := cel.TypeParamType("V")
+	vPrimeType := cel.TypeParamType("V1")
+	mapKVType := cel.MapType(kType, vType)
+	mapKVPrimeType := cel.MapType(kType, vPrimeType)
+	opts := []cel.EnvOption{
+		cel.Macros(
+			cel.ReceiverMacro("all", 3, quantifierAll),
+			cel.ReceiverMacro("exists", 3, quantifierExists),
+			cel.ReceiverMacro("existsOne", 3, quantifierExistsOne),
+			cel.ReceiverMacro("exists_one", 3, quantifierExistsOne),
+			cel.ReceiverMacro("transformList", 3, transformList),
+			cel.ReceiverMacro("transformList", 4, transformList),
+			cel.ReceiverMacro("transformMap", 3, transformMap),
+			cel.ReceiverMacro("transformMap", 4, transformMap),
+		),
+		cel.Function(mapInsert,
+			cel.Overload(mapInsertOverload, []*cel.Type{mapKVType, kType, vType}, mapKVPrimeType,
+				cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+					m := args[0].(traits.Mapper)
+					k := args[1]
+					v := args[2]
+					return types.InsertMapKeyValue(m, k, v)
+				})),
+		),
+	}
+	return opts
+}
+
+func (compreV2Lib) ProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{}
+}
+
+func quantifierAll(mef cel.MacroExprFactory, target ast.Expr, args []ast.Expr) (ast.Expr, *cel.Error) {
+	iterVar1, err := extractIterVar(mef, args[0])
+	if err != nil {
+		return nil, err
+	}
+	iterVar2, err := extractIterVar(mef, args[1])
+	if err != nil {
+		return nil, err
+	}
+	return mef.NewComprehensionTwoVar(
+		target,
+		iterVar1,
+		iterVar2,
+		parser.AccumulatorName,
+		/*accuInit=*/ mef.NewLiteral(types.True),
+		/*condition=*/ mef.NewCall(operators.NotStrictlyFalse, mef.NewAccuIdent()),
+		/*step=*/ mef.NewCall(operators.LogicalAnd, mef.NewAccuIdent(), args[2]),
+		/*result=*/ mef.NewAccuIdent(),
+	), nil
+}
+
+func quantifierExists(mef cel.MacroExprFactory, target ast.Expr, args []ast.Expr) (ast.Expr, *cel.Error) {
+	iterVar1, err := extractIterVar(mef, args[0])
+	if err != nil {
+		return nil, err
+	}
+	iterVar2, err := extractIterVar(mef, args[1])
+	if err != nil {
+		return nil, err
+	}
+	return mef.NewComprehensionTwoVar(
+		target,
+		iterVar1,
+		iterVar2,
+		parser.AccumulatorName,
+		/*accuInit=*/ mef.NewLiteral(types.False),
+		/*condition=*/ mef.NewCall(operators.NotStrictlyFalse, mef.NewCall(operators.LogicalNot, mef.NewAccuIdent())),
+		/*step=*/ mef.NewCall(operators.LogicalOr, mef.NewAccuIdent(), args[2]),
+		/*result=*/ mef.NewAccuIdent(),
+	), nil
+}
+
+func quantifierExistsOne(mef cel.MacroExprFactory, target ast.Expr, args []ast.Expr) (ast.Expr, *cel.Error) {
+	iterVar1, err := extractIterVar(mef, args[0])
+	if err != nil {
+		return nil, err
+	}
+	iterVar2, err := extractIterVar(mef, args[1])
+	if err != nil {
+		return nil, err
+	}
+	return mef.NewComprehensionTwoVar(
+		target,
+		iterVar1,
+		iterVar2,
+		parser.AccumulatorName,
+		/*accuInit=*/ mef.NewLiteral(types.Int(0)),
+		/*condition=*/ mef.NewLiteral(types.True),
+		/*step=*/ mef.NewCall(operators.Conditional, args[2],
+			mef.NewCall(operators.Add, mef.NewAccuIdent(), mef.NewLiteral(types.Int(1))),
+			mef.NewAccuIdent()),
+		/*result=*/ mef.NewCall(operators.Equals, mef.NewAccuIdent(), mef.NewLiteral(types.Int(1))),
+	), nil
+}
+
+func transformList(mef cel.MacroExprFactory, target ast.Expr, args []ast.Expr) (ast.Expr, *cel.Error) {
+	iterVar1, err := extractIterVar(mef, args[0])
+	if err != nil {
+		return nil, err
+	}
+	iterVar2, err := extractIterVar(mef, args[1])
+	if err != nil {
+		return nil, err
+	}
+
+	var transform ast.Expr
+	var filter ast.Expr
+	if len(args) == 4 {
+		filter = args[2]
+		transform = args[3]
+	} else {
+		filter = nil
+		transform = args[2]
+	}
+
+	//  __result__ = __result__ + [transform]
+	step := mef.NewCall(operators.Add, mef.NewAccuIdent(), mef.NewList(transform))
+	if filter != nil {
+		//  __result__ = (filter) ? __result__ + [transform] : __result__
+		step = mef.NewCall(operators.Conditional, filter, step, mef.NewAccuIdent())
+	}
+
+	return mef.NewComprehensionTwoVar(
+		target,
+		iterVar1,
+		iterVar2,
+		parser.AccumulatorName,
+		/*accuInit=*/ mef.NewList(),
+		/*condition=*/ mef.NewLiteral(types.True),
+		step,
+		/*result=*/ mef.NewAccuIdent(),
+	), nil
+}
+
+func transformMap(mef cel.MacroExprFactory, target ast.Expr, args []ast.Expr) (ast.Expr, *cel.Error) {
+	iterVar1, err := extractIterVar(mef, args[0])
+	if err != nil {
+		return nil, err
+	}
+	iterVar2, err := extractIterVar(mef, args[1])
+	if err != nil {
+		return nil, err
+	}
+
+	var transform ast.Expr
+	var filter ast.Expr
+	if len(args) == 4 {
+		filter = args[2]
+		transform = args[3]
+	} else {
+		filter = nil
+		transform = args[2]
+	}
+
+	// __result__ = cel.@mapInsert(__result__, iterVar1, transform)
+	step := mef.NewCall(mapInsert, mef.NewAccuIdent(), mef.NewIdent(iterVar1), transform)
+	if filter != nil {
+		// __result__ = (filter) ? cel.@mapInsert(__result__, iterVar1, transform) : __result__
+		step = mef.NewCall(operators.Conditional, filter, step, mef.NewAccuIdent())
+	}
+	return mef.NewComprehensionTwoVar(
+		target,
+		iterVar1,
+		iterVar2,
+		parser.AccumulatorName,
+		/*accuInit=*/ mef.NewMap(),
+		/*condition=*/ mef.NewLiteral(types.True),
+		step,
+		/*result=*/ mef.NewAccuIdent(),
+	), nil
+}
+
+func extractIterVar(meh cel.MacroExprFactory, target ast.Expr) (string, *cel.Error) {
+	iterVar, found := extractIdent(target)
+	if !found {
+		return "", meh.NewError(target.ID(), "iteration variable must be a simple name")
+	}
+	return iterVar, nil
+}

--- a/ext/comprehensions_test.go
+++ b/ext/comprehensions_test.go
@@ -1,0 +1,168 @@
+package ext
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+)
+
+func TestTwoVarComprehensions(t *testing.T) {
+	compreTests := []struct {
+		expr string
+	}{
+		// list.all()
+		{expr: "[1, 2, 3, 4].all(i, v, i < 5 && v > 0)"},
+		{expr: "[1, 2, 3, 4].all(i, v, i < v)"},
+		{expr: "[1, 2, 3, 4].all(i, v, i > v) == false"},
+		{expr: `
+		cel.bind(listA, [1, 2, 3, 4],
+		cel.bind(listB, [1, 2, 3, 4, 5],
+		   listA.all(i, v, listB[?i].hasValue() && listB[i] == v)
+		))
+		`},
+		{expr: `
+		cel.bind(listA, [1, 2, 3, 4, 5, 6],
+		cel.bind(listB, [1, 2, 3, 4, 5],
+		   listA.all(i, v, listB[?i].hasValue() && listB[i] == v)
+		)) == false
+		`},
+		// list.exists()
+		{expr: `
+		cel.bind(l, ['hello', 'world', 'hello!', 'worlds'],
+		  l.exists(i, v,
+		    v.startsWith('hello') && l[?(i+1)].optMap(next, next.endsWith('world')).orValue(false)
+		  )
+		)
+		`},
+		// list.existsOne()
+		{expr: `
+		cel.bind(l, ['hello', 'world', 'hello!', 'worlds'],
+		  l.existsOne(i, v,
+		    v.startsWith('hello') && l[?(i+1)].optMap(next, next.endsWith('world')).orValue(false)
+		  )
+		)
+		`},
+		{expr: `
+		cel.bind(l, ['hello', 'goodbye', 'hello!', 'goodbye'],
+		  l.exists_one(i, v,
+		    v.startsWith('hello') && l[?(i+1)].optMap(next, next == "goodbye").orValue(false)
+		  )
+		) == false
+		`},
+		// list.transformList()
+		{expr: `
+		cel.bind(l, ['Hello', 'world'],
+		  l.transformList(i, v, "[%d]%s".format([i, v.lowerAscii()]))
+		) == ["[0]hello", "[1]world"]
+		`},
+		{expr: `
+		cel.bind(l, ['hello', 'world'],
+		  l.transformList(i, v, v.startsWith('greeting'), "[%d]%s".format([i, v]))
+		) == []
+		`},
+		// map.all()
+		{expr: `
+		cel.bind(m, {'hello': 'world', 'hello!': 'world'},
+		  m.all(k, v, k.startsWith('hello') && v == 'world')
+		)
+		`},
+		{expr: `
+		cel.bind(m, {'hello': 'world', 'hello!': 'worlds'},
+		  m.all(k, v, k.startsWith('hello') && v.endsWith('world'))
+		) == false
+		`},
+		// map.exists()
+		{expr: `
+		cel.bind(m, {'hello': 'world', 'hello!': 'worlds'},
+		  m.exists(k, v, k.startsWith('hello') && v.endsWith('world'))
+		)
+		`},
+		// map.existsOne()
+		{expr: `
+		cel.bind(m, {'hello': 'world', 'hello!': 'worlds'},
+		  m.existsOne(k, v, k.startsWith('hello') && v.endsWith('world'))
+		)
+		`},
+		// map.exists_one()
+		{expr: `
+		cel.bind(m, {'hello': 'world', 'hello!': 'worlds'},
+		  m.exists_one(k, v, k.startsWith('hello') && v.endsWith('world'))
+		)
+		`},
+		{expr: `
+		cel.bind(m, {'hello': 'world', 'hello!': 'wow, world'},
+		  m.exists_one(k, v, k.startsWith('hello') && v.endsWith('world'))
+		) == false
+		`},
+		// map.transformList()
+		{expr: `
+		cel.bind(m, {'Hello': 'world'},
+		  m.transformList(k, v, "%s=%s".format([k.lowerAscii(), v]))
+		) == ["hello=world"]
+		`},
+		{expr: `
+		cel.bind(m, {'hello': 'world'},
+		  m.transformList(k, v, k.startsWith('greeting'), "%s=%s".format([k, v]))
+		) == []
+		`},
+		// map.transformMap()
+		{expr: `
+		cel.bind(m, {'hello': 'world', 'goodbye': 'cruel world'},
+			m.transformMap(k, v, "%s, %s!".format([k, v]))
+		) == {'hello': 'hello, world!', 'goodbye': 'goodbye, cruel world!'}
+		`},
+		{expr: `
+		cel.bind(m, {'hello': 'world', 'goodbye': 'cruel world'},
+			m.transformMap(k, v, v.startsWith('world'), "%s, %s!".format([k, v]))
+		) == {'hello': 'hello, world!'}
+		`},
+	}
+
+	env := testCompreEnv(t)
+	for i, tst := range compreTests {
+		tc := tst
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var asts []*cel.Ast
+			pAst, iss := env.Parse(tc.expr)
+			if iss.Err() != nil {
+				t.Fatalf("env.Parse(%v) failed: %v", tc.expr, iss.Err())
+			}
+			asts = append(asts, pAst)
+			cAst, iss := env.Check(pAst)
+			if iss.Err() != nil {
+				t.Fatalf("env.Check(%v) failed: %v", tc.expr, iss.Err())
+			}
+			asts = append(asts, cAst)
+
+			for _, ast := range asts {
+				prg, err := env.Program(ast)
+				if err != nil {
+					t.Fatalf("env.Program() failed: %v", err)
+				}
+				out, _, err := prg.Eval(cel.NoVars())
+				if err != nil {
+					t.Fatalf("prg.Eval() failed: %v", err)
+				}
+				if out.Value() != true {
+					t.Errorf("prg.Eval() got %v, wanted true for expr: %s", out.Value(), tc.expr)
+				}
+			}
+		})
+	}
+}
+
+func testCompreEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
+	t.Helper()
+	baseOpts := []cel.EnvOption{
+		TwoVarComprehensions(),
+		Bindings(),
+		Strings(),
+		cel.OptionalTypes(),
+		cel.EnableMacroCallTracking()}
+	env, err := cel.NewEnv(append(baseOpts, opts...)...)
+	if err != nil {
+		t.Fatalf("cel.NewEnv(TwoVarComprehensions()) failed: %v", err)
+	}
+	return env
+}

--- a/ext/guards.go
+++ b/ext/guards.go
@@ -50,14 +50,18 @@ func listStringOrError(strs []string, err error) ref.Val {
 	return types.DefaultTypeAdapter.NativeToValue(strs)
 }
 
-func macroTargetMatchesNamespace(ns string, target ast.Expr) bool {
+func extractIdent(target ast.Expr) (string, bool) {
 	switch target.Kind() {
 	case ast.IdentKind:
-		if target.AsIdent() != ns {
-			return false
-		}
-		return true
+		return target.AsIdent(), true
 	default:
-		return false
+		return "", false
 	}
+}
+
+func macroTargetMatchesNamespace(ns string, target ast.Expr) bool {
+	if id, found := extractIdent(target); found {
+		return id == ns
+	}
+	return false
 }

--- a/ext/lists.go
+++ b/ext/lists.go
@@ -39,6 +39,7 @@ var comparableTypes = []*cel.Type{
 
 // Lists returns a cel.EnvOption to configure extended functions for list manipulation.
 // As a general note, all indices are zero-based.
+//
 // # Slice
 //
 // Returns a new sub-list using the indexes provided.

--- a/parser/helper.go
+++ b/parser/helper.go
@@ -115,7 +115,7 @@ func (p *parserHelper) newObjectField(fieldID int64, field string, value ast.Exp
 
 func (p *parserHelper) newComprehension(ctx any,
 	iterRange ast.Expr,
-	iterVar string,
+	iterVar,
 	accuVar string,
 	accuInit ast.Expr,
 	condition ast.Expr,
@@ -123,6 +123,18 @@ func (p *parserHelper) newComprehension(ctx any,
 	result ast.Expr) ast.Expr {
 	return p.exprFactory.NewComprehension(
 		p.newID(ctx), iterRange, iterVar, accuVar, accuInit, condition, step, result)
+}
+
+func (p *parserHelper) newComprehensionTwoVar(ctx any,
+	iterRange ast.Expr,
+	iterVar, iterVar2,
+	accuVar string,
+	accuInit ast.Expr,
+	condition ast.Expr,
+	step ast.Expr,
+	result ast.Expr) ast.Expr {
+	return p.exprFactory.NewComprehensionTwoVar(
+		p.newID(ctx), iterRange, iterVar, iterVar2, accuVar, accuInit, condition, step, result)
 }
 
 func (p *parserHelper) newID(ctx any) int64 {
@@ -383,8 +395,10 @@ func (e *exprHelper) Copy(expr ast.Expr) ast.Expr {
 		cond := e.Copy(compre.LoopCondition())
 		step := e.Copy(compre.LoopStep())
 		result := e.Copy(compre.Result())
-		return e.exprFactory.NewComprehension(copyID,
-			iterRange, compre.IterVar(), compre.AccuVar(), accuInit, cond, step, result)
+		// All comprehensions can be represented by the two-variable comprehension since the
+		// differentiation between one and two-variable is whether the iterVar2 value is non-empty.
+		return e.exprFactory.NewComprehensionTwoVar(copyID,
+			iterRange, compre.IterVar(), compre.IterVar2(), compre.AccuVar(), accuInit, cond, step, result)
 	}
 	return e.exprFactory.NewUnspecifiedExpr(copyID)
 }
@@ -430,6 +444,20 @@ func (e *exprHelper) NewComprehension(
 	result ast.Expr) ast.Expr {
 	return e.exprFactory.NewComprehension(
 		e.nextMacroID(), iterRange, iterVar, accuVar, accuInit, condition, step, result)
+}
+
+// NewComprehensionTwoVar implements the ExprHelper interface method.
+func (e *exprHelper) NewComprehensionTwoVar(
+	iterRange ast.Expr,
+	iterVar,
+	iterVar2,
+	accuVar string,
+	accuInit,
+	condition,
+	step,
+	result ast.Expr) ast.Expr {
+	return e.exprFactory.NewComprehensionTwoVar(
+		e.nextMacroID(), iterRange, iterVar, iterVar2, accuVar, accuInit, condition, step, result)
 }
 
 // NewIdent implements the ExprHelper interface method.

--- a/parser/macro.go
+++ b/parser/macro.go
@@ -170,11 +170,12 @@ type ExprHelper interface {
 	// NewStructField creates a new struct field initializer from the field name and value.
 	NewStructField(field string, init ast.Expr, optional bool) ast.EntryExpr
 
-	// NewComprehension creates a new comprehension instruction.
+	// NewComprehension creates a new one-variable comprehension instruction.
 	//
 	// - iterRange represents the expression that resolves to a list or map where the elements or
 	//   keys (respectively) will be iterated over.
-	// - iterVar is the iteration variable name.
+	// - iterVar is the variable name for the list element value, or the map key, depending on the
+	//   range type.
 	// - accuVar is the accumulation variable name, typically parser.AccumulatorName.
 	// - accuInit is the initial expression whose value will be set for the accuVar prior to
 	//   folding.
@@ -186,11 +187,36 @@ type ExprHelper interface {
 	// environment in the step and condition expressions. Presently, the name __result__ is commonly
 	// used by built-in macros but this may change in the future.
 	NewComprehension(iterRange ast.Expr,
-		iterVar string,
+		iterVar,
 		accuVar string,
-		accuInit ast.Expr,
-		condition ast.Expr,
-		step ast.Expr,
+		accuInit,
+		condition,
+		step,
+		result ast.Expr) ast.Expr
+
+	// NewComprehensionTwoVar creates a new two-variable comprehension instruction.
+	//
+	// - iterRange represents the expression that resolves to a list or map where the elements or
+	//   keys (respectively) will be iterated over.
+	// - iterVar is the iteration variable assigned to the list index or the map key.
+	// - iterVar2 is the iteration variable assigned to the list element value or the map key value.
+	// - accuVar is the accumulation variable name, typically parser.AccumulatorName.
+	// - accuInit is the initial expression whose value will be set for the accuVar prior to
+	//   folding.
+	// - condition is the expression to test to determine whether to continue folding.
+	// - step is the expression to evaluation at the conclusion of a single fold iteration.
+	// - result is the computation to evaluate at the conclusion of the fold.
+	//
+	// The accuVar should not shadow variable names that you would like to reference within the
+	// environment in the step and condition expressions. Presently, the name __result__ is commonly
+	// used by built-in macros but this may change in the future.
+	NewComprehensionTwoVar(iterRange ast.Expr,
+		iterVar,
+		iterVar2,
+		accuVar string,
+		accuInit,
+		condition,
+		step,
 		result ast.Expr) ast.Expr
 
 	// NewIdent creates an identifier Expr value.


### PR DESCRIPTION
Support for iterating over map entries (key, value) or list elements (index, value)

This expanded power allows for coordinated indexing into other lists or maps more easily.
Additionally, this change allows for map entry value transformations. 