### PR TITLE
Fix string reverse member overload name

### DIFF
--- a/ext/strings.go
+++ b/ext/strings.go
@@ -520,7 +520,7 @@ func (lib *stringLib) CompileOptions() []cel.EnvOption {
 	if lib.version >= 3 {
 		opts = append(opts,
 			cel.Function("reverse",
-				cel.MemberOverload("reverse", []*cel.Type{cel.StringType}, cel.StringType,
+				cel.MemberOverload("string_reverse", []*cel.Type{cel.StringType}, cel.StringType,
 					cel.UnaryBinding(func(str ref.Val) ref.Val {
 						s := str.(types.String)
 						return stringOrError(reverse(string(s)))


### PR DESCRIPTION
Update the string `reverse()` overload id to be unique to the type.

In the future overload IDs for a given function should not be equal to
the function name as this can interfere with dynamic dispatch for a
parsed-only expression.

This change should be a no-op for anyone using `reverse` today as
the behavior will effectively cause existing expressions to use the 
dynamic dispatch rather than the specific overload once more overloads
are introduced under the `reverse` function.