### PR TITLE
Init function bindings on environment init

### DIFF
--- a/cel/decls_test.go
+++ b/cel/decls_test.go
@@ -157,17 +157,13 @@ func TestFunctionMerge(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "already has a singleton binding") {
 		t.Errorf("NewCustomEnv(size, size) did not produce the expected error: %v", err)
 	}
-	e, err = NewCustomEnv(size,
+	_, err = NewCustomEnv(size,
 		Function("size",
 			Overload("size_int", []*Type{IntType}, IntType,
 				UnaryBinding(func(arg ref.Val) ref.Val { return types.Int(2) }),
 			),
 		),
 	)
-	if err != nil {
-		t.Fatalf("NewCustomEnv(size, <custom>) failed: %v", err)
-	}
-	_, err = e.Program(ast)
 	if err == nil || !strings.Contains(err.Error(), "incompatible with specialized overloads") {
 		t.Errorf("NewCustomEnv(size, size_specialization) did not produce the expected error: %v", err)
 	}

--- a/cel/decls_test.go
+++ b/cel/decls_test.go
@@ -157,13 +157,17 @@ func TestFunctionMerge(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "already has a singleton binding") {
 		t.Errorf("NewCustomEnv(size, size) did not produce the expected error: %v", err)
 	}
-	_, err = NewCustomEnv(size,
+	e, err = NewCustomEnv(size,
 		Function("size",
 			Overload("size_int", []*Type{IntType}, IntType,
 				UnaryBinding(func(arg ref.Val) ref.Val { return types.Int(2) }),
 			),
 		),
 	)
+	if err != nil {
+		t.Fatalf("NewCustomEnv(size, <custom>) failed: %v", err)
+	}
+	_, err = e.Program(ast)
 	if err == nil || !strings.Contains(err.Error(), "incompatible with specialized overloads") {
 		t.Errorf("NewCustomEnv(size, size_specialization) did not produce the expected error: %v", err)
 	}

--- a/cel/env.go
+++ b/cel/env.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/cel-go/common/containers"
 	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/env"
+	"github.com/google/cel-go/common/functions"
 	"github.com/google/cel-go/common/stdlib"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
@@ -129,18 +130,19 @@ func FormatCELType(t *Type) string {
 // Env encapsulates the context necessary to perform parsing, type checking, or generation of
 // evaluable programs for different expressions.
 type Env struct {
-	Container       *containers.Container
-	variables       []*decls.VariableDecl
-	functions       map[string]*decls.FunctionDecl
-	macros          []Macro
-	contextProto    protoreflect.MessageDescriptor
-	adapter         types.Adapter
-	provider        types.Provider
-	features        map[int]bool
-	appliedFeatures map[int]bool
-	libraries       map[string]SingletonLibrary
-	validators      []ASTValidator
-	costOptions     []checker.CostOption
+	Container        *containers.Container
+	variables        []*decls.VariableDecl
+	functions        map[string]*decls.FunctionDecl
+	functionBindings []*functions.Overload
+	macros           []Macro
+	contextProto     protoreflect.MessageDescriptor
+	adapter          types.Adapter
+	provider         types.Provider
+	features         map[int]bool
+	appliedFeatures  map[int]bool
+	libraries        map[string]SingletonLibrary
+	validators       []ASTValidator
+	costOptions      []checker.CostOption
 
 	// Internal parser representation
 	prsr     *parser.Parser
@@ -320,18 +322,19 @@ func NewCustomEnv(opts ...EnvOption) (*Env, error) {
 		return nil, err
 	}
 	return (&Env{
-		variables:       []*decls.VariableDecl{},
-		functions:       map[string]*decls.FunctionDecl{},
-		macros:          []parser.Macro{},
-		Container:       containers.DefaultContainer,
-		adapter:         registry,
-		provider:        registry,
-		features:        map[int]bool{},
-		appliedFeatures: map[int]bool{},
-		libraries:       map[string]SingletonLibrary{},
-		validators:      []ASTValidator{},
-		progOpts:        []ProgramOption{},
-		costOptions:     []checker.CostOption{},
+		variables:        []*decls.VariableDecl{},
+		functions:        map[string]*decls.FunctionDecl{},
+		functionBindings: []*functions.Overload{},
+		macros:           []parser.Macro{},
+		Container:        containers.DefaultContainer,
+		adapter:          registry,
+		provider:         registry,
+		features:         map[int]bool{},
+		appliedFeatures:  map[int]bool{},
+		libraries:        map[string]SingletonLibrary{},
+		validators:       []ASTValidator{},
+		progOpts:         []ProgramOption{},
+		costOptions:      []checker.CostOption{},
 	}).configure(opts)
 }
 
@@ -791,6 +794,16 @@ func (e *Env) configure(opts []EnvOption) (*Env, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	// Precalculate function bindings
+	e.functionBindings = []*functions.Overload{}
+	for _, fn := range e.functions {
+		bindings, err := fn.Bindings()
+		if err != nil {
+			return nil, err
+		}
+		e.functionBindings = append(e.functionBindings, bindings...)
 	}
 
 	return e, nil

--- a/cel/program.go
+++ b/cel/program.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/functions"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter"
@@ -189,6 +190,21 @@ func newProgram(e *Env, a *ast.AST, opts []ProgramOption) (Program, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	e.funcBindOnce.Do(func() {
+		var bindings []*functions.Overload
+		e.functionBindings = []*functions.Overload{}
+		for _, fn := range e.functions {
+			bindings, err = fn.Bindings()
+			if err != nil {
+				return
+			}
+			e.functionBindings = append(e.functionBindings, bindings...)
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	// Add the function bindings created via Function() options.

--- a/cel/program.go
+++ b/cel/program.go
@@ -192,15 +192,9 @@ func newProgram(e *Env, a *ast.AST, opts []ProgramOption) (Program, error) {
 	}
 
 	// Add the function bindings created via Function() options.
-	for _, fn := range e.functions {
-		bindings, err := fn.Bindings()
-		if err != nil {
-			return nil, err
-		}
-		err = disp.Add(bindings...)
-		if err != nil {
-			return nil, err
-		}
+	err = disp.Add(e.functionBindings...)
+	if err != nil {
+		return nil, err
 	}
 
 	// Set the attribute factory after the options have been set.


### PR DESCRIPTION
While performing some performance testing for one of my projects, I saw that in case of creating many (a lot of) CEL programs in the same environment, creation of function bindings for them can take a significant percentage of CPU time, because they are being regenerated on every program creation, which, as I can see from code, feels really excessive. This PR suggest a way to perform calculation of bindings once for environment configuration and then reuse this bindings in program creation.

Probably, there also should be provided a way to change this behavior through options, let me know if that feels more acceptable with them.

# Pull Requests Guidelines

See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details about when to create
a GitHub [Pull Request][1] and when other kinds of contributions or
consultation might be more desirable.

When creating a new pull request, please fork the repo and work within a
development branch.

## Commit Messages

* Most changes should be accompanied by tests.
* Commit messages should explain _why_ the changes were made.
```
Summary of change in 50 characters or less

Background on why the change is being made with additional detail on
consequences of the changes elsewhere in the code or to the general
functionality of the library. Multiple paragraphs may be used, but
please keep lines to 72 characters or less.
```

## Reviews

* Perform a self-review.
* Make sure the Travis CI build passes.
* Assign a reviewer once both the above have been completed.

## Merging

* If a CEL maintaner approves the change, it may be merged by the author if
  they have write access. Otherwise, the change will be merged by a maintainer.
* Multiple commits should be squashed before merging.
* Please append the line `closes #<issue-num>: description` in the merge message,
  if applicable.

[1]:  https://help.github.com/articles/about-pull-requests