### PR TITLE
Lightweight observable evaluation

### DIFF
--- a/cel/options.go
+++ b/cel/options.go
@@ -404,7 +404,7 @@ type ProgramOption func(p *prog) (*prog, error)
 // InterpretableDecorators can be used to inspect, alter, or replace the Program plan.
 func CustomDecorator(dec interpreter.InterpretableDecorator) ProgramOption {
 	return func(p *prog) (*prog, error) {
-		p.decorators = append(p.decorators, dec)
+		p.plannerOptions = append(p.plannerOptions, interpreter.CustomDecorator(dec))
 		return p, nil
 	}
 }

--- a/cel/program.go
+++ b/cel/program.go
@@ -162,12 +162,6 @@ type prog struct {
 	costLimit         *uint64
 }
 
-type perEvalCtx struct {
-	details     *EvalDetails
-	costTracker *interpreter.CostTracker
-	init        func()
-}
-
 // newProgram creates a program instance with an environment, an ast, and an optional list of
 // ProgramOption values.
 //

--- a/cel/program.go
+++ b/cel/program.go
@@ -151,28 +151,21 @@ type prog struct {
 
 	// Intermediate state used to configure the InterpretableDecorator set provided
 	// to the initInterpretable call.
-	decorators         []interpreter.InterpretableDecorator
+	plannerOptions     []interpreter.PlannerOption
 	regexOptimizations []*interpreter.RegexOptimization
 
 	// Interpretable configured from an Ast and aggregate decorator set based on program options.
 	interpretable     interpreter.Interpretable
+	observable        *interpreter.ObservableInterpretable
 	callCostEstimator interpreter.ActualCostEstimator
 	costOptions       []interpreter.CostTrackerOption
 	costLimit         *uint64
 }
 
