### PR TITLE
Support for feature flags and validators in env.Config

### DIFF
--- a/cel/env.go
+++ b/cel/env.go
@@ -265,11 +265,15 @@ func (e *Env) ToConfig(name string) (*env.Config, error) {
 
 	// Serialize validators
 	for _, val := range e.Validators() {
-		conf.AddValidators(env.NewValidator(val.Name()))
+		// Only add configurable validators to the env.Config as all others are
+		// expected to be implicitly enabled via extension libraries.
+		if confVal, ok := val.(ConfigurableASTValidator); ok {
+			conf.AddValidators(confVal.ToConfig())
+		}
 	}
 
 	// Serialize features
-	for featID, enabled := range e.appliedFeatures {
+	for featID, enabled := range e.features {
 		featName, found := featureNameByID(featID)
 		if !found {
 			// If the feature isn't named, it isn't intended to be publicly exposed

--- a/cel/env.go
+++ b/cel/env.go
@@ -263,6 +263,21 @@ func (e *Env) ToConfig(name string) (*env.Config, error) {
 		}
 	}
 
+	// Serialize validators
+	for _, val := range e.Validators() {
+		conf.AddValidators(env.NewValidator(val.Name()))
+	}
+
+	// Serialize features
+	for featID, enabled := range e.appliedFeatures {
+		featName, found := featureNameByID(featID)
+		if !found {
+			// If the feature isn't named, it isn't intended to be publicly exposed
+			continue
+		}
+		conf.AddFeatures(env.NewFeature(featName, enabled))
+	}
+
 	return conf, nil
 }
 
@@ -541,7 +556,7 @@ func (e *Env) Functions() map[string]*decls.FunctionDecl {
 
 // Variables returns the set of variables associated with the environment.
 func (e *Env) Variables() []*decls.VariableDecl {
-	return e.variables
+	return e.variables[:]
 }
 
 // HasValidator returns whether a specific ASTValidator has been configured in the environment.
@@ -552,6 +567,11 @@ func (e *Env) HasValidator(name string) bool {
 		}
 	}
 	return false
+}
+
+// Validators returns the set of ASTValidators configured on the environment.
+func (e *Env) Validators() []ASTValidator {
+	return e.validators[:]
 }
 
 // Parse parses the input expression value `txt` to a Ast and/or a set of Issues.

--- a/cel/options.go
+++ b/cel/options.go
@@ -73,6 +73,26 @@ const (
 	featureIdentEscapeSyntax
 )
 
+var featureIDsToNames = map[int]string{
+	featureEnableMacroCallTracking:     "cel.feature.macro_call_tracking",
+	featureCrossTypeNumericComparisons: "cel.feature.cross_type_numeric_comparisons",
+	featureIdentEscapeSyntax:           "cel.feature.backtick_identifier_syntax",
+}
+
+func featureNameByID(id int) (string, bool) {
+	name, found := featureIDsToNames[id]
+	return name, found
+}
+
+func featureIDByName(name string) (int, bool) {
+	for id, n := range featureIDsToNames {
+		if n == name {
+			return id, true
+		}
+	}
+	return 0, false
+}
+
 // EnvOption is a functional interface for configuring the environment.
 type EnvOption func(e *Env) (*Env, error)
 

--- a/cel/options.go
+++ b/cel/options.go
@@ -551,7 +551,7 @@ func configToEnvOptions(config *env.Config, provider types.Provider, optFactorie
 		envOpts = append(envOpts, VariableDecls(vars...))
 	}
 
-	// Cnofigure functions
+	// Configure functions
 	if len(config.Functions) != 0 {
 		funcs := make([]*decls.FunctionDecl, 0, len(config.Functions))
 		for _, f := range config.Functions {
@@ -566,6 +566,10 @@ func configToEnvOptions(config *env.Config, provider types.Provider, optFactorie
 
 	// Configure features
 	for _, feat := range config.Features {
+		// Note, if a feature is not found, it is skipped as it is possible the feature
+		// is not intended to be supported publicly. In the future, a refinement of
+		// to this strategy to report unrecognized features and validators should probably
+		// be covered as a standard ConfigOptionFactory
 		if id, found := featureIDByName(feat.Name); found {
 			envOpts = append(envOpts, features(id, feat.Enabled))
 		}

--- a/cel/options.go
+++ b/cel/options.go
@@ -76,7 +76,7 @@ const (
 var featureIDsToNames = map[int]string{
 	featureEnableMacroCallTracking:     "cel.feature.macro_call_tracking",
 	featureCrossTypeNumericComparisons: "cel.feature.cross_type_numeric_comparisons",
-	featureIdentEscapeSyntax:           "cel.feature.backtick_identifier_syntax",
+	featureIdentEscapeSyntax:           "cel.feature.backtick_escape_syntax",
 }
 
 func featureNameByID(id int) (string, bool) {
@@ -476,28 +476,27 @@ type ConfigOptionFactory func(any) (EnvOption, bool)
 // as the type provider configured at the time when the config is processed is the one used to derive
 // type references from the configuration.
 func FromConfig(config *env.Config, optFactories ...ConfigOptionFactory) EnvOption {
-	return func(env *Env) (*Env, error) {
+	return func(e *Env) (*Env, error) {
 		if err := config.Validate(); err != nil {
 			return nil, err
 		}
-		opts, err := configToEnvOptions(config, env.CELTypeProvider(), optFactories)
+		opts, err := configToEnvOptions(config, e.CELTypeProvider(), optFactories)
 		if err != nil {
 			return nil, err
 		}
 		for _, o := range opts {
-			env, err = o(env)
+			e, err = o(e)
 			if err != nil {
 				return nil, err
 			}
 		}
-		return env, nil
+		return e, nil
 	}
 }
 
 // configToEnvOptions generates a set of EnvOption values (or error) based on a config, a type provider,
 // and an optional set of environment options.
 func configToEnvOptions(config *env.Config, provider types.Provider, optFactories []ConfigOptionFactory) ([]EnvOption, error) {
-	// note: ported from cel-go/policy/config.go
 	envOpts := []EnvOption{}
 	// Configure the standard lib subset.
 	if config.StdLib != nil {
@@ -539,6 +538,7 @@ func configToEnvOptions(config *env.Config, provider types.Provider, optFactorie
 		envOpts = append(envOpts, DeclareContextProto(pbMsg.ProtoReflect().Descriptor()))
 	}
 
+	// Configure variables
 	if len(config.Variables) != 0 {
 		vars := make([]*decls.VariableDecl, 0, len(config.Variables))
 		for _, v := range config.Variables {
@@ -550,6 +550,8 @@ func configToEnvOptions(config *env.Config, provider types.Provider, optFactorie
 		}
 		envOpts = append(envOpts, VariableDecls(vars...))
 	}
+
+	// Cnofigure functions
 	if len(config.Functions) != 0 {
 		funcs := make([]*decls.FunctionDecl, 0, len(config.Functions))
 		for _, f := range config.Functions {
@@ -561,20 +563,56 @@ func configToEnvOptions(config *env.Config, provider types.Provider, optFactorie
 		}
 		envOpts = append(envOpts, FunctionDecls(funcs...))
 	}
-	for _, e := range config.Extensions {
-		extHandled := false
-		for _, optFac := range optFactories {
-			if opt, useOption := optFac(e); useOption {
-				envOpts = append(envOpts, opt)
-				extHandled = true
-				break
-			}
-		}
-		if !extHandled {
-			return nil, fmt.Errorf("unrecognized extension: %s", e.Name)
+
+	// Configure features
+	for _, feat := range config.Features {
+		if id, found := featureIDByName(feat.Name); found {
+			envOpts = append(envOpts, features(id, feat.Enabled))
 		}
 	}
+
+	// Configure validators
+	for _, val := range config.Validators {
+		if fac, found := astValidatorFactories[val.Name]; found {
+			envOpts = append(envOpts, func(e *Env) (*Env, error) {
+				validator, err := fac(val)
+				if err != nil {
+					return nil, fmt.Errorf("%w", err)
+				}
+				return ASTValidators(validator)(e)
+			})
+		} else if opt, handled := handleExtendedConfigOption(val, optFactories); handled {
+			envOpts = append(envOpts, opt)
+		}
+		// we don't error when the validator isn't found as it may be part
+		// of an extension library and enabled implicitly.
+	}
+
+	// Configure extensions
+	for _, ext := range config.Extensions {
+		// version number has been validated by the call to `Validate`
+		ver, _ := ext.VersionNumber()
+		if ext.Name == "optional" {
+			envOpts = append(envOpts, OptionalTypes(OptionalTypesVersion(ver)))
+		} else {
+			opt, handled := handleExtendedConfigOption(ext, optFactories)
+			if !handled {
+				return nil, fmt.Errorf("unrecognized extension: %s", ext.Name)
+			}
+			envOpts = append(envOpts, opt)
+		}
+	}
+
 	return envOpts, nil
+}
+
+func handleExtendedConfigOption(conf any, optFactories []ConfigOptionFactory) (EnvOption, bool) {
+	for _, optFac := range optFactories {
+		if opt, useOption := optFac(conf); useOption {
+			return opt, true
+		}
+	}
+	return nil, false
 }
 
 // EvalOption indicates an evaluation option that may affect the evaluation behavior or information

--- a/cel/validator.go
+++ b/cel/validator.go
@@ -20,11 +20,16 @@ import (
 	"regexp"
 
 	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/env"
 	"github.com/google/cel-go/common/overloads"
 )
 
 const (
-	homogeneousValidatorName = "cel.validator.homogeneous_types"
+	durationValidatorName     = "cel.validator.duration"
+	regexValidatorName        = "cel.validator.matches"
+	timestampValidatorName    = "cel.validator.timestamp"
+	homogeneousValidatorName  = "cel.validator.homogeneous_literals"
+	nestingLimitValidatorName = "cel.validator.comprehension_nesting_limit"
 
 	// HomogeneousAggregateLiteralExemptFunctions is the ValidatorConfig key used to configure
 	// the set of function names which are exempt from homogeneous type checks. The expected type
@@ -35,6 +40,35 @@ const (
 	// clauses; however, all other uses of a mixed element type list, would be unexpected.
 	HomogeneousAggregateLiteralExemptFunctions = homogeneousValidatorName + ".exempt"
 )
+
+var (
+	astValidatorFactories = map[string]ASTValidatorFactory{
+		nestingLimitValidatorName: func(val *env.Validator) (ASTValidator, error) {
+			if limit, found := val.ConfigValue("limit"); found {
+				if val, isInt := limit.(int); isInt {
+					return ValidateComprehensionNestingLimit(val), nil
+				}
+				return nil, fmt.Errorf("invalid validator: %s unsupported limit type: %v", nestingLimitValidatorName, limit)
+			}
+			return nil, fmt.Errorf("invalid validator: %s missing limit", nestingLimitValidatorName)
+		},
+		durationValidatorName: func(*env.Validator) (ASTValidator, error) {
+			return ValidateDurationLiterals(), nil
+		},
+		regexValidatorName: func(*env.Validator) (ASTValidator, error) {
+			return ValidateRegexLiterals(), nil
+		},
+		timestampValidatorName: func(*env.Validator) (ASTValidator, error) {
+			return ValidateTimestampLiterals(), nil
+		},
+		homogeneousValidatorName: func(*env.Validator) (ASTValidator, error) {
+			return ValidateHomogeneousAggregateLiterals(), nil
+		},
+	}
+)
+
+// ASTValidatorFactory creates an ASTValidator as configured by the input map
+type ASTValidatorFactory func(*env.Validator) (ASTValidator, error)
 
 // ASTValidators configures a set of ASTValidator instances into the target environment.
 //
@@ -68,6 +102,18 @@ type ASTValidator interface {
 	// See individual validators for more information on their configuration keys and configuration
 	// properties.
 	Validate(*Env, ValidatorConfig, *ast.AST, *Issues)
+}
+
+// ConfigurableASTValidator supports conversion of an object to an `env.Validator` instance used for
+// YAML serialization.
+type ConfigurableASTValidator interface {
+	// ToConfig converts the internal configuration of an ASTValidator into an env.Validator instance
+	// which minimally must include the validator name, but may also include a map[string]any config
+	// object to be serialized to YAML. The string keys represent the configuration parameter name,
+	// and the any value must mirror the internally supported type associated with the config key.
+	//
+	// Note: only primitive CEL types are supported by CEL validators at this time.
+	ToConfig() *env.Validator
 }
 
 // ValidatorConfig provides an accessor method for querying validator configuration state.
@@ -199,6 +245,11 @@ func (v formatValidator) Name() string {
 	return fmt.Sprintf("cel.validator.%s", v.funcName)
 }
 
+// ToConfig converts the ASTValidator to an env.Validator specifying the validator name.
+func (v formatValidator) ToConfig() *env.Validator {
+	return env.NewValidator(v.Name())
+}
+
 // Validate searches the AST for uses of a given function name with a constant argument and performs a check
 // on whether the argument is a valid literal value.
 func (v formatValidator) Validate(e *Env, _ ValidatorConfig, a *ast.AST, iss *Issues) {
@@ -240,6 +291,11 @@ type homogeneousAggregateLiteralValidator struct{}
 // Name returns the unique name of the homogeneous type validator.
 func (homogeneousAggregateLiteralValidator) Name() string {
 	return homogeneousValidatorName
+}
+
+// ToConfig converts the ASTValidator to an env.Validator specifying the validator name.
+func (v homogeneousAggregateLiteralValidator) ToConfig() *env.Validator {
+	return env.NewValidator(v.Name())
 }
 
 // Validate validates that all lists and map literals have homogeneous types, i.e. don't contain dyn types.
@@ -336,10 +392,18 @@ type nestingLimitValidator struct {
 	limit int
 }
 
+// Name returns the name of the nesting limit validator.
 func (v nestingLimitValidator) Name() string {
-	return "cel.validator.comprehension_nesting_limit"
+	return nestingLimitValidatorName
 }
 
+// ToConfig converts the ASTValidator to an env.Validator specifying the validator name and the nesting limit
+// as an integer value: {"limit": int}
+func (v nestingLimitValidator) ToConfig() *env.Validator {
+	return env.NewValidator(v.Name()).SetConfig(map[string]any{"limit": v.limit})
+}
+
+// Validate implements the ASTValidator interface method.
 func (v nestingLimitValidator) Validate(e *Env, _ ValidatorConfig, a *ast.AST, iss *Issues) {
 	root := ast.NavigateAST(a)
 	comprehensions := ast.MatchDescendants(root, ast.KindMatcher(ast.ComprehensionKind))

--- a/cel/validator.go
+++ b/cel/validator.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	homogeneousValidatorName = "cel.lib.std.validate.types.homogeneous"
+	homogeneousValidatorName = "cel.validator.homogeneous_types"
 
 	// HomogeneousAggregateLiteralExemptFunctions is the ValidatorConfig key used to configure
 	// the set of function names which are exempt from homogeneous type checks. The expected type
@@ -196,7 +196,7 @@ type formatValidator struct {
 
 // Name returns the unique name of this function format validator.
 func (v formatValidator) Name() string {
-	return fmt.Sprintf("cel.lib.std.validate.functions.%s", v.funcName)
+	return fmt.Sprintf("cel.validator.%s", v.funcName)
 }
 
 // Validate searches the AST for uses of a given function name with a constant argument and performs a check
@@ -337,7 +337,7 @@ type nestingLimitValidator struct {
 }
 
 func (v nestingLimitValidator) Name() string {
-	return "cel.lib.std.validate.comprehension_nesting_limit"
+	return "cel.validator.comprehension_nesting_limit"
 }
 
 func (v nestingLimitValidator) Validate(e *Env, _ ValidatorConfig, a *ast.AST, iss *Issues) {

--- a/common/env/env.go
+++ b/common/env/env.go
@@ -48,6 +48,8 @@ type Config struct {
 	ContextVariable *ContextVariable `yaml:"context_variable,omitempty"`
 	Variables       []*Variable      `yaml:"variables,omitempty"`
 	Functions       []*Function      `yaml:"functions,omitempty"`
+	Validators      []*Validator     `yaml:"validators,omitempty"`
+	Features        []*Feature       `yaml:"features,omitempty"`
 }
 
 // Validate validates the whole configuration is well-formed.
@@ -82,6 +84,11 @@ func (c *Config) Validate() error {
 	}
 	for _, fn := range c.Functions {
 		if err := fn.Validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	for _, val := range c.Validators {
+		if err := val.Validate(); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -169,6 +176,16 @@ func (c *Config) AddImports(imps ...*Import) *Config {
 // AddExtensions appends a set of extensions to the config.
 func (c *Config) AddExtensions(exts ...*Extension) *Config {
 	c.Extensions = append(c.Extensions, exts...)
+	return c
+}
+
+func (c *Config) AddValidators(vals ...*Validator) *Config {
+	c.Validators = append(c.Validators, vals...)
+	return c
+}
+
+func (c *Config) AddFeatures(feats ...*Feature) *Config {
+	c.Features = append(c.Features, feats...)
 	return c
 }
 
@@ -623,6 +640,43 @@ func (lib *LibrarySubset) AddIncludedFunctions(funcs ...*Function) *LibrarySubse
 func (lib *LibrarySubset) AddExcludedFunctions(funcs ...*Function) *LibrarySubset {
 	lib.ExcludeFunctions = append(lib.ExcludeFunctions, funcs...)
 	return lib
+}
+
+func NewValidator(name string) *Validator {
+	return &Validator{Name: name}
+}
+
+type Validator struct {
+	Name string `yaml:"name"`
+}
+
+func (v *Validator) Validate() error {
+	if v == nil {
+		return errors.New("invalid validator: nil")
+	}
+	if v.Name == "" {
+		return errors.New("invalid validator: missing name")
+	}
+	return nil
+}
+
+func NewFeature(name string, enabled bool) *Feature {
+	return &Feature{Name: name, Enabled: enabled}
+}
+
+type Feature struct {
+	Name    string `yaml:"name"`
+	Enabled bool   `yaml:"enabled"`
+}
+
+func (feat *Feature) Validate() error {
+	if feat == nil {
+		return errors.New("invalid feature: nil")
+	}
+	if feat.Name == "" {
+		return errors.New("invalid feature: missing name")
+	}
+	return nil
 }
 
 // NewTypeDesc describes a simple or complex type with parameters.

--- a/common/env/testdata/extended_env.yaml
+++ b/common/env/testdata/extended_env.yaml
@@ -38,3 +38,13 @@ functions:
               is_type_param: true
         return:
           type_name: "bool"
+validators:
+  - name: cel.validator.duration
+  - name: cel.validator.matches
+  - name: cel.validator.timestamp
+  - name: cel.validator.nesting_comprehension_limit
+    config:
+      limit: 2
+features:
+  - name: cel.feature.macro_call_tracking
+    enabled: true

--- a/ext/bindings.go
+++ b/ext/bindings.go
@@ -149,7 +149,7 @@ type blockValidationExemption struct{}
 
 // Name returns the name of the validator.
 func (blockValidationExemption) Name() string {
-	return "cel.lib.ext.validate.functions.cel.block"
+	return "cel.validator.cel_block"
 }
 
 // Configure implements the ASTValidatorConfigurer interface and augments the list of functions to skip

--- a/ext/formatting.go
+++ b/ext/formatting.go
@@ -407,7 +407,7 @@ type stringFormatValidator struct{}
 
 // Name returns the name of the validator.
 func (stringFormatValidator) Name() string {
-	return "cel.lib.ext.validate.functions.string.format"
+	return "cel.validator.string_format"
 }
 
 // Configure implements the ASTValidatorConfigurer interface and augments the list of functions to skip

--- a/policy/config.go
+++ b/policy/config.go
@@ -42,7 +42,7 @@ func extensionOptionFactory(configElement any) (cel.EnvOption, bool) {
 		return nil, false
 	}
 	// If the version is 'latest', set the version value to the max uint.
-	ver, err := ext.GetVersion()
+	ver, err := ext.VersionNumber()
 	if err != nil {
 		return func(*cel.Env) (*cel.Env, error) {
 			return nil, fmt.Errorf("invalid extension version: %s - %s", ext.Name, ext.Version)
@@ -66,9 +66,6 @@ var extFactories = map[string]extensionFactory{
 	},
 	"math": func(version uint32) cel.EnvOption {
 		return ext.Math(ext.MathVersion(version))
-	},
-	"optional": func(version uint32) cel.EnvOption {
-		return cel.OptionalTypes(cel.OptionalTypesVersion(version))
 	},
 	"protos": func(version uint32) cel.EnvOption {
 		return ext.Protos(ext.ProtosVersion(version))


### PR DESCRIPTION
Support for feature flags and validators in `env.Config` as both the
output from `cel.Env` and as an input to the `cel.FromConfig` option.

Note: only `ConfigurableASTValidators` are included as serializable
since some validators are included within other libraries whereas
configurable validators are intended to be standalone.

Note: this implies that libraries should support configuration similar
to validators. Filed https://github.com/google/cel-go/issues/1131 to track
