### PR TITLE
Fix godoc formatting for Lists and OptionalTypes functions

### DIFF
--- a/cel/library.go
+++ b/cel/library.go
@@ -263,7 +263,7 @@ func (stdLibrary) ProgramOptions() []ProgramOption {
 // be expressed with `optMap`.
 //
 //	msg.?elements.optFlatMap(e, e[?0]) // return the first element if present.
-
+//
 // # First
 //
 // Introduced in version: 2
@@ -272,7 +272,7 @@ func (stdLibrary) ProgramOptions() []ProgramOption {
 // optional.None.
 //
 // [1, 2, 3].first().value() == 1
-
+//
 // # Last
 //
 // Introduced in version: 2
@@ -283,7 +283,7 @@ func (stdLibrary) ProgramOptions() []ProgramOption {
 // [1, 2, 3].last().value() == 3
 //
 // This is syntactic sugar for msg.elements[msg.elements.size()-1].
-
+//
 // # Unwrap / UnwrapOpt
 //
 // Introduced in version: 2
@@ -293,7 +293,6 @@ func (stdLibrary) ProgramOptions() []ProgramOption {
 //
 // optional.unwrap([optional.of(42), optional.none()]) == [42]
 // [optional.of(42), optional.none()].unwrapOpt() == [42]
-
 func OptionalTypes(opts ...OptionalTypesOption) EnvOption {
 	lib := &optionalLib{version: math.MaxUint32}
 	for _, opt := range opts {

--- a/ext/lists.go
+++ b/ext/lists.go
@@ -134,7 +134,7 @@ var comparableTypes = []*cel.Type{
 //
 //	<list(T)>.sortBy(<bindingName>, <keyExpr>) -> <list(T)>
 //	keyExpr returns a value in {int, uint, double, bool, duration, timestamp, string, bytes}
-
+//
 // Examples:
 //
 //	[
@@ -143,7 +143,6 @@ var comparableTypes = []*cel.Type{
 //	  Player { name: "baz", score: 1000 },
 //	].sortBy(e, e.score).map(e, e.name)
 //	== ["bar", "foo", "baz"]
-
 func Lists(options ...ListsOption) cel.EnvOption {
 	l := &listsLib{version: math.MaxUint32}
 	for _, o := range options {


### PR DESCRIPTION
This PR fixes the godoc formatting for the Lists and OptionalTypes functions by removing unnecessary blank lines. These blank lines caused godoc to misinterpret the documentation structure, leading to incomplete rendering. Now, the documentation is correctly parsed and consistently formatted.