### PR TITLE
Add test runner option to configure a custom test suite parser

### DIFF
--- a/tools/celtest/BUILD.bazel
+++ b/tools/celtest/BUILD.bazel
@@ -67,7 +67,9 @@ go_test(
         "//common/types:go_default_library",
         "//common/types/ref:go_default_library",
         "//policy:go_default_library",
+        "//test:go_default_library",
         "//tools/compiler:go_default_library",
+        "@dev_cel_expr//conformance/test:go_default_library",
         "@in_gopkg_yaml_v3//:go_default_library",
     ]
 )

--- a/tools/celtest/test_runner.go
+++ b/tools/celtest/test_runner.go
@@ -257,7 +257,8 @@ func (p *tsParser) ParseYAML(path string) (*test.Suite, error) {
 	return testSuite, err
 }
 
-// DefaultTestSuiteParser returns a TestRunnerOption which configures the test runner with a test suite parser.
+// DefaultTestSuiteParser returns a TestRunnerOption which configures the test runner with
+// the default test suite parser.
 func DefaultTestSuiteParser(path string) TestRunnerOption {
 	return func(tr *TestRunner) (*TestRunner, error) {
 		if path == "" {
@@ -265,6 +266,15 @@ func DefaultTestSuiteParser(path string) TestRunnerOption {
 		}
 		tr.TestSuiteFilePath = path
 		tr.testSuiteParser = &tsParser{}
+		return tr, nil
+	}
+}
+
+// TestSuiteParserOption returns a TestRunnerOption which configures the test runner with
+// a custom test suite parser.
+func TestSuiteParserOption(p TestSuiteParser) TestRunnerOption {
+	return func(tr *TestRunner) (*TestRunner, error) {
+		tr.testSuiteParser = p
 		return tr, nil
 	}
 }

--- a/tools/celtest/test_runner.go
+++ b/tools/celtest/test_runner.go
@@ -363,13 +363,23 @@ func TestExpression(value string) TestRunnerOption {
 	}
 }
 
-// TestCompiler configures a compiler to use for testing.
+// TestCompiler returns a TestRunnerOption which configures the test runner with
+// a compiler created using the set of compiler options.
 func TestCompiler(compileOpts ...any) TestRunnerOption {
 	return func(tr *TestRunner) (*TestRunner, error) {
 		c, err := compiler.NewCompiler(compileOpts...)
 		if err != nil {
 			return nil, err
 		}
+		tr.Compiler = c
+		return tr, nil
+	}
+}
+
+// CustomTestCompiler returns a TestRunnerOption which configures the test runner with
+// a custom compiler.
+func CustomTestCompiler(c compiler.Compiler) TestRunnerOption {
+	return func(tr *TestRunner) (*TestRunner, error) {
 		tr.Compiler = c
 		return tr, nil
 	}

--- a/tools/celtest/test_runner_test.go
+++ b/tools/celtest/test_runner_test.go
@@ -230,17 +230,19 @@ type tsparser struct {
 	TestSuiteParser
 }
 
+// ParseTextproto implements the ParseTextproto method of the TestSuiteParser interface.
 func (p *tsparser) ParseTextproto(_ string) (*conformancepb.TestSuite, error) {
 	return nil, nil
 }
 
+// ParseYAML implements the ParseYAML method of the TestSuiteParser interface.
 func (p *tsparser) ParseYAML(_ string) (*test.Suite, error) {
 	testCase := &test.Case{
 		Name: "sample test case",
 		Input: map[string]*test.InputValue{
-			"i": &test.InputValue{Value: 21},
-			"j": &test.InputValue{Value: 42},
-			"a": &test.InputValue{Value: false},
+			"i": {Value: 21},
+			"j": {Value: 42},
+			"a": {Value: false},
 		},
 		Output: &test.Output{Value: true},
 	}

--- a/tools/celtest/test_runner_test.go
+++ b/tools/celtest/test_runner_test.go
@@ -119,10 +119,7 @@ func TestTriggerTestsWithRunnerOptions(t *testing.T) {
 		if err != nil {
 			t.Fatalf("compiler.NewCompiler() failed: %v", err)
 		}
-		compilerOpt := TestRunnerOption(func(tr *TestRunner) (*TestRunner, error) {
-			tr.Compiler = c
-			return tr, nil
-		})
+		compilerOpt := CustomTestCompiler(c)
 		opts := []TestRunnerOption{compilerOpt, testSuiteParser, testCELPolicy}
 		TriggerTests(t, opts...)
 	})

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,8 +3,7 @@ module github.com/google/cel-go/tools
 go 1.23.0
 
 require (
-	cel.dev/expr v0.23.1
-	github.com/bazelbuild/rules_go v0.54.0
+	cel.dev/expr v0.24.0
 	github.com/google/cel-go v0.22.0
 	github.com/google/cel-go/policy v0.0.0-20250311174852-f5ea07b389a1
 	github.com/google/go-cmp v0.6.0

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,9 +1,7 @@
-cel.dev/expr v0.23.1 h1:K4KOtPCJQjVggkARsjG9RWXP6O4R73aHeJMa/dmCQQg=
-cel.dev/expr v0.23.1/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
+cel.dev/expr v0.24.0 h1:56OvJKSH3hDGL0ml5uSxZmz3/3Pq4tJ+fb1unVLAFcY=
+cel.dev/expr v0.24.0/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
-github.com/bazelbuild/rules_go v0.54.0 h1:D9aCU7j5rdRxg2rXOZX5zHZ395XC0KbgC4rnyaQ3ofM=
-github.com/bazelbuild/rules_go v0.54.0/go.mod h1:T90Gpyq4HDFlsrvtQa2CBdHNJ2P4rAu/uUTmQbanzf0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This change adds the following:
1. A TestRunnerOption which allows configuring a custom test suite parser in the test runner.
2. A TestRunnerOption which allows configuring a custom compiler in the test runner