### PR TITLE
Support for cel.@block during policy composition

### DIFF
--- a/cel/env.go
+++ b/cel/env.go
@@ -459,6 +459,12 @@ func (e *Env) ParseSource(src Source) (*Ast, *Issues) {
 
 // Program generates an evaluable instance of the Ast within the environment (Env).
 func (e *Env) Program(ast *Ast, opts ...ProgramOption) (Program, error) {
+	return e.PlanProgram(ast.NativeRep(), opts...)
+}
+
+// PlanProgram generates an evaluable instance of the AST in the go-native representation within
+// the environment (Env).
+func (e *Env) PlanProgram(a *celast.AST, opts ...ProgramOption) (Program, error) {
 	optSet := e.progOpts
 	if len(opts) != 0 {
 		mergedOpts := []ProgramOption{}
@@ -466,7 +472,7 @@ func (e *Env) Program(ast *Ast, opts ...ProgramOption) (Program, error) {
 		mergedOpts = append(mergedOpts, opts...)
 		optSet = mergedOpts
 	}
-	return newProgram(e, ast, optSet)
+	return newProgram(e, a, optSet)
 }
 
 // CELTypeAdapter returns the `types.Adapter` configured for the environment.

--- a/cel/optimizer.go
+++ b/cel/optimizer.go
@@ -211,6 +211,16 @@ type OptimizerContext struct {
 	*Issues
 }
 
+// ExtendEnv auguments the context's environment with the additional options.
+func (opt *OptimizerContext) ExtendEnv(opts ...EnvOption) error {
+	e, err := opt.Env.Extend(opts...)
+	if err != nil {
+		return err
+	}
+	opt.Env = e
+	return nil
+}
+
 // ASTOptimizer applies an optimization over an AST and returns the optimized result.
 type ASTOptimizer interface {
 	// Optimize optimizes a type-checked AST within an Environment and accumulates any issues.

--- a/cel/program.go
+++ b/cel/program.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter"
@@ -151,7 +152,7 @@ func (p *prog) clone() *prog {
 // ProgramOption values.
 //
 // If the program cannot be configured the prog will be nil, with a non-nil error response.
-func newProgram(e *Env, a *Ast, opts []ProgramOption) (Program, error) {
+func newProgram(e *Env, a *ast.AST, opts []ProgramOption) (Program, error) {
 	// Build the dispatcher, interpreter, and default program value.
 	disp := interpreter.NewDispatcher()
 
@@ -255,9 +256,9 @@ func newProgram(e *Env, a *Ast, opts []ProgramOption) (Program, error) {
 	return p.initInterpretable(a, decorators)
 }
 
-func (p *prog) initInterpretable(a *Ast, decs []interpreter.InterpretableDecorator) (*prog, error) {
+func (p *prog) initInterpretable(a *ast.AST, decs []interpreter.InterpretableDecorator) (*prog, error) {
 	// When the AST has been exprAST it contains metadata that can be used to speed up program execution.
-	interpretable, err := p.interpreter.NewInterpretable(a.impl, decs...)
+	interpretable, err := p.interpreter.NewInterpretable(a, decs...)
 	if err != nil {
 		return nil, err
 	}

--- a/conformance/BUILD.bazel
+++ b/conformance/BUILD.bazel
@@ -68,6 +68,7 @@ go_test(
     deps = [
         "//cel:go_default_library",
         "//common:go_default_library",
+        "//common/ast:go_default_library",
         "//common/types:go_default_library",
         "//common/types/ref:go_default_library",
         "//ext:go_default_library",

--- a/conformance/BUILD.bazel
+++ b/conformance/BUILD.bazel
@@ -32,6 +32,7 @@ _ALL_TESTS = [
     "@dev_cel_expr//tests/simple:testdata/timestamps.textproto",
     "@dev_cel_expr//tests/simple:testdata/unknowns.textproto",
     "@dev_cel_expr//tests/simple:testdata/wrappers.textproto",
+    "@dev_cel_expr//tests/simple:testdata/block_ext.textproto",
 ]
 
 _TESTS_TO_SKIP = [

--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common"
+	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/ext"
@@ -89,6 +90,7 @@ func init() {
 		ext.Math(),
 		ext.Protos(),
 		ext.Strings(),
+		cel.Lib(celBlockLib{}),
 	}
 
 	var err error
@@ -278,4 +280,90 @@ func TestConformance(t *testing.T) {
 			}
 		}
 	}
+}
+
+type celBlockLib struct{}
+
+func (celBlockLib) LibraryName() string {
+	return "cel.lib.ext.cel.block.conformance"
+}
+
+func (celBlockLib) CompileOptions() []cel.EnvOption {
+	// Simulate indexed arguments which would normally have strong types associated
+	// with the values as part of a static optimization pass
+	maxIndices := 30
+	indexOpts := make([]cel.EnvOption, maxIndices)
+	for i := 0; i < maxIndices; i++ {
+		indexOpts[i] = cel.Variable(fmt.Sprintf("@index%d", i), cel.DynType)
+	}
+	return append([]cel.EnvOption{
+		cel.Macros(
+			// cel.block([args], expr)
+			cel.ReceiverMacro("block", 2, celBlock),
+			// cel.index(int)
+			cel.ReceiverMacro("index", 1, celIndex),
+			// cel.iterVar(int, int)
+			cel.ReceiverMacro("iterVar", 2, celCompreVar("cel.iterVar", "@it")),
+			// cel.accuVar(int, int)
+			cel.ReceiverMacro("accuVar", 2, celCompreVar("cel.accuVar", "@ac")),
+		),
+	}, indexOpts...)
+}
+
+func (celBlockLib) ProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{}
+}
+
+func celBlock(mef cel.MacroExprFactory, target ast.Expr, args []ast.Expr) (ast.Expr, *cel.Error) {
+	if !isCELNamespace(target) {
+		return nil, nil
+	}
+	bindings := args[0]
+	if bindings.Kind() != ast.ListKind {
+		return bindings, mef.NewError(bindings.ID(), "cel.block requires the first arg to be a list literal")
+	}
+	return mef.NewCall("cel.@block", args...), nil
+}
+
+func celIndex(mef cel.MacroExprFactory, target ast.Expr, args []ast.Expr) (ast.Expr, *cel.Error) {
+	if !isCELNamespace(target) {
+		return nil, nil
+	}
+	index := args[0]
+	if !isNonNegativeInt(index) {
+		return index, mef.NewError(index.ID(), "cel.index requires a single non-negative int constant arg")
+	}
+	indexVal := index.AsLiteral().(types.Int)
+	return mef.NewIdent(fmt.Sprintf("@index%d", indexVal)), nil
+}
+
+func celCompreVar(funcName, varPrefix string) cel.MacroFactory {
+	return func(mef cel.MacroExprFactory, target ast.Expr, args []ast.Expr) (ast.Expr, *cel.Error) {
+		if !isCELNamespace(target) {
+			return nil, nil
+		}
+		depth := args[0]
+		if !isNonNegativeInt(depth) {
+			return depth, mef.NewError(depth.ID(), fmt.Sprintf("%s requires two non-negative int constant args", funcName))
+		}
+		unique := args[1]
+		if !isNonNegativeInt(unique) {
+			return unique, mef.NewError(unique.ID(), fmt.Sprintf("%s requires two non-negative int constant args", funcName))
+		}
+		depthVal := depth.AsLiteral().(types.Int)
+		uniqueVal := unique.AsLiteral().(types.Int)
+		return mef.NewIdent(fmt.Sprintf("%s:%d:%d", varPrefix, depthVal, uniqueVal)), nil
+	}
+}
+
+func isCELNamespace(target ast.Expr) bool {
+	return target.Kind() == ast.IdentKind && target.AsIdent() == "cel"
+}
+
+func isNonNegativeInt(expr ast.Expr) bool {
+	if expr.Kind() != ast.LiteralKind {
+		return false
+	}
+	val := expr.AsLiteral()
+	return val.Type() == cel.IntType && val.(types.Int) >= 0
 }

--- a/ext/bindings.go
+++ b/ext/bindings.go
@@ -15,9 +15,18 @@
 package ext
 
 import (
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/interpreter"
 )
 
 // Bindings returns a cel.EnvOption to configure support for local variable
@@ -41,32 +50,86 @@ import (
 //	[d, e, f].exists(elem, elem in valid_values))
 //
 // Local bindings are not guaranteed to be evaluated before use.
-func Bindings() cel.EnvOption {
-	return cel.Lib(celBindings{})
+func Bindings(options ...BindingsOption) cel.EnvOption {
+	b := &celBindings{version: math.MaxUint32}
+	for _, o := range options {
+		b = o(b)
+	}
+	return cel.Lib(b)
 }
 
 const (
 	celNamespace  = "cel"
 	bindMacro     = "bind"
+	blockFunc     = "@block"
 	unusedIterVar = "#unused"
 )
 
-type celBindings struct{}
+// BindingsOption declares a functional operator for configuring the Bindings library behavior.
+type BindingsOption func(*celBindings) *celBindings
 
-func (celBindings) LibraryName() string {
+// BindingsVersion sets the version of the bindings library to an explicit version.
+func BindingsVersion(version uint32) BindingsOption {
+	return func(lib *celBindings) *celBindings {
+		lib.version = version
+		return lib
+	}
+}
+
+type celBindings struct {
+	version uint32
+}
+
+func (*celBindings) LibraryName() string {
 	return "cel.lib.ext.cel.bindings"
 }
 
-func (celBindings) CompileOptions() []cel.EnvOption {
-	return []cel.EnvOption{
+func (lib *celBindings) CompileOptions() []cel.EnvOption {
+	opts := []cel.EnvOption{
 		cel.Macros(
 			// cel.bind(var, <init>, <expr>)
 			cel.ReceiverMacro(bindMacro, 3, celBind),
 		),
 	}
+	if lib.version >= 1 {
+		// The cel.@block signature takes a list of subexpressions and a typed expression which is
+		// used as the output type.
+		paramType := cel.TypeParamType("T")
+		opts = append(opts,
+			cel.Function("cel.@block",
+				cel.Overload("cel_block_list",
+					[]*cel.Type{cel.ListType(cel.DynType), paramType}, paramType)),
+		)
+	}
+	return opts
 }
 
-func (celBindings) ProgramOptions() []cel.ProgramOption {
+func (lib *celBindings) ProgramOptions() []cel.ProgramOption {
+	if lib.version >= 1 {
+		celBlockPlan := func(i interpreter.Interpretable) (interpreter.Interpretable, error) {
+			call, ok := i.(interpreter.InterpretableCall)
+			if !ok {
+				return i, nil
+			}
+			switch call.Function() {
+			case "cel.@block":
+				args := call.Args()
+				if len(args) != 2 {
+					return nil, fmt.Errorf("cel.@block expects two arguments, but got %d", len(args))
+				}
+				block, ok := args[0].(interpreter.InterpretableConstructor)
+				if !ok {
+					return nil, errors.New("cel.@block expects a list constructor as the first argument")
+				}
+				slotExprs := block.InitVals()
+				expr := args[1]
+				return newBlockScope(slotExprs, expr), nil
+			default:
+				return i, nil
+			}
+		}
+		return []cel.ProgramOption{cel.CustomDecorator(celBlockPlan)}
+	}
 	return []cel.ProgramOption{}
 }
 
@@ -94,3 +157,74 @@ func celBind(mef cel.MacroExprFactory, target ast.Expr, args []ast.Expr) (ast.Ex
 		resultExpr,
 	), nil
 }
+
+func newBlockScope(slotExprs []interpreter.Interpretable, expr interpreter.Interpretable) *blockScope {
+	bs := &blockScope{
+		slotExprs: slotExprs,
+		expr:      expr,
+	}
+	bs.slotActivationPool = &sync.Pool{
+		New: func() any {
+			sa := &slotActivation{
+				slotExprs: slotExprs,
+				slotVals:  make([]ref.Val, len(slotExprs)),
+			}
+			return sa
+		},
+	}
+	return bs
+}
+
+type blockScope struct {
+	slotExprs          []interpreter.Interpretable
+	expr               interpreter.Interpretable
+	slotActivationPool *sync.Pool
+}
+
+func (bs *blockScope) ID() int64 {
+	return bs.expr.ID()
+}
+
+func (bs *blockScope) Eval(activation interpreter.Activation) ref.Val {
+	sa := bs.slotActivationPool.Get().(*slotActivation)
+	sa.Activation = activation
+	defer bs.clearSlots(sa)
+	return bs.expr.Eval(sa)
+}
+
+func (bs *blockScope) clearSlots(sa *slotActivation) {
+	sa.reset()
+	bs.slotActivationPool.Put(sa)
+}
+
+type slotActivation struct {
+	interpreter.Activation
+	slotExprs []interpreter.Interpretable
+	slotVals  []ref.Val
+}
+
+func (sa *slotActivation) ResolveName(name string) (any, bool) {
+	if idx, found := strings.CutPrefix(name, indexPrefix); found {
+		idx, err := strconv.Atoi(idx)
+		if err != nil {
+			return nil, false
+		}
+		v := sa.slotVals[idx]
+		if v != nil {
+			return v, true
+		}
+		v = sa.slotExprs[idx].Eval(sa)
+		sa.slotVals[idx] = v
+		return v, true
+	}
+	return sa.Activation.ResolveName(name)
+}
+
+func (sa *slotActivation) reset() {
+	sa.Activation = nil
+	clear(sa.slotVals)
+}
+
+var (
+	indexPrefix = "@index"
+)

--- a/ext/bindings_test.go
+++ b/ext/bindings_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
 )
 
 var bindingTests = []struct {
@@ -131,38 +132,130 @@ func BenchmarkBindings(b *testing.B) {
 
 func TestBlockEval(t *testing.T) {
 	fac := ast.NewExprFactory()
-	blockExpr := fac.NewCall(
-		1, "cel.@block",
-		fac.NewList(2, []ast.Expr{
-			fac.NewIdent(3, "x"),
-			fac.NewIdent(4, "@index0"),
-			fac.NewIdent(5, "@index1"),
-		}, []int32{}),
-		fac.NewCall(9, operators.Add,
-			fac.NewCall(6, operators.Add,
-				fac.NewIdent(7, "@index2"),
-				fac.NewIdent(8, "@index1")),
-			fac.NewIdent(10, "@index0"),
-		),
-	)
-	blockAST := ast.NewAST(blockExpr, nil)
-	env, err := cel.NewEnv(
-		Bindings(),
-		cel.Variable("x", cel.StringType),
-	)
-	if err != nil {
-		t.Fatalf("cel.NewEnv(Bindings()) failed: %v", err)
+	tests := []struct {
+		name string
+		expr ast.Expr
+		opts []cel.EnvOption
+		in   map[string]any
+		out  ref.Val
+	}{
+		{
+			name: "chained block",
+			expr: fac.NewCall(
+				1, "cel.@block",
+				fac.NewList(2, []ast.Expr{
+					fac.NewIdent(3, "x"),
+					fac.NewIdent(4, "@index0"),
+					fac.NewIdent(5, "@index1"),
+				}, []int32{}),
+				fac.NewCall(9, operators.Add,
+					fac.NewCall(6, operators.Add,
+						fac.NewIdent(7, "@index2"),
+						fac.NewIdent(8, "@index1")),
+					fac.NewIdent(10, "@index0"),
+				),
+			),
+			opts: []cel.EnvOption{
+				cel.Variable("x", cel.StringType),
+			},
+			in:  map[string]any{"x": "hello"},
+			out: types.String("hellohellohello"),
+		},
+		{
+			name: "empty block",
+			expr: fac.NewCall(
+				1, "cel.@block",
+				fac.NewList(2, []ast.Expr{}, []int32{}),
+				fac.NewCall(3, operators.LogicalNot, fac.NewLiteral(4, types.False)),
+			),
+			in:  map[string]any{},
+			out: types.True,
+		},
+		{
+			name: "mixed block constant values",
+			expr: fac.NewCall(
+				1, "cel.@block",
+				fac.NewList(2, []ast.Expr{
+					fac.NewLiteral(3, types.String("hello")),
+					fac.NewLiteral(4, types.Int(5)),
+				}, []int32{}),
+				fac.NewCall(5, operators.Equals,
+					fac.NewCall(6, "size",
+						fac.NewIdent(7, "@index0")),
+					fac.NewIdent(8, "@index1"),
+				),
+			),
+			opts: []cel.EnvOption{
+				cel.ExtendedValidations(),
+			},
+			in:  map[string]any{},
+			out: types.True,
+		},
+		{
+			name: "mixed block dynamic values",
+			expr: fac.NewCall(
+				1, "cel.@block",
+				fac.NewList(2, []ast.Expr{
+					fac.NewIdent(3, "x"),
+					fac.NewLiteral(4, types.Int(5)),
+				}, []int32{}),
+				fac.NewCall(5, operators.Equals,
+					fac.NewCall(6, "size",
+						fac.NewIdent(7, "@index0")),
+					fac.NewIdent(8, "@index1"),
+				),
+			),
+			opts: []cel.EnvOption{
+				cel.Variable("x", cel.StringType),
+				cel.ExtendedValidations(),
+			},
+			in:  map[string]any{"x": "goodbye"},
+			out: types.False,
+		},
+		{
+			name: "mixed block constant values dyn var",
+			expr: fac.NewCall(
+				1, "cel.@block",
+				fac.NewList(2, []ast.Expr{
+					fac.NewLiteral(3, types.String("hello")),
+				}, []int32{}),
+				fac.NewCall(4, operators.Equals,
+					fac.NewCall(5, "size",
+						fac.NewIdent(6, "@index0")),
+					fac.NewIdent(7, "y"),
+				),
+			),
+			opts: []cel.EnvOption{
+				cel.Variable("y", cel.IntType),
+				cel.ExtendedValidations(),
+			},
+			in: map[string]any{
+				"y": 5,
+			},
+			out: types.True,
+		},
 	}
-	prg, err := env.PlanProgram(blockAST)
-	if err != nil {
-		t.Fatalf("PlanProgram() failed: %v", err)
-	}
-	out, _, err := prg.Eval(map[string]any{"x": "hello"})
-	if err != nil {
-		t.Fatalf("prg.Eval() failed: %v", err)
-	}
-	if out.Equal(types.String("hellohellohello")) != types.True {
-		t.Errorf("got %v, wanted 'hellohelloehello'", out)
+	for _, tst := range tests {
+		tc := tst
+		t.Run(tc.name, func(t *testing.T) {
+			blockAST := ast.NewAST(tc.expr, nil)
+			opts := append([]cel.EnvOption{Bindings()}, tc.opts...)
+			env, err := cel.NewEnv(opts...)
+			if err != nil {
+				t.Fatalf("cel.NewEnv(Bindings()) failed: %v", err)
+			}
+			prg, err := env.PlanProgram(blockAST, cel.EvalOptions(cel.OptOptimize))
+			if err != nil {
+				t.Fatalf("PlanProgram() failed: %v", err)
+			}
+			out, _, err := prg.Eval(tc.in)
+			if err != nil {
+				t.Fatalf("prg.Eval() failed: %v", err)
+			}
+			if out.Equal(tc.out) != types.True {
+				t.Errorf("got %v, wanted %v", out, tc.out)
+			}
+		})
 	}
 }
 

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -97,7 +97,7 @@ type InterpretableCall interface {
 	Args() []Interpretable
 }
 
-// InterpretableConstructor interface for inspecting  Interpretable instructions that initialize a list, map
+// InterpretableConstructor interface for inspecting Interpretable instructions that initialize a list, map
 // or struct.
 type InterpretableConstructor interface {
 	Interpretable

--- a/policy/compiler_test.go
+++ b/policy/compiler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/ext"
 	"github.com/google/cel-go/interpreter"
 )
 
@@ -159,7 +160,8 @@ func compile(t testing.TB, name string, parseOpts []ParserOption, envOpts []cel.
 		cel.DefaultUTCTimeZone(true),
 		cel.OptionalTypes(),
 		cel.EnableMacroCallTracking(),
-		cel.ExtendedValidations())
+		cel.ExtendedValidations(),
+		ext.Bindings())
 	if err != nil {
 		t.Fatalf("cel.NewEnv() failed: %v", err)
 	}


### PR DESCRIPTION
Support for `cel.@block` during policy expression composition.

This feature ensures that all variables are lazily evaluated and optimally
planned in a way which minimizes expression recursion. Future enhancements
may further compact or refine expressions by way of common subexpression
elimination.

Block also improves performance across several of the tracked use cases:

```
                                                                           │             sec/op             │   sec/op     vs base                │
Compile/k8s/invalid/restricted_container-10                                                     2.036µ ± 1%   1.960µ ± 3%   -3.73% (p=0.001 n=10)
Compile/nested_rule/banned/restricted_origin-10                                                 506.1n ± 0%   426.0n ± 1%  -15.84% (p=0.000 n=10)
Compile/nested_rule/banned/by_default-10                                                        413.7n ± 0%   345.8n ± 1%  -16.42% (p=0.000 n=10)
Compile/nested_rule/permitted/valid_origin-10                                                   404.2n ± 4%   335.9n ± 1%  -16.90% (p=0.000 n=10)
Compile/nested_rule2/banned/restricted_origin-10                                                492.2n ± 0%   404.4n ± 0%  -17.86% (p=0.000 n=10)
Compile/nested_rule2/banned/by_default-10                                                       352.8n ± 0%   259.7n ± 1%  -26.39% (p=0.000 n=10)
Compile/nested_rule2/banned/unconfigured_region-10                                              285.2n ± 0%   283.2n ± 1%   -0.70% (p=0.006 n=10)
Compile/nested_rule2/permitted/valid_origin-10                                                  278.8n ± 0%   273.2n ± 5%   -1.97% (p=0.017 n=10)
Compile/nested_rule3/banned/restricted_origin-10                                                623.8n ± 0%   544.5n ± 2%  -12.72% (p=0.000 n=10)
Compile/nested_rule3/banned/by_default-10                                                       488.7n ± 2%   395.1n ± 2%  -19.16% (p=0.000 n=10)
Compile/nested_rule3/banned/unconfigured_region-10                                              411.9n ± 2%   412.7n ± 3%        ~ (p=0.698 n=10)
Compile/nested_rule3/permitted/valid_origin-10                                                  285.3n ± 3%   276.9n ± 1%   -2.96% (p=0.001 n=10)
Compile/context_pb/valid/good_spec-10                                                           808.8n ± 3%   797.6n ± 2%        ~ (p=0.066 n=10)
Compile/context_pb/invalid/bad_spec-10                                                          1.442µ ± 4%   1.428µ ± 1%   -1.01% (p=0.012 n=10)
Compile/pb/valid/good_spec-10                                                                   941.6n ± 2%   942.7n ± 3%        ~ (p=0.565 n=10)
Compile/pb/invalid/bad_spec-10                                                                  1.500µ ± 2%   1.524µ ± 2%   +1.63% (p=0.030 n=10)
Compile/required_labels/valid/matching-10                                                       2.889µ ± 1%   2.558µ ± 2%  -11.47% (p=0.000 n=10)
Compile/required_labels/missing/env-10                                                          2.361µ ± 1%   2.184µ ± 1%   -7.50% (p=0.000 n=10)
Compile/required_labels/missing/experiment-10                                                   2.417µ ± 1%   2.238µ ± 1%   -7.43% (p=0.000 n=10)
Compile/required_labels/invalid/env-10                                                          4.099µ ± 6%   3.818µ ± 6%   -6.87% (p=0.001 n=10)
Compile/restricted_destinations/valid/ip_allowed-10                                             1.614µ ± 1%   1.174µ ± 1%  -27.26% (p=0.000 n=10)
Compile/restricted_destinations/valid/nationality_allowed-10                                    1.598µ ± 1%   1.165µ ± 2%  -27.07% (p=0.000 n=10)
Compile/restricted_destinations/invalid/destination_ip_prohibited-10                           1119.5n ± 3%   679.0n ± 1%  -39.35% (p=0.000 n=10)
Compile/restricted_destinations/invalid/resource_nationality_prohibited-10                     1398.5n ± 2%   969.2n ± 5%  -30.69% (p=0.000 n=10)
Compile/limits/now_after_hours/7pm-10                                                          1146.5n ± 4%   979.6n ± 4%  -14.55% (p=0.000 n=10)
Compile/limits/now_after_hours/8pm-10                                                           1.637µ ± 1%   1.161µ ± 0%  -29.06% (p=0.000 n=10)
Compile/limits/now_after_hours/9pm-10                                                           1.765µ ± 1%   1.258µ ± 1%  -28.73% (p=0.000 n=10)
Compile/limits/now_after_hours/11pm-10                                                          1.854µ ± 2%   1.338µ ± 4%  -27.83% (p=0.000 n=10)
geomean                                                                                         949.6n        808.5n       -14.85%
```

Depends on #1048