### PR TITLE
Expose public methods to convert function and variable decl to v1 Decl

### DIFF
--- a/common/decls/decls.go
+++ b/common/decls/decls.go
@@ -782,6 +782,11 @@ func TypeVariable(t *types.Type) *VariableDecl {
 	return NewVariable(t.TypeName(), types.NewTypeTypeWithParam(t))
 }
 
+// VariableDeclToExprDecl converts a go-native variable declaration into a protobuf-type variable declaration.
+func VariableDeclToExprDecl(v *VariableDecl) (*exprpb.Decl, error) {
+	return variableDeclToExprDecl(v)
+}
+
 // variableDeclToExprDecl converts a go-native variable declaration into a protobuf-type variable declaration.
 func variableDeclToExprDecl(v *VariableDecl) (*exprpb.Decl, error) {
 	varType, err := types.TypeToExprType(v.Type())
@@ -789,6 +794,11 @@ func variableDeclToExprDecl(v *VariableDecl) (*exprpb.Decl, error) {
 		return nil, err
 	}
 	return chkdecls.NewVar(v.Name(), varType), nil
+}
+
+// FunctionDeclToExprDecl converts a go-native function declaration into a protobuf-typed function declaration.
+func FunctionDeclToExprDecl(f *FunctionDecl) (*exprpb.Decl, error) {
+	return functionDeclToExprDecl(f)
 }
 
 // functionDeclToExprDecl converts a go-native function declaration into a protobuf-typed function declaration.

--- a/common/decls/decls_test.go
+++ b/common/decls/decls_test.go
@@ -984,7 +984,7 @@ func TestFunctionDeclToExprDecl(t *testing.T) {
 		},
 	}
 	for _, tst := range tests {
-		exDecl, err := functionDeclToExprDecl(tst.fn)
+		exDecl, err := FunctionDeclToExprDecl(tst.fn)
 		if err != nil {
 			t.Fatalf("FunctionDeclToExprDecl(%v) failed: %v", tst.fn, err)
 		}
@@ -1048,7 +1048,7 @@ func TestTypeVariable(t *testing.T) {
 }
 
 func TestVariableDeclToExprDecl(t *testing.T) {
-	a, err := variableDeclToExprDecl(NewVariable("a", types.BoolType))
+	a, err := VariableDeclToExprDecl(NewVariable("a", types.BoolType))
 	if err != nil {
 		t.Fatalf("VariableDeclToExprDecl() failed: %v", err)
 	}
@@ -1059,7 +1059,7 @@ func TestVariableDeclToExprDecl(t *testing.T) {
 }
 
 func TestVariableDeclToExprDeclInvalid(t *testing.T) {
-	out, err := variableDeclToExprDecl(NewVariable("bad", &types.Type{}))
+	out, err := VariableDeclToExprDecl(NewVariable("bad", &types.Type{}))
 	if err == nil {
 		t.Fatalf("VariableDeclToExprDecl() succeeded: %v, wanted error", out)
 	}


### PR DESCRIPTION
Expose public methods to convert decls.FunctionDecl and decls.VariableDecl to v1alpha1.expr.Decl. 
The public methods relay the call to the existing private methods.
These changes are needed to support the currently under development cel test runner.