### PR TITLE
ContextEval support for Unknowns

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -1042,7 +1042,7 @@ func TestContextEvalUnknowns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prg.ContextEval() failed: %v", err)
 	}
-	if out.Equal(ctxOut) != types.True {
+	if !reflect.DeepEqual(out, ctxOut) {
 		t.Errorf("got %v, wanted %v", out, ctxOut)
 	}
 }

--- a/cel/program.go
+++ b/cel/program.go
@@ -442,6 +442,11 @@ func (a *ctxEvalActivation) Parent() interpreter.Activation {
 	return a.parent
 }
 
+func (a *ctxEvalActivation) AsPartialActivation() (interpreter.PartialActivation, bool) {
+	pa, ok := a.parent.(interpreter.PartialActivation)
+	return pa, ok
+}
+
 func newCtxEvalActivationPool() *ctxEvalActivationPool {
 	return &ctxEvalActivationPool{
 		Pool: sync.Pool{

--- a/interpreter/activation.go
+++ b/interpreter/activation.go
@@ -158,7 +158,8 @@ type PartialActivation interface {
 
 // partialActivationConverter indicates whether an Activation implementation supports conversion to a PartialActivation
 type partialActivationConverter interface {
-	asPartialActivation() (PartialActivation, bool)
+	// AsPartialActivation converts the current activation to a PartialActivation
+	AsPartialActivation() (PartialActivation, bool)
 }
 
 // partActivation is the default implementations of the PartialActivation interface.
@@ -172,19 +173,19 @@ func (a *partActivation) UnknownAttributePatterns() []*AttributePattern {
 	return a.unknowns
 }
 
-// asPartialActivation returns the partActivation as a PartialActivation interface.
-func (a *partActivation) asPartialActivation() (PartialActivation, bool) {
+// AsPartialActivation returns the partActivation as a PartialActivation interface.
+func (a *partActivation) AsPartialActivation() (PartialActivation, bool) {
 	return a, true
 }
 
-func asPartialActivation(vars Activation) (PartialActivation, bool) {
+func AsPartialActivation(vars Activation) (PartialActivation, bool) {
 	// Only internal activation instances may implement this interface
 	if pv, ok := vars.(partialActivationConverter); ok {
-		return pv.asPartialActivation()
+		return pv.AsPartialActivation()
 	}
 	// Since Activations may be hierarchical, test whether a parent converts to a PartialActivation
 	if vars.Parent() != nil {
-		return asPartialActivation(vars.Parent())
+		return AsPartialActivation(vars.Parent())
 	}
 	return nil, false
 }

--- a/interpreter/attribute_patterns.go
+++ b/interpreter/attribute_patterns.go
@@ -358,7 +358,7 @@ func (m *attributeMatcher) AddQualifier(qual Qualifier) (Attribute, error) {
 func (m *attributeMatcher) Resolve(vars Activation) (any, error) {
 	id := m.NamespacedAttribute.ID()
 	// Bug in how partial activation is resolved, should search parents as well.
-	partial, isPartial := asPartialActivation(vars)
+	partial, isPartial := AsPartialActivation(vars)
 	if isPartial {
 		unk, err := m.fac.matchesUnknownPatterns(
 			partial,

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -1370,16 +1370,16 @@ func (f *folder) Parent() Activation {
 // if they were provided to the input activation, or an empty set if the proxied activation is not partial.
 func (f *folder) UnknownAttributePatterns() []*AttributePattern {
 	if pv, ok := f.activation.(partialActivationConverter); ok {
-		if partial, isPartial := pv.asPartialActivation(); isPartial {
+		if partial, isPartial := pv.AsPartialActivation(); isPartial {
 			return partial.UnknownAttributePatterns()
 		}
 	}
 	return []*AttributePattern{}
 }
 
-func (f *folder) asPartialActivation() (PartialActivation, bool) {
+func (f *folder) AsPartialActivation() (PartialActivation, bool) {
 	if pv, ok := f.activation.(partialActivationConverter); ok {
-		if _, isPartial := pv.asPartialActivation(); isPartial {
+		if _, isPartial := pv.AsPartialActivation(); isPartial {
 			return f, true
 		}
 	}


### PR DESCRIPTION
Expose the `asPartialActivation` method as a publicly available method
to fix issues with conversion of an internal `ContextEval` activation to a
`PartialActivation` if so configured.

Closes #1124 