### PR TITLE
Fix nil-type when two-var comprehension has a dyn range

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -529,9 +529,15 @@ func (c *checker) checkComprehension(e ast.Expr) {
 		c.isAssignable(types.DynType, rangeType)
 		// Set the range iteration variable to type DYN as well.
 		varType = types.DynType
+		if comp.HasIterVar2() {
+			var2Type = types.DynType
+		}
 	default:
 		c.errors.notAComprehensionRange(comp.IterRange().ID(), c.location(comp.IterRange()), rangeType)
 		varType = types.ErrorType
+		if comp.HasIterVar2() {
+			var2Type = types.ErrorType
+		}
 	}
 
 	// Create a block scope for the loop.

--- a/ext/comprehensions_test.go
+++ b/ext/comprehensions_test.go
@@ -139,6 +139,9 @@ func TestTwoVarComprehensions(t *testing.T) {
 		{'Hello': 'world'}.transformList(k, v, "%s=%s".format([k.lowerAscii(), v])) == ["hello=world"]
 		`},
 		{expr: `
+		dyn({'Hello': 'world'}).transformList(k, v, "%s=%s".format([k.lowerAscii(), v])) == ["hello=world"]
+		`},
+		{expr: `
 		{'hello': 'world'}.transformList(k, v, k.startsWith('greeting'), "%s=%s".format([k, v])) == []
 		`},
 		{expr: `
@@ -152,6 +155,10 @@ func TestTwoVarComprehensions(t *testing.T) {
 		// map.transformMap()
 		{expr: `
 		{'hello': 'world', 'goodbye': 'cruel world'}.transformMap(k, v, "%s, %s!".format([k, v]))
+		   == {'hello': 'hello, world!', 'goodbye': 'goodbye, cruel world!'}
+		`},
+		{expr: `
+		dyn({'hello': 'world', 'goodbye': 'cruel world'}).transformMap(k, v, "%s, %s!".format([k, v]))
 		   == {'hello': 'hello, world!', 'goodbye': 'goodbye, cruel world!'}
 		`},
 		{expr: `

--- a/policy/compiler_test.go
+++ b/policy/compiler_test.go
@@ -192,6 +192,10 @@ func (r *runner) setup(t testing.TB) {
 	if err != nil {
 		t.Fatalf("cel.AstToString() failed: %v", err)
 	}
+	_, err = cel.AstToCheckedExpr(ast)
+	if err != nil {
+		t.Fatalf("cel.AstToCheckedExpr() failed: %v", err)
+	}
 	if r.expr != "" && normalize(pExpr) != normalize(r.expr) {
 		t.Errorf("cel.AstToString() got %s, wanted %s", pExpr, r.expr)
 	}


### PR DESCRIPTION
The second variable type wasn't being set on two-var comprehensions when the range is a dyn type.