### PR TITLE
Fix optional test to short-circuit

### DIFF
--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -506,7 +506,7 @@ func (p *planner) planCreateList(expr ast.Expr) (Interpretable, error) {
 		id:           expr.ID(),
 		elems:        elems,
 		optionals:    optionals,
-		hasOptionals: len(optionals) != 0,
+		hasOptionals: len(optionalIndices) != 0,
 		adapter:      p.adapter,
 	}, nil
 }
@@ -518,6 +518,7 @@ func (p *planner) planCreateMap(expr ast.Expr) (Interpretable, error) {
 	optionals := make([]bool, len(entries))
 	keys := make([]Interpretable, len(entries))
 	vals := make([]Interpretable, len(entries))
+	hasOptionals := false
 	for i, e := range entries {
 		entry := e.AsMapEntry()
 		keyVal, err := p.Plan(entry.Key())
@@ -532,13 +533,14 @@ func (p *planner) planCreateMap(expr ast.Expr) (Interpretable, error) {
 		}
 		vals[i] = valVal
 		optionals[i] = entry.IsOptional()
+		hasOptionals = hasOptionals || entry.IsOptional()
 	}
 	return &evalMap{
 		id:           expr.ID(),
 		keys:         keys,
 		vals:         vals,
 		optionals:    optionals,
-		hasOptionals: len(optionals) != 0,
+		hasOptionals: hasOptionals,
 		adapter:      p.adapter,
 	}, nil
 }
@@ -554,6 +556,7 @@ func (p *planner) planCreateStruct(expr ast.Expr) (Interpretable, error) {
 	optionals := make([]bool, len(objFields))
 	fields := make([]string, len(objFields))
 	vals := make([]Interpretable, len(objFields))
+	hasOptionals := false
 	for i, f := range objFields {
 		field := f.AsStructField()
 		fields[i] = field.Name()
@@ -563,6 +566,7 @@ func (p *planner) planCreateStruct(expr ast.Expr) (Interpretable, error) {
 		}
 		vals[i] = val
 		optionals[i] = field.IsOptional()
+		hasOptionals = hasOptionals || field.IsOptional()
 	}
 	return &evalObj{
 		id:           expr.ID(),
@@ -570,7 +574,7 @@ func (p *planner) planCreateStruct(expr ast.Expr) (Interpretable, error) {
 		fields:       fields,
 		vals:         vals,
 		optionals:    optionals,
-		hasOptionals: len(optionals) != 0,
+		hasOptionals: hasOptionals,
 		provider:     p.provider,
 	}, nil
 }


### PR DESCRIPTION
List, map, and struct creations will short-circuit the optional element codepaths
if it is determined during planning that these literals do not contain optional
elements. The code is functional, but `hasOptionals` was trivially `false` due
to a bug in the planning code. This has been corrected.