### PR TITLE
Expand visibility of  parser/gen package

### DIFF
--- a/parser/gen/BUILD.bazel
+++ b/parser/gen/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 package(
-    default_visibility = ["//parser:__subpackages__"],
+    default_visibility = ["//:__subpackages__"],
     licenses = ["notice"],  # Apache 2.0
 )
 


### PR DESCRIPTION
Attempt to address issues related to sub-package visibility

Since the root-level package name has `vendor` inserted in front of it during the vendoring,
the expectation is that the expansion from `//parser:__subpackage__` to `//:__subpackages__`
will preserve the intent of the visibility rule while also making vendored code happy.

#947 