### PR TITLE
Option to configure CEL via env.Config object

### DIFF
--- a/cel/env_test.go
+++ b/cel/env_test.go
@@ -29,6 +29,7 @@ import (
 
 	proto3pb "github.com/google/cel-go/test/proto3pb"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestAstNil(t *testing.T) {
@@ -306,27 +307,27 @@ func TestFunctions(t *testing.T) {
 
 func TestEnvToConfig(t *testing.T) {
 	tests := []struct {
-		name       string
-		opts       []EnvOption
-		wantConfig *env.Config
+		name string
+		opts []EnvOption
+		want *env.Config
 	}{
 		{
-			name:       "std env",
-			wantConfig: env.NewConfig("std env"),
+			name: "std env",
+			want: env.NewConfig("std env"),
 		},
 		{
 			name: "std env - container",
 			opts: []EnvOption{
 				Container("example.container"),
 			},
-			wantConfig: env.NewConfig("std env - container").SetContainer("example.container"),
+			want: env.NewConfig("std env - container").SetContainer("example.container"),
 		},
 		{
 			name: "std env - aliases",
 			opts: []EnvOption{
 				Abbrevs("example.type.name"),
 			},
-			wantConfig: env.NewConfig("std env - aliases").AddImports(env.NewImport("example.type.name")),
+			want: env.NewConfig("std env - aliases").AddImports(env.NewImport("example.type.name")),
 		},
 		{
 			name: "std env disabled",
@@ -335,7 +336,7 @@ func TestEnvToConfig(t *testing.T) {
 					return NewCustomEnv()
 				},
 			},
-			wantConfig: env.NewConfig("std env disabled").SetStdLib(
+			want: env.NewConfig("std env disabled").SetStdLib(
 				env.NewLibrarySubset().SetDisabled(true)),
 		},
 		{
@@ -343,15 +344,15 @@ func TestEnvToConfig(t *testing.T) {
 			opts: []EnvOption{
 				Variable("var", IntType),
 			},
-			wantConfig: env.NewConfig("std env - with variable").AddVariables(env.NewVariable("var", env.NewTypeDesc("int"))),
+			want: env.NewConfig("std env - with variable").AddVariables(env.NewVariable("var", env.NewTypeDesc("int"))),
 		},
 		{
 			name: "std env - with function",
 			opts: []EnvOption{Function("hello", Overload("hello_string", []*Type{StringType}, StringType))},
-			wantConfig: env.NewConfig("std env - with function").AddFunctions(
-				env.NewFunction("hello", []*env.Overload{
+			want: env.NewConfig("std env - with function").AddFunctions(
+				env.NewFunction("hello",
 					env.NewOverload("hello_string",
-						[]*env.TypeDesc{env.NewTypeDesc("string")}, env.NewTypeDesc("string"))},
+						[]*env.TypeDesc{env.NewTypeDesc("string")}, env.NewTypeDesc("string")),
 				)),
 		},
 		{
@@ -359,14 +360,14 @@ func TestEnvToConfig(t *testing.T) {
 			opts: []EnvOption{
 				OptionalTypes(),
 			},
-			wantConfig: env.NewConfig("optional lib").AddExtensions(env.NewExtension("optional", math.MaxUint32)),
+			want: env.NewConfig("optional lib").AddExtensions(env.NewExtension("optional", math.MaxUint32)),
 		},
 		{
 			name: "optional lib - versioned",
 			opts: []EnvOption{
 				OptionalTypes(OptionalTypesVersion(1)),
 			},
-			wantConfig: env.NewConfig("optional lib - versioned").AddExtensions(env.NewExtension("optional", 1)),
+			want: env.NewConfig("optional lib - versioned").AddExtensions(env.NewExtension("optional", 1)),
 		},
 		{
 			name: "optional lib - alt last()",
@@ -374,11 +375,11 @@ func TestEnvToConfig(t *testing.T) {
 				OptionalTypes(),
 				Function("last", MemberOverload("string_last", []*Type{StringType}, StringType)),
 			},
-			wantConfig: env.NewConfig("optional lib - alt last()").
+			want: env.NewConfig("optional lib - alt last()").
 				AddExtensions(env.NewExtension("optional", math.MaxUint32)).
-				AddFunctions(env.NewFunction("last", []*env.Overload{
+				AddFunctions(env.NewFunction("last",
 					env.NewMemberOverload("string_last", env.NewTypeDesc("string"), []*env.TypeDesc{}, env.NewTypeDesc("string")),
-				})),
+				)),
 		},
 		{
 			name: "context proto - with extra variable",
@@ -386,7 +387,7 @@ func TestEnvToConfig(t *testing.T) {
 				DeclareContextProto((&proto3pb.TestAllTypes{}).ProtoReflect().Descriptor()),
 				Variable("extra", StringType),
 			},
-			wantConfig: env.NewConfig("context proto - with extra variable").
+			want: env.NewConfig("context proto - with extra variable").
 				SetContextVariable(env.NewContextVariable("google.expr.proto3.test.TestAllTypes")).
 				AddVariables(env.NewVariable("extra", env.NewTypeDesc("string"))),
 		},
@@ -395,7 +396,7 @@ func TestEnvToConfig(t *testing.T) {
 			opts: []EnvOption{
 				DeclareContextProto((&proto3pb.TestAllTypes{}).ProtoReflect().Descriptor()),
 			},
-			wantConfig: env.NewConfig("context proto").SetContextVariable(env.NewContextVariable("google.expr.proto3.test.TestAllTypes")),
+			want: env.NewConfig("context proto").SetContextVariable(env.NewContextVariable("google.expr.proto3.test.TestAllTypes")),
 		},
 	}
 
@@ -410,8 +411,8 @@ func TestEnvToConfig(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ToConfig() failed: %v", err)
 			}
-			if !reflect.DeepEqual(gotConfig, tc.wantConfig) {
-				t.Errorf("e.Config() got %v, wanted %v", gotConfig, tc.wantConfig)
+			if !reflect.DeepEqual(gotConfig, tc.want) {
+				t.Errorf("e.Config() got %v, wanted %v", gotConfig, tc.want)
 			}
 		})
 	}
@@ -513,6 +514,15 @@ func BenchmarkEnvExtendEagerDecls(b *testing.B) {
 			b.Fatalf("env.Compile(123) failed: %v", iss.Err())
 		}
 	}
+}
+
+func mustContextProto(t *testing.T, pb proto.Message) Activation {
+	t.Helper()
+	ctx, err := ContextProtoVars(pb)
+	if err != nil {
+		t.Fatalf("ContextProtoVars() failed: %v", err)
+	}
+	return ctx
 }
 
 type customLegacyProvider struct {

--- a/cel/env_test.go
+++ b/cel/env_test.go
@@ -27,9 +27,10 @@ import (
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 
+	"google.golang.org/protobuf/proto"
+
 	proto3pb "github.com/google/cel-go/test/proto3pb"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
-	"google.golang.org/protobuf/proto"
 )
 
 func TestAstNil(t *testing.T) {

--- a/cel/library.go
+++ b/cel/library.go
@@ -150,11 +150,6 @@ func (*stdLibrary) LibraryAlias() string {
 	return "stdlib"
 }
 
-// LibraryVersion returns the version of the library.
-func (*stdLibrary) LibraryVersion() uint32 {
-	return math.MaxUint32
-}
-
 // LibrarySubset returns the env.LibrarySubset definition associated with the CEL Library.
 func (lib *stdLibrary) LibrarySubset() *env.LibrarySubset {
 	return lib.subset
@@ -183,6 +178,10 @@ func (lib *stdLibrary) CompileOptions() []EnvOption {
 	return []EnvOption{
 		func(e *Env) (*Env, error) {
 			var err error
+			if err = lib.subset.Validate(); err != nil {
+				return nil, err
+			}
+			e.variables = append(e.variables, stdlib.Types()...)
 			for _, fn := range funcs {
 				existing, found := e.functions[fn.Name()]
 				if found {
@@ -193,10 +192,6 @@ func (lib *stdLibrary) CompileOptions() []EnvOption {
 				}
 				e.functions[fn.Name()] = fn
 			}
-			return e, nil
-		},
-		func(e *Env) (*Env, error) {
-			e.variables = append(e.variables, stdlib.Types()...)
 			return e, nil
 		},
 		Macros(macros...),

--- a/policy/compiler_test.go
+++ b/policy/compiler_test.go
@@ -158,7 +158,7 @@ func compile(t testing.TB, name string, parseOpts []ParserOption, envOpts []cel.
 	if policy.name.Value != name {
 		t.Errorf("policy name is %v, wanted %q", policy.name, name)
 	}
-	env, err := cel.NewEnv(
+	env, err := cel.NewCustomEnv(
 		cel.OptionalTypes(),
 		cel.EnableMacroCallTracking(),
 		cel.ExtendedValidations(),

--- a/policy/compiler_test.go
+++ b/policy/compiler_test.go
@@ -172,11 +172,7 @@ func compile(t testing.TB, name string, parseOpts []ParserOption, envOpts []cel.
 		t.Fatalf("env.Extend() with env options %v, failed: %v", config, err)
 	}
 	// Configure declarations
-	configOpts, err := config.AsEnvOptions(env.CELTypeProvider())
-	if err != nil {
-		t.Fatalf("config.AsEnvOptions() failed: %v", err)
-	}
-	env, err = env.Extend(configOpts...)
+	env, err = env.Extend(FromConfig(config))
 	if err != nil {
 		t.Fatalf("env.Extend() with config options %v, failed: %v", config, err)
 	}

--- a/policy/config.go
+++ b/policy/config.go
@@ -22,6 +22,11 @@ import (
 	"github.com/google/cel-go/ext"
 )
 
+// FromConfig configures a CEL policy environment from a config file.
+//
+// This option supports all extensions supported by policies, whereas the cel.FromConfig supports
+// a set of configuration ConfigOptionFactory values to handle extensions and other config features
+// which may be defined outside of the `cel` package.
 func FromConfig(config *env.Config) cel.EnvOption {
 	return cel.FromConfig(config, extensionOptionFactory)
 }

--- a/policy/config.go
+++ b/policy/config.go
@@ -15,123 +15,35 @@
 package policy
 
 import (
-	"errors"
 	"fmt"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/env"
-	"github.com/google/cel-go/common/types"
-	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/ext"
 )
 
-// NewConfig returns a YAML serializable policy environment.
-func NewConfig(e *env.Config) *Config {
-	return &Config{Config: e}
+func FromConfig(config *env.Config) cel.EnvOption {
+	return cel.FromConfig(config, extensionOptionFactory)
 }
 
-// Config represents a YAML serializable CEL environment configuration.
-type Config struct {
-	*env.Config
-}
-
-// AsEnvOptions converts the Config value to a collection of cel environment options.
-func (c *Config) AsEnvOptions(provider types.Provider) ([]cel.EnvOption, error) {
-	envOpts := []cel.EnvOption{}
-	// Configure the standard lib subset.
-	if c.StdLib != nil {
-		if c.StdLib.Disabled {
-			envOpts = append(envOpts, func(e *cel.Env) (*cel.Env, error) {
-				if !e.HasLibrary("cel.lib.std") {
-					return e, nil
-				}
-				return cel.NewCustomEnv()
-			})
-		} else {
-			envOpts = append(envOpts, func(e *cel.Env) (*cel.Env, error) {
-				return cel.NewCustomEnv(cel.StdLib(cel.StdLibSubset(c.StdLib)))
-			})
-		}
+// extensionOptionFactory converts an ExtensionConfig value to a CEL environment option.
+func extensionOptionFactory(configElement any) (cel.EnvOption, bool) {
+	ext, isExtension := configElement.(*env.Extension)
+	if !isExtension {
+		return nil, false
 	}
-
-	// Configure the container
-	if c.Container != "" {
-		envOpts = append(envOpts, cel.Container(c.Container))
-	}
-
-	// Configure abbreviations
-	for _, imp := range c.Imports {
-		envOpts = append(envOpts, cel.Abbrevs(imp.Name))
-	}
-
-	// Configure the context variable declaration
-	if c.ContextVariable != nil {
-		if len(c.Variables) > 0 {
-			return nil, errors.New("either the context_variable or the variables may be set, but not both")
-		}
-		typeName := c.ContextVariable.TypeName
-		if typeName == "" {
-			return nil, errors.New("invalid context variable, must set type name field")
-		}
-		if _, found := provider.FindStructType(typeName); !found {
-			return nil, fmt.Errorf("could not find context proto type name: %s", typeName)
-		}
-		// Attempt to instantiate the proto in order to reflect to its descriptor
-		msg := provider.NewValue(typeName, map[string]ref.Val{})
-		pbMsg, ok := msg.Value().(proto.Message)
-		if !ok {
-			return nil, fmt.Errorf("type name was not a protobuf: %T", msg.Value())
-		}
-		envOpts = append(envOpts, cel.DeclareContextProto(pbMsg.ProtoReflect().Descriptor()))
-	}
-
-	if len(c.Variables) != 0 {
-		vars := make([]*decls.VariableDecl, 0, len(c.Variables))
-		for _, v := range c.Variables {
-			vDef, err := v.AsCELVariable(provider)
-			if err != nil {
-				return nil, err
-			}
-			vars = append(vars, vDef)
-		}
-		envOpts = append(envOpts, cel.VariableDecls(vars...))
-	}
-	if len(c.Functions) != 0 {
-		funcs := make([]*decls.FunctionDecl, 0, len(c.Functions))
-		for _, f := range c.Functions {
-			fnDef, err := f.AsCELFunction(provider)
-			if err != nil {
-				return nil, err
-			}
-			funcs = append(funcs, fnDef)
-		}
-		envOpts = append(envOpts, cel.FunctionDecls(funcs...))
-	}
-	for _, e := range c.Extensions {
-		opt, err := extensionEnvOption(e)
-		if err != nil {
-			return nil, err
-		}
-		envOpts = append(envOpts, opt)
-	}
-	return envOpts, nil
-}
-
-// extensionEnvOption converts an ExtensionConfig value to a CEL environment option.
-func extensionEnvOption(ec *env.Extension) (cel.EnvOption, error) {
-	fac, found := extFactories[ec.Name]
+	fac, found := extFactories[ext.Name]
 	if !found {
-		return nil, fmt.Errorf("unrecognized extension: %s", ec.Name)
+		return nil, false
 	}
 	// If the version is 'latest', set the version value to the max uint.
-	ver, err := ec.GetVersion()
+	ver, err := ext.GetVersion()
 	if err != nil {
-		return nil, err
+		return func(*cel.Env) (*cel.Env, error) {
+			return nil, fmt.Errorf("invalid extension version: %s - %s", ext.Name, ext.Version)
+		}, true
 	}
-	return fac(ver), nil
+	return fac(ver), true
 }
 
 // extensionFactory accepts a version and produces a CEL environment associated with the versioned extension.

--- a/policy/config_test.go
+++ b/policy/config_test.go
@@ -127,7 +127,7 @@ variables:
   - name: "bad_type"
     type:
       type_name: "strings"`,
-			err: "invalid variable type for 'bad_type': undefined type name: strings",
+			err: `invalid variable "bad_type": undefined type name: "strings"`,
 		},
 		{
 			config: `
@@ -135,7 +135,7 @@ variables:
   - name: "bad_list"
     type:
       type_name: "list"`,
-			err: "invalid variable type for 'bad_list': list type has unexpected param count: 0",
+			err: `invalid variable "bad_list": invalid type: list expects 1 parameter, got 0`,
 		},
 		{
 			config: `
@@ -145,7 +145,7 @@ variables:
       type_name: "map"
       params:
         - type_name: "string"`,
-			err: "invalid variable type for 'bad_map': map type has unexpected param count: 1",
+			err: `invalid variable "bad_map": invalid type: map expects 2 parameters, got 1`,
 		},
 		{
 			config: `
@@ -155,7 +155,7 @@ variables:
       type_name: "list"
       params:
         - type_name: "number"`,
-			err: "invalid variable type for 'bad_list_type_param': undefined type name: number",
+			err: `invalid variable "bad_list_type_param": undefined type name: "number"`,
 		},
 		{
 			config: `
@@ -166,21 +166,21 @@ variables:
       params:
         - type_name: "string"
         - type_name: "invalid_opaque_type"`,
-			err: "invalid variable type for 'bad_map_type_param': undefined type name: invalid_opaque_type",
+			err: `invalid variable "bad_map_type_param": undefined type name: "invalid_opaque_type"`,
 		},
 		{
 			config: `
 context_variable:
   type_name: "bad.proto.MessageType"
 `,
-			err: "could not find context proto type name: bad.proto.MessageType",
+			err: `invalid context proto type: "bad.proto.MessageType"`,
 		},
 		{
 			config: `
 variables:
   - type:
       type_name: "no variable name"`,
-			err: "invalid variable, must declare a name",
+			err: "invalid variable: missing variable name",
 		},
 
 		{
@@ -191,7 +191,7 @@ functions:
       - id: "zero_arity"
         return:
           type_name: "mystery"`,
-			err: "undefined type name: mystery",
+			err: `invalid function "bad_return": undefined type name: "mystery"`,
 		},
 		{
 			config: `
@@ -203,7 +203,7 @@ functions:
           type_name: "unknown"
         return:
           type_name: "null_type"`,
-			err: "undefined type name: unknown",
+			err: `invalid function "bad_target": undefined type name: "unknown"`,
 		},
 		{
 			config: `
@@ -215,7 +215,7 @@ functions:
           - type_name: "unknown"
         return:
           type_name: "null_type"`,
-			err: "undefined type name: unknown",
+			err: `invalid function "bad_arg": undefined type name: "unknown"`,
 		},
 		{
 			config: `
@@ -225,7 +225,7 @@ functions:
       - id: "unary_global"
         args:
           - type_name: "null_type"`,
-			err: "missing return type on overload: unary_global",
+			err: `invalid function "missing_return": invalid overload "unary_global" return: invalid type: nil`,
 		},
 	}
 	baseEnv, err := cel.NewEnv(cel.OptionalTypes())

--- a/policy/config_test.go
+++ b/policy/config_test.go
@@ -103,7 +103,7 @@ variables:
 	}
 	for _, tst := range tests {
 		c := parseConfigYaml(t, tst)
-		_, err := c.AsEnvOptions(baseEnv.CELTypeProvider())
+		_, err := baseEnv.Extend(FromConfig(c))
 		if err != nil {
 			t.Errorf("AsEnvOptions() generated error: %v", err)
 		}
@@ -234,17 +234,17 @@ functions:
 	}
 	for _, tst := range tests {
 		c := parseConfigYaml(t, tst.config)
-		_, err := c.AsEnvOptions(baseEnv.CELTypeProvider())
+		_, err := baseEnv.Extend(FromConfig(c))
 		if err == nil || err.Error() != tst.err {
 			t.Errorf("AsEnvOptions() got error: %v, wanted %s", err, tst.err)
 		}
 	}
 }
 
-func parseConfigYaml(t *testing.T, doc string) *Config {
+func parseConfigYaml(t *testing.T, doc string) *env.Config {
 	config := &env.Config{}
 	if err := yaml.Unmarshal([]byte(doc), config); err != nil {
 		t.Fatalf("yaml.Unmarshal(%q) failed: %v", doc, err)
 	}
-	return NewConfig(config)
+	return config
 }

--- a/policy/helper_test.go
+++ b/policy/helper_test.go
@@ -278,7 +278,7 @@ func readPolicy(t testing.TB, fileName string) *Source {
 	return ByteSource(policyBytes, fileName)
 }
 
-func readPolicyConfig(t testing.TB, fileName string) *Config {
+func readPolicyConfig(t testing.TB, fileName string) *env.Config {
 	t.Helper()
 	testCaseBytes, err := os.ReadFile(fileName)
 	if err != nil {
@@ -289,7 +289,7 @@ func readPolicyConfig(t testing.TB, fileName string) *Config {
 	if err != nil {
 		log.Fatalf("yaml.Unmarshal(%s) error: %v", fileName, err)
 	}
-	return NewConfig(config)
+	return config
 }
 
 func readTestSuite(t testing.TB, fileName string) *TestSuite {


### PR DESCRIPTION
EnvOption to configure CEL via Config object

Introduces validation methods and checks on all env exposed classes,
specifically `env.Config.Validate()` is called before processing any config
object within the `cel.FromConfig()` option.

This change also introduces limitations on how an environment can be 
constructed when being used with standard library subsetting ... any
singleton library which is being subset must be subset at the time it is
configured. Any subsequent attempt to configure the singleton will either
be ignored or result in an error. The `FromConfig` option validates collisions
within the pre-existing config, but there is no subsequent validation
afterwards.
