### PR TITLE
Add support for typed conformance tests.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -101,8 +101,8 @@ go_repository(
 go_repository(
     name = "dev_cel_expr",
     importpath = "cel.dev/expr",
-    sum = "h1:CJ6drgk+Hf96lkLikr4rFf19WrU0BOWEihyZnI2TAzo=",
-    version = "v0.18.0",
+    sum = "h1:NciYrtDRIR0lNCnH1LFJegdjspNx9fI59O7TWcua/W4=",
+    version = "v0.19.1",
 )
 
 # local_repository(

--- a/common/types/types.go
+++ b/common/types/types.go
@@ -768,6 +768,19 @@ func ProtoAsType(t *celpb.Type) (*Type, error) {
 	}
 }
 
+// TypeToProto converts from a CEL-native type representation to canonical CEL celpb.Type protobuf type.
+func TypeToProto(t *Type) (*celpb.Type, error) {
+	exprType, err := TypeToExprType(t)
+	if err != nil {
+		return nil, err
+	}
+	var pbtype celpb.Type
+	if err = convertProto(exprType, &pbtype); err != nil {
+		return nil, err
+	}
+	return &pbtype, nil
+}
+
 func maybeWrapper(t *Type, pbType *exprpb.Type) *exprpb.Type {
 	if t.IsAssignableType(NullType) {
 		return chkdecls.NewWrapperType(pbType)

--- a/conformance/BUILD.bazel
+++ b/conformance/BUILD.bazel
@@ -30,6 +30,7 @@ _ALL_TESTS = [
     "@dev_cel_expr//tests/simple:testdata/string.textproto",
     "@dev_cel_expr//tests/simple:testdata/string_ext.textproto",
     "@dev_cel_expr//tests/simple:testdata/timestamps.textproto",
+    "@dev_cel_expr//tests/simple:testdata/type_deduction.textproto",
     "@dev_cel_expr//tests/simple:testdata/unknowns.textproto",
     "@dev_cel_expr//tests/simple:testdata/wrappers.textproto",
     "@dev_cel_expr//tests/simple:testdata/block_ext.textproto",

--- a/conformance/go.mod
+++ b/conformance/go.mod
@@ -3,7 +3,7 @@ module github.com/google/cel-go/conformance
 go 1.21.1
 
 require (
-	cel.dev/expr v0.18.0
+	cel.dev/expr v0.19.1
 	github.com/bazelbuild/rules_go v0.49.0
 	github.com/google/cel-go v0.21.0
 	github.com/google/go-cmp v0.6.0

--- a/conformance/go.sum
+++ b/conformance/go.sum
@@ -1,5 +1,9 @@
 cel.dev/expr v0.18.0 h1:CJ6drgk+Hf96lkLikr4rFf19WrU0BOWEihyZnI2TAzo=
 cel.dev/expr v0.18.0/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
+cel.dev/expr v0.19.0 h1:lXuo+nDhpyJSpWxpPVi5cPUwzKb+dsdOiw6IreM5yt0=
+cel.dev/expr v0.19.0/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
+cel.dev/expr v0.19.1 h1:NciYrtDRIR0lNCnH1LFJegdjspNx9fI59O7TWcua/W4=
+cel.dev/expr v0.19.1/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/bazelbuild/rules_go v0.49.0 h1:5vCbuvy8Q11g41lseGJDc5vxhDjJtfxr6nM/IC4VmqM=

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 toolchain go1.23.0
 
 require (
-	cel.dev/expr v0.18.0
+	cel.dev/expr v0.19.1
 	github.com/antlr4-go/antlr/v4 v4.13.0
 	github.com/stoewer/go-strcase v1.2.0
 	golang.org/x/text v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 cel.dev/expr v0.18.0 h1:CJ6drgk+Hf96lkLikr4rFf19WrU0BOWEihyZnI2TAzo=
 cel.dev/expr v0.18.0/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
+cel.dev/expr v0.19.0 h1:lXuo+nDhpyJSpWxpPVi5cPUwzKb+dsdOiw6IreM5yt0=
+cel.dev/expr v0.19.0/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
+cel.dev/expr v0.19.1 h1:NciYrtDRIR0lNCnH1LFJegdjspNx9fI59O7TWcua/W4=
+cel.dev/expr v0.19.1/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# cel.dev/expr v0.18.0
+# cel.dev/expr v0.19.1
 ## explicit; go 1.21.1
 cel.dev/expr
 # github.com/antlr4-go/antlr/v4 v4.13.0


### PR DESCRIPTION
- Update test runner to support typed tests
- add conversion from native type to canonical proto rep
- bump cel-spec version to 0.19.1
