### PR TITLE
Update tag-based parsing to use lambda for additional customization

### DIFF
--- a/ext/native_test.go
+++ b/ext/native_test.go
@@ -827,7 +827,8 @@ func TestNativeTypeConvertToType(t *testing.T) {
 	for i, tst := range nativeTests {
 		tc := tst
 		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
-			nt, err := newNativeType(tc.tag, reflect.TypeOf(&TestAllTypes{}))
+			handler := fieldNameByTag(tc.tag)
+			nt, err := newNativeType(handler, reflect.TypeOf(&TestAllTypes{}))
 			if err != nil {
 				t.Fatalf("newNativeType() failed: %v", err)
 			}
@@ -842,7 +843,7 @@ func TestNativeTypeConvertToType(t *testing.T) {
 }
 
 func TestNativeTypeConvertToNative(t *testing.T) {
-	nt, err := newNativeType("cel", reflect.TypeOf(&TestAllTypes{}))
+	nt, err := newNativeType(fieldNameByTag("cel"), reflect.TypeOf(&TestAllTypes{}))
 	if err != nil {
 		t.Fatalf("newNativeType() failed: %v", err)
 	}
@@ -853,7 +854,7 @@ func TestNativeTypeConvertToNative(t *testing.T) {
 }
 
 func TestNativeTypeHasTrait(t *testing.T) {
-	nt, err := newNativeType("cel", reflect.TypeOf(&TestAllTypes{}))
+	nt, err := newNativeType(fieldNameByTag("cel"), reflect.TypeOf(&TestAllTypes{}))
 	if err != nil {
 		t.Fatalf("newNativeType() failed: %v", err)
 	}
@@ -863,7 +864,7 @@ func TestNativeTypeHasTrait(t *testing.T) {
 }
 
 func TestNativeTypeValue(t *testing.T) {
-	nt, err := newNativeType("cel", reflect.TypeOf(&TestAllTypes{}))
+	nt, err := newNativeType(fieldNameByTag("cel"), reflect.TypeOf(&TestAllTypes{}))
 	if err != nil {
 		t.Fatalf("newNativeType() failed: %v", err)
 	}
@@ -873,7 +874,7 @@ func TestNativeTypeValue(t *testing.T) {
 }
 
 func TestNativeStructWithMultipleSameFieldNames(t *testing.T) {
-	_, err := newNativeType("cel", reflect.TypeOf(TestStructWithMultipleSameNames{}))
+	_, err := newNativeType(fieldNameByTag("cel"), reflect.TypeOf(TestStructWithMultipleSameNames{}))
 	if err == nil {
 		t.Fatal("newNativeType() did not fail as expected")
 	}


### PR DESCRIPTION
This allows callers to override a bit more about struct field parsing. In particular, it's useful when parsing tags to perform escaping of tags that aren't supported CEL field names.
This allows implementation of something similar to what Kuberentes does with CEL field names:
https://kubernetes.io/docs/reference/using-api/cel/#escaping.

# Pull Requests Guidelines

See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details about when to create
a GitHub [Pull Request][1] and when other kinds of contributions or
consultation might be more desirable.

When creating a new pull request, please fork the repo and work within a
development branch.

## Commit Messages

* Most changes should be accompanied by tests.
* Commit messages should explain _why_ the changes were made.
```
Summary of change in 50 characters or less

Background on why the change is being made with additional detail on
consequences of the changes elsewhere in the code or to the general
functionality of the library. Multiple paragraphs may be used, but
please keep lines to 72 characters or less.
```

## Reviews

* Perform a self-review.
* Make sure the Travis CI build passes.
* Assign a reviewer once both the above have been completed.

## Merging

* If a CEL maintaner approves the change, it may be merged by the author if
  they have write access. Otherwise, the change will be merged by a maintainer.
* Multiple commits should be squashed before merging.
* Please append the line `closes #<issue-num>: description` in the merge message,
  if applicable.

[1]:  https://help.github.com/articles/about-pull-requests