### PR TITLE
Update NativeTypes doc to reflect how to enable cel tag

### DIFF
--- a/ext/native.go
+++ b/ext/native.go
@@ -81,7 +81,7 @@ var (
 // the time that it is invoked.
 //
 // There is also the possibility to rename the fields of native structs by setting the `cel` tag
-// for fields you want to override. In order to enable this feature, pass in the `EnableStructTag`
+// for fields you want to override. In order to enable this feature, pass in the `ParseStructTags(true)`
 // option. Here is an example to see it in action:
 //
 // ```go


### PR DESCRIPTION
Fixes https://github.com/google/cel-go/issues/1147

Prior, NativeTypes function doc says that 
> There is also the possibility to rename the fields of native structs by setting the `cel` tag for fields you want to override. In order to enable this feature, pass in the `EnableStructTag` option.

However, `EnableStructTag` doesn't exist.

This PR corrects the code comment.


