### PR TITLE
Canonical environment description and stdlib subsetting

### DIFF
--- a/cel/BUILD.bazel
+++ b/cel/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//common/ast:go_default_library",
         "//common/containers:go_default_library",
         "//common/decls:go_default_library",
+        "//common/env:go_default_library",
         "//common/functions:go_default_library",
         "//common/operators:go_default_library",
         "//common/overloads:go_default_library",

--- a/cel/decls.go
+++ b/cel/decls.go
@@ -148,6 +148,16 @@ func Variable(name string, t *Type) EnvOption {
 	}
 }
 
+// VariableDecls configures a set of fully defined cel.VariableDecl instances in the environment.
+func VariableDecls(vars ...*decls.VariableDecl) EnvOption {
+	return func(e *Env) (*Env, error) {
+		for _, v := range vars {
+			e.variables = append(e.variables, v)
+		}
+		return e, nil
+	}
+}
+
 // Function defines a function and overloads with optional singleton or per-overload bindings.
 //
 // Using Function is roughly equivalent to calling Declarations() to declare the function signatures
@@ -209,7 +219,7 @@ func ExcludeOverloads(overloadIDs ...string) OverloadSelector {
 	return decls.ExcludeOverloads(overloadIDs...)
 }
 
-// FunctionDecls provides one or more fully formed function declaration to be added to the environment.
+// FunctionDecls provides one or more fully formed function declarations to be added to the environment.
 func FunctionDecls(funcs ...*decls.FunctionDecl) EnvOption {
 	return func(e *Env) (*Env, error) {
 		var err error

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -2377,7 +2377,6 @@ func TestCheck(t *testing.T) {
 				t.Fatalf("NewEnv(cont, reg) failed: %v", err)
 			}
 			if !tc.disableStdEnv {
-				env.AddIdents(stdlib.Types()...)
 				env.AddFunctions(stdlib.Functions()...)
 			}
 			if tc.env.idents != nil {
@@ -2467,7 +2466,6 @@ func BenchmarkCheck(b *testing.B) {
 				b.Fatalf("NewEnv(cont, reg) failed: %v", err)
 			}
 			if !tc.disableStdEnv {
-				env.AddIdents(stdlib.Types()...)
 				env.AddFunctions(stdlib.Functions()...)
 			}
 			if tc.env.idents != nil {
@@ -2583,7 +2581,6 @@ func TestCheckErrorData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEnv(cont, reg) failed: %v", err)
 	}
-	env.AddIdents(stdlib.Types()...)
 	env.AddFunctions(stdlib.Functions()...)
 	_, iss = Check(ast, src, env)
 	if len(iss.GetErrors()) != 1 {

--- a/checker/env_test.go
+++ b/checker/env_test.go
@@ -26,16 +26,6 @@ import (
 	"github.com/google/cel-go/parser"
 )
 
-func TestOverlappingIdentifier(t *testing.T) {
-	env := newStdEnv(t)
-	err := env.AddIdents(decls.NewVariable("int", types.TypeType))
-	if err == nil {
-		t.Error("Got nil, wanted error")
-	} else if !strings.Contains(err.Error(), "overlapping identifier") {
-		t.Errorf("Got %v, wanted overlapping identifier error", err)
-	}
-}
-
 func TestOverlappingMacro(t *testing.T) {
 	env := newStdEnv(t)
 	hasFn, err := decls.NewFunction("has",
@@ -92,10 +82,6 @@ func BenchmarkCopyDeclarations(b *testing.B) {
 	if err != nil {
 		b.Fatalf("NewEnv() failed: %v", err)
 	}
-	err = env.AddIdents(stdlib.Types()...)
-	if err != nil {
-		b.Fatalf("env.AddIdents(stdlib.Types()...) failed: %v", err)
-	}
 	err = env.AddFunctions(stdlib.Functions()...)
 	if err != nil {
 		b.Fatalf("env.AddFunctions(stdlib.Functions()...) failed: %v", err)
@@ -111,13 +97,9 @@ func newStdEnv(t *testing.T) *Env {
 	if err != nil {
 		t.Fatalf("NewEnv() failed: %v", err)
 	}
-	err = env.AddIdents(stdlib.Types()...)
-	if err != nil {
-		t.Fatalf("env.Add(stdlib.TypeExprDecls()...) failed: %v", err)
-	}
 	err = env.AddFunctions(stdlib.Functions()...)
 	if err != nil {
-		t.Fatalf("env.Add(stdlib.FunctionExprDecls()...) failed: %v", err)
+		t.Fatalf("env.Add(stdlib.Functions()...) failed: %v", err)
 	}
 	return env
 }

--- a/common/ast/navigable_test.go
+++ b/common/ast/navigable_test.go
@@ -594,10 +594,6 @@ func newTestEnv(t testing.TB, cont *containers.Container, reg *types.Registry) *
 	if err != nil {
 		t.Fatalf("checker.NewEnv(%v, %v) failed: %v", cont, reg, err)
 	}
-	err = env.AddIdents(stdlib.Types()...)
-	if err != nil {
-		t.Fatalf("env.Add(stdlib.Types()...) failed: %v", err)
-	}
 	err = env.AddFunctions(stdlib.Functions()...)
 	if err != nil {
 		t.Fatalf("env.Add(stdlib.Functions()...) failed: %v", err)

--- a/common/decls/decls.go
+++ b/common/decls/decls.go
@@ -148,6 +148,10 @@ func (f *FunctionDecl) Merge(other *FunctionDecl) (*FunctionDecl, error) {
 	return merged, nil
 }
 
+// FunctionSubsetter subsets a function declaration or returns nil and false if the function
+// subset was empty.
+type FunctionSubsetter func(fn *FunctionDecl) (*FunctionDecl, bool)
+
 // OverloadSelector selects an overload associated with a given function when it returns true.
 //
 // Used in combination with the Subset method.

--- a/common/env/BUILD.bazel
+++ b/common/env/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "env.go",
+    ],
+    importpath = "github.com/google/cel-go/common/env",
+    deps = [
+        "//common/decls:go_default_library",
+        "//common/types:go_default_library",
+    ],
+)

--- a/common/env/env.go
+++ b/common/env/env.go
@@ -1,0 +1,348 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package env provides a representation of a CEL environment.
+package env
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/google/cel-go/common/decls"
+	"github.com/google/cel-go/common/types"
+)
+
+// NewConfig creates an instance of a YAML serializable CEL environment configuration.
+func NewConfig() *Config {
+	return &Config{
+		Imports:    []*Import{},
+		Extensions: []*Extension{},
+		Variables:  []*Variable{},
+		Functions:  []*Function{},
+	}
+}
+
+// Config represents a serializable form of the CEL environment configuration.
+//
+// Note: custom validations, feature flags, and performance tuning parameters are
+// not (yet) considered part of the core CEL environment configuration and should
+// be managed separately until a common convention for such configuration settings
+// can be developed.
+type Config struct {
+	Name            string           `yaml:"name"`
+	Description     string           `yaml:"description,omitempty"`
+	Container       string           `yaml:"container,omitempty"`
+	Imports         []*Import        `yaml:"imports,omitempty"`
+	StdLib          *LibrarySubset   `yaml:"stdlib,omitempty"`
+	Extensions      []*Extension     `yaml:"extensions,omitempty"`
+	ContextVariable *ContextVariable `yaml:"context_variable,omitempty"`
+	Variables       []*Variable      `yaml:"variables,omitempty"`
+	Functions       []*Function      `yaml:"functions,omitempty"`
+}
+
+// Import represents a type name that will be appreviated by its simple name using
+// the cel.Abbrevs() option.
+type Import struct {
+	Name string `yaml:"name"`
+}
+
+// Variable represents a typed variable declaration which will be published via the
+// cel.VariableDecls() option.
+type Variable struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+
+	// Type represents the type declaration for the variable.
+	//
+	// Deprecated: use the embedded *TypeDesc fields directly.
+	Type *TypeDesc `yaml:"type,omitempty"`
+
+	// TypeDesc is an embedded set of fields allowing for the specification of the Variable type.
+	*TypeDesc `yaml:",inline"`
+}
+
+// GetType returns the variable type description.
+func (vd *Variable) GetType() *TypeDesc {
+	if vd == nil {
+		return nil
+	}
+	if vd.TypeDesc != nil {
+		return vd.TypeDesc
+	}
+	if vd.Type != nil {
+		return vd.Type
+	}
+	return nil
+}
+
+// AsCELVariable converts the serializable form of the Variable into a CEL environment declaration.
+func (vd *Variable) AsCELVariable(tp types.Provider) (*decls.VariableDecl, error) {
+	if vd.Name == "" {
+		return nil, fmt.Errorf("invalid variable, must declare a name")
+	}
+	if vd.GetType() != nil {
+		t, err := vd.GetType().AsCELType(tp)
+		if err != nil {
+			return nil, fmt.Errorf("invalid variable type for '%s': %w", vd.Name, err)
+		}
+		return decls.NewVariable(vd.Name, t), nil
+	}
+	return nil, fmt.Errorf("invalid variable '%s', no type specified", vd.Name)
+}
+
+// ContextVariable represents a structured message whose fields are to be treated as the top-level
+// variable identifiers within CEL expressions.
+type ContextVariable struct {
+	// TypeName represents the fully qualified typename of the context variable.
+	// Currently, only protobuf types are supported.
+	TypeName string `yaml:"type_name"`
+}
+
+// Function represents the serializable format of a function and its overloads.
+type Function struct {
+	Name        string      `yaml:"name"`
+	Description string      `yaml:"description"`
+	Overloads   []*Overload `yaml:"overloads"`
+}
+
+// AsCELFunction converts the serializable form of the Function into CEL environment declaration.
+func (fn *Function) AsCELFunction(tp types.Provider) (*decls.FunctionDecl, error) {
+	overloads := make([]decls.FunctionOpt, len(fn.Overloads))
+	var err error
+	for i, o := range fn.Overloads {
+		overloads[i], err = o.AsFunctionOption(tp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return decls.NewFunction(fn.Name, overloads...)
+}
+
+// Overload represents the serializable format of a function overload.
+type Overload struct {
+	ID          string      `yaml:"id"`
+	Description string      `yaml:"description"`
+	Target      *TypeDesc   `yaml:"target"`
+	Args        []*TypeDesc `yaml:"args"`
+	Return      *TypeDesc   `yaml:"return"`
+}
+
+// AsFunctionOption converts the serializable form of the Overload into a function declaration option.
+func (od *Overload) AsFunctionOption(tp types.Provider) (decls.FunctionOpt, error) {
+	args := make([]*types.Type, len(od.Args))
+	var err error
+	for i, a := range od.Args {
+		args[i], err = a.AsCELType(tp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if od.Return == nil {
+		return nil, fmt.Errorf("missing return type on overload: %v", od.ID)
+	}
+	result, err := od.Return.AsCELType(tp)
+	if err != nil {
+		return nil, err
+	}
+	if od.Target != nil {
+		t, err := od.Target.AsCELType(tp)
+		if err != nil {
+			return nil, err
+		}
+		args = append([]*types.Type{t}, args...)
+		return decls.MemberOverload(od.ID, args, result), nil
+	}
+	return decls.Overload(od.ID, args, result), nil
+}
+
+// Extension represents a named and optionally versioned extension library configured in the environment.
+type Extension struct {
+	// Name is either the LibraryName() or some short-hand simple identifier which is understood by the config-handler.
+	Name string `yaml:"name"`
+
+	// Version may either be an unsigned long value or the string 'latest'. If empty, the value is treated as '0'.
+	Version string `yaml:"version,omitempty"`
+}
+
+// GetVersion returns the parsed version string, or an error if the version cannot be parsed.
+func (e *Extension) GetVersion() (uint32, error) {
+	if e.Version == "latest" {
+		return math.MaxUint32, nil
+	}
+	if e.Version == "" {
+		return uint32(0), nil
+	}
+	ver, err := strconv.ParseUint(e.Version, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("error parsing uint version: %w", err)
+	}
+	return uint32(ver), nil
+}
+
+// LibrarySubset indicates a subset of the macros and function supported by a subsettable library.
+type LibrarySubset struct {
+	// DisableMacros disables macros for the given library.
+	DisableMacros bool `yaml:"disable_macros"`
+
+	// IncludeMacros specifies a set of macro function names to include in the subset.
+	IncludeMacros []string `yaml:"include_macros"`
+
+	// ExcludeMacros specifies a set of macro function names to exclude from the subset.
+	// Note: if IncludeMacros is non-empty, then ExcludeFunctions is ignored.
+	ExcludeMacros []string `yaml:"exclude_macros"`
+
+	// IncludeFunctions specifies a set of functions to include in the subset.
+	//
+	// Note: the overloads specified in the subset need only specify their ID.
+	// Note: if IncludeFunctions is non-empty, then ExcludeFunctions is ignored.
+	IncludeFunctions []*Function `yaml:"include_functions"`
+
+	// ExcludeFunctions specifies the set of functions to exclude from the subset.
+	//
+	// Note: the overloads specified in the subset need only specify their ID.
+	ExcludeFunctions []*Function `yaml:"exclude_functions"`
+}
+
+// SubsetFunction produces a function declaration which matches the supported subset, or nil
+// if the function is not supported by the LibrarySubset.
+//
+// For IncludeFunctions, if the function does not specify a set of overloads to include, the
+// whole function definition is included. If overloads are set, then a new function which
+// includes only the specified overloads is produced.
+//
+// For ExcludeFunctions, if the function does not specify a set of overloads to exclude, the
+// whole function definition is excluded. If overloads are set, then a new function which
+// includes only the permitted overloads is produced.
+func (lib *LibrarySubset) SubsetFunction(fn *decls.FunctionDecl) (*decls.FunctionDecl, bool) {
+	if len(lib.IncludeFunctions) != 0 {
+		for _, include := range lib.IncludeFunctions {
+			if include.Name != fn.Name() {
+				continue
+			}
+			if len(include.Overloads) == 0 {
+				return fn, true
+			}
+			overloadIDs := make([]string, len(include.Overloads))
+			for i, o := range include.Overloads {
+				overloadIDs[i] = o.ID
+			}
+			return fn.Subset(decls.IncludeOverloads(overloadIDs...)), true
+		}
+		return nil, false
+	}
+	if len(lib.ExcludeFunctions) != 0 {
+		for _, exclude := range lib.ExcludeFunctions {
+			if exclude.Name != fn.Name() {
+				continue
+			}
+			if len(exclude.Overloads) == 0 {
+				return nil, false
+			}
+			overloadIDs := make([]string, len(exclude.Overloads))
+			for i, o := range exclude.Overloads {
+				overloadIDs[i] = o.ID
+			}
+			return fn.Subset(decls.ExcludeOverloads(overloadIDs...)), true
+		}
+		return fn, true
+	}
+	return fn, true
+}
+
+// SubsetMacro indicates whether the macro function should be included in the library subset.
+func (lib *LibrarySubset) SubsetMacro(macroFunction string) bool {
+	if lib.DisableMacros {
+		return false
+	}
+	if len(lib.IncludeMacros) != 0 {
+		for _, name := range lib.IncludeMacros {
+			if name == macroFunction {
+				return true
+			}
+		}
+		return false
+	}
+	if len(lib.ExcludeMacros) != 0 {
+		for _, name := range lib.ExcludeMacros {
+			if name == macroFunction {
+				return false
+			}
+		}
+		return true
+	}
+	return true
+}
+
+// TypeDesc represents the serializable format of a CEL *types.Type value.
+type TypeDesc struct {
+	TypeName    string      `yaml:"type_name"`
+	Params      []*TypeDesc `yaml:"params"`
+	IsTypeParam bool        `yaml:"is_type_param"`
+}
+
+// AsCELType converts the serializable object to a *types.Type value.
+func (td *TypeDesc) AsCELType(tp types.Provider) (*types.Type, error) {
+	var err error
+	switch td.TypeName {
+	case "dyn":
+		return types.DynType, nil
+	case "map":
+		if len(td.Params) == 2 {
+			kt, err := td.Params[0].AsCELType(tp)
+			if err != nil {
+				return nil, err
+			}
+			vt, err := td.Params[1].AsCELType(tp)
+			if err != nil {
+				return nil, err
+			}
+			return types.NewMapType(kt, vt), nil
+		}
+		return nil, fmt.Errorf("map type has unexpected param count: %d", len(td.Params))
+	case "list":
+		if len(td.Params) == 1 {
+			et, err := td.Params[0].AsCELType(tp)
+			if err != nil {
+				return nil, err
+			}
+			return types.NewListType(et), nil
+		}
+		return nil, fmt.Errorf("list type has unexpected param count: %d", len(td.Params))
+	default:
+		if td.IsTypeParam {
+			return types.NewTypeParamType(td.TypeName), nil
+		}
+		if msgType, found := tp.FindStructType(td.TypeName); found {
+			// First parameter is the type name.
+			return msgType.Parameters()[0], nil
+		}
+		t, found := tp.FindIdent(td.TypeName)
+		if !found {
+			return nil, fmt.Errorf("undefined type name: %v", td.TypeName)
+		}
+		_, ok := t.(*types.Type)
+		if ok && len(td.Params) == 0 {
+			return t.(*types.Type), nil
+		}
+		params := make([]*types.Type, len(td.Params))
+		for i, p := range td.Params {
+			params[i], err = p.AsCELType(tp)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return types.NewOpaqueType(td.TypeName, params...), nil
+	}
+}

--- a/common/env/env.go
+++ b/common/env/env.go
@@ -356,7 +356,7 @@ func (td *TypeDesc) AsCELType(tp types.Provider) (*types.Type, error) {
 			return types.NewListType(et), nil
 		}
 		return nil, fmt.Errorf("list type has unexpected param count: %d", len(td.Params))
-	case "optional", "optional_type":
+	case "optional_type":
 		if len(td.Params) == 1 {
 			et, err := td.Params[0].AsCELType(tp)
 			if err != nil {

--- a/common/env/env_test.go
+++ b/common/env/env_test.go
@@ -1,0 +1,29 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/common/types"
+)
+
+func TestConfig(t *testing.T) {
+
+}
+
+func TestTypeDescAsCELType(t *testing.T) {
+	types.NewRegistry()
+}

--- a/common/env/env_test.go
+++ b/common/env/env_test.go
@@ -15,15 +15,687 @@
 package env
 
 import (
+	"errors"
+	"math"
+	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/types"
 )
 
 func TestConfig(t *testing.T) {
-
+	conf := NewConfig()
+	if conf == nil {
+		t.Fatal("got nil config, wanted non-nil value")
+	}
 }
 
-func TestTypeDescAsCELType(t *testing.T) {
-	types.NewRegistry()
+func TestVariableGetType(t *testing.T) {
+	tests := []struct {
+		name string
+		v    *Variable
+		t    *TypeDesc
+	}{
+		{
+			name: "nil-safety check",
+			v:    nil,
+			t:    nil,
+		},
+		{
+			name: "nil type access",
+			v:    &Variable{},
+			t:    nil,
+		},
+		{
+			name: "nested type desc",
+			v:    &Variable{TypeDesc: &TypeDesc{}},
+			t:    &TypeDesc{},
+		},
+		{
+			name: "field type desc",
+			v:    &Variable{Type: &TypeDesc{}},
+			t:    &TypeDesc{},
+		},
+		{
+			name: "nested type desc precedence",
+			v: &Variable{
+				TypeDesc: &TypeDesc{TypeName: "type.name.EmbeddedType"},
+				Type:     &TypeDesc{TypeName: "type.name.FieldType"},
+			},
+			t: &TypeDesc{TypeName: "type.name.EmbeddedType"},
+		},
+	}
+
+	for _, tst := range tests {
+		tc := tst
+		t.Run(tc.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tc.v.GetType(), tc.t) {
+				t.Errorf("GetType() got %v, wanted %v", tc.v.GetType(), tc.t)
+			}
+		})
+	}
+}
+
+func TestVariableAsCELVariable(t *testing.T) {
+	tests := []struct {
+		name string
+		v    *Variable
+		want any
+	}{
+		{
+			name: "nil-safety check",
+			v:    nil,
+			want: errors.New("nil Variable"),
+		},
+		{
+			name: "no variable name",
+			v:    &Variable{},
+			want: errors.New("invalid variable"),
+		},
+		{
+			name: "no type",
+			v: &Variable{
+				Name: "hello",
+			},
+			want: errors.New("no type specified"),
+		},
+		{
+			name: "bad type",
+			v: &Variable{
+				Name:     "hello",
+				TypeDesc: &TypeDesc{},
+			},
+			want: errors.New("declare a type name"),
+		},
+		{
+			name: "int type",
+			v: &Variable{
+				Name:     "int_var",
+				TypeDesc: &TypeDesc{TypeName: "int"},
+			},
+			want: decls.NewVariable("int_var", types.IntType),
+		},
+		{
+			name: "uint type",
+			v: &Variable{
+				Name:     "uint_var",
+				TypeDesc: &TypeDesc{TypeName: "uint"},
+			},
+			want: decls.NewVariable("uint_var", types.UintType),
+		},
+		{
+			name: "dyn type",
+			v: &Variable{
+				Name:     "dyn_var",
+				TypeDesc: &TypeDesc{TypeName: "dyn"},
+			},
+			want: decls.NewVariable("dyn_var", types.DynType),
+		},
+		{
+			name: "list type",
+			v: &Variable{
+				Name:     "list_var",
+				TypeDesc: &TypeDesc{TypeName: "list", Params: []*TypeDesc{{TypeName: "T", IsTypeParam: true}}},
+			},
+			want: decls.NewVariable("list_var", types.NewListType(types.NewTypeParamType("T"))),
+		},
+		{
+			name: "map type",
+			v: &Variable{
+				Name: "map_var",
+				TypeDesc: &TypeDesc{
+					TypeName: "map",
+					Params: []*TypeDesc{
+						{TypeName: "string"},
+						{TypeName: "optional_type",
+							Params: []*TypeDesc{{TypeName: "T", IsTypeParam: true}}},
+					},
+				},
+			},
+			want: decls.NewVariable("map_var",
+				types.NewMapType(types.StringType, types.NewOptionalType(types.NewTypeParamType("T")))),
+		},
+		{
+			name: "set type",
+			v: &Variable{
+				Name: "set_var",
+				TypeDesc: &TypeDesc{
+					TypeName: "set",
+					Params: []*TypeDesc{
+						{TypeName: "string"},
+					},
+				},
+			},
+			want: decls.NewVariable("set_var", types.NewOpaqueType("set", types.StringType)),
+		},
+		{
+			name: "string type - nested type precedence",
+			v: &Variable{
+				Name:     "hello",
+				TypeDesc: &TypeDesc{TypeName: "string"},
+				Type:     &TypeDesc{TypeName: "int"},
+			},
+			want: decls.NewVariable("hello", types.StringType),
+		},
+		{
+			name: "wrapper type variable",
+			v: &Variable{
+				Name:     "msg",
+				TypeDesc: &TypeDesc{TypeName: "google.protobuf.StringValue"},
+			},
+			want: decls.NewVariable("msg", types.NewNullableType(types.StringType)),
+		},
+	}
+
+	tp, err := types.NewRegistry()
+	if err != nil {
+		t.Fatalf("types.NewRegistry() failed: %v", err)
+	}
+	tp.RegisterType(types.NewOpaqueType("set", types.NewTypeParamType("T")))
+	for _, tst := range tests {
+		tc := tst
+		t.Run(tc.name, func(t *testing.T) {
+			gotVar, err := tc.v.AsCELVariable(tp)
+			if err != nil {
+				wantErr, ok := tc.want.(error)
+				if !ok {
+					t.Fatalf("AsCELVariable() got error %v, wanted %v", err, tc.want)
+				}
+				if !strings.Contains(err.Error(), wantErr.Error()) {
+					t.Fatalf("AsCELVariable() got error %v, wanted error contining %v", err, wantErr)
+				}
+				return
+			}
+			if !gotVar.DeclarationIsEquivalent(tc.want.(*decls.VariableDecl)) {
+				t.Errorf("AsCELVariable() got %v, wanted %v", gotVar, tc.want)
+			}
+		})
+	}
+}
+
+func TestFunctionAsCELFunction(t *testing.T) {
+	tests := []struct {
+		name string
+		f    *Function
+		want any
+	}{
+		{
+			name: "nil function",
+			f:    nil,
+			want: errors.New("nil Function"),
+		},
+		{
+			name: "unnamed function",
+			f:    &Function{},
+			want: errors.New("must declare a name"),
+		},
+		{
+			name: "no overloads",
+			f:    &Function{Name: "no_overloads"},
+			want: errors.New("must declare an overload"),
+		},
+		{
+			name: "nil overload",
+			f:    &Function{Name: "no_overloads", Overloads: []*Overload{nil}},
+			want: errors.New("nil Overload"),
+		},
+		{
+			name: "no return type",
+			f: &Function{Name: "size",
+				Overloads: []*Overload{
+					{ID: "size_string",
+						Args: []*TypeDesc{{TypeName: "string"}},
+					},
+				},
+			},
+			want: errors.New("missing return type"),
+		},
+		{
+			name: "bad return type",
+			f: &Function{Name: "size",
+				Overloads: []*Overload{
+					{ID: "size_string",
+						Args:   []*TypeDesc{{TypeName: "string"}},
+						Return: &TypeDesc{},
+					},
+				},
+			},
+			want: errors.New("invalid type"),
+		},
+		{
+			name: "bad arg type",
+			f: &Function{Name: "size",
+				Overloads: []*Overload{
+					{ID: "size_string",
+						Args:   []*TypeDesc{{}},
+						Return: &TypeDesc{},
+					},
+				},
+			},
+			want: errors.New("invalid type"),
+		},
+		{
+			name: "bad target type",
+			f: &Function{Name: "size",
+				Overloads: []*Overload{
+					{ID: "string_size",
+						Target: &TypeDesc{},
+						Args:   []*TypeDesc{},
+						Return: &TypeDesc{TypeName: "int"},
+					},
+				},
+			},
+			want: errors.New("invalid type"),
+		},
+		{
+			name: "global function",
+			f: &Function{Name: "size",
+				Overloads: []*Overload{
+					{ID: "size_string",
+						Args:   []*TypeDesc{{TypeName: "string"}},
+						Return: &TypeDesc{TypeName: "int"}},
+				},
+			},
+			want: mustNewFunction(t, "size", decls.Overload("size_string", []*types.Type{types.StringType}, types.IntType)),
+		},
+		{
+			name: "member function",
+			f: &Function{Name: "size",
+				Overloads: []*Overload{
+					{ID: "string_size",
+						Target: &TypeDesc{TypeName: "string"},
+						Return: &TypeDesc{TypeName: "int"}},
+				},
+			},
+			want: mustNewFunction(t, "size", decls.MemberOverload("string_size", []*types.Type{types.StringType}, types.IntType)),
+		},
+	}
+	tp, err := types.NewRegistry()
+	if err != nil {
+		t.Fatalf("types.NewRegistry() failed: %v", err)
+	}
+	tp.RegisterType(types.NewOpaqueType("set", types.NewTypeParamType("T")))
+	for _, tst := range tests {
+		tc := tst
+		t.Run(tc.name, func(t *testing.T) {
+			gotFn, err := tc.f.AsCELFunction(tp)
+			if err != nil {
+				wantErr, ok := tc.want.(error)
+				if !ok {
+					t.Fatalf("AsCELFunction() got error %v, wanted %v", err, tc.want)
+				}
+				if !strings.Contains(err.Error(), wantErr.Error()) {
+					t.Fatalf("AsCELFunction() got error %v, wanted error contining %v", err, wantErr)
+				}
+				return
+			}
+			assertFuncEquals(t, gotFn, tc.want.(*decls.FunctionDecl))
+		})
+	}
+}
+
+func TestTypeDescAsCELTypeErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		t    *TypeDesc
+		want any
+	}{
+		{
+			name: "nil-safety check",
+			t:    nil,
+			want: errors.New("nil TypeDesc"),
+		},
+		{
+			name: "no type name",
+			t:    &TypeDesc{},
+			want: errors.New("invalid type"),
+		},
+		{
+			name: "invalid optional",
+			t:    &TypeDesc{TypeName: "optional"},
+			want: errors.New("unexpected param count"),
+		},
+		{
+			name: "invalid optional param type",
+			t:    &TypeDesc{TypeName: "optional", Params: []*TypeDesc{{}}},
+			want: errors.New("invalid type"),
+		},
+		{
+			name: "invalid list",
+			t:    &TypeDesc{TypeName: "list"},
+			want: errors.New("unexpected param count"),
+		},
+		{
+			name: "invalid list param type",
+			t:    &TypeDesc{TypeName: "list", Params: []*TypeDesc{{}}},
+			want: errors.New("invalid type"),
+		},
+		{
+			name: "invalid map",
+			t:    &TypeDesc{TypeName: "map"},
+			want: errors.New("unexpected param count"),
+		},
+		{
+			name: "invalid map key type",
+			t:    &TypeDesc{TypeName: "map", Params: []*TypeDesc{{}, {}}},
+			want: errors.New("invalid type"),
+		},
+		{
+			name: "invalid map value type",
+			t:    &TypeDesc{TypeName: "map", Params: []*TypeDesc{{TypeName: "string"}, {}}},
+			want: errors.New("invalid type"),
+		},
+		{
+			name: "invalid set",
+			t:    &TypeDesc{TypeName: "set", Params: []*TypeDesc{{}}},
+			want: errors.New("invalid type"),
+		},
+		{
+			name: "undefined type identifier",
+			t:    &TypeDesc{TypeName: "vector"},
+			want: errors.New("undefined type"),
+		},
+	}
+	tp, err := types.NewRegistry()
+	if err != nil {
+		t.Fatalf("types.NewRegistry() failed: %v", err)
+	}
+	tp.RegisterType(types.NewOpaqueType("set", types.NewTypeParamType("T")))
+	for _, tst := range tests {
+		tc := tst
+		t.Run(tc.name, func(t *testing.T) {
+			gotVar, err := tc.t.AsCELType(tp)
+			if err != nil {
+				wantErr, ok := tc.want.(error)
+				if !ok {
+					t.Fatalf("AsCELType() got error %v, wanted %v", err, tc.want)
+				}
+				if !strings.Contains(err.Error(), wantErr.Error()) {
+					t.Fatalf("AsCELType() got error %v, wanted error contining %v", err, wantErr)
+				}
+				return
+			}
+			if !reflect.DeepEqual(gotVar, tc.want.(*decls.VariableDecl)) {
+				t.Errorf("AsCELType() got %v, wanted %v", gotVar, tc.want)
+			}
+		})
+	}
+}
+
+func TestSubsetFunction(t *testing.T) {
+	tests := []struct {
+		name     string
+		lib      *LibrarySubset
+		orig     *decls.FunctionDecl
+		subset   *decls.FunctionDecl
+		included bool
+	}{
+		{
+			name:     "nil lib, included",
+			orig:     mustNewFunction(t, "size", decls.Overload("size_string", []*types.Type{types.StringType}, types.IntType)),
+			subset:   mustNewFunction(t, "size", decls.Overload("size_string", []*types.Type{types.StringType}, types.IntType)),
+			included: true,
+		},
+		{
+			name:     "empty, included",
+			lib:      &LibrarySubset{},
+			orig:     mustNewFunction(t, "size", decls.Overload("size_string", []*types.Type{types.StringType}, types.IntType)),
+			subset:   mustNewFunction(t, "size", decls.Overload("size_string", []*types.Type{types.StringType}, types.IntType)),
+			included: true,
+		},
+		{
+			name: "lib, not included allow-list",
+			lib: &LibrarySubset{
+				IncludeFunctions: []*Function{
+					{Name: "int"},
+				},
+			},
+			orig:     mustNewFunction(t, "size", decls.Overload("size_string", []*types.Type{types.StringType}, types.IntType)),
+			included: false,
+		},
+		{
+			name: "lib, included whole function",
+			lib: &LibrarySubset{
+				IncludeFunctions: []*Function{
+					{Name: "size"},
+				},
+			},
+			orig:     mustNewFunction(t, "size", decls.Overload("size_string", []*types.Type{types.StringType}, types.IntType)),
+			subset:   mustNewFunction(t, "size", decls.Overload("size_string", []*types.Type{types.StringType}, types.IntType)),
+			included: true,
+		},
+		{
+			name: "lib, included overload subset",
+			lib: &LibrarySubset{
+				IncludeFunctions: []*Function{
+					{Name: "size", Overloads: []*Overload{{ID: "size_string"}}},
+				},
+			},
+			orig: mustNewFunction(t, "size",
+				decls.Overload("size_string", []*types.Type{types.StringType}, types.IntType),
+				decls.Overload("size_list", []*types.Type{types.NewListType(types.NewTypeParamType("T"))}, types.IntType),
+			),
+			subset:   mustNewFunction(t, "size", decls.Overload("size_string", []*types.Type{types.StringType}, types.IntType)),
+			included: true,
+		},
+		{
+			name: "lib, included deny-list",
+			lib: &LibrarySubset{
+				ExcludeFunctions: []*Function{
+					{Name: "int"},
+				},
+			},
+			orig:     mustNewFunction(t, "size", decls.Overload("size_string", []*types.Type{types.StringType}, types.IntType)),
+			subset:   mustNewFunction(t, "size", decls.Overload("size_string", []*types.Type{types.StringType}, types.IntType)),
+			included: true,
+		},
+		{
+			name: "lib, excluded whole function",
+			lib: &LibrarySubset{
+				ExcludeFunctions: []*Function{
+					{Name: "size"},
+				},
+			},
+			orig:     mustNewFunction(t, "size", decls.Overload("size_string", []*types.Type{types.StringType}, types.IntType)),
+			included: false,
+		},
+		{
+			name: "lib, excluded partial function",
+			lib: &LibrarySubset{
+				ExcludeFunctions: []*Function{
+					{Name: "size", Overloads: []*Overload{{ID: "size_list"}}},
+				},
+			},
+			orig: mustNewFunction(t, "size",
+				decls.Overload("size_string", []*types.Type{types.StringType}, types.IntType),
+				decls.Overload("size_list", []*types.Type{types.NewListType(types.NewTypeParamType("T"))}, types.IntType),
+			),
+			subset:   mustNewFunction(t, "size", decls.Overload("size_string", []*types.Type{types.StringType}, types.IntType)),
+			included: true,
+		},
+	}
+	for _, tst := range tests {
+		tc := tst
+		t.Run(tc.name, func(t *testing.T) {
+			got, included := tc.lib.SubsetFunction(tc.orig)
+			if included != tc.included {
+				t.Fatalf("SubsetFunction() got included %t, wanted %t", included, tc.included)
+			}
+			if !tc.included {
+				return
+			}
+			assertFuncEquals(t, got, tc.subset)
+		})
+	}
+}
+
+func TestSubsetMacro(t *testing.T) {
+	tests := []struct {
+		name      string
+		lib       *LibrarySubset
+		macroName string
+		included  bool
+	}{
+		{
+			name:      "nil lib, included",
+			macroName: "has",
+			included:  true,
+		},
+		{
+			name:      "empty, included",
+			lib:       &LibrarySubset{},
+			macroName: "has",
+			included:  true,
+		},
+		{
+			name:      "empty, included",
+			lib:       &LibrarySubset{DisableMacros: true},
+			macroName: "has",
+			included:  false,
+		},
+		{
+			name: "lib, not included allow-list",
+			lib: &LibrarySubset{
+				IncludeMacros: []string{"exists"},
+			},
+			macroName: "has",
+			included:  false,
+		},
+		{
+			name: "lib, included allow-list",
+			lib: &LibrarySubset{
+				IncludeMacros: []string{"exists"},
+			},
+			macroName: "exists",
+			included:  true,
+		},
+		{
+			name: "lib, not included deny-list",
+			lib: &LibrarySubset{
+				ExcludeMacros: []string{"exists"},
+			},
+			macroName: "exists",
+			included:  false,
+		},
+		{
+			name: "lib, included deny-list",
+			lib: &LibrarySubset{
+				ExcludeMacros: []string{"exists"},
+			},
+			macroName: "has",
+			included:  true,
+		},
+	}
+	for _, tst := range tests {
+		tc := tst
+		t.Run(tc.name, func(t *testing.T) {
+			included := tc.lib.SubsetMacro(tc.macroName)
+			if included != tc.included {
+				t.Fatalf("SubsetMacro() got included %t, wanted %t", included, tc.included)
+			}
+		})
+	}
+}
+
+func TestExtensionGetVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		ext  *Extension
+		want any
+	}{
+		{
+			name: "nil extension",
+			want: errors.New("nil Extension"),
+		},
+		{
+			name: "unset version",
+			ext:  &Extension{},
+			want: uint32(0),
+		},
+		{
+			name: "numeric version",
+			ext:  &Extension{Version: "1"},
+			want: uint32(1),
+		},
+		{
+			name: "latest version",
+			ext:  &Extension{Version: "latest"},
+			want: uint32(math.MaxUint32),
+		},
+		{
+			name: "bad version",
+			ext:  &Extension{Version: "1.0"},
+			want: errors.New("invalid syntax"),
+		},
+	}
+	for _, tst := range tests {
+		tc := tst
+		t.Run(tc.name, func(t *testing.T) {
+			ver, err := tc.ext.GetVersion()
+			if err != nil {
+				wantErr, ok := tc.want.(error)
+				if !ok {
+					t.Fatalf("GetVersion() got error %v, wanted %v", err, tc.want)
+				}
+				if !strings.Contains(err.Error(), wantErr.Error()) {
+					t.Fatalf("GetVersion() got error %v, wanted error contining %v", err, wantErr)
+				}
+				return
+			}
+			if tc.want.(uint32) != ver {
+				t.Fatalf("GetVersion() got %d, wanted %v", ver, tc.want)
+			}
+		})
+	}
+}
+
+func mustNewFunction(t *testing.T, name string, opts ...decls.FunctionOpt) *decls.FunctionDecl {
+	t.Helper()
+	fn, err := decls.NewFunction(name, opts...)
+	if err != nil {
+		t.Fatalf("decls.NewFunction() failed: %v", err)
+	}
+	return fn
+}
+
+func assertFuncEquals(t *testing.T, got, want *decls.FunctionDecl) {
+	t.Helper()
+	if got.Name() != want.Name() {
+		t.Fatalf("got function name %s, wanted %s", got.Name(), want.Name())
+	}
+	if len(got.OverloadDecls()) != len(want.OverloadDecls()) {
+		t.Fatalf("got overload count %d, wanted %d", len(got.OverloadDecls()), len(want.OverloadDecls()))
+	}
+	for i, gotOverload := range got.OverloadDecls() {
+		wantOverload := want.OverloadDecls()[i]
+		if gotOverload.ID() != wantOverload.ID() {
+			t.Errorf("got overload id: %s, wanted: %s", gotOverload.ID(), wantOverload.ID())
+		}
+		if gotOverload.IsMemberFunction() != wantOverload.IsMemberFunction() {
+			t.Errorf("got is member function %t, wanted %t", gotOverload.IsMemberFunction(), wantOverload.IsMemberFunction())
+		}
+		if len(gotOverload.ArgTypes()) != len(wantOverload.ArgTypes()) {
+			t.Fatalf("got arg count %d, wanted %d", len(gotOverload.ArgTypes()), len(wantOverload.ArgTypes()))
+		}
+		for i, p := range gotOverload.ArgTypes() {
+			wp := wantOverload.ArgTypes()[i]
+			if !p.IsExactType(wp) {
+				t.Errorf("got arg[%d] type %v, wanted %v", i, p, wp)
+			}
+		}
+		if len(gotOverload.TypeParams()) != len(wantOverload.TypeParams()) {
+			t.Fatalf("got type param count %d, wanted %d", len(gotOverload.TypeParams()), len(wantOverload.TypeParams()))
+		}
+		for i, p := range gotOverload.TypeParams() {
+			wp := wantOverload.TypeParams()[i]
+			if p != wp {
+				t.Errorf("got type param[%d] %s, wanted %s", i, p, wp)
+			}
+		}
+		if !gotOverload.ResultType().IsExactType(wantOverload.ResultType()) {
+			t.Errorf("got result type %v, wanted %v", gotOverload.ResultType(), wantOverload.ResultType())
+		}
+	}
 }

--- a/common/types/types.go
+++ b/common/types/types.go
@@ -164,9 +164,9 @@ var (
 			traits.SubtractorType,
 	}
 	// ListType represents the runtime list type.
-	ListType = NewListType(nil)
+	ListType = NewListType(DynType)
 	// MapType represents the runtime map type.
-	MapType = NewMapType(nil, nil)
+	MapType = NewMapType(DynType, DynType)
 	// NullType represents the type of a null value.
 	NullType = &Type{
 		kind:            NullTypeKind,

--- a/common/types/types_test.go
+++ b/common/types/types_test.go
@@ -92,11 +92,11 @@ func TestTypeString(t *testing.T) {
 		},
 		{
 			in:  ListType,
-			out: "list()",
+			out: "list(dyn)",
 		},
 		{
 			in:  MapType,
-			out: "map(, )",
+			out: "map(dyn, dyn)",
 		},
 	}
 	for _, tst := range tests {

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-cel.dev/expr v0.18.0 h1:CJ6drgk+Hf96lkLikr4rFf19WrU0BOWEihyZnI2TAzo=
-cel.dev/expr v0.18.0/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
-cel.dev/expr v0.19.0 h1:lXuo+nDhpyJSpWxpPVi5cPUwzKb+dsdOiw6IreM5yt0=
-cel.dev/expr v0.19.0/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
 cel.dev/expr v0.19.1 h1:NciYrtDRIR0lNCnH1LFJegdjspNx9fI59O7TWcua/W4=
 cel.dev/expr v0.19.1/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -2183,10 +2183,6 @@ func newTestEnv(t testing.TB, cont *containers.Container, reg *types.Registry) *
 	if err != nil {
 		t.Fatalf("checker.NewEnv(%v, %v) failed: %v", cont, reg, err)
 	}
-	err = env.AddIdents(stdlib.Types()...)
-	if err != nil {
-		t.Fatalf("env.Add(stdlib.Types()...) failed: %v", err)
-	}
 	err = env.AddFunctions(stdlib.Functions()...)
 	if err != nil {
 		t.Fatalf("env.Add(stdlib.Functions()...) failed: %v", err)

--- a/policy/BUILD.bazel
+++ b/policy/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//common/ast:go_default_library",
         "//common/containers:go_default_library",
         "//common/decls:go_default_library",
+        "//common/env:go_default_library",
         "//common/operators:go_default_library",
         "//common/types:go_default_library",
         "//common/types/ref:go_default_library",

--- a/policy/compiler_test.go
+++ b/policy/compiler_test.go
@@ -31,8 +31,10 @@ import (
 
 func TestCompile(t *testing.T) {
 	for _, tst := range policyTests {
-		r := newRunner(t, tst.name, tst.expr, tst.parseOpts, tst.envOpts...)
-		r.run(t)
+		t.Run(tst.name, func(t *testing.T) {
+			r := newRunner(t, tst.name, tst.expr, tst.parseOpts, tst.envOpts...)
+			r.run(t)
+		})
 	}
 }
 
@@ -171,7 +173,7 @@ func compile(t testing.TB, name string, parseOpts []ParserOption, envOpts []cel.
 		t.Fatalf("env.Extend() with env options %v, failed: %v", config, err)
 	}
 	// Configure declarations
-	configOpts, err := config.AsEnvOptions(env)
+	configOpts, err := config.AsEnvOptions(env.CELTypeProvider())
 	if err != nil {
 		t.Fatalf("config.AsEnvOptions() failed: %v", err)
 	}

--- a/policy/config.go
+++ b/policy/config.go
@@ -17,48 +17,92 @@ package policy
 import (
 	"errors"
 	"fmt"
-	"math"
-	"strconv"
 
 	"google.golang.org/protobuf/proto"
 
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/decls"
+	"github.com/google/cel-go/common/env"
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/ext"
 )
 
+// NewConfig returns a YAML serializable policy environment.
+func NewConfig(e *env.Config) *Config {
+	return &Config{Config: e}
+}
+
 // Config represents a YAML serializable CEL environment configuration.
 type Config struct {
-	Name        string             `yaml:"name"`
-	Description string             `yaml:"description"`
-	Container   string             `yaml:"container"`
-	Extensions  []*ExtensionConfig `yaml:"extensions"`
-	Variables   []*VariableDecl    `yaml:"variables"`
-	Functions   []*FunctionDecl    `yaml:"functions"`
+	*env.Config
 }
 
 // AsEnvOptions converts the Config value to a collection of cel environment options.
-func (c *Config) AsEnvOptions(baseEnv *cel.Env) ([]cel.EnvOption, error) {
+func (c *Config) AsEnvOptions(provider types.Provider) ([]cel.EnvOption, error) {
 	envOpts := []cel.EnvOption{}
+	// Configure the standard lib subset.
+	if c.StdLib != nil {
+		envOpts = append(envOpts, func(e *cel.Env) (*cel.Env, error) {
+			return cel.NewCustomEnv(cel.StdLib(cel.StdLibSubset(c.StdLib)))
+		})
+	}
+
+	// Configure the container
 	if c.Container != "" {
 		envOpts = append(envOpts, cel.Container(c.Container))
 	}
+
+	// Configure abbreviations
+	for _, imp := range c.Imports {
+		envOpts = append(envOpts, cel.Abbrevs(imp.Name))
+	}
+
+	// Configure the context variable declaration
+	if c.ContextVariable != nil {
+		if len(c.Variables) > 0 {
+			return nil, errors.New("either the context_variable or the variables may be set, but not both")
+		}
+		typeName := c.ContextVariable.TypeName
+		if typeName == "" {
+			return nil, errors.New("invalid context variable, must set type name field")
+		}
+		if _, found := provider.FindStructType(typeName); !found {
+			return nil, fmt.Errorf("could not find context proto type name: %s", typeName)
+		}
+		// Attempt to instantiate the proto in order to reflect to its descriptor
+		msg := provider.NewValue(typeName, map[string]ref.Val{})
+		pbMsg, ok := msg.Value().(proto.Message)
+		if !ok {
+			return nil, fmt.Errorf("type name was not a protobuf: %T", msg.Value())
+		}
+		envOpts = append(envOpts, cel.DeclareContextProto(pbMsg.ProtoReflect().Descriptor()))
+	}
+
+	if len(c.Variables) != 0 {
+		vars := make([]*decls.VariableDecl, 0, len(c.Variables))
+		for _, v := range c.Variables {
+			vDef, err := v.AsCELVariable(provider)
+			if err != nil {
+				return nil, err
+			}
+			vars = append(vars, vDef)
+		}
+		envOpts = append(envOpts, cel.VariableDecls(vars...))
+	}
+	if len(c.Functions) != 0 {
+		funcs := make([]*decls.FunctionDecl, 0, len(c.Functions))
+		for _, f := range c.Functions {
+			fnDef, err := f.AsCELFunction(provider)
+			if err != nil {
+				return nil, err
+			}
+			funcs = append(funcs, fnDef)
+		}
+		envOpts = append(envOpts, cel.FunctionDecls(funcs...))
+	}
 	for _, e := range c.Extensions {
-		opt, err := e.AsEnvOption(baseEnv)
-		if err != nil {
-			return nil, err
-		}
-		envOpts = append(envOpts, opt)
-	}
-	for _, v := range c.Variables {
-		opt, err := v.AsEnvOption(baseEnv)
-		if err != nil {
-			return nil, err
-		}
-		envOpts = append(envOpts, opt)
-	}
-	for _, f := range c.Functions {
-		opt, err := f.AsEnvOption(baseEnv)
+		opt, err := extensionEnvOption(e)
 		if err != nil {
 			return nil, err
 		}
@@ -67,202 +111,24 @@ func (c *Config) AsEnvOptions(baseEnv *cel.Env) ([]cel.EnvOption, error) {
 	return envOpts, nil
 }
 
-// ExtensionFactory accepts a version number and produces a CEL environment associated with the versioned
-// extension.
-type ExtensionFactory func(uint32) cel.EnvOption
-
-// ExtensionResolver provides a way to lookup ExtensionFactory instances by extension name.
-type ExtensionResolver interface {
-	// ResolveExtension returns an ExtensionFactory bound to the given name, if one exists.
-	ResolveExtension(name string) (ExtensionFactory, bool)
-}
-
-// ExtensionConfig represents a YAML serializable definition of a versioned extension library reference.
-type ExtensionConfig struct {
-	Name    string `yaml:"name"`
-	Version string `yaml:"version"`
-	ExtensionResolver
-}
-
-// AsEnvOption converts an ExtensionConfig value to a CEL environment option.
-func (ec *ExtensionConfig) AsEnvOption(baseEnv *cel.Env) (cel.EnvOption, error) {
+// extensionEnvOption converts an ExtensionConfig value to a CEL environment option.
+func extensionEnvOption(ec *env.Extension) (cel.EnvOption, error) {
 	fac, found := extFactories[ec.Name]
-	if !found && ec.ExtensionResolver != nil {
-		fac, found = ec.ResolveExtension(ec.Name)
-	}
 	if !found {
 		return nil, fmt.Errorf("unrecognized extension: %s", ec.Name)
 	}
 	// If the version is 'latest', set the version value to the max uint.
-	if ec.Version == "latest" {
-		return fac(math.MaxUint32), nil
-	}
-	if ec.Version == "" {
-		return fac(0), nil
-	}
-	ver, err := strconv.ParseUint(ec.Version, 10, 32)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing uint version: %w", err)
-	}
-	return fac(uint32(ver)), nil
-}
-
-// VariableDecl represents a YAML serializable CEL variable declaration.
-type VariableDecl struct {
-	Name         string    `yaml:"name"`
-	Type         *TypeDecl `yaml:"type"`
-	ContextProto string    `yaml:"context_proto"`
-}
-
-// AsEnvOption converts a VariableDecl type to a CEL environment option.
-//
-// Note, variable definitions with differing type definitions will result in an error during
-// the compile step.
-func (vd *VariableDecl) AsEnvOption(baseEnv *cel.Env) (cel.EnvOption, error) {
-	if vd.Name != "" {
-		t, err := vd.Type.AsCELType(baseEnv)
-		if err != nil {
-			return nil, fmt.Errorf("invalid variable type for '%s': %w", vd.Name, err)
-		}
-		return cel.Variable(vd.Name, t), nil
-	}
-	if vd.ContextProto != "" {
-		if _, found := baseEnv.CELTypeProvider().FindStructType(vd.ContextProto); !found {
-			return nil, fmt.Errorf("could not find context proto type name: %s", vd.ContextProto)
-		}
-		// Attempt to instantiate the proto in order to reflect to its descriptor
-		msg := baseEnv.CELTypeProvider().NewValue(vd.ContextProto, map[string]ref.Val{})
-		pbMsg, ok := msg.Value().(proto.Message)
-		if !ok {
-			return nil, fmt.Errorf("type name was not a protobuf: %T", msg.Value())
-		}
-		return cel.DeclareContextProto(pbMsg.ProtoReflect().Descriptor()), nil
-	}
-	return nil, errors.New("invalid variable, must set 'name' or 'context_proto' field")
-}
-
-// TypeDecl represents a YAML serializable CEL type reference.
-type TypeDecl struct {
-	TypeName    string      `yaml:"type_name"`
-	Params      []*TypeDecl `yaml:"params"`
-	IsTypeParam bool        `yaml:"is_type_param"`
-}
-
-// AsCELType converts the TypeDecl value to a cel.Type value using the input base environment.
-//
-// All extension types referenced by name within the `TypeDecl.TypeName` field must be configured
-// within the base CEL environment argument.
-func (td *TypeDecl) AsCELType(baseEnv *cel.Env) (*cel.Type, error) {
-	var err error
-	switch td.TypeName {
-	case "dyn":
-		return cel.DynType, nil
-	case "map":
-		if len(td.Params) == 2 {
-			kt, err := td.Params[0].AsCELType(baseEnv)
-			if err != nil {
-				return nil, err
-			}
-			vt, err := td.Params[1].AsCELType(baseEnv)
-			if err != nil {
-				return nil, err
-			}
-			return cel.MapType(kt, vt), nil
-		}
-		return nil, fmt.Errorf("map type has unexpected param count: %d", len(td.Params))
-	case "list":
-		if len(td.Params) == 1 {
-			et, err := td.Params[0].AsCELType(baseEnv)
-			if err != nil {
-				return nil, err
-			}
-			return cel.ListType(et), nil
-		}
-		return nil, fmt.Errorf("list type has unexpected param count: %d", len(td.Params))
-	default:
-		if td.IsTypeParam {
-			return cel.TypeParamType(td.TypeName), nil
-		}
-		if msgType, found := baseEnv.CELTypeProvider().FindStructType(td.TypeName); found {
-			// First parameter is the type name.
-			return msgType.Parameters()[0], nil
-		}
-		t, found := baseEnv.CELTypeProvider().FindIdent(td.TypeName)
-		if !found {
-			return nil, fmt.Errorf("undefined type name: %v", td.TypeName)
-		}
-		_, ok := t.(*cel.Type)
-		if ok && len(td.Params) == 0 {
-			return t.(*cel.Type), nil
-		}
-		params := make([]*cel.Type, len(td.Params))
-		for i, p := range td.Params {
-			params[i], err = p.AsCELType(baseEnv)
-			if err != nil {
-				return nil, err
-			}
-		}
-		return cel.OpaqueType(td.TypeName, params...), nil
-	}
-}
-
-// FunctionDecl represents a YAML serializable declaration of a CEL function.
-type FunctionDecl struct {
-	Name      string          `yaml:"name"`
-	Overloads []*OverloadDecl `yaml:"overloads"`
-}
-
-// AsEnvOption converts a FunctionDecl value into a cel.EnvOption using the input environment.
-func (fd *FunctionDecl) AsEnvOption(baseEnv *cel.Env) (cel.EnvOption, error) {
-	overloads := make([]cel.FunctionOpt, len(fd.Overloads))
-	var err error
-	for i, o := range fd.Overloads {
-		overloads[i], err = o.AsFunctionOption(baseEnv)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return cel.Function(fd.Name, overloads...), nil
-}
-
-// OverloadDecl represents a YAML serializable declaration of a CEL function overload.
-type OverloadDecl struct {
-	OverloadID string      `yaml:"id"`
-	Target     *TypeDecl   `yaml:"target"`
-	Args       []*TypeDecl `yaml:"args"`
-	Return     *TypeDecl   `yaml:"return"`
-}
-
-// AsFunctionOption converts an OverloadDecl value into a cel.FunctionOpt using the input environment.
-func (od *OverloadDecl) AsFunctionOption(baseEnv *cel.Env) (cel.FunctionOpt, error) {
-	args := make([]*cel.Type, len(od.Args))
-	var err error
-	for i, a := range od.Args {
-		args[i], err = a.AsCELType(baseEnv)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if od.Return == nil {
-		return nil, fmt.Errorf("missing return type on overload: %v", od.OverloadID)
-	}
-	result, err := od.Return.AsCELType(baseEnv)
+	ver, err := ec.GetVersion()
 	if err != nil {
 		return nil, err
 	}
-	if od.Target != nil {
-		t, err := od.Target.AsCELType(baseEnv)
-		if err != nil {
-			return nil, err
-		}
-		args = append([]*cel.Type{t}, args...)
-		return cel.MemberOverload(od.OverloadID, args, result), nil
-	}
-	return cel.Overload(od.OverloadID, args, result), nil
+	return fac(ver), nil
 }
 
-var extFactories = map[string]ExtensionFactory{
+// extensionFactory accepts a version and produces a CEL environment associated with the versioned extension.
+type extensionFactory func(uint32) cel.EnvOption
+
+var extFactories = map[string]extensionFactory{
 	"bindings": func(version uint32) cel.EnvOption {
 		return ext.Bindings(ext.BindingsVersion(version))
 	},

--- a/policy/config_test.go
+++ b/policy/config_test.go
@@ -165,8 +165,8 @@ variables:
       type_name: "map"
       params:
         - type_name: "string"
-        - type_name: "optional"`,
-			err: "invalid variable type for 'bad_map_type_param': undefined type name: optional",
+        - type_name: "invalid_opaque_type"`,
+			err: "invalid variable type for 'bad_map_type_param': undefined type name: invalid_opaque_type",
 		},
 		{
 			config: `

--- a/policy/go.mod
+++ b/policy/go.mod
@@ -9,7 +9,7 @@ require (
 )
 
 require (
-	cel.dev/expr v0.18.0 // indirect
+	cel.dev/expr v0.19.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	golang.org/x/exp v0.0.0-20240823005443-9b4947da3948 // indirect

--- a/policy/go.sum
+++ b/policy/go.sum
@@ -1,5 +1,5 @@
-cel.dev/expr v0.18.0 h1:CJ6drgk+Hf96lkLikr4rFf19WrU0BOWEihyZnI2TAzo=
-cel.dev/expr v0.18.0/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
+cel.dev/expr v0.19.1 h1:NciYrtDRIR0lNCnH1LFJegdjspNx9fI59O7TWcua/W4=
+cel.dev/expr v0.19.1/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/policy/helper_test.go
+++ b/policy/helper_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/env"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 
@@ -362,12 +363,12 @@ func readPolicyConfig(t testing.TB, fileName string) *Config {
 	if err != nil {
 		t.Fatalf("os.ReadFile(%s) failed: %v", fileName, err)
 	}
-	config := &Config{}
+	config := &env.Config{}
 	err = yaml.Unmarshal(testCaseBytes, config)
 	if err != nil {
 		log.Fatalf("yaml.Unmarshal(%s) error: %v", fileName, err)
 	}
-	return config
+	return NewConfig(config)
 }
 
 func readTestSuite(t testing.TB, fileName string) *TestSuite {

--- a/policy/parser.go
+++ b/policy/parser.go
@@ -484,7 +484,7 @@ func (p *parserImpl) parseYAML(src *Source) *Policy {
 	var docNode yaml.Node
 	err := sourceToYAML(src, &docNode)
 	if err != nil {
-		p.iss.ReportErrorAtID(0, err.Error())
+		p.iss.ReportErrorAtID(0, "%s", err.Error())
 		return nil
 	}
 	// Entry point always has a single Content node

--- a/policy/testdata/context_pb/config.yaml
+++ b/policy/testdata/context_pb/config.yaml
@@ -17,5 +17,5 @@ container: "google.expr.proto3"
 extensions:
   - name: "strings"
     version: 2
-variables:
-  - context_proto: "google.expr.proto3.test.TestAllTypes"
+context_variable:
+  type_name: "google.expr.proto3.test.TestAllTypes"

--- a/policy/testdata/k8s/config.yaml
+++ b/policy/testdata/k8s/config.yaml
@@ -18,16 +18,13 @@ extensions:
     version: 2
 variables:
   - name: "resource.labels"
-    type:
-      type_name: "map"
-      params:
-        - type_name: "string"
-        - type_name: "string"
+    type_name: "map"
+    params:
+      - type_name: "string"
+      - type_name: "string"
   - name: "resource.containers"
-    type:
-      type_name: "list"
-      params:
-        - type_name: "string"
+    type_name: "list"
+    params:
+      - type_name: "string"
   - name: "resource.namespace"
-    type:
-      type_name: "string"
+    type_name: "string"

--- a/policy/testdata/nested_rule/config.yaml
+++ b/policy/testdata/nested_rule/config.yaml
@@ -15,8 +15,7 @@
 name: "nested_rule"
 variables:
   - name: "resource"
-    type:
-      type_name: "map"
-      params:
-        - type_name: "string"
-        - type_name: "dyn"
+    type_name: "map"
+    params:
+      - type_name: "string"
+      - type_name: "dyn"

--- a/policy/testdata/pb/config.yaml
+++ b/policy/testdata/pb/config.yaml
@@ -19,5 +19,4 @@ extensions:
     version: 2
 variables:
   - name: "spec"
-    type:
-      type_name: "google.expr.proto3.test.TestAllTypes"
+    type_name: "google.expr.proto3.test.TestAllTypes"

--- a/policy/testdata/required_labels/config.yaml
+++ b/policy/testdata/required_labels/config.yaml
@@ -20,14 +20,12 @@ extensions:
   - name: "two-var-comprehensions"
 variables:
   - name: "spec"
-    type:
-      type_name: "map"
-      params:
-        - type_name: "string"
-        - type_name: "dyn"
+    type_name: "map"
+    params:
+      - type_name: "string"
+      - type_name: "dyn"
   - name: "resource"
-    type:
-      type_name: "map"
-      params:
-        - type_name: "string"
-        - type_name: "dyn"
+    type_name: "map"
+    params:
+      - type_name: "string"
+      - type_name: "dyn"

--- a/policy/testdata/restricted_destinations/base_config.yaml
+++ b/policy/testdata/restricted_destinations/base_config.yaml
@@ -18,28 +18,22 @@ extensions:
 - name: "sets"
 variables:
 - name: "destination.ip"
-  type:
-    type_name: "string"
+  type_name: "string"
 - name: "origin.ip"
-  type:
-    type_name: "string"
+  type_name: "string"
 - name: "spec.restricted_destinations"
-  type:
-    type_name: "list"
-    params:
-    - type_name: "string"
+  type_name: "list"
+  params:
+  - type_name: "string"
 - name: "spec.origin"
-  type:
-    type_name: "string"
+  type_name: "string"
 - name: "request"
-  type:
-    type_name: "map"
-    params:
-    - type_name: "string"
-    - type_name: "dyn"
+  type_name: "map"
+  params:
+  - type_name: "string"
+  - type_name: "dyn"
 - name: "resource"
-  type:
-    type_name: "map"
-    params:
-    - type_name: "string"
-    - type_name: "dyn"
+  type_name: "map"
+  params:
+  - type_name: "string"
+  - type_name: "dyn"

--- a/policy/testdata/restricted_destinations/config.yaml
+++ b/policy/testdata/restricted_destinations/config.yaml
@@ -18,31 +18,25 @@ extensions:
   - name: "sets"
 variables:
   - name: "destination.ip"
-    type:
-      type_name: "string"
+    type_name: "string"
   - name: "origin.ip"
-    type:
-      type_name: "string"
+    type_name: "string"
   - name: "spec.restricted_destinations"
-    type:
-      type_name: "list"
-      params:
-        - type_name: "string"
+    type_name: "list"
+    params:
+      - type_name: "string"
   - name: "spec.origin"
-    type:
-      type_name: "string"
+    type_name: "string"
   - name: "request"
-    type:
-      type_name: "map"
-      params:
-        - type_name: "string"
-        - type_name: "dyn"
+    type_name: "map"
+    params:
+      - type_name: "string"
+      - type_name: "dyn"
   - name: "resource"
-    type:
-      type_name: "map"
-      params:
-        - type_name: "string"
-        - type_name: "dyn"
+    type_name: "map"
+    params:
+      - type_name: "string"
+      - type_name: "dyn"
 functions:
   - name: "locationCode"
     overloads:


### PR DESCRIPTION
Support for subsetting the CEL standard environment via a canonical environment
description which is YAML-serializable.

This change also removes a behavior which would potentially break forward compatible
changes, as now type declarations are not included into the variable declaration set.
In the past a duplicate declaration for `int` would accept the precedence of the variable
with the same name (erroring if there were type differences) rather than permitting
the user-provided variable to mask the type identifier.

Closes #1078
Closes #899
Closes #844
Closes #290