### PR TITLE
Introduce versioning options to all extensions

### DIFF
--- a/ext/comprehensions.go
+++ b/ext/comprehensions.go
@@ -16,6 +16,7 @@ package ext
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/ast"
@@ -159,19 +160,36 @@ const (
 //
 //	{'greeting': 'aloha', 'farewell': 'aloha'}
 //	  .transformMapEntry(keyVar, valueVar, {valueVar: keyVar}) // error, duplicate key
-func TwoVarComprehensions() cel.EnvOption {
-	return cel.Lib(compreV2Lib{})
+func TwoVarComprehensions(options ...TwoVarComprehensionsOption) cel.EnvOption {
+	l := &compreV2Lib{version: math.MaxUint32}
+	for _, o := range options {
+		l = o(l)
+	}
+	return cel.Lib(l)
 }
 
-type compreV2Lib struct{}
+// TwoVarComprehensionsOption declares a functional operator for configuring two-variable comprehensions.
+type TwoVarComprehensionsOption func(*compreV2Lib) *compreV2Lib
+
+// TwoVarComprehensionsVersion sets the library version for two-variable comprehensions.
+func TwoVarComprehensionsVersion(version uint32) TwoVarComprehensionsOption {
+	return func(lib *compreV2Lib) *compreV2Lib {
+		lib.version = version
+		return lib
+	}
+}
+
+type compreV2Lib struct {
+	version uint32
+}
 
 // LibraryName implements that SingletonLibrary interface method.
-func (compreV2Lib) LibraryName() string {
+func (*compreV2Lib) LibraryName() string {
 	return "cel.lib.ext.comprev2"
 }
 
 // CompileOptions implements the cel.Library interface method.
-func (compreV2Lib) CompileOptions() []cel.EnvOption {
+func (*compreV2Lib) CompileOptions() []cel.EnvOption {
 	kType := cel.TypeParamType("K")
 	vType := cel.TypeParamType("V")
 	mapKVType := cel.MapType(kType, vType)
@@ -217,7 +235,7 @@ func (compreV2Lib) CompileOptions() []cel.EnvOption {
 }
 
 // ProgramOptions implements the cel.Library interface method
-func (compreV2Lib) ProgramOptions() []cel.ProgramOption {
+func (*compreV2Lib) ProgramOptions() []cel.ProgramOption {
 	return []cel.ProgramOption{}
 }
 

--- a/ext/comprehensions_test.go
+++ b/ext/comprehensions_test.go
@@ -345,6 +345,13 @@ func TestTwoVarComprehensionsRuntimeErrors(t *testing.T) {
 	}
 }
 
+func TestTwoVarComprehensionsVersion(t *testing.T) {
+	_, err := cel.NewEnv(TwoVarComprehensions(TwoVarComprehensionsVersion(0)))
+	if err != nil {
+		t.Fatalf("TwoVarComprehensionVersion(0) failed: %v", err)
+	}
+}
+
 func testCompreEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
 	t.Helper()
 	baseOpts := []cel.EnvOption{

--- a/ext/encoders.go
+++ b/ext/encoders.go
@@ -16,6 +16,7 @@ package ext
 
 import (
 	"encoding/base64"
+	"math"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
@@ -47,17 +48,34 @@ import (
 // Examples:
 //
 //	base64.encode(b'hello') // return b'aGVsbG8='
-func Encoders() cel.EnvOption {
-	return cel.Lib(encoderLib{})
+func Encoders(options ...EncodersOption) cel.EnvOption {
+	l := &encoderLib{version: math.MaxUint32}
+	for _, o := range options {
+		l = o(l)
+	}
+	return cel.Lib(l)
 }
 
-type encoderLib struct{}
+// EncodersOption declares a functional operator for configuring encoder extensions.
+type EncodersOption func(*encoderLib) *encoderLib
 
-func (encoderLib) LibraryName() string {
+// EncodersVersion sets the library version for encoder extensions.
+func EncodersVersion(version uint32) EncodersOption {
+	return func(lib *encoderLib) *encoderLib {
+		lib.version = version
+		return lib
+	}
+}
+
+type encoderLib struct {
+	version uint32
+}
+
+func (*encoderLib) LibraryName() string {
 	return "cel.lib.ext.encoders"
 }
 
-func (encoderLib) CompileOptions() []cel.EnvOption {
+func (*encoderLib) CompileOptions() []cel.EnvOption {
 	return []cel.EnvOption{
 		cel.Function("base64.decode",
 			cel.Overload("base64_decode_string", []*cel.Type{cel.StringType}, cel.BytesType,
@@ -74,7 +92,7 @@ func (encoderLib) CompileOptions() []cel.EnvOption {
 	}
 }
 
-func (encoderLib) ProgramOptions() []cel.ProgramOption {
+func (*encoderLib) ProgramOptions() []cel.ProgramOption {
 	return []cel.ProgramOption{}
 }
 

--- a/ext/encoders_test.go
+++ b/ext/encoders_test.go
@@ -86,3 +86,10 @@ func TestEncoders(t *testing.T) {
 		})
 	}
 }
+
+func TestEncodersVersion(t *testing.T) {
+	_, err := cel.NewEnv(Encoders(EncodersVersion(0)))
+	if err != nil {
+		t.Fatalf("EncodersVersion(0) failed: %v", err)
+	}
+}

--- a/ext/native.go
+++ b/ext/native.go
@@ -17,6 +17,7 @@ package ext
 import (
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"strings"
 	"time"
@@ -98,7 +99,9 @@ var (
 func NativeTypes(args ...any) cel.EnvOption {
 	return func(env *cel.Env) (*cel.Env, error) {
 		nativeTypes := make([]any, 0, len(args))
-		tpOptions := nativeTypeOptions{}
+		tpOptions := nativeTypeOptions{
+			version: math.MaxUint32,
+		}
 
 		for _, v := range args {
 			switch v := v.(type) {
@@ -127,6 +130,14 @@ func NativeTypes(args ...any) cel.EnvOption {
 
 // NativeTypesOption is a functional interface for configuring handling of native types.
 type NativeTypesOption func(*nativeTypeOptions) error
+
+// NativeTypesVersion sets the native types version support for native extensions functions.
+func NativeTypesVersion(version uint32) NativeTypesOption {
+	return func(opts *nativeTypeOptions) error {
+		opts.version = version
+		return nil
+	}
+}
 
 // NativeTypesFieldNameHandler is a handler for mapping a reflect.StructField to a CEL field name.
 // This can be used to override the default Go struct field to CEL field name mapping.
@@ -158,6 +169,9 @@ type nativeTypeOptions struct {
 	// This is most commonly used for switching to parsing based off the struct field tag,
 	// such as "cel" or "json".
 	fieldNameHandler NativeTypesFieldNameHandler
+
+	// version is the native types library version.
+	version uint32
 }
 
 // ParseStructTags configures if native types field names should be overridable by CEL struct tags.

--- a/ext/native_test.go
+++ b/ext/native_test.go
@@ -941,6 +941,13 @@ func TestNativeStructEmbedded(t *testing.T) {
 	}
 }
 
+func TestNativeTypesVersion(t *testing.T) {
+	_, err := cel.NewEnv(NativeTypes(NativeTypesVersion(0)))
+	if err != nil {
+		t.Fatalf("NewEnv(NativeTypes(NativeTypesVersion(0))) failed: %v", err)
+	}
+}
+
 // testEnv initializes the test environment common to all tests.
 func testNativeEnv(t *testing.T, opts ...any) *cel.Env {
 	t.Helper()

--- a/ext/protos.go
+++ b/ext/protos.go
@@ -15,6 +15,8 @@
 package ext
 
 import (
+	"math"
+
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/ast"
 )
@@ -49,8 +51,23 @@ import (
 // Examples:
 //
 //	proto.hasExt(msg, google.expr.proto2.test.int32_ext) // returns true || false
-func Protos() cel.EnvOption {
-	return cel.Lib(protoLib{})
+func Protos(options ...ProtosOption) cel.EnvOption {
+	l := &protoLib{version: math.MaxUint32}
+	for _, o := range options {
+		l = o(l)
+	}
+	return cel.Lib(l)
+}
+
+// ProtosOption declares a functional operator for configuring protobuf utilities.
+type ProtosOption func(*protoLib) *protoLib
+
+// ProtosVersion sets the library version for extensions for protobuf utilities.
+func ProtosVersion(version uint32) ProtosOption {
+	return func(lib *protoLib) *protoLib {
+		lib.version = version
+		return lib
+	}
 }
 
 var (
@@ -59,7 +76,9 @@ var (
 	getExtension   = "getExt"
 )
 
-type protoLib struct{}
+type protoLib struct {
+	version uint32
+}
 
 // LibraryName implements the SingletonLibrary interface method.
 func (protoLib) LibraryName() string {

--- a/ext/protos_test.go
+++ b/ext/protos_test.go
@@ -219,6 +219,13 @@ func TestProtosWithExtension(t *testing.T) {
 	}
 }
 
+func TestProtosVersion(t *testing.T) {
+	_, err := cel.NewEnv(Protos(ProtosVersion(0)))
+	if err != nil {
+		t.Fatalf("ProtosVersion(0) failed: %v", err)
+	}
+}
+
 // msgWithExtensions generates a new example message with all possible extensions set.
 func msgWithExtensions() *proto2pb.ExampleType {
 	msg := &proto2pb.ExampleType{

--- a/ext/sets.go
+++ b/ext/sets.go
@@ -77,11 +77,28 @@ import (
 //	sets.intersects([1], []) // false
 //	sets.intersects([1], [1, 2]) // true
 //	sets.intersects([[1], [2, 3]], [[1, 2], [2, 3.0]]) // true
-func Sets() cel.EnvOption {
-	return cel.Lib(setsLib{})
+func Sets(options ...SetsOption) cel.EnvOption {
+	l := &setsLib{}
+	for _, o := range options {
+		l = o(l)
+	}
+	return cel.Lib(l)
 }
 
-type setsLib struct{}
+// SetsOption declares a functional operator for configuring set extensions.
+type SetsOption func(*setsLib) *setsLib
+
+// SetsVersion sets the library version for set extensions.
+func SetsVersion(version uint32) SetsOption {
+	return func(lib *setsLib) *setsLib {
+		lib.version = version
+		return lib
+	}
+}
+
+type setsLib struct {
+	version uint32
+}
 
 // LibraryName implements the SingletonLibrary interface method.
 func (setsLib) LibraryName() string {

--- a/ext/sets_test.go
+++ b/ext/sets_test.go
@@ -497,6 +497,13 @@ func TestSetsMembershipRewriter(t *testing.T) {
 	}
 }
 
+func TestSetsVersion(t *testing.T) {
+	_, err := cel.NewEnv(Sets(SetsVersion(0)))
+	if err != nil {
+		t.Fatalf("SetsVersion(0) failed: %v", err)
+	}
+}
+
 func testSetsEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
 	t.Helper()
 	baseOpts := []cel.EnvOption{cel.EnableMacroCallTracking(), Sets()}

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -387,6 +387,12 @@ func TestStringsVersions(t *testing.T) {
 				"quote":  `strings.quote('\a \b "double quotes"') == '"\\a \\b \\"double quotes\\""'`,
 			},
 		},
+		{
+			version: 3,
+			supportedFunctions: map[string]string{
+				"reverse": "'taco'.reverse() == 'ocat'",
+			},
+		},
 	}
 	for _, lib := range versionCases {
 		env, err := cel.NewEnv(Strings(StringsVersion(lib.version)))
@@ -425,10 +431,6 @@ func TestStringsVersions(t *testing.T) {
 			}
 		})
 	}
-}
-
-func version(v uint32) *uint32 {
-	return &v
 }
 
 func TestStringsWithExtension(t *testing.T) {

--- a/policy/config.go
+++ b/policy/config.go
@@ -264,30 +264,30 @@ func (od *OverloadDecl) AsFunctionOption(baseEnv *cel.Env) (cel.FunctionOpt, err
 
 var extFactories = map[string]ExtensionFactory{
 	"bindings": func(version uint32) cel.EnvOption {
-		return ext.Bindings()
+		return ext.Bindings(ext.BindingsVersion(version))
 	},
 	"encoders": func(version uint32) cel.EnvOption {
-		return ext.Encoders()
+		return ext.Encoders(ext.EncodersVersion(version))
 	},
 	"lists": func(version uint32) cel.EnvOption {
-		return ext.Lists()
+		return ext.Lists(ext.ListsVersion(version))
 	},
 	"math": func(version uint32) cel.EnvOption {
-		return ext.Math()
+		return ext.Math(ext.MathVersion(version))
 	},
 	"optional": func(version uint32) cel.EnvOption {
 		return cel.OptionalTypes(cel.OptionalTypesVersion(version))
 	},
 	"protos": func(version uint32) cel.EnvOption {
-		return ext.Protos()
+		return ext.Protos(ext.ProtosVersion(version))
 	},
 	"sets": func(version uint32) cel.EnvOption {
-		return ext.Sets()
+		return ext.Sets(ext.SetsVersion(version))
 	},
 	"strings": func(version uint32) cel.EnvOption {
 		return ext.Strings(ext.StringsVersion(version))
 	},
 	"two-var-comprehensions": func(version uint32) cel.EnvOption {
-		return ext.TwoVarComprehensions()
+		return ext.TwoVarComprehensions(ext.TwoVarComprehensionsVersion(version))
 	},
 }


### PR DESCRIPTION
Whether extensions support versioning or not, all extensions now support a version option
in order to remain insulated from versioned features added at a later date.