### PR TITLE
Improve policy compiler error message for incompatible outputs.

### DIFF
--- a/policy/compiler.go
+++ b/policy/compiler.go
@@ -378,7 +378,7 @@ func (c *compiler) checkMatchOutputTypesAgree(rule *CompiledRule, iss *cel.Issue
 		// Handle assignability as the output type is assignable to the match output or vice versa.
 		// During composition, this is roughly how the type-checker will handle the type agreement check.
 		if !(outputType.IsAssignableType(matchOutputType) || matchOutputType.IsAssignableType(outputType)) {
-			iss.ReportErrorAtID(m.Output().SourceID(), "incompatible output types: %s not assignable to %s", outputType, matchOutputType)
+			iss.ReportErrorAtID(m.Output().SourceID(), "incompatible output types: match block has output type %s, but previous match blocks have output type %s", matchOutputType, outputType)
 			return
 		}
 	}

--- a/policy/helper_test.go
+++ b/policy/helper_test.go
@@ -206,7 +206,7 @@ ERROR: testdata/errors/policy.yaml:38:75: Syntax error: extraneous input ']' exp
 ERROR: testdata/errors/policy.yaml:41:67: undeclared reference to 'format' (in container '')
  |         "invalid values provided on one or more labels: %s".format([variables.invalid])
  | ..................................................................^
-ERROR: testdata/errors/policy.yaml:45:16: incompatible output types: bool not assignable to string
+ERROR: testdata/errors/policy.yaml:45:16: incompatible output types: match block has output type string, but previous match blocks have output type bool
  |       output: "'false'"
  | ...............^`,
 		},


### PR DESCRIPTION
The previous message was confusing to users in the situation where the output of the current block was correct, but the previous blocks had incorrect types. It made them believe that the incorrect type was the "expected" output type for the rule, and that the problem was at the error line/column.

For example, the rule:

```
rule:
  match:
    - condition: foo
      output: "'incorrect'"
    - condition: bar
      output: "false"
    - output: "true"
```

would point at the "bar" block as having the wrong type, even though the wrong type is in the "foo" block.

The new message makes it clear that the error arises from the type of the block being incompatible with the *previous* block types -- not with the expected output of the rule.
