### PR TITLE
Add documentation for YAML quirks in celpolicy

### DIFF
--- a/policy/BUILD.bazel
+++ b/policy/BUILD.bazel
@@ -71,6 +71,7 @@ go_test(
         "//common/types/ref:go_default_library",
         "//test/proto3pb:go_default_library",
         "@in_gopkg_yaml_v3//:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
     ],
 )
 

--- a/policy/testdata/yaml_parsing/config.yaml
+++ b/policy/testdata/yaml_parsing/config.yaml
@@ -1,0 +1,5 @@
+name: "yaml_parsing"
+
+variables:
+  - name: "match_id"
+    type_name: "string"

--- a/policy/testdata/yaml_parsing/policy.yaml
+++ b/policy/testdata/yaml_parsing/policy.yaml
@@ -1,0 +1,34 @@
+name: yaml_parsing
+
+description: |
+  A block literal description with mutliple lines.
+   - line 2
+   - line 3
+
+rule:
+  match:
+    - condition: "match_id == 'folded_unambiguous'"
+      output: >
+        "a string expression that " +
+        "is folded"
+    - condition: "match_id == 'folded_line_break'"
+      output: >
+        '''a string expression that
+        is folded'''
+    - condition: "match_id == 'folded_line_break_indent'"
+      output: >
+          '''a string expression that
+          is folded'''
+    - condition: "match_id == 'literal_unambiguous'"
+      output: |
+          "a string expression that " +
+          "is a literal block"
+    - condition: "match_id == 'literal_line_break'"
+      output: |
+        '''a string expression that
+        is a literal block'''
+    - condition: "match_id == 'literal_line_break_indent'"
+      output: |
+          '''a string expression that
+          is a literal block'''
+    - output: "'no match encountered'"

--- a/policy/testdata/yaml_parsing_cel_error/config.yaml
+++ b/policy/testdata/yaml_parsing_cel_error/config.yaml
@@ -1,0 +1,4 @@
+name: "yaml_parsing_cel_error"
+variables:
+  - name: "match_id"
+    type_name: "string"

--- a/policy/testdata/yaml_parsing_cel_error/policy.yaml
+++ b/policy/testdata/yaml_parsing_cel_error/policy.yaml
@@ -1,0 +1,24 @@
+name: yaml_parsing_cel_error
+
+description: |
+    A block literal description with mutliple lines.
+
+rule:
+  match:
+    - condition: "match_id == 'folded_error_presentation'"
+      output: >
+        "foo" +
+        ("bar" + 1)
+    - condition: "match_id == 'folded_error_presentation_indent'"
+      output: >
+          "foo" +
+          ("bar" + 1)
+    - condition: "match_id == 'literal_error_presentation'"
+      output: |
+        "foo" +
+        ("bar" + 1)
+    - condition: "match_id == 'literal_error_presentation_indent'"
+      output: |
+          "foo" +
+          ("bar" + 1)
+    - output: "'no match encountered'"


### PR DESCRIPTION
Also add top-level description field.

The celpolicy parser has special handling for CEL expressions embedded in
the YAML document in order to preserve location information. This is used
to help the CEL compiler correctly highlight error location.

As a consequence, the CEL expression will include characters that are
normally not considered meaningful in YAML, and the literal and folded style
for multiline strings are treated identically.