### PR TITLE
Remove non-functional optional check in test-only selection

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -2670,6 +2670,22 @@ func TestOptionalValuesEval(t *testing.T) {
 		out  any
 	}{
 		{
+			expr: `has({'foo': optional.none()}.foo)`,
+			out:  types.True,
+		},
+		{
+			expr: `has({'foo': optional.none()}.foo.value)`,
+			out:  types.False,
+		},
+		{
+			expr: `has({?'foo': optional.none()}.foo)`,
+			out:  types.False,
+		},
+		{
+			expr: `has({?'foo': optional.none()}.foo.value)`,
+			out:  "no such key: foo",
+		},
+		{
 			expr: `{}.?invalid`,
 			out:  types.OptionalNone,
 		},

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -194,9 +194,6 @@ func (q *testOnlyQualifier) Qualify(vars Activation, obj any) (any, error) {
 	if unk, isUnk := out.(types.Unknown); isUnk {
 		return unk, nil
 	}
-	if opt, isOpt := out.(types.Optional); isOpt {
-		return opt.HasValue(), nil
-	}
 	return present, nil
 }
 


### PR DESCRIPTION
During test-only select expressions a check to see whether a field
was optional was testing the wrong type (`types.Optional` versus
`*types.Optional`) which wound up producing the correct behavior
regarding presence on maps. 

Test cases added to validate the desired behavior.