### PR TITLE
Fix the key collision contract for mutable maps

### DIFF
--- a/common/types/map.go
+++ b/common/types/map.go
@@ -337,7 +337,7 @@ type mutableMap struct {
 // Insert implements the traits.MutableMapper interface method, returning true if the key insertion
 // succeeds.
 func (m *mutableMap) Insert(k, v ref.Val) ref.Val {
-	if _, found := m.mutableValues[k]; found {
+	if _, found := m.Find(k); found {
 		return NewErr("insert failed: key %v already exists", k)
 	}
 	m.mutableValues[k] = v

--- a/ext/README.md
+++ b/ext/README.md
@@ -796,7 +796,9 @@ Examples:
 Comprehension which converts a map or a list into a map value; however, this
 transform expects the entry expression be a map literal. If the transform
 produces an entry which duplicates a key in the target map, the comprehension
-will error.
+will error. Note, that key equality is determined using CEL equality which
+asserts that numeric values which are equal, even if they don't have the same
+type will cause a key collision.
 
 Elements in the map may optionally be filtered according to a predicate
 expression, where elements that satisfy the predicate are transformed.

--- a/ext/comprehensions.go
+++ b/ext/comprehensions.go
@@ -136,7 +136,9 @@ const (
 //
 // Comprehension which converts a map or a list into a map value; however, this transform
 // expects the entry expression be a map literal. If the tranform produces an entry which
-// duplicates a key in the target map, the comprehension will error.
+// duplicates a key in the target map, the comprehension will error.  Note, that key
+// equality is determined using CEL equality which asserts that numeric values which are
+// equal, even if they don't have the same type will cause a key collision.
 //
 // Elements in the map may optionally be filtered according to a predicate expression, where
 // elements that satisfy the predicate are transformed.

--- a/ext/comprehensions_test.go
+++ b/ext/comprehensions_test.go
@@ -307,6 +307,10 @@ func TestTwoVarComprehensionsRuntimeErrors(t *testing.T) {
 			expr: "[1, 1].transformMapEntry(i, v, {v: i})",
 			err:  "insert failed: key 1 already exists",
 		},
+		{
+			expr: `[0, 0u].transformMapEntry(i, v, {v: i})`,
+			err:  "insert failed: key 0 already exists",
+		},
 	}
 	env := testCompreEnv(t)
 	for i, tst := range tests {


### PR DESCRIPTION
Fix the key collision contract for mutable maps by using CEL equality
to determine whether a key exists within a map. This is consistent with
the spec expectations for map literal construction as well.