### PR TITLE
Re-export interpreter.AttributePattern in package cel.

### DIFF
--- a/cel/program.go
+++ b/cel/program.go
@@ -75,7 +75,7 @@ func NewActivation(bindings any) (Activation, error) {
 	return interpreter.NewActivation(bindings)
 }
 
-// PartialActivation extends the Activation interface with a set of UnknownAttributePatterns.
+// PartialActivation extends the Activation interface with a set of unknown AttributePatterns.
 type PartialActivation = interpreter.PartialActivation
 
 // NoVars returns an empty Activation.
@@ -91,7 +91,7 @@ func NoVars() Activation {
 //
 // The `vars` value may either be an Activation or any valid input to the NewActivation call.
 func PartialVars(vars any,
-	unknowns ...*interpreter.AttributePattern) (PartialActivation, error) {
+	unknowns ...*AttributePatternType) (PartialActivation, error) {
 	return interpreter.NewPartialActivation(vars, unknowns...)
 }
 
@@ -108,12 +108,15 @@ func PartialVars(vars any,
 // fully qualified variable name may be `ns.app.a`, `ns.a`, or `a` per the CEL namespace resolution
 // rules. Pick the fully qualified variable name that makes sense within the container as the
 // AttributePattern `varName` argument.
+func AttributePattern(varName string) *AttributePatternType {
+	return interpreter.NewAttributePattern(varName)
+}
+
+// AttributePatternType represents a top-level variable with an optional set of qualifier patterns.
 //
 // See the interpreter.AttributePattern and interpreter.AttributeQualifierPattern for more info
 // about how to create and manipulate AttributePattern values.
-func AttributePattern(varName string) *interpreter.AttributePattern {
-	return interpreter.NewAttributePattern(varName)
-}
+type AttributePatternType = interpreter.AttributePattern
 
 // EvalDetails holds additional information observed during the Eval() call.
 type EvalDetails struct {


### PR DESCRIPTION
The AttributePattern name is taken by a helper function. A different name is thus picked to avoid breaking changes to existing consumers of package cel.

This helps to make `package cel` more complete as the entry point of CEL. Without this change, a consumer of `package cel` can only call `cel.AttributePattern("a")` but cannot create a slice of it, e.g. to pass to `cel.PartialVars(act, ...slice)` var-args.

# Pull Requests Guidelines

See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details about when to create
a GitHub [Pull Request][1] and when other kinds of contributions or
consultation might be more desirable.

When creating a new pull request, please fork the repo and work within a
development branch.

## Commit Messages

* Most changes should be accompanied by tests.
* Commit messages should explain _why_ the changes were made.
```
Summary of change in 50 characters or less

Background on why the change is being made with additional detail on
consequences of the changes elsewhere in the code or to the general
functionality of the library. Multiple paragraphs may be used, but
please keep lines to 72 characters or less.
```

## Reviews

* Perform a self-review.
* Make sure the Travis CI build passes.
* Assign a reviewer once both the above have been completed.

## Merging

* If a CEL maintaner approves the change, it may be merged by the author if
  they have write access. Otherwise, the change will be merged by a maintainer.
* Multiple commits should be squashed before merging.
* Please append the line `closes #<issue-num>: description` in the merge message,
  if applicable.

[1]:  https://help.github.com/articles/about-pull-requests