### PR TITLE
Default enable DefaultUTCTimeZone

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -2146,47 +2146,150 @@ func TestRegexOptimizer(t *testing.T) {
 	}
 }
 
-func TestDefaultUTCTimeZone(t *testing.T) {
-	env := testEnv(t, Variable("x", TimestampType), DefaultUTCTimeZone(true))
-	out, err := interpret(t, env, `
-		x.getFullYear() == 1970
-		&& x.getMonth() == 0
-		&& x.getDayOfYear() == 0
-		&& x.getDayOfMonth() == 0
-		&& x.getDate() == 1
-		&& x.getDayOfWeek() == 4
-		&& x.getHours() == 2
-		&& x.getMinutes() == 5
-		&& x.getSeconds() == 6
-		&& x.getMilliseconds() == 1
-		&& x.getFullYear('-07:30') == 1969
-		&& x.getDayOfYear('-07:30') == 364
-		&& x.getMonth('-07:30') == 11
-		&& x.getDayOfMonth('-07:30') == 30
-		&& x.getDate('-07:30') == 31
-		&& x.getDayOfWeek('-07:30') == 3
-		&& x.getHours('-07:30') == 18
-		&& x.getMinutes('-07:30') == 35
-		&& x.getSeconds('-07:30') == 6
-		&& x.getMilliseconds('-07:30') == 1
-		&& x.getFullYear('23:15') == 1970
-		&& x.getDayOfYear('23:15') == 1
-		&& x.getMonth('23:15') == 0
-		&& x.getDayOfMonth('23:15') == 1
-		&& x.getDate('23:15') == 2
-		&& x.getDayOfWeek('23:15') == 5
-		&& x.getHours('23:15') == 1
-		&& x.getMinutes('23:15') == 20
-		&& x.getSeconds('23:15') == 6
-		&& x.getMilliseconds('23:15') == 1`,
-		map[string]any{
-			"x": time.Unix(7506, 1000000).Local(),
-		})
-	if err != nil {
-		t.Fatalf("prg.Eval() failed: %v", err)
+func TestDefaultUTCTimeZoneDisabled(t *testing.T) {
+	testEnvs := []struct {
+		name string
+		env  *Env
+	}{
+		{"default", testEnv(t, Variable("x", TimestampType))},
+		{"enabled", testEnv(t, Variable("x", TimestampType), DefaultUTCTimeZone(true))},
+		{"disabled", testEnv(t, Variable("x", TimestampType), DefaultUTCTimeZone(false))},
 	}
-	if out != types.True {
-		t.Errorf("Eval() got %v, wanted true", out)
+	exprs := []struct {
+		name   string
+		value  string
+		envOut map[string]ref.Val
+	}{
+		{
+			name: "default-timezone",
+			value: `
+			x.getFullYear() == 1970
+			&& x.getMonth() == 0
+			&& x.getDayOfYear() == 0
+			&& x.getDayOfMonth() == 0
+			&& x.getDate() == 1
+			&& x.getDayOfWeek() == 4
+			&& x.getHours() == 2
+			&& x.getMinutes() == 5
+			&& x.getSeconds() == 6
+			&& x.getMilliseconds() == 1`,
+			envOut: map[string]ref.Val{
+				"default":  types.True,
+				"enabled":  types.True,
+				"disabled": types.False,
+			},
+		},
+		{
+			name:  "default-local-year",
+			value: `x.getFullYear()`,
+			envOut: map[string]ref.Val{
+				"default":  types.Int(1970),
+				"enabled":  types.Int(1970),
+				"disabled": types.Int(1969),
+			},
+		},
+		{
+			name:  "default-local-day-of-year",
+			value: `x.getDayOfYear()`,
+			envOut: map[string]ref.Val{
+				"default":  types.Int(0),
+				"enabled":  types.Int(0),
+				"disabled": types.Int(364),
+			},
+		},
+		{
+			name:  "default-local-month",
+			value: `x.getMonth()`,
+			envOut: map[string]ref.Val{
+				"default":  types.Int(0),
+				"enabled":  types.Int(0),
+				"disabled": types.Int(11),
+			},
+		},
+		{
+			name: "default-local-day-of-month",
+			value: `
+			x.getDayOfMonth() == 30
+			&& x.getDate() == 31`,
+			envOut: map[string]ref.Val{
+				"default":  types.False,
+				"enabled":  types.False,
+				"disabled": types.True,
+			},
+		},
+		{
+			name:  "default-local-dates",
+			value: `x.getDayOfWeek()`,
+			envOut: map[string]ref.Val{
+				"default":  types.Int(4),
+				"enabled":  types.Int(4),
+				"disabled": types.Int(3),
+			},
+		},
+		{
+			name: "default-local-times",
+			value: `
+			x.getHours() == 18
+			&& x.getMinutes() == 5
+			&& x.getSeconds() == 6
+			&& x.getMilliseconds() == 1`,
+			envOut: map[string]ref.Val{
+				"default":  types.False,
+				"enabled":  types.False,
+				"disabled": types.True,
+			},
+		},
+		{
+			name: "explicit",
+			value: `
+			x.getFullYear('-07:30') == 1969
+			&& x.getDayOfYear('-07:30') == 364
+			&& x.getMonth('-07:30') == 11
+			&& x.getDayOfMonth('-07:30') == 30
+			&& x.getDate('-07:30') == 31
+			&& x.getDayOfWeek('-07:30') == 3
+			&& x.getHours('-07:30') == 18
+			&& x.getMinutes('-07:30') == 35
+			&& x.getSeconds('-07:30') == 6
+			&& x.getMilliseconds('-07:30') == 1
+			&& x.getFullYear('23:15') == 1970
+			&& x.getDayOfYear('23:15') == 1
+			&& x.getMonth('23:15') == 0
+			&& x.getDayOfMonth('23:15') == 1
+			&& x.getDate('23:15') == 2
+			&& x.getDayOfWeek('23:15') == 5
+			&& x.getHours('23:15') == 1
+			&& x.getMinutes('23:15') == 20
+			&& x.getSeconds('23:15') == 6
+			&& x.getMilliseconds('23:15') == 1`,
+			envOut: map[string]ref.Val{
+				"default":  types.True,
+				"enabled":  types.True,
+				"disabled": types.True,
+			},
+		},
+	}
+
+	offset, _ := time.ParseDuration("-8h")
+	vars := map[string]any{
+		"x": time.Unix(7506, 1000000).In(time.FixedZone("", int(offset.Seconds()))),
+	}
+	for _, e := range testEnvs {
+		te := e
+		for _, expr := range exprs {
+			ex := expr
+			t.Run(fmt.Sprintf("%s/%s", te.name, ex.name), func(t *testing.T) {
+				env := te.env
+				expr := ex.value
+				out, err := interpret(t, env, expr, vars)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if out.Equal(ex.envOut[te.name]) != types.True {
+					t.Errorf("interpret got %v, wanted %v", out, ex.envOut[te.name])
+				}
+			})
+		}
 	}
 }
 
@@ -2194,7 +2297,6 @@ func TestDefaultUTCTimeZoneExtension(t *testing.T) {
 	env := testEnv(t,
 		Variable("x", TimestampType),
 		Variable("y", DurationType),
-		DefaultUTCTimeZone(true),
 	)
 	env, err := env.Extend()
 	if err != nil {
@@ -2220,7 +2322,7 @@ func TestDefaultUTCTimeZoneExtension(t *testing.T) {
 }
 
 func TestDefaultUTCTimeZoneError(t *testing.T) {
-	env := testEnv(t, Variable("x", TimestampType), DefaultUTCTimeZone(true))
+	env := testEnv(t, Variable("x", TimestampType))
 	out, err := interpret(t, env, `
 		x.getFullYear(':xx') == 1969
 		|| x.getDayOfYear('xx:') == 364

--- a/cel/library.go
+++ b/cel/library.go
@@ -17,9 +17,6 @@ package cel
 import (
 	"fmt"
 	"math"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/decls"
@@ -720,250 +717,99 @@ func (opt *evalOptionalOrValue) Eval(ctx interpreter.Activation) ref.Val {
 	return opt.rhs.Eval(ctx)
 }
 
-type timeUTCLibrary struct{}
+type timeLegacyLibrary struct{}
 
-func (timeUTCLibrary) CompileOptions() []EnvOption {
+func (timeLegacyLibrary) CompileOptions() []EnvOption {
 	return timeOverloadDeclarations
 }
 
-func (timeUTCLibrary) ProgramOptions() []ProgramOption {
+func (timeLegacyLibrary) ProgramOptions() []ProgramOption {
 	return []ProgramOption{}
 }
 
 // Declarations and functions which enable using UTC on time.Time inputs when the timezone is unspecified
 // in the CEL expression.
 var (
-	utcTZ = types.String("UTC")
-
 	timeOverloadDeclarations = []EnvOption{
-		Function(overloads.TimeGetHours,
-			MemberOverload(overloads.DurationToHours, []*Type{DurationType}, IntType,
-				UnaryBinding(types.DurationGetHours))),
-		Function(overloads.TimeGetMinutes,
-			MemberOverload(overloads.DurationToMinutes, []*Type{DurationType}, IntType,
-				UnaryBinding(types.DurationGetMinutes))),
-		Function(overloads.TimeGetSeconds,
-			MemberOverload(overloads.DurationToSeconds, []*Type{DurationType}, IntType,
-				UnaryBinding(types.DurationGetSeconds))),
-		Function(overloads.TimeGetMilliseconds,
-			MemberOverload(overloads.DurationToMilliseconds, []*Type{DurationType}, IntType,
-				UnaryBinding(types.DurationGetMilliseconds))),
 		Function(overloads.TimeGetFullYear,
 			MemberOverload(overloads.TimestampToYear, []*Type{TimestampType}, IntType,
 				UnaryBinding(func(ts ref.Val) ref.Val {
-					return timestampGetFullYear(ts, utcTZ)
+					t := ts.(types.Timestamp)
+					return t.Receive(overloads.TimeGetFullYear, overloads.TimestampToYear, []ref.Val{})
 				}),
-			),
-			MemberOverload(overloads.TimestampToYearWithTz, []*Type{TimestampType, StringType}, IntType,
-				BinaryBinding(timestampGetFullYear),
 			),
 		),
 		Function(overloads.TimeGetMonth,
 			MemberOverload(overloads.TimestampToMonth, []*Type{TimestampType}, IntType,
 				UnaryBinding(func(ts ref.Val) ref.Val {
-					return timestampGetMonth(ts, utcTZ)
+					t := ts.(types.Timestamp)
+					return t.Receive(overloads.TimeGetMonth, overloads.TimestampToMonth, []ref.Val{})
 				}),
-			),
-			MemberOverload(overloads.TimestampToMonthWithTz, []*Type{TimestampType, StringType}, IntType,
-				BinaryBinding(timestampGetMonth),
 			),
 		),
 		Function(overloads.TimeGetDayOfYear,
 			MemberOverload(overloads.TimestampToDayOfYear, []*Type{TimestampType}, IntType,
 				UnaryBinding(func(ts ref.Val) ref.Val {
-					return timestampGetDayOfYear(ts, utcTZ)
-				}),
-			),
-			MemberOverload(overloads.TimestampToDayOfYearWithTz, []*Type{TimestampType, StringType}, IntType,
-				BinaryBinding(func(ts, tz ref.Val) ref.Val {
-					return timestampGetDayOfYear(ts, tz)
+					t := ts.(types.Timestamp)
+					return t.Receive(overloads.TimeGetDayOfYear, overloads.TimestampToDayOfYear, []ref.Val{})
 				}),
 			),
 		),
 		Function(overloads.TimeGetDayOfMonth,
 			MemberOverload(overloads.TimestampToDayOfMonthZeroBased, []*Type{TimestampType}, IntType,
 				UnaryBinding(func(ts ref.Val) ref.Val {
-					return timestampGetDayOfMonthZeroBased(ts, utcTZ)
+					t := ts.(types.Timestamp)
+					return t.Receive(overloads.TimeGetDayOfMonth, overloads.TimestampToDayOfMonthZeroBased, []ref.Val{})
 				}),
-			),
-			MemberOverload(overloads.TimestampToDayOfMonthZeroBasedWithTz, []*Type{TimestampType, StringType}, IntType,
-				BinaryBinding(timestampGetDayOfMonthZeroBased),
 			),
 		),
 		Function(overloads.TimeGetDate,
 			MemberOverload(overloads.TimestampToDayOfMonthOneBased, []*Type{TimestampType}, IntType,
 				UnaryBinding(func(ts ref.Val) ref.Val {
-					return timestampGetDayOfMonthOneBased(ts, utcTZ)
+					t := ts.(types.Timestamp)
+					return t.Receive(overloads.TimeGetDate, overloads.TimestampToDayOfMonthOneBased, []ref.Val{})
 				}),
-			),
-			MemberOverload(overloads.TimestampToDayOfMonthOneBasedWithTz, []*Type{TimestampType, StringType}, IntType,
-				BinaryBinding(timestampGetDayOfMonthOneBased),
 			),
 		),
 		Function(overloads.TimeGetDayOfWeek,
 			MemberOverload(overloads.TimestampToDayOfWeek, []*Type{TimestampType}, IntType,
 				UnaryBinding(func(ts ref.Val) ref.Val {
-					return timestampGetDayOfWeek(ts, utcTZ)
+					t := ts.(types.Timestamp)
+					return t.Receive(overloads.TimeGetDayOfWeek, overloads.TimestampToDayOfWeek, []ref.Val{})
 				}),
-			),
-			MemberOverload(overloads.TimestampToDayOfWeekWithTz, []*Type{TimestampType, StringType}, IntType,
-				BinaryBinding(timestampGetDayOfWeek),
 			),
 		),
 		Function(overloads.TimeGetHours,
 			MemberOverload(overloads.TimestampToHours, []*Type{TimestampType}, IntType,
 				UnaryBinding(func(ts ref.Val) ref.Val {
-					return timestampGetHours(ts, utcTZ)
+					t := ts.(types.Timestamp)
+					return t.Receive(overloads.TimeGetHours, overloads.TimestampToHours, []ref.Val{})
 				}),
-			),
-			MemberOverload(overloads.TimestampToHoursWithTz, []*Type{TimestampType, StringType}, IntType,
-				BinaryBinding(timestampGetHours),
 			),
 		),
 		Function(overloads.TimeGetMinutes,
 			MemberOverload(overloads.TimestampToMinutes, []*Type{TimestampType}, IntType,
 				UnaryBinding(func(ts ref.Val) ref.Val {
-					return timestampGetMinutes(ts, utcTZ)
+					t := ts.(types.Timestamp)
+					return t.Receive(overloads.TimeGetMinutes, overloads.TimestampToMinutes, []ref.Val{})
 				}),
-			),
-			MemberOverload(overloads.TimestampToMinutesWithTz, []*Type{TimestampType, StringType}, IntType,
-				BinaryBinding(timestampGetMinutes),
 			),
 		),
 		Function(overloads.TimeGetSeconds,
 			MemberOverload(overloads.TimestampToSeconds, []*Type{TimestampType}, IntType,
 				UnaryBinding(func(ts ref.Val) ref.Val {
-					return timestampGetSeconds(ts, utcTZ)
+					t := ts.(types.Timestamp)
+					return t.Receive(overloads.TimeGetSeconds, overloads.TimestampToSeconds, []ref.Val{})
 				}),
-			),
-			MemberOverload(overloads.TimestampToSecondsWithTz, []*Type{TimestampType, StringType}, IntType,
-				BinaryBinding(timestampGetSeconds),
 			),
 		),
 		Function(overloads.TimeGetMilliseconds,
 			MemberOverload(overloads.TimestampToMilliseconds, []*Type{TimestampType}, IntType,
 				UnaryBinding(func(ts ref.Val) ref.Val {
-					return timestampGetMilliseconds(ts, utcTZ)
+					t := ts.(types.Timestamp)
+					return t.Receive(overloads.TimeGetMilliseconds, overloads.TimestampToMilliseconds, []ref.Val{})
 				}),
-			),
-			MemberOverload(overloads.TimestampToMillisecondsWithTz, []*Type{TimestampType, StringType}, IntType,
-				BinaryBinding(timestampGetMilliseconds),
 			),
 		),
 	}
 )
-
-func timestampGetFullYear(ts, tz ref.Val) ref.Val {
-	t, err := inTimeZone(ts, tz)
-	if err != nil {
-		return types.NewErrFromString(err.Error())
-	}
-	return types.Int(t.Year())
-}
-
-func timestampGetMonth(ts, tz ref.Val) ref.Val {
-	t, err := inTimeZone(ts, tz)
-	if err != nil {
-		return types.NewErrFromString(err.Error())
-	}
-	// CEL spec indicates that the month should be 0-based, but the Time value
-	// for Month() is 1-based.
-	return types.Int(t.Month() - 1)
-}
-
-func timestampGetDayOfYear(ts, tz ref.Val) ref.Val {
-	t, err := inTimeZone(ts, tz)
-	if err != nil {
-		return types.NewErrFromString(err.Error())
-	}
-	return types.Int(t.YearDay() - 1)
-}
-
-func timestampGetDayOfMonthZeroBased(ts, tz ref.Val) ref.Val {
-	t, err := inTimeZone(ts, tz)
-	if err != nil {
-		return types.NewErrFromString(err.Error())
-	}
-	return types.Int(t.Day() - 1)
-}
-
-func timestampGetDayOfMonthOneBased(ts, tz ref.Val) ref.Val {
-	t, err := inTimeZone(ts, tz)
-	if err != nil {
-		return types.NewErrFromString(err.Error())
-	}
-	return types.Int(t.Day())
-}
-
-func timestampGetDayOfWeek(ts, tz ref.Val) ref.Val {
-	t, err := inTimeZone(ts, tz)
-	if err != nil {
-		return types.NewErrFromString(err.Error())
-	}
-	return types.Int(t.Weekday())
-}
-
-func timestampGetHours(ts, tz ref.Val) ref.Val {
-	t, err := inTimeZone(ts, tz)
-	if err != nil {
-		return types.NewErrFromString(err.Error())
-	}
-	return types.Int(t.Hour())
-}
-
-func timestampGetMinutes(ts, tz ref.Val) ref.Val {
-	t, err := inTimeZone(ts, tz)
-	if err != nil {
-		return types.NewErrFromString(err.Error())
-	}
-	return types.Int(t.Minute())
-}
-
-func timestampGetSeconds(ts, tz ref.Val) ref.Val {
-	t, err := inTimeZone(ts, tz)
-	if err != nil {
-		return types.NewErrFromString(err.Error())
-	}
-	return types.Int(t.Second())
-}
-
-func timestampGetMilliseconds(ts, tz ref.Val) ref.Val {
-	t, err := inTimeZone(ts, tz)
-	if err != nil {
-		return types.NewErrFromString(err.Error())
-	}
-	return types.Int(t.Nanosecond() / 1000000)
-}
-
-func inTimeZone(ts, tz ref.Val) (time.Time, error) {
-	t := ts.(types.Timestamp)
-	val := string(tz.(types.String))
-	ind := strings.Index(val, ":")
-	if ind == -1 {
-		loc, err := time.LoadLocation(val)
-		if err != nil {
-			return time.Time{}, err
-		}
-		return t.In(loc), nil
-	}
-
-	// If the input is not the name of a timezone (for example, 'US/Central'), it should be a numerical offset from UTC
-	// in the format ^(+|-)(0[0-9]|1[0-4]):[0-5][0-9]$. The numerical input is parsed in terms of hours and minutes.
-	hr, err := strconv.Atoi(string(val[0:ind]))
-	if err != nil {
-		return time.Time{}, err
-	}
-	min, err := strconv.Atoi(string(val[ind+1:]))
-	if err != nil {
-		return time.Time{}, err
-	}
-	var offset int
-	if string(val[0]) == "-" {
-		offset = hr*60 - min
-	} else {
-		offset = hr*60 + min
-	}
-	secondsEastOfUTC := int((time.Duration(offset) * time.Minute).Seconds())
-	timezone := time.FixedZone("", secondsEastOfUTC)
-	return t.In(timezone), nil
-}

--- a/common/stdlib/standard.go
+++ b/common/stdlib/standard.go
@@ -16,6 +16,10 @@
 package stdlib
 
 import (
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/functions"
 	"github.com/google/cel-go/common/operators"
@@ -28,6 +32,7 @@ import (
 var (
 	stdFunctions []*decls.FunctionDecl
 	stdTypes     []*decls.VariableDecl
+	utcTZ        = types.String("UTC")
 )
 
 func init() {
@@ -497,71 +502,115 @@ func init() {
 		// Timestamp / duration functions
 		function(overloads.TimeGetFullYear,
 			decls.MemberOverload(overloads.TimestampToYear,
-				argTypes(types.TimestampType), types.IntType),
+				argTypes(types.TimestampType), types.IntType,
+				decls.UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetFullYear(ts, utcTZ)
+				})),
 			decls.MemberOverload(overloads.TimestampToYearWithTz,
-				argTypes(types.TimestampType, types.StringType), types.IntType)),
+				argTypes(types.TimestampType, types.StringType), types.IntType,
+				decls.BinaryBinding(timestampGetFullYear))),
 
 		function(overloads.TimeGetMonth,
 			decls.MemberOverload(overloads.TimestampToMonth,
-				argTypes(types.TimestampType), types.IntType),
+				argTypes(types.TimestampType), types.IntType,
+				decls.UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetMonth(ts, utcTZ)
+				})),
 			decls.MemberOverload(overloads.TimestampToMonthWithTz,
-				argTypes(types.TimestampType, types.StringType), types.IntType)),
+				argTypes(types.TimestampType, types.StringType), types.IntType,
+				decls.BinaryBinding(timestampGetMonth))),
 
 		function(overloads.TimeGetDayOfYear,
 			decls.MemberOverload(overloads.TimestampToDayOfYear,
-				argTypes(types.TimestampType), types.IntType),
+				argTypes(types.TimestampType), types.IntType,
+				decls.UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetDayOfYear(ts, utcTZ)
+				})),
 			decls.MemberOverload(overloads.TimestampToDayOfYearWithTz,
-				argTypes(types.TimestampType, types.StringType), types.IntType)),
+				argTypes(types.TimestampType, types.StringType), types.IntType,
+				decls.BinaryBinding(timestampGetDayOfYear))),
 
 		function(overloads.TimeGetDayOfMonth,
 			decls.MemberOverload(overloads.TimestampToDayOfMonthZeroBased,
-				argTypes(types.TimestampType), types.IntType),
+				argTypes(types.TimestampType), types.IntType,
+				decls.UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetDayOfMonthZeroBased(ts, utcTZ)
+				})),
 			decls.MemberOverload(overloads.TimestampToDayOfMonthZeroBasedWithTz,
-				argTypes(types.TimestampType, types.StringType), types.IntType)),
+				argTypes(types.TimestampType, types.StringType), types.IntType,
+				decls.BinaryBinding(timestampGetDayOfMonthZeroBased))),
 
 		function(overloads.TimeGetDate,
 			decls.MemberOverload(overloads.TimestampToDayOfMonthOneBased,
-				argTypes(types.TimestampType), types.IntType),
+				argTypes(types.TimestampType), types.IntType,
+				decls.UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetDayOfMonthOneBased(ts, utcTZ)
+				})),
 			decls.MemberOverload(overloads.TimestampToDayOfMonthOneBasedWithTz,
-				argTypes(types.TimestampType, types.StringType), types.IntType)),
+				argTypes(types.TimestampType, types.StringType), types.IntType,
+				decls.BinaryBinding(timestampGetDayOfMonthOneBased))),
 
 		function(overloads.TimeGetDayOfWeek,
 			decls.MemberOverload(overloads.TimestampToDayOfWeek,
-				argTypes(types.TimestampType), types.IntType),
+				argTypes(types.TimestampType), types.IntType,
+				decls.UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetDayOfWeek(ts, utcTZ)
+				})),
 			decls.MemberOverload(overloads.TimestampToDayOfWeekWithTz,
-				argTypes(types.TimestampType, types.StringType), types.IntType)),
+				argTypes(types.TimestampType, types.StringType), types.IntType,
+				decls.BinaryBinding(timestampGetDayOfWeek))),
 
 		function(overloads.TimeGetHours,
 			decls.MemberOverload(overloads.TimestampToHours,
-				argTypes(types.TimestampType), types.IntType),
+				argTypes(types.TimestampType), types.IntType,
+				decls.UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetHours(ts, utcTZ)
+				})),
 			decls.MemberOverload(overloads.TimestampToHoursWithTz,
-				argTypes(types.TimestampType, types.StringType), types.IntType),
+				argTypes(types.TimestampType, types.StringType), types.IntType,
+				decls.BinaryBinding(timestampGetHours)),
 			decls.MemberOverload(overloads.DurationToHours,
-				argTypes(types.DurationType), types.IntType)),
+				argTypes(types.DurationType), types.IntType,
+				decls.UnaryBinding(types.DurationGetHours))),
 
 		function(overloads.TimeGetMinutes,
 			decls.MemberOverload(overloads.TimestampToMinutes,
-				argTypes(types.TimestampType), types.IntType),
+				argTypes(types.TimestampType), types.IntType,
+				decls.UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetMinutes(ts, utcTZ)
+				})),
 			decls.MemberOverload(overloads.TimestampToMinutesWithTz,
-				argTypes(types.TimestampType, types.StringType), types.IntType),
+				argTypes(types.TimestampType, types.StringType), types.IntType,
+				decls.BinaryBinding(timestampGetMinutes)),
 			decls.MemberOverload(overloads.DurationToMinutes,
-				argTypes(types.DurationType), types.IntType)),
+				argTypes(types.DurationType), types.IntType,
+				decls.UnaryBinding(types.DurationGetMinutes))),
 
 		function(overloads.TimeGetSeconds,
 			decls.MemberOverload(overloads.TimestampToSeconds,
-				argTypes(types.TimestampType), types.IntType),
+				argTypes(types.TimestampType), types.IntType,
+				decls.UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetSeconds(ts, utcTZ)
+				})),
 			decls.MemberOverload(overloads.TimestampToSecondsWithTz,
-				argTypes(types.TimestampType, types.StringType), types.IntType),
+				argTypes(types.TimestampType, types.StringType), types.IntType,
+				decls.BinaryBinding(timestampGetSeconds)),
 			decls.MemberOverload(overloads.DurationToSeconds,
-				argTypes(types.DurationType), types.IntType)),
+				argTypes(types.DurationType), types.IntType,
+				decls.UnaryBinding(types.DurationGetSeconds))),
 
 		function(overloads.TimeGetMilliseconds,
 			decls.MemberOverload(overloads.TimestampToMilliseconds,
-				argTypes(types.TimestampType), types.IntType),
+				argTypes(types.TimestampType), types.IntType,
+				decls.UnaryBinding(func(ts ref.Val) ref.Val {
+					return timestampGetMilliseconds(ts, utcTZ)
+				})),
 			decls.MemberOverload(overloads.TimestampToMillisecondsWithTz,
-				argTypes(types.TimestampType, types.StringType), types.IntType),
+				argTypes(types.TimestampType, types.StringType), types.IntType,
+				decls.BinaryBinding(timestampGetMilliseconds)),
 			decls.MemberOverload(overloads.DurationToMilliseconds,
-				argTypes(types.DurationType), types.IntType)),
+				argTypes(types.DurationType), types.IntType,
+				decls.UnaryBinding(types.DurationGetMilliseconds))),
 	}
 }
 
@@ -617,4 +666,119 @@ func convertToType(t ref.Type) functions.UnaryOp {
 	return func(val ref.Val) ref.Val {
 		return val.ConvertToType(t)
 	}
+}
+
+func timestampGetFullYear(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErrFromString(err.Error())
+	}
+	return types.Int(t.Year())
+}
+
+func timestampGetMonth(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErrFromString(err.Error())
+	}
+	// CEL spec indicates that the month should be 0-based, but the Time value
+	// for Month() is 1-based.
+	return types.Int(t.Month() - 1)
+}
+
+func timestampGetDayOfYear(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErrFromString(err.Error())
+	}
+	return types.Int(t.YearDay() - 1)
+}
+
+func timestampGetDayOfMonthZeroBased(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErrFromString(err.Error())
+	}
+	return types.Int(t.Day() - 1)
+}
+
+func timestampGetDayOfMonthOneBased(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErrFromString(err.Error())
+	}
+	return types.Int(t.Day())
+}
+
+func timestampGetDayOfWeek(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErrFromString(err.Error())
+	}
+	return types.Int(t.Weekday())
+}
+
+func timestampGetHours(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErrFromString(err.Error())
+	}
+	return types.Int(t.Hour())
+}
+
+func timestampGetMinutes(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErrFromString(err.Error())
+	}
+	return types.Int(t.Minute())
+}
+
+func timestampGetSeconds(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErrFromString(err.Error())
+	}
+	return types.Int(t.Second())
+}
+
+func timestampGetMilliseconds(ts, tz ref.Val) ref.Val {
+	t, err := inTimeZone(ts, tz)
+	if err != nil {
+		return types.NewErrFromString(err.Error())
+	}
+	return types.Int(t.Nanosecond() / 1000000)
+}
+
+func inTimeZone(ts, tz ref.Val) (time.Time, error) {
+	t := ts.(types.Timestamp)
+	val := string(tz.(types.String))
+	ind := strings.Index(val, ":")
+	if ind == -1 {
+		loc, err := time.LoadLocation(val)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return t.In(loc), nil
+	}
+
+	// If the input is not the name of a timezone (for example, 'US/Central'), it should be a numerical offset from UTC
+	// in the format ^(+|-)(0[0-9]|1[0-4]):[0-5][0-9]$. The numerical input is parsed in terms of hours and minutes.
+	hr, err := strconv.Atoi(string(val[0:ind]))
+	if err != nil {
+		return time.Time{}, err
+	}
+	min, err := strconv.Atoi(string(val[ind+1:]))
+	if err != nil {
+		return time.Time{}, err
+	}
+	var offset int
+	if string(val[0]) == "-" {
+		offset = hr*60 - min
+	} else {
+		offset = hr*60 + min
+	}
+	secondsEastOfUTC := int((time.Duration(offset) * time.Minute).Seconds())
+	timezone := time.FixedZone("", secondsEastOfUTC)
+	return t.In(timezone), nil
 }

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -708,6 +708,46 @@ func testData(t testing.TB) []testCase {
 			expr: `timestamp(2) >= timestamp(2)`,
 		},
 		{
+			name: "timestamp_methods",
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("x", types.TimestampType),
+			},
+			in: map[string]any{
+				"x": time.Unix(7506, 1000000).Local(),
+			},
+			expr: `
+			x.getFullYear() == 1970
+			&& x.getMonth() == 0
+			&& x.getDayOfYear() == 0
+			&& x.getDayOfMonth() == 0
+			&& x.getDate() == 1
+			&& x.getDayOfWeek() == 4
+			&& x.getHours() == 2
+			&& x.getMinutes() == 5
+			&& x.getSeconds() == 6
+			&& x.getMilliseconds() == 1
+			&& x.getFullYear('-07:30') == 1969
+			&& x.getDayOfYear('-07:30') == 364
+			&& x.getMonth('-07:30') == 11
+			&& x.getDayOfMonth('-07:30') == 30
+			&& x.getDate('-07:30') == 31
+			&& x.getDayOfWeek('-07:30') == 3
+			&& x.getHours('-07:30') == 18
+			&& x.getMinutes('-07:30') == 35
+			&& x.getSeconds('-07:30') == 6
+			&& x.getMilliseconds('-07:30') == 1
+			&& x.getFullYear('23:15') == 1970
+			&& x.getDayOfYear('23:15') == 1
+			&& x.getMonth('23:15') == 0
+			&& x.getDayOfMonth('23:15') == 1
+			&& x.getDate('23:15') == 2
+			&& x.getDayOfWeek('23:15') == 5
+			&& x.getHours('23:15') == 1
+			&& x.getMinutes('23:15') == 20
+			&& x.getSeconds('23:15') == 6
+			&& x.getMilliseconds('23:15') == 1`,
+		},
+		{
 			name: "string_to_timestamp",
 			expr: `timestamp('1986-04-26T01:23:40Z')`,
 			out:  &tpb.Timestamp{Seconds: 514862620},

--- a/policy/compiler_test.go
+++ b/policy/compiler_test.go
@@ -159,7 +159,6 @@ func compile(t testing.TB, name string, parseOpts []ParserOption, envOpts []cel.
 		t.Errorf("policy name is %v, wanted %q", policy.name, name)
 	}
 	env, err := cel.NewEnv(
-		cel.DefaultUTCTimeZone(true),
 		cel.OptionalTypes(),
 		cel.EnableMacroCallTracking(),
 		cel.ExtendedValidations(),


### PR DESCRIPTION
In most cases the default UTC timezone is used whenever CEL is provided
a protobuf based input; however, there are limited cases where a Go-native
time value may be provided and the time is based on the local timezone 
carried in the `time` value. This change makes `DefaultUTCTimeZone(true)`
a no-op as it is default enabled, and must be explicitly opted-out.

The use of `DefaultUTCTimeZone(false)` will only be permitted until
release v0.25.0