### PR TITLE
Update type formatting for type params

### DIFF
--- a/common/types/types.go
+++ b/common/types/types.go
@@ -399,6 +399,9 @@ func (t *Type) WithTraits(traits int) *Type {
 
 // String returns a human-readable definition of the type name.
 func (t *Type) String() string {
+	if t.Kind() == TypeParamKind {
+		return fmt.Sprintf("<%s>", t.DeclaredTypeName())
+	}
 	if len(t.Parameters()) == 0 {
 		return t.DeclaredTypeName()
 	}

--- a/common/types/types_test.go
+++ b/common/types/types_test.go
@@ -83,7 +83,7 @@ func TestTypeString(t *testing.T) {
 		},
 		{
 			in:  NewTypeParamType("T"),
-			out: "T",
+			out: "<T>",
 		},
 		// nil-safety tests
 		{


### PR DESCRIPTION
Update formatting on type-param types to better distinguish them from proper types

Before: `T`
After: `<T>`