### PR TITLE
Add option to use inaccessible accumulator var

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -777,18 +777,9 @@ func TestMacroInterop(t *testing.T) {
 }
 
 func TestMacroModern(t *testing.T) {
-	existsOneMacro := ReceiverMacro("exists_one", 2,
-		func(mef MacroExprFactory, iterRange celast.Expr, args []celast.Expr) (celast.Expr, *Error) {
-			return parser.MakeExistsOne(mef, iterRange, args)
-		})
-	transformMacro := ReceiverMacro("transform", 2,
-		func(mef MacroExprFactory, iterRange celast.Expr, args []celast.Expr) (celast.Expr, *Error) {
-			return parser.MakeMap(mef, iterRange, args)
-		})
-	filterMacro := ReceiverMacro("filter", 2,
-		func(mef MacroExprFactory, iterRange celast.Expr, args []celast.Expr) (celast.Expr, *Error) {
-			return parser.MakeFilter(mef, iterRange, args)
-		})
+	existsOneMacro := ReceiverMacro("exists_one", 2, parser.MakeExistsOne)
+	transformMacro := ReceiverMacro("transform", 2, parser.MakeMap)
+	filterMacro := ReceiverMacro("filter", 2, parser.MakeFilter)
 	pairMacro := GlobalMacro("pair", 2,
 		func(mef MacroExprFactory, iterRange celast.Expr, args []celast.Expr) (celast.Expr, *Error) {
 			return mef.NewMap(mef.NewMapEntry(args[0], args[1], false)), nil

--- a/cel/options.go
+++ b/cel/options.go
@@ -666,9 +666,9 @@ func ParserExpressionSizeLimit(limit int) EnvOption {
 
 // EnableHiddenAccumulatorName sets the parser to use the identifier '@result' for accumulators
 // which is not normally accessible from CEL source.
-func EnableHiddenAccumulatorName() EnvOption {
+func EnableHiddenAccumulatorName(enabled bool) EnvOption {
 	return func(e *Env) (*Env, error) {
-		e.prsrOpts = append(e.prsrOpts, parser.EnableHiddenAccumulatorName(true))
+		e.prsrOpts = append(e.prsrOpts, parser.EnableHiddenAccumulatorName(enabled))
 		return e, nil
 	}
 }

--- a/cel/options.go
+++ b/cel/options.go
@@ -664,6 +664,15 @@ func ParserExpressionSizeLimit(limit int) EnvOption {
 	}
 }
 
+// EnableHiddenAccumulatorName sets the parser to use the identifier '@result' for accumulators
+// which is not normally accessible from CEL source.
+func EnableHiddenAccumulatorName() EnvOption {
+	return func(e *Env) (*Env, error) {
+		e.prsrOpts = append(e.prsrOpts, parser.EnableHiddenAccumulatorName(true))
+		return e, nil
+	}
+}
+
 func maybeInteropProvider(provider any) (types.Provider, error) {
 	switch p := provider.(type) {
 	case types.Provider:

--- a/checker/cost.go
+++ b/checker/cost.go
@@ -672,9 +672,13 @@ func (c *coster) addPath(e ast.Expr, path []string) {
 	c.exprPath[e.ID()] = path
 }
 
+func isAccumulatorVar(name string) bool {
+	return name == parser.AccumulatorName || name == parser.HiddenAccumulatorName
+}
+
 func (c *coster) newAstNode(e ast.Expr) *astNode {
 	path := c.getPath(e)
-	if len(path) > 0 && path[0] == parser.AccumulatorName {
+	if len(path) > 0 && isAccumulatorVar(path[0]) {
 		// only provide paths to root vars; omit accumulator vars
 		path = nil
 	}

--- a/common/ast/factory.go
+++ b/common/ast/factory.go
@@ -43,6 +43,9 @@ type ExprFactory interface {
 	//comprehension.
 	NewAccuIdent(id int64) Expr
 
+	// AccuIdentName reports the name of the accumulator variable to be used within a comprehension.
+	AccuIdentName() string
+
 	// NewLiteral creates an Expr value representing a literal value, such as a string or integer.
 	NewLiteral(id int64, value ref.Val) Expr
 
@@ -78,11 +81,23 @@ type ExprFactory interface {
 	isExprFactory()
 }
 
-type baseExprFactory struct{}
+type baseExprFactory struct {
+	accumulatorName string
+}
 
 // NewExprFactory creates an ExprFactory instance.
 func NewExprFactory() ExprFactory {
-	return &baseExprFactory{}
+	return &baseExprFactory{
+		"__result__",
+	}
+}
+
+// NewExprFactoryWithAccumulator creates an ExprFactory instance with a custom
+// accumulator identifier name.
+func NewExprFactoryWithAccumulator(id string) ExprFactory {
+	return &baseExprFactory{
+		id,
+	}
 }
 
 func (fac *baseExprFactory) NewCall(id int64, function string, args ...Expr) Expr {
@@ -138,7 +153,11 @@ func (fac *baseExprFactory) NewIdent(id int64, name string) Expr {
 }
 
 func (fac *baseExprFactory) NewAccuIdent(id int64) Expr {
-	return fac.NewIdent(id, "__result__")
+	return fac.NewIdent(id, fac.AccuIdentName())
+}
+
+func (fac *baseExprFactory) AccuIdentName() string {
+	return fac.accumulatorName
 }
 
 func (fac *baseExprFactory) NewLiteral(id int64, value ref.Val) Expr {

--- a/ext/comprehensions_test.go
+++ b/ext/comprehensions_test.go
@@ -621,7 +621,9 @@ func testCompreEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
 		Lists(),
 		Strings(),
 		cel.OptionalTypes(),
-		cel.EnableMacroCallTracking()}
+		cel.EnableMacroCallTracking(),
+		cel.EnableHiddenAccumulatorName(),
+	}
 	env, err := cel.NewEnv(append(baseOpts, opts...)...)
 	if err != nil {
 		t.Fatalf("cel.NewEnv(TwoVarComprehensions()) failed: %v", err)

--- a/ext/comprehensions_test.go
+++ b/ext/comprehensions_test.go
@@ -622,7 +622,7 @@ func testCompreEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
 		Strings(),
 		cel.OptionalTypes(),
 		cel.EnableMacroCallTracking(),
-		cel.EnableHiddenAccumulatorName(),
+		cel.EnableHiddenAccumulatorName(true),
 	}
 	env, err := cel.NewEnv(append(baseOpts, opts...)...)
 	if err != nil {

--- a/parser/helper.go
+++ b/parser/helper.go
@@ -470,6 +470,11 @@ func (e *exprHelper) NewAccuIdent() ast.Expr {
 	return e.exprFactory.NewAccuIdent(e.nextMacroID())
 }
 
+// AccuIdentName implements the ExprHelper interface method.
+func (e *exprHelper) AccuIdentName() string {
+	return e.exprFactory.AccuIdentName()
+}
+
 // NewGlobalCall implements the ExprHelper interface method.
 func (e *exprHelper) NewCall(function string, args ...ast.Expr) ast.Expr {
 	return e.exprFactory.NewCall(e.nextMacroID(), function, args...)

--- a/parser/options.go
+++ b/parser/options.go
@@ -27,6 +27,7 @@ type options struct {
 	enableOptionalSyntax             bool
 	enableVariadicOperatorASTs       bool
 	enableIdentEscapeSyntax          bool
+	enableHiddenAccumulatorName      bool
 }
 
 // Option configures the behavior of the parser.
@@ -133,6 +134,18 @@ func EnableOptionalSyntax(optionalSyntax bool) Option {
 func EnableIdentEscapeSyntax(enableIdentEscapeSyntax bool) Option {
 	return func(opts *options) error {
 		opts.enableIdentEscapeSyntax = enableIdentEscapeSyntax
+		return nil
+	}
+}
+
+// EnableHiddenAccumulatorName uses an accumulator variable name that is not a
+// normally accessible identifier in source for comprehension macros. Compatibility notes:
+// with this option enabled, a parsed AST would be semantically the same as if disabled, but would
+// have different internal identifiers in any of the built-in comprehension sub-expressions. When
+// disabled, it is possible but almost certainly a logic error to access the accumulator variable.
+func EnableHiddenAccumulatorName(enabled bool) Option {
+	return func(opts *options) error {
+		opts.enableHiddenAccumulatorName = enabled
 		return nil
 	}
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -89,7 +89,11 @@ func mustNewParser(opts ...Option) *Parser {
 // Parse parses the expression represented by source and returns the result.
 func (p *Parser) Parse(source common.Source) (*ast.AST, *common.Errors) {
 	errs := common.NewErrors(source)
-	fac := ast.NewExprFactory()
+	accu := AccumulatorName
+	if p.enableHiddenAccumulatorName {
+		accu = HiddenAccumulatorName
+	}
+	fac := ast.NewExprFactoryWithAccumulator(accu)
 	impl := parser{
 		errors:                           &parseErrors{errs},
 		exprFactory:                      fac,

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1887,6 +1887,241 @@ var testCases = []testInfo{
          | '\udead' == '\ufffd'
          | ^`,
 	},
+	// Macro tests with new accumulator name
+	{
+		I: `m.exists(v, f)`,
+		Opts: []Option{
+			EnableHiddenAccumulatorName(true),
+		},
+		P: `__comprehension__(
+				// Variable
+				v,
+				// Target
+				m^#1:*expr.Expr_IdentExpr#,
+				// Accumulator
+				@result,
+				// Init
+				false^#5:*expr.Constant_BoolValue#,
+				// LoopCondition
+				@not_strictly_false(
+					!_(
+					  @result^#6:*expr.Expr_IdentExpr#
+					)^#7:*expr.Expr_CallExpr#
+				)^#8:*expr.Expr_CallExpr#,
+				// LoopStep
+				_||_(
+					@result^#9:*expr.Expr_IdentExpr#,
+					f^#4:*expr.Expr_IdentExpr#
+				)^#10:*expr.Expr_CallExpr#,
+				// Result
+				@result^#11:*expr.Expr_IdentExpr#)^#12:*expr.Expr_ComprehensionExpr#`,
+		M: `m^#1:*expr.Expr_IdentExpr#.exists(
+				v^#3:*expr.Expr_IdentExpr#,
+				f^#4:*expr.Expr_IdentExpr#
+				  )^#12:exists#`,
+	},
+	{
+		I: `m.all(v, f)`,
+		Opts: []Option{
+			EnableHiddenAccumulatorName(true),
+		},
+		P: `__comprehension__(
+				// Variable
+				v,
+				// Target
+				m^#1:*expr.Expr_IdentExpr#,
+				// Accumulator
+				@result,
+				// Init
+				true^#5:*expr.Constant_BoolValue#,
+				// LoopCondition
+				@not_strictly_false(
+					@result^#6:*expr.Expr_IdentExpr#
+				)^#7:*expr.Expr_CallExpr#,
+				// LoopStep
+				_&&_(
+					@result^#8:*expr.Expr_IdentExpr#,
+					f^#4:*expr.Expr_IdentExpr#
+				)^#9:*expr.Expr_CallExpr#,
+				// Result
+				@result^#10:*expr.Expr_IdentExpr#)^#11:*expr.Expr_ComprehensionExpr#`,
+		M: `m^#1:*expr.Expr_IdentExpr#.all(
+				v^#3:*expr.Expr_IdentExpr#,
+				f^#4:*expr.Expr_IdentExpr#
+				  )^#11:all#`,
+	},
+	{
+		I: `m.existsOne(v, f)`,
+		Opts: []Option{
+			EnableHiddenAccumulatorName(true),
+		},
+		P: `__comprehension__(
+				// Variable
+				v,
+				// Target
+				m^#1:*expr.Expr_IdentExpr#,
+				// Accumulator
+				@result,
+				// Init
+				0^#5:*expr.Constant_Int64Value#,
+				// LoopCondition
+				true^#6:*expr.Constant_BoolValue#,
+				// LoopStep
+				_?_:_(
+					f^#4:*expr.Expr_IdentExpr#,
+					_+_(
+						  @result^#7:*expr.Expr_IdentExpr#,
+					  1^#8:*expr.Constant_Int64Value#
+					)^#9:*expr.Expr_CallExpr#,
+					@result^#10:*expr.Expr_IdentExpr#
+				)^#11:*expr.Expr_CallExpr#,
+				// Result
+				_==_(
+					@result^#12:*expr.Expr_IdentExpr#,
+					1^#13:*expr.Constant_Int64Value#
+				)^#14:*expr.Expr_CallExpr#)^#15:*expr.Expr_ComprehensionExpr#`,
+		M: `m^#1:*expr.Expr_IdentExpr#.existsOne(
+				v^#3:*expr.Expr_IdentExpr#,
+				f^#4:*expr.Expr_IdentExpr#
+				  )^#15:existsOne#`,
+	},
+	{
+		I: `m.map(v, f)`,
+		Opts: []Option{
+			EnableHiddenAccumulatorName(true),
+		},
+		P: `__comprehension__(
+				// Variable
+				v,
+				// Target
+				m^#1:*expr.Expr_IdentExpr#,
+				// Accumulator
+				@result,
+				// Init
+				[]^#5:*expr.Expr_ListExpr#,
+				// LoopCondition
+				true^#6:*expr.Constant_BoolValue#,
+				// LoopStep
+				_+_(
+					@result^#7:*expr.Expr_IdentExpr#,
+					[
+						f^#4:*expr.Expr_IdentExpr#
+					]^#8:*expr.Expr_ListExpr#
+				)^#9:*expr.Expr_CallExpr#,
+				// Result
+				@result^#10:*expr.Expr_IdentExpr#)^#11:*expr.Expr_ComprehensionExpr#`,
+		M: `m^#1:*expr.Expr_IdentExpr#.map(
+				v^#3:*expr.Expr_IdentExpr#,
+				f^#4:*expr.Expr_IdentExpr#
+				  )^#11:map#`,
+	},
+	{
+		I: `m.map(v, p, f)`,
+		Opts: []Option{
+			EnableHiddenAccumulatorName(true),
+		},
+		P: `__comprehension__(
+				// Variable
+				v,
+				// Target
+				m^#1:*expr.Expr_IdentExpr#,
+				// Accumulator
+				@result,
+				// Init
+				[]^#6:*expr.Expr_ListExpr#,
+				// LoopCondition
+				true^#7:*expr.Constant_BoolValue#,
+				// LoopStep
+				_?_:_(
+					p^#4:*expr.Expr_IdentExpr#,
+					_+_(
+						@result^#8:*expr.Expr_IdentExpr#,
+						[
+							f^#5:*expr.Expr_IdentExpr#
+						]^#9:*expr.Expr_ListExpr#
+					)^#10:*expr.Expr_CallExpr#,
+					@result^#11:*expr.Expr_IdentExpr#
+				)^#12:*expr.Expr_CallExpr#,
+				// Result
+				@result^#13:*expr.Expr_IdentExpr#)^#14:*expr.Expr_ComprehensionExpr#`,
+		M: `m^#1:*expr.Expr_IdentExpr#.map(
+				v^#3:*expr.Expr_IdentExpr#,
+				p^#4:*expr.Expr_IdentExpr#,
+				f^#5:*expr.Expr_IdentExpr#
+				  )^#14:map#`,
+	},
+
+	{
+		I: `m.filter(v, p)`,
+		Opts: []Option{
+			EnableHiddenAccumulatorName(true),
+		},
+		P: `__comprehension__(
+				// Variable
+				v,
+				// Target
+				m^#1:*expr.Expr_IdentExpr#,
+				// Accumulator
+				@result,
+				// Init
+				[]^#5:*expr.Expr_ListExpr#,
+				// LoopCondition
+				true^#6:*expr.Constant_BoolValue#,
+				// LoopStep
+				_?_:_(
+					p^#4:*expr.Expr_IdentExpr#,
+					_+_(
+						@result^#7:*expr.Expr_IdentExpr#,
+						[
+							v^#3:*expr.Expr_IdentExpr#
+						]^#8:*expr.Expr_ListExpr#
+					)^#9:*expr.Expr_CallExpr#,
+					@result^#10:*expr.Expr_IdentExpr#
+				)^#11:*expr.Expr_CallExpr#,
+				// Result
+				@result^#12:*expr.Expr_IdentExpr#)^#13:*expr.Expr_ComprehensionExpr#`,
+		M: `m^#1:*expr.Expr_IdentExpr#.filter(
+				v^#3:*expr.Expr_IdentExpr#,
+				p^#4:*expr.Expr_IdentExpr#
+				  )^#13:filter#`,
+	},
+	// Preserve restriction on old accumulator var name for consistency until new name is defaulted.
+	{
+		I: `m.filter(__result__, false)`,
+		Opts: []Option{
+			EnableHiddenAccumulatorName(true),
+		},
+		E: `ERROR: <input>:1:10: iteration variable overwrites accumulator variable
+             | m.filter(__result__, false)
+             | .........^`,
+	},
+	{
+		I: `m.map(__result__, __result__)`,
+		Opts: []Option{
+			EnableHiddenAccumulatorName(true),
+		},
+		E: `ERROR: <input>:1:7: iteration variable overwrites accumulator variable
+             | m.map(__result__, __result__)
+             | ......^`,
+	},
+	{
+		I: `[].existsOne(__result__, __result__)`,
+		Opts: []Option{
+			EnableHiddenAccumulatorName(true),
+		},
+		E: `ERROR: <input>:1:14: iteration variable overwrites accumulator variable
+             | [].existsOne(__result__, __result__)
+             | .............^`,
+	},
+	{
+		I: `m.filter(a.b, false)`,
+		Opts: []Option{
+			EnableHiddenAccumulatorName(true),
+		},
+		E: `ERROR: <input>:1:11: argument is not an identifier
+				 | m.filter(a.b, false)
+				 | ..........^`,
+	},
 }
 
 type testInfo struct {


### PR DESCRIPTION
Add an option to use `@result` as the accumulator variable for builtin comprehensions. The current default `__result__` is accessible in the CEL Source, allowing for expressions to type check but lead to unexpected or incorrect results. `@result'` isn't a normally accessible identifier in the source expression so a bit safer as a default.
