### PR TITLE
Update PruneAst to support constants of optional type

### DIFF
--- a/interpreter/prune.go
+++ b/interpreter/prune.go
@@ -88,7 +88,7 @@ func PruneAst(expr ast.Expr, macroCalls map[int64]ast.Expr, state EvalState) *as
 
 func (p *astPruner) maybeCreateLiteral(id int64, val ref.Val) (ast.Expr, bool) {
 	switch v := val.(type) {
-	case types.Bool, types.Bytes, types.Double, types.Int, types.Null, types.String, types.Uint:
+	case types.Bool, types.Bytes, types.Double, types.Int, types.Null, types.String, types.Uint, *types.Optional:
 		p.state.SetValue(id, val)
 		return p.NewLiteral(id, val), true
 	case types.Duration:

--- a/interpreter/prune_test.go
+++ b/interpreter/prune_test.go
@@ -35,7 +35,6 @@ type testInfo struct {
 	expr      string
 	out       string
 	iterRange string
-	enabled   bool
 }
 
 var testCases = []testInfo{

--- a/interpreter/prune_test.go
+++ b/interpreter/prune_test.go
@@ -217,6 +217,26 @@ var testCases = []testInfo{
 		out:  `a.?b`,
 	},
 	{
+		in:   partialActivation(map[string]any{"a": map[string]any{"b": 10}}),
+		expr: `a.?b`,
+		out:  `optional.of(10)`,
+	},
+	{
+		in:   partialActivation(map[string]any{"a": map[string]any{"b": "hi"}}),
+		expr: `a.?b`,
+		out:  `optional.of("hi")`,
+	},
+	{
+		in:   partialActivation(map[string]any{"a": map[string]any{}}),
+		expr: `a.?b`,
+		out:  `optional.none()`,
+	},
+	{
+		in:   partialActivation(map[string]any{"a": map[string]any{"b": 10}}),
+		expr: `a.b`,
+		out:  "10",
+	},
+	{
 		in:   unknownActivation("a"),
 		expr: `a[?"b"]`,
 		out:  `a[?"b"]`,

--- a/interpreter/prune_test.go
+++ b/interpreter/prune_test.go
@@ -34,6 +34,7 @@ type testInfo struct {
 	expr      string
 	out       string
 	iterRange string
+	enabled   bool
 }
 
 var testCases = []testInfo{
@@ -222,9 +223,14 @@ var testCases = []testInfo{
 		out:  `optional.of(10)`,
 	},
 	{
-		in:   partialActivation(map[string]any{"a": map[string]any{"b": "hi"}}),
-		expr: `a.?b`,
-		out:  `optional.of("hi")`,
+		in:   partialActivation(map[string]any{"a": map[string]any{"b": 10}}),
+		expr: `a[?"b"]`,
+		out:  `optional.of(10)`,
+	},
+	{
+		in:   unknownActivation(),
+		expr: `{'b': optional.of(10)}.?b`,
+		out:  `optional.of(optional.of(10))`,
 	},
 	{
 		in:   partialActivation(map[string]any{"a": map[string]any{}}),

--- a/parser/unparser.go
+++ b/parser/unparser.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
 )
 
 // Unparse takes an input expression and source position information and generates a human-readable
@@ -273,8 +274,7 @@ func (un *unparser) visitCallUnary(expr ast.Expr) error {
 	return un.visitMaybeNested(args[0], nested)
 }
 
-func (un *unparser) visitConst(expr ast.Expr) error {
-	val := expr.AsLiteral()
+func (un *unparser) visitConstVal(val ref.Val) error {
 	optional := false
 	if optVal, ok := val.(*types.Optional); ok {
 		if !optVal.HasValue() {
@@ -313,11 +313,22 @@ func (un *unparser) visitConst(expr ast.Expr) error {
 		ui := strconv.FormatUint(uint64(val), 10)
 		un.str.WriteString(ui)
 		un.str.WriteString("u")
+	case *types.Optional:
+		if err := un.visitConstVal(val); err != nil {
+			return err
+		}
 	default:
-		return fmt.Errorf("unsupported constant: %v", expr)
+		return errors.New("unsupported constant")
 	}
 	if optional {
 		un.str.WriteString(")")
+	}
+	return nil
+}
+func (un *unparser) visitConst(expr ast.Expr) error {
+	val := expr.AsLiteral()
+	if err := un.visitConstVal(val); err != nil {
+		return fmt.Errorf("unsupported constant: %v", expr)
 	}
 	return nil
 }

--- a/parser/unparser.go
+++ b/parser/unparser.go
@@ -275,6 +275,16 @@ func (un *unparser) visitCallUnary(expr ast.Expr) error {
 
 func (un *unparser) visitConst(expr ast.Expr) error {
 	val := expr.AsLiteral()
+	optional := false
+	if optVal, ok := val.(*types.Optional); ok {
+		if !optVal.HasValue() {
+			un.str.WriteString("optional.none()")
+			return nil
+		}
+		optional = true
+		un.str.WriteString("optional.of(")
+		val = optVal.GetValue()
+	}
 	switch val := val.(type) {
 	case types.Bool:
 		un.str.WriteString(strconv.FormatBool(bool(val)))
@@ -305,6 +315,9 @@ func (un *unparser) visitConst(expr ast.Expr) error {
 		un.str.WriteString("u")
 	default:
 		return fmt.Errorf("unsupported constant: %v", expr)
+	}
+	if optional {
+		un.str.WriteString(")")
 	}
 	return nil
 }


### PR DESCRIPTION
This PR enables the prune function to evaluate `{'b': 10}.?b` as `optional.of(10)`.