-func (p *prog) clone() *prog {
-	costOptsCopy := make([]interpreter.CostTrackerOption, len(p.costOptions))
-	copy(costOptsCopy, p.costOptions)
-
-	return &prog{
-		Env:                     p.Env,
-		evalOpts:                p.evalOpts,
-		defaultVars:             p.defaultVars,
-		dispatcher:              p.dispatcher,
-		interpreter:             p.interpreter,
-		interruptCheckFrequency: p.interruptCheckFrequency,
-	}
+type perEvalCtx struct {
+	details     *EvalDetails
+	costTracker *interpreter.CostTracker
+	init        func()
 }
 
 // newProgram creates a program instance with an environment, an ast, and an optional list of
@@ -186,10 +179,10 @@ func newProgram(e *Env, a *ast.AST, opts []ProgramOption) (Program, error) {
 	// Ensure the default attribute factory is set after the adapter and provider are
 	// configured.
 	p := &prog{
-		Env:         e,
-		decorators:  []interpreter.InterpretableDecorator{},
-		dispatcher:  disp,
-		costOptions: []interpreter.CostTrackerOption{},
+		Env:            e,
+		plannerOptions: []interpreter.PlannerOption{},
+		dispatcher:     disp,
+		costOptions:    []interpreter.CostTrackerOption{},
 	}
 
 	// Configure the program via the ProgramOption values.
@@ -227,74 +220,71 @@ func newProgram(e *Env, a *ast.AST, opts []ProgramOption) (Program, error) {
 	p.interpreter = interp
 
 	// Translate the EvalOption flags into InterpretableDecorator instances.
-	decorators := make([]interpreter.InterpretableDecorator, len(p.decorators))
-	copy(decorators, p.decorators)
+	plannerOptions := make([]interpreter.PlannerOption, len(p.plannerOptions))
+	copy(plannerOptions, p.plannerOptions)
 
 	// Enable interrupt checking if there's a non-zero check frequency
 	if p.interruptCheckFrequency > 0 {
-		decorators = append(decorators, interpreter.InterruptableEval())
+		plannerOptions = append(plannerOptions, interpreter.InterruptableEval())
 	}
 	// Enable constant folding first.
 	if p.evalOpts&OptOptimize == OptOptimize {
-		decorators = append(decorators, interpreter.Optimize())
+		plannerOptions = append(plannerOptions, interpreter.Optimize())
 		p.regexOptimizations = append(p.regexOptimizations, interpreter.MatchesRegexOptimization)
 	}
 	// Enable regex compilation of constants immediately after folding constants.
 	if len(p.regexOptimizations) > 0 {
-		decorators = append(decorators, interpreter.CompileRegexConstants(p.regexOptimizations...))
+		plannerOptions = append(plannerOptions, interpreter.CompileRegexConstants(p.regexOptimizations...))
 	}
 
 	// Enable exhaustive eval, state tracking and cost tracking last since they require a factory.
 	if p.evalOpts&(OptExhaustiveEval|OptTrackState|OptTrackCost) != 0 {
-		factory := func(state interpreter.EvalState, costTracker *interpreter.CostTracker) (Program, error) {
-			costTracker.Estimator = p.callCostEstimator
-			costTracker.Limit = p.costLimit
-			for _, costOpt := range p.costOptions {
-				err := costOpt(costTracker)
-				if err != nil {
-					return nil, err
-				}
-			}
-			// Limit capacity to guarantee a reallocation when calling 'append(decs, ...)' below. This
-			// prevents the underlying memory from being shared between factory function calls causing
-			// undesired mutations.
-			decs := decorators[:len(decorators):len(decorators)]
-			var observers []interpreter.EvalObserver
-
-			if p.evalOpts&(OptExhaustiveEval|OptTrackState) != 0 {
-				// EvalStateObserver is required for OptExhaustiveEval.
-				observers = append(observers, interpreter.EvalStateObserver(state))
-			}
-			if p.evalOpts&OptTrackCost == OptTrackCost {
-				observers = append(observers, interpreter.CostObserver(costTracker))
-			}
-
-			// Enable exhaustive eval over a basic observer since it offers a superset of features.
-			if p.evalOpts&OptExhaustiveEval == OptExhaustiveEval {
-				decs = append(decs, interpreter.ExhaustiveEval(), interpreter.Observe(observers...))
-			} else if len(observers) > 0 {
-				decs = append(decs, interpreter.Observe(observers...))
-			}
-
-			return p.clone().initInterpretable(a, decs)
+		costOptCount := len(p.costOptions)
+		if p.costLimit != nil {
+			costOptCount++
 		}
-		return newProgGen(factory)
+		costOpts := make([]interpreter.CostTrackerOption, 0, costOptCount)
+		costOpts = append(costOpts, p.costOptions...)
+		if p.costLimit != nil {
+			costOpts = append(costOpts, interpreter.CostTrackerLimit(*p.costLimit))
+		}
+		trackerFactory := func() (*interpreter.CostTracker, error) {
+			return interpreter.NewCostTracker(p.callCostEstimator, costOpts...)
+		}
+		var observers []interpreter.PlannerOption
+		if p.evalOpts&(OptExhaustiveEval|OptTrackState) != 0 {
+			// EvalStateObserver is required for OptExhaustiveEval.
+			observers = append(observers, interpreter.EvalStateObserver())
+		}
+		if p.evalOpts&OptTrackCost == OptTrackCost {
+			observers = append(observers, interpreter.CostObserver(interpreter.CostTrackerFactory(trackerFactory)))
+		}
+		// Enable exhaustive eval over a basic observer since it offers a superset of features.
+		if p.evalOpts&OptExhaustiveEval == OptExhaustiveEval {
+			plannerOptions = append(plannerOptions,
+				append([]interpreter.PlannerOption{interpreter.ExhaustiveEval()}, observers...)...)
+		} else if len(observers) > 0 {
+			plannerOptions = append(plannerOptions, observers...)
+		}
 	}
-	return p.initInterpretable(a, decorators)
+	return p.initInterpretable(a, plannerOptions)
 }
 
-func (p *prog) initInterpretable(a *ast.AST, decs []interpreter.InterpretableDecorator) (*prog, error) {
+func (p *prog) initInterpretable(a *ast.AST, plannerOptions []interpreter.PlannerOption) (*prog, error) {
 	// When the AST has been exprAST it contains metadata that can be used to speed up program execution.
-	interpretable, err := p.interpreter.NewInterpretable(a, decs...)
+	interpretable, err := p.interpreter.NewInterpretable(a, plannerOptions...)
 	if err != nil {
 		return nil, err
 	}
 	p.interpretable = interpretable
+	if oi, ok := interpretable.(*interpreter.ObservableInterpretable); ok {
+		p.observable = oi
+	}
 	return p, nil
 }
 
 // Eval implements the Program interface method.
-func (p *prog) Eval(input any) (v ref.Val, det *EvalDetails, err error) {
+func (p *prog) Eval(input any) (out ref.Val, det *EvalDetails, err error) {
 	// Configure error recovery for unexpected panics during evaluation. Note, the use of named
 	// return values makes it possible to modify the error response during the recovery
 	// function.
@@ -322,12 +312,24 @@ func (p *prog) Eval(input any) (v ref.Val, det *EvalDetails, err error) {
 	if p.defaultVars != nil {
 		vars = interpreter.NewHierarchicalActivation(p.defaultVars, vars)
 	}
-	v = p.interpretable.Eval(vars)
+	if p.observable != nil {
+		det = &EvalDetails{}
+		out = p.observable.ObserveEval(vars, func(observed any) {
+			switch o := observed.(type) {
+			case interpreter.EvalState:
+				det.state = o
+			case *interpreter.CostTracker:
+				det.costTracker = o
+			}
+		})
+	} else {
+		out = p.interpretable.Eval(vars)
+	}
 	// The output of an internal Eval may have a value (`v`) that is a types.Err. This step
 	// translates the CEL value to a Go error response. This interface does not quite match the
 	// RPC signature which allows for multiple errors to be returned, but should be sufficient.
-	if types.IsError(v) {
-		err = v.(*types.Err)
+	if types.IsError(out) {
+		err = out.(*types.Err)
 	}
 	return
 }
@@ -353,88 +355,6 @@ func (p *prog) ContextEval(ctx context.Context, input any) (ref.Val, *EvalDetail
 		return nil, nil, fmt.Errorf("invalid input, wanted Activation or map[string]any, got: (%T)%v", input, input)
 	}
 	return p.Eval(vars)
-}
-
-// progFactory is a helper alias for marking a program creation factory function.
-type progFactory func(interpreter.EvalState, *interpreter.CostTracker) (Program, error)
-
-// progGen holds a reference to a progFactory instance and implements the Program interface.
-type progGen struct {
-	factory progFactory
-}
-
-// newProgGen tests the factory object by calling it once and returns a factory-based Program if
-// the test is successful.
-func newProgGen(factory progFactory) (Program, error) {
-	// Test the factory to make sure that configuration errors are spotted at config
-	tracker, err := interpreter.NewCostTracker(nil)
-	if err != nil {
-		return nil, err
-	}
-	_, err = factory(interpreter.NewEvalState(), tracker)
-	if err != nil {
-		return nil, err
-	}
-	return &progGen{factory: factory}, nil
-}
-
-// Eval implements the Program interface method.
-func (gen *progGen) Eval(input any) (ref.Val, *EvalDetails, error) {
-	// The factory based Eval() differs from the standard evaluation model in that it generates a
-	// new EvalState instance for each call to ensure that unique evaluations yield unique stateful
-	// results.
-	state := interpreter.NewEvalState()
-	costTracker, err := interpreter.NewCostTracker(nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	det := &EvalDetails{state: state, costTracker: costTracker}
-
-	// Generate a new instance of the interpretable using the factory configured during the call to
-	// newProgram(). It is incredibly unlikely that the factory call will generate an error given
-	// the factory test performed within the Program() call.
-	p, err := gen.factory(state, costTracker)
-	if err != nil {
-		return nil, det, err
-	}
-
-	// Evaluate the input, returning the result and the 'state' within EvalDetails.
-	v, _, err := p.Eval(input)
-	if err != nil {
-		return v, det, err
-	}
-	return v, det, nil
-}
-
-// ContextEval implements the Program interface method.
-func (gen *progGen) ContextEval(ctx context.Context, input any) (ref.Val, *EvalDetails, error) {
-	if ctx == nil {
-		return nil, nil, fmt.Errorf("context can not be nil")
-	}
-	// The factory based Eval() differs from the standard evaluation model in that it generates a
-	// new EvalState instance for each call to ensure that unique evaluations yield unique stateful
-	// results.
-	state := interpreter.NewEvalState()
-	costTracker, err := interpreter.NewCostTracker(nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	det := &EvalDetails{state: state, costTracker: costTracker}
-
-	// Generate a new instance of the interpretable using the factory configured during the call to
-	// newProgram(). It is incredibly unlikely that the factory call will generate an error given
-	// the factory test performed within the Program() call.
-	p, err := gen.factory(state, costTracker)
-	if err != nil {
-		return nil, det, err
-	}
-
-	// Evaluate the input, returning the result and the 'state' within EvalDetails.
-	v, _, err := p.ContextEval(ctx, input)
-	if err != nil {
-		return v, det, err
-	}
-	return v, det, nil
 }
 
 type ctxEvalActivation struct {

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -109,6 +109,44 @@ type InterpretableConstructor interface {
 	Type() ref.Type
 }
 
+// ObservableInterpretable is an Interpretable which supports stateful observation, such as tracing
+// or cost-tracking.
+type ObservableInterpretable struct {
+	Interpretable
+	observers []StatefulObserver
+}
+
+// ID implements the Interpretable method to get the expression id associated with the step.
+func (oi *ObservableInterpretable) ID() int64 {
+	return oi.Interpretable.ID()
+}
+
+// Eval proxies to the ObserveEval method while invoking a no-op callback to report the observations.
+func (oi *ObservableInterpretable) Eval(vars Activation) ref.Val {
+	return oi.ObserveEval(vars, func(any) {})
+}
+
+// ObserveEval evaluates an interpretable and performs per-evaluation state-tracking.
+//
+// This method is concurrency safe and the expectation is that the observer function will use
+// a switch statement to determine the type of the state which has been reported back from the call.
+func (oi *ObservableInterpretable) ObserveEval(vars Activation, observer func(any)) ref.Val {
+	var err error
+	// Initialize the state needed for the observers to function.
+	for _, obs := range oi.observers {
+		vars, err = obs.InitState(vars)
+		if err != nil {
+			return types.WrapErr(err)
+		}
+	}
+	result := oi.Interpretable.Eval(vars)
+	// Get the state which needs to be reported back as having been observed.
+	for _, obs := range oi.observers {
+		observer(obs.GetState(vars))
+	}
+	return result
+}
+
 // Core Interpretable implementations used during the program planning phase.
 
 type evalTestOnly struct {
@@ -822,9 +860,9 @@ type evalWatch struct {
 }
 
 // Eval implements the Interpretable interface method.
-func (e *evalWatch) Eval(ctx Activation) ref.Val {
-	val := e.Interpretable.Eval(ctx)
-	e.observer(e.ID(), e.Interpretable, val)
+func (e *evalWatch) Eval(vars Activation) ref.Val {
+	val := e.Interpretable.Eval(vars)
+	e.observer(vars, e.ID(), e.Interpretable, val)
 	return val
 }
 
@@ -883,7 +921,7 @@ func (e *evalWatchAttr) AddQualifier(q Qualifier) (Attribute, error) {
 // Eval implements the Interpretable interface method.
 func (e *evalWatchAttr) Eval(vars Activation) ref.Val {
 	val := e.InterpretableAttribute.Eval(vars)
-	e.observer(e.ID(), e.InterpretableAttribute, val)
+	e.observer(vars, e.ID(), e.InterpretableAttribute, val)
 	return val
 }
 
@@ -904,7 +942,7 @@ func (e *evalWatchConstQual) Qualify(vars Activation, obj any) (any, error) {
 	} else {
 		val = e.adapter.NativeToValue(out)
 	}
-	e.observer(e.ID(), e.ConstantQualifier, val)
+	e.observer(vars, e.ID(), e.ConstantQualifier, val)
 	return out, err
 }
 
@@ -920,7 +958,7 @@ func (e *evalWatchConstQual) QualifyIfPresent(vars Activation, obj any, presence
 		val = types.Bool(present)
 	}
 	if present || presenceOnly {
-		e.observer(e.ID(), e.ConstantQualifier, val)
+		e.observer(vars, e.ID(), e.ConstantQualifier, val)
 	}
 	return out, present, err
 }
@@ -947,7 +985,7 @@ func (e *evalWatchAttrQual) Qualify(vars Activation, obj any) (any, error) {
 	} else {
 		val = e.adapter.NativeToValue(out)
 	}
-	e.observer(e.ID(), e.Attribute, val)
+	e.observer(vars, e.ID(), e.Attribute, val)
 	return out, err
 }
 
@@ -963,7 +1001,7 @@ func (e *evalWatchAttrQual) QualifyIfPresent(vars Activation, obj any, presenceO
 		val = types.Bool(present)
 	}
 	if present || presenceOnly {
-		e.observer(e.ID(), e.Attribute, val)
+		e.observer(vars, e.ID(), e.Attribute, val)
 	}
 	return out, present, err
 }
@@ -984,7 +1022,7 @@ func (e *evalWatchQual) Qualify(vars Activation, obj any) (any, error) {
 	} else {
 		val = e.adapter.NativeToValue(out)
 	}
-	e.observer(e.ID(), e.Qualifier, val)
+	e.observer(vars, e.ID(), e.Qualifier, val)
 	return out, err
 }
 
@@ -1000,7 +1038,7 @@ func (e *evalWatchQual) QualifyIfPresent(vars Activation, obj any, presenceOnly 
 		val = types.Bool(present)
 	}
 	if present || presenceOnly {
-		e.observer(e.ID(), e.Qualifier, val)
+		e.observer(vars, e.ID(), e.Qualifier, val)
 	}
 	return out, present, err
 }
@@ -1014,7 +1052,7 @@ type evalWatchConst struct {
 // Eval implements the Interpretable interface method.
 func (e *evalWatchConst) Eval(vars Activation) ref.Val {
 	val := e.Value()
-	e.observer(e.ID(), e.InterpretableConst, val)
+	e.observer(vars, e.ID(), e.InterpretableConst, val)
 	return val
 }
 
@@ -1187,13 +1225,13 @@ func (a *evalAttr) Eval(ctx Activation) ref.Val {
 }
 
 // Qualify proxies to the Attribute's Qualify method.
-func (a *evalAttr) Qualify(ctx Activation, obj any) (any, error) {
-	return a.attr.Qualify(ctx, obj)
+func (a *evalAttr) Qualify(vars Activation, obj any) (any, error) {
+	return a.attr.Qualify(vars, obj)
 }
 
 // QualifyIfPresent proxies to the Attribute's QualifyIfPresent method.
-func (a *evalAttr) QualifyIfPresent(ctx Activation, obj any, presenceOnly bool) (any, bool, error) {
-	return a.attr.QualifyIfPresent(ctx, obj, presenceOnly)
+func (a *evalAttr) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
+	return a.attr.QualifyIfPresent(vars, obj, presenceOnly)
 }
 
 func (a *evalAttr) IsOptional() bool {
@@ -1226,9 +1264,9 @@ func (c *evalWatchConstructor) ID() int64 {
 }
 
 // Eval implements the Interpretable Eval function.
-func (c *evalWatchConstructor) Eval(ctx Activation) ref.Val {
-	val := c.constructor.Eval(ctx)
-	c.observer(c.ID(), c.constructor, val)
+func (c *evalWatchConstructor) Eval(vars Activation) ref.Val {
+	val := c.constructor.Eval(vars)
+	c.observer(vars, c.ID(), c.constructor, val)
 	return val
 }
 

--- a/interpreter/prune_test.go
+++ b/interpreter/prune_test.go
@@ -498,7 +498,7 @@ func TestPrune(t *testing.T) {
 		dispatcher.Add(funcBindings(t, optionalDecls(t)...)...)
 		interp := NewInterpreter(dispatcher, containers.DefaultContainer, reg, reg, attrs)
 		interpretable, err := interp.NewInterpretable(parsed,
-			ExhaustiveEval(), Observe(EvalStateObserver(state)))
+			ExhaustiveEval(), EvalStateObserver(EvalStateFactory(func() EvalState { return state })))
 		if err != nil {
 			t.Fatalf("NewUncheckedInterpretable() failed: %v", err)
 		}

--- a/interpreter/runtimecost_test.go
+++ b/interpreter/runtimecost_test.go
@@ -143,7 +143,10 @@ func computeCost(t *testing.T, expr string, vars []*decls.VariableDecl, ctx Acti
 		t.Fatalf("checker.Cost() failed: %v", err)
 	}
 	interp := newStandardInterpreter(t, cont, reg, reg, attrs)
-	prg, err := interp.NewInterpretable(checked, Observe(CostObserver(costTracker)))
+	prg, err := interp.NewInterpretable(checked,
+		CostObserver(CostTrackerFactory(func() (*CostTracker, error) {
+			return costTracker, nil
+		})))
 	if err != nil {
 		t.Fatalf(`Failed to check expression "%s", error: %v`, expr, errs.GetErrors())
 	}


### PR DESCRIPTION
Transitions from replanning expressions on each invocation to generating
stateful metadata in a concurrency friendly manner. Offers a 2-4x speedup
over the previous method.

Before:

```
BenchmarkEvalOptions/optimize-12         	 2753293	       571.3 ns/op	      32 B/op	       2 allocs/op
BenchmarkEvalOptions/track-state-12      	  170517	      6829 ns/op	    1729 B/op	      42 allocs/op
BenchmarkEvalOptions/exhaustive-eval-12  	  127220	      8569 ns/op	    1785 B/op	      44 allocs/op
```

After:

```
BenchmarkEvalOptions/optimize-12         	 3305553	       526.5 ns/op	      32 B/op	       2 allocs/op
BenchmarkEvalOptions/track-state-12      	  595286	      1957 ns/op	     368 B/op	       8 allocs/op
BenchmarkEvalOptions/exhaustive-eval-12  	  578535	      2251 ns/op	     368 B/op	       8 allocs/op
```