### PR TITLE
Support for splitting nested branching operators within policies

### DIFF
--- a/common/ast/ast.go
+++ b/common/ast/ast.go
@@ -465,6 +465,9 @@ func (v *maxIDVisitor) VisitEntryExpr(e EntryExpr) {
 
 type heightVisitor map[int64]int
 
+// VisitExpr computes the height of a given node as the max height of its children plus one.
+//
+// Identifiers and literals are treated as having a height of zero.
 func (hv heightVisitor) VisitExpr(e Expr) {
 	// default includes IdentKind, LiteralKind
 	hv[e.ID()] = 0
@@ -496,6 +499,7 @@ func (hv heightVisitor) VisitExpr(e Expr) {
 	}
 }
 
+// VisitEntryExpr computes the max height of a map or struct entry and associates the height with the entry id.
 func (hv heightVisitor) VisitEntryExpr(e EntryExpr) {
 	hv[e.ID()] = 0
 	switch e.Kind() {

--- a/common/ast/ast.go
+++ b/common/ast/ast.go
@@ -160,6 +160,13 @@ func MaxID(a *AST) int64 {
 	return visitor.maxID + 1
 }
 
+// Heights computes the heights of all AST expressions and returns a map from expression id to height.
+func Heights(a *AST) map[int64]int {
+	visitor := make(heightVisitor)
+	PostOrderVisit(a.Expr(), visitor)
+	return visitor
+}
+
 // NewSourceInfo creates a simple SourceInfo object from an input common.Source value.
 func NewSourceInfo(src common.Source) *SourceInfo {
 	var lineOffsets []int32
@@ -454,4 +461,71 @@ func (v *maxIDVisitor) VisitEntryExpr(e EntryExpr) {
 	if v.maxID < e.ID() {
 		v.maxID = e.ID()
 	}
+}
+
+type heightVisitor map[int64]int
+
+func (hv heightVisitor) VisitExpr(e Expr) {
+	// default includes IdentKind, LiteralKind
+	hv[e.ID()] = 0
+	switch e.Kind() {
+	case SelectKind:
+		hv[e.ID()] = 1 + hv[e.AsSelect().Operand().ID()]
+	case CallKind:
+		c := e.AsCall()
+		height := hv.maxHeight(c.Args()...)
+		if c.IsMemberFunction() {
+			tHeight := hv[c.Target().ID()]
+			if tHeight > height {
+				height = tHeight
+			}
+		}
+		hv[e.ID()] = 1 + height
+	case ListKind:
+		l := e.AsList()
+		hv[e.ID()] = 1 + hv.maxHeight(l.Elements()...)
+	case MapKind:
+		m := e.AsMap()
+		hv[e.ID()] = 1 + hv.maxEntryHeight(m.Entries()...)
+	case StructKind:
+		s := e.AsStruct()
+		hv[e.ID()] = 1 + hv.maxEntryHeight(s.Fields()...)
+	case ComprehensionKind:
+		comp := e.AsComprehension()
+		hv[e.ID()] = 1 + hv.maxHeight(comp.IterRange(), comp.AccuInit(), comp.LoopCondition(), comp.LoopStep(), comp.Result())
+	}
+}
+
+func (hv heightVisitor) VisitEntryExpr(e EntryExpr) {
+	hv[e.ID()] = 0
+	switch e.Kind() {
+	case MapEntryKind:
+		me := e.AsMapEntry()
+		hv[e.ID()] = hv.maxHeight(me.Value(), me.Key())
+	case StructFieldKind:
+		sf := e.AsStructField()
+		hv[e.ID()] = hv[sf.Value().ID()]
+	}
+}
+
+func (hv heightVisitor) maxHeight(exprs ...Expr) int {
+	max := 0
+	for _, e := range exprs {
+		h := hv[e.ID()]
+		if h > max {
+			max = h
+		}
+	}
+	return max
+}
+
+func (hv heightVisitor) maxEntryHeight(entries ...EntryExpr) int {
+	max := 0
+	for _, e := range entries {
+		h := hv[e.ID()]
+		if h > max {
+			max = h
+		}
+	}
+	return max
 }

--- a/common/ast/ast_test.go
+++ b/common/ast/ast_test.go
@@ -339,6 +339,31 @@ func TestMaxID(t *testing.T) {
 	}
 }
 
+func TestHeights(t *testing.T) {
+	tests := []struct {
+		expr   string
+		height int
+	}{
+		{`'a' == 'b'`, 1},
+		{`'a'.size()`, 1},
+		{`[1, 2].size()`, 2},
+		{`size('a')`, 1},
+		{`has({'a': 1}.a)`, 2},
+		{`{'a': 1}`, 1},
+		{`{'a': 1}['a']`, 2},
+		{`[1, 2, 3].exists(i, i % 2 == 1)`, 4},
+		{`google.expr.proto3.test.TestAllTypes{}`, 1},
+		{`google.expr.proto3.test.TestAllTypes{repeated_int32: [1, 2]}`, 2},
+	}
+	for _, tst := range tests {
+		checked := mustTypeCheck(t, tst.expr)
+		maxHeight := ast.Heights(checked)[checked.Expr().ID()]
+		if maxHeight != tst.height {
+			t.Errorf("ast.Heights(%q) got max height %d, wanted %d", tst.expr, maxHeight, tst.height)
+		}
+	}
+}
+
 func mockRelativeSource(t testing.TB, text string, lineOffsets []int32, baseLocation common.Location) common.Source {
 	t.Helper()
 	return &mockSource{

--- a/common/ast/navigable.go
+++ b/common/ast/navigable.go
@@ -237,8 +237,13 @@ func visit(expr Expr, visitor Visitor, order visitOrder, depth, maxDepth int) {
 	case StructKind:
 		s := expr.AsStruct()
 		for _, f := range s.Fields() {
-			visitor.VisitEntryExpr(f)
+			if order == preOrder {
+				visitor.VisitEntryExpr(f)
+			}
 			visit(f.AsStructField().Value(), visitor, order, depth+1, maxDepth)
+			if order == postOrder {
+				visitor.VisitEntryExpr(f)
+			}
 		}
 	}
 	if order == postOrder {

--- a/policy/compiler.go
+++ b/policy/compiler.go
@@ -198,7 +198,8 @@ func Compile(env *cel.Env, p *Policy, opts ...CompilerOption) (*cel.Ast, *cel.Is
 	if iss.Err() != nil {
 		return nil, iss
 	}
-	composer := NewRuleComposer(env, p)
+	// An error cannot happen when composing without supplying options
+	composer, _ := NewRuleComposer(env)
 	return composer.Compose(rule)
 }
 

--- a/policy/compiler_test.go
+++ b/policy/compiler_test.go
@@ -49,7 +49,7 @@ func TestRuleComposerError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEnv() failed: %v", err)
 	}
-	_, err = NewRuleComposer(env, FirstMatchUnnestHeight(-1))
+	_, err = NewRuleComposer(env, ExpressionUnnestHeight(-1))
 	if err == nil || !strings.Contains(err.Error(), "invalid unnest") {
 		t.Errorf("NewRuleComposer() got %v, wanted 'invalid unnest'", err)
 	}

--- a/policy/composer.go
+++ b/policy/composer.go
@@ -45,7 +45,7 @@ func NewRuleComposer(env *cel.Env, opts ...ComposerOption) (*RuleComposer, error
 	composer := &RuleComposer{
 		env: env,
 		// set the default match nesting depth to something reasonable.
-		firstMatchUnnestHeight: 10,
+		firstMatchUnnestHeight: 25,
 	}
 	var err error
 	for _, opt := range opts {

--- a/policy/helper_test.go
+++ b/policy/helper_test.go
@@ -212,6 +212,24 @@ var (
 			spec.labels,
 			@index0.filter(l, !(l in resource.labels)),
 			resource.labels.transformList(l, value, l in @index0 && value != @index0[l], l),
+			@index1.size(), @index3 > 0,
+			"missing one or more required labels: %s".format([@index1]),
+			optional.of(@index5),
+			@index2.size(),
+			@index7 > 0,
+			"invalid values provided on one or more labels: %s".format([@index2]),
+			optional.of(@index9),
+			optional.none()],
+			@index4 ? @index6 : (@index8 ? @index10 : @index11))`,
+		},
+		{
+			name:         "required_labels",
+			composerOpts: []ComposerOption{FirstMatchUnnestHeight(4)},
+			composed: `
+		cel.@block([
+			spec.labels,
+			@index0.filter(l, !(l in resource.labels)),
+			resource.labels.transformList(l, value, l in @index0 && value != @index0[l], l),
 			(@index2.size() > 0)
 			  ? optional.of("invalid values provided on one or more labels: %s".format([@index2]))
 			  : optional.none()
@@ -222,7 +240,7 @@ var (
 		},
 		{
 			name:         "nested_rule2",
-			composerOpts: []ComposerOption{FirstMatchUnnestHeight(3)},
+			composerOpts: []ComposerOption{FirstMatchUnnestHeight(4)},
 			composed: `
 	cel.@block([
 	  ["us", "uk", "es"],
@@ -251,37 +269,6 @@ var (
 		},
 		{
 			name:         "limits",
-			composerOpts: []ComposerOption{FirstMatchUnnestHeight(1)},
-			composed: `
-	cel.@block([
-		"hello",
-		"goodbye",
-		"me",
-		"%s, %s",
-		@index3.format([@index1, @index2]),
-		(now.getHours() < 24) ? optional.of(@index4 + "!!!") : optional.none(),
-		(now.getHours() < 22) ? optional.of(@index4 + "!!") : @index5,
-		(now.getHours() < 21) ? optional.of(@index4 + "!") : @index6],
-		(now.getHours() >= 20) ? @index7 : optional.of(@index3.format([@index0, @index2])))`,
-		},
-		{
-			name:         "limits",
-			composerOpts: []ComposerOption{FirstMatchUnnestHeight(2)},
-			composed: `
-	cel.@block([
-		"hello",
-		"goodbye",
-		"me",
-		"%s, %s",
-		@index3.format([@index1, @index2]),
-		(now.getHours() < 24) ? optional.of(@index4 + "!!!") : optional.none(),
-		(now.getHours() < 22) ? optional.of(@index4 + "!!") : @index5],
-		(now.getHours() >= 20)
-		? ((now.getHours() < 21) ? optional.of(@index4 + "!") : @index6)
-		: optional.of(@index3.format([@index0, @index2])))`,
-		},
-		{
-			name:         "limits",
 			composerOpts: []ComposerOption{FirstMatchUnnestHeight(3)},
 			composed: `
 	cel.@block([
@@ -290,12 +277,44 @@ var (
 		"me",
 		"%s, %s",
 		@index3.format([@index1, @index2]),
-		(now.getHours() < 24) ? optional.of(@index4 + "!!!") : optional.none()],
+		(now.getHours() < 24) ? optional.of(@index4 + "!!!") : optional.none(),
+		optional.of(@index3.format([@index0, @index2]))],
 		(now.getHours() >= 20)
-		? ((now.getHours() < 21)
-		    ? optional.of(@index4 + "!") : ((now.getHours() < 22)
-			? optional.of(@index4 + "!!") : @index5))
-		: optional.of(@index3.format([@index0, @index2])))`,
+		? ((now.getHours() < 21) ? optional.of(@index4 + "!") :
+		  ((now.getHours() < 22) ? optional.of(@index4 + "!!") : @index5))
+		: @index6)`,
+		},
+		{
+			name:         "limits",
+			composerOpts: []ComposerOption{FirstMatchUnnestHeight(4)},
+			composed: `
+	cel.@block([
+		"hello",
+		"goodbye",
+		"me",
+		"%s, %s",
+		@index3.format([@index1, @index2]),
+		(now.getHours() < 22) ? optional.of(@index4 + "!!") :
+		((now.getHours() < 24) ? optional.of(@index4 + "!!!") : optional.none())],
+		(now.getHours() >= 20)
+		? ((now.getHours() < 21) ? optional.of(@index4 + "!") : @index5)
+		: optional.of(@index3.format([@index0, @index2])))
+		`,
+		},
+		{
+			name:         "limits",
+			composerOpts: []ComposerOption{FirstMatchUnnestHeight(5)},
+			composed: `
+	cel.@block([
+		"hello",
+		"goodbye",
+		"me",
+		"%s, %s",
+		@index3.format([@index1, @index2]),
+		(now.getHours() < 21) ? optional.of(@index4 + "!") :
+		((now.getHours() < 22) ? optional.of(@index4 + "!!") :
+		((now.getHours() < 24) ? optional.of(@index4 + "!!!") : optional.none()))],
+		(now.getHours() >= 20) ? @index5 : optional.of(@index3.format([@index0, @index2])))`,
 		},
 	}
 

--- a/policy/testdata/unnest/config.yaml
+++ b/policy/testdata/unnest/config.yaml
@@ -1,0 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "unnest"
+variables:
+  - name: values
+    type_name: list
+    params:
+      - type_name: int

--- a/policy/testdata/unnest/policy.yaml
+++ b/policy/testdata/unnest/policy.yaml
@@ -1,0 +1,32 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: unnest
+rule:
+  variables:
+    - name: even_greater
+      expression: >
+        values.filter(x, x > 2)
+  match:
+    - condition: >
+        variables.even_greater.size() == 0 ? false :
+        variables.even_greater.all(x, x % 2 == 0)
+      output: >
+        "some divisible by 2"
+    - condition: "values.map(x, x * 3).exists(x, x % 4 == 0)"
+      output: >
+        "at least one divisible by 4"
+    - condition: "values.map(x, x * x * x).exists(x, x % 6 == 0)"
+      output: >
+        "at least one power of 6"

--- a/policy/testdata/unnest/tests.yaml
+++ b/policy/testdata/unnest/tests.yaml
@@ -1,0 +1,50 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: "Unnest tests unnesting of comprehension sequences"
+section:
+  - name: "divisible by 2"
+    tests:
+     - name: "true"
+       input:
+          values:
+            expr: "[4, 6]"
+       output: >
+        "some divisible by 2"
+     - name: "false"
+       input:
+         values:
+           expr: "[1, 3, 5]"
+       output: "optional.none()"
+     - name: "empty-set"
+       input:
+         values:
+           expr: "[1, 2]"
+       output: "optional.none()"
+  - name: "divisible by 4"
+    tests:
+     - name: "true"
+       input:
+          values:
+            expr: "[4, 7]"
+       output: >
+        "at least one divisible by 4"
+  - name: "power of 6"
+    tests:
+     - name: "true"
+       input:
+          values:
+            expr: "[6, 7]"
+       output: >
+        "at least one power of 6"


### PR DESCRIPTION
Introduce support for splitting nested match blocks according to a configurable height limit.

When expressions are more than 25 levels deep, logical AND, logical OR, and conditional operators
will automatically be split into local variables within a `cel.@block`. This depth is configurable
in the event that a different limit is desired.