### PR TITLE
Comprehension nesting limit typo, allow nesting limit validator to accept doubles as limits

### DIFF
--- a/cel/env_test.go
+++ b/cel/env_test.go
@@ -877,10 +877,16 @@ func TestEnvFromConfigErrors(t *testing.T) {
 			want: errors.New("invalid validator"),
 		},
 		{
-			name: "invalid validator config type",
+			name: "invalid validator config type - unsupported type",
 			conf: env.NewConfig("invalid validator config").
-				AddValidators(env.NewValidator("cel.validator.comprehension_nesting_limit").SetConfig(map[string]any{"limit": 2.0})),
+				AddValidators(env.NewValidator("cel.validator.comprehension_nesting_limit").SetConfig(map[string]any{"limit": "2"})),
 			want: errors.New("invalid validator"),
+		},
+		{
+			name: "invalid validator config type - fractional",
+			conf: env.NewConfig("invalid validator config").
+				AddValidators(env.NewValidator("cel.validator.comprehension_nesting_limit").SetConfig(map[string]any{"limit": 2.5})),
+			want: errors.New("invalid validator: cel.validator.comprehension_nesting_limit, limit value is not a whole number: 2.5"),
 		},
 	}
 	for _, tst := range tests {

--- a/cel/validator.go
+++ b/cel/validator.go
@@ -45,6 +45,14 @@ var (
 	astValidatorFactories = map[string]ASTValidatorFactory{
 		nestingLimitValidatorName: func(val *env.Validator) (ASTValidator, error) {
 			if limit, found := val.ConfigValue("limit"); found {
+				// In case of protos, config value is of type by google.protobuf.Value, which numeric values are always a double.
+				if val, isDouble := limit.(float64); isDouble {
+					if val != float64(int64(val)) {
+						return nil, fmt.Errorf("invalid validator: %s, limit value is not a whole number: %v", nestingLimitValidatorName, limit)
+					}
+					return ValidateComprehensionNestingLimit(int(val)), nil
+				}
+
 				if val, isInt := limit.(int); isInt {
 					return ValidateComprehensionNestingLimit(val), nil
 				}

--- a/common/env/env_test.go
+++ b/common/env/env_test.go
@@ -106,7 +106,7 @@ func TestConfig(t *testing.T) {
 				NewValidator("cel.validator.duration"),
 				NewValidator("cel.validator.matches"),
 				NewValidator("cel.validator.timestamp"),
-				NewValidator("cel.validator.nesting_comprehension_limit").
+				NewValidator("cel.validator.comprehension_nesting_limit").
 					SetConfig(map[string]any{"limit": 2}),
 			),
 		},

--- a/common/env/testdata/extended_env.yaml
+++ b/common/env/testdata/extended_env.yaml
@@ -53,7 +53,7 @@ validators:
   - name: cel.validator.duration
   - name: cel.validator.matches
   - name: cel.validator.timestamp
-  - name: cel.validator.nesting_comprehension_limit
+  - name: cel.validator.comprehension_nesting_limit
     config:
       limit: 2
 features:

--- a/tools/compiler/compiler.go
+++ b/tools/compiler/compiler.go
@@ -323,7 +323,7 @@ func envToValidators(pbEnv *configpb.Environment) ([]*env.Validator, error) {
 		config := map[string]any{}
 		for k, v := range pbValidator.GetConfig() {
 			val := types.DefaultTypeAdapter.NativeToValue(v)
-			config[k] = val
+			config[k] = val.Value()
 		}
 		validator.SetConfig(config)
 		validators = append(validators, validator)

--- a/tools/compiler/compiler_test.go
+++ b/tools/compiler/compiler_test.go
@@ -323,7 +323,7 @@ func testEnvProto() *configpb.Environment {
 			{
 				Name: "cel.validator.comprehension_nesting_limit",
 				Config: map[string]*structpb.Value{
-					"limits": structpb.NewNumberValue(2),
+					"limit": structpb.NewNumberValue(2),
 				},
 			},
 		},

--- a/tools/compiler/compiler_test.go
+++ b/tools/compiler/compiler_test.go
@@ -321,7 +321,7 @@ func testEnvProto() *configpb.Environment {
 		Validators: []*configpb.Validator{
 			{Name: "cel.validator.duration"},
 			{
-				Name: "cel.validator.nesting_comprehension_limit",
+				Name: "cel.validator.comprehension_nesting_limit",
 				Config: map[string]*structpb.Value{
 					"limits": structpb.NewNumberValue(2),
 				},

--- a/tools/compiler/testdata/config.yaml
+++ b/tools/compiler/testdata/config.yaml
@@ -74,7 +74,7 @@ functions:
           type_name: "string"
 validators:
   - name: cel.validator.duration
-  - name: cel.validator.nesting_comprehension_limit
+  - name: cel.validator.comprehension_nesting_limit
     config:
       limit: 2
 features:


### PR DESCRIPTION
cel.validator.nesting_comprehension_limit -> cel.validator.comprehension_nesting_limit

Separately, this revealed a bug where we weren't able to instantiate the comprehension nesting limit validator from textproto's config, [because its limit value is always a double](https://github.com/google/cel-spec/blob/9f069b3ee58b02d6f6736c5ebd6587075c1a1b22/proto/cel/expr/conformance/env_config.proto#L131).