### PR TITLE
Check arg count when validating optFieldSelect

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -145,6 +145,17 @@ func (c *checker) checkSelect(e ast.Expr) {
 func (c *checker) checkOptSelect(e ast.Expr) {
 	// Collect metadata related to the opt select call packaged by the parser.
 	call := e.AsCall()
+	if len(call.Args()) != 2 || call.IsMemberFunction() {
+		t := ""
+		if call.IsMemberFunction() {
+			t = " member call with"
+		}
+		c.errors.notAnOptionalFieldSelectionCall(e.ID(), c.location(e),
+			fmt.Sprintf(
+				"incorrect signature.%s argument count: %d%s", t, len(call.Args())))
+		return
+	}
+
 	operand := call.Args()[0]
 	field := call.Args()[1]
 	fieldName, isString := maybeUnwrapString(field)

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -2595,6 +2595,46 @@ func TestCheckErrorData(t *testing.T) {
 	}
 }
 
+func TestCheckInvalidOptSelectMember(t *testing.T) {
+	fac := ast.NewExprFactory()
+	target := fac.NewStruct(1, "Foo", nil)
+	arg1 := fac.NewStruct(2, "Foo", nil)
+	arg2 := fac.NewLiteral(3, types.String("field"))
+	call := fac.NewMemberCall(4, "_?._", target, arg1, arg2)
+
+	// This is not valid syntax, just for illustration purposes.
+	src := common.NewTextSource("Foo{}._?._(Foo{}, 'field')")
+	parsed := ast.NewAST(call, ast.NewSourceInfo(src))
+	reg := newTestRegistry(t)
+	env, err := NewEnv(containers.DefaultContainer, reg)
+	if err != nil {
+		t.Fatalf("NewEnv(cont, reg) failed: %v", err)
+	}
+	_, iss := Check(parsed, src, env)
+	if !strings.Contains(iss.ToDisplayString(), "incorrect signature. member call") {
+		t.Errorf("got %s, wanted 'incorrect signature. member call'", iss.ToDisplayString())
+	}
+}
+
+func TestCheckInvalidOptSelectMissingArg(t *testing.T) {
+	fac := ast.NewExprFactory()
+	arg1 := fac.NewStruct(1, "Foo", nil)
+	call := fac.NewCall(2, "_?._", arg1)
+
+	// This is not valid syntax, just for illustration purposes.
+	src := common.NewTextSource("_?._(Foo{})")
+	parsed := ast.NewAST(call, ast.NewSourceInfo(src))
+	reg := newTestRegistry(t)
+	env, err := NewEnv(containers.DefaultContainer, reg)
+	if err != nil {
+		t.Fatalf("NewEnv(cont, reg) failed: %v", err)
+	}
+	_, iss := Check(parsed, src, env)
+	if !strings.Contains(iss.ToDisplayString(), "incorrect signature. argument count: 1") {
+		t.Errorf("got %s, wanted 'incorrect signature. argument count: 1'", iss.ToDisplayString())
+	}
+}
+
 func TestCheckInvalidLiteral(t *testing.T) {
 	fac := ast.NewExprFactory()
 	durLiteral := fac.NewLiteral(1, types.Duration{Duration: time.Second})

--- a/checker/errors.go
+++ b/checker/errors.go
@@ -45,6 +45,10 @@ func (e *typeErrors) notAComprehensionRange(id int64, l common.Location, t *type
 		FormatCELType(t))
 }
 
+func (e *typeErrors) notAnOptionalFieldSelectionCall(id int64, l common.Location, err string) {
+	e.errs.ReportErrorAtID(id, l, "unsupported optional field selection: %s", err)
+}
+
 func (e *typeErrors) notAnOptionalFieldSelection(id int64, l common.Location, field ast.Expr) {
 	e.errs.ReportErrorAtID(id, l, "unsupported optional field selection: %v", field)
 }


### PR DESCRIPTION
Add a check for correct call shape before indexing into call expr arguments in checkOptSelect.

Manually constructed ASTs could lead to a panic.