### PR TITLE
Add type checker changes for supporting annotations.

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -154,7 +154,7 @@ func (c *checker) checkOptSelect(e ast.Expr) {
 		}
 		c.errors.notAnOptionalFieldSelectionCall(e.ID(), c.location(e),
 			fmt.Sprintf(
-				"incorrect signature.%s argument count: %d%s", t, len(call.Args())))
+				"incorrect signature.%s argument count: %d", t, len(call.Args())))
 		return
 	}
 

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -72,6 +72,7 @@ func (c *checker) check(e ast.Expr) {
 	if e == nil {
 		return
 	}
+	e = maybeFetchExprFromAnnotationCall(e)
 	switch e.Kind() {
 	case ast.LiteralKind:
 		literal := ref.Val(e.AsLiteral())
@@ -135,7 +136,8 @@ func (c *checker) checkSelect(e ast.Expr) {
 		}
 	}
 
-	resultType := c.checkSelectField(e, sel.Operand(), sel.FieldName(), false)
+	operand := maybeFetchExprFromAnnotationCall(sel.Operand())
+	resultType := c.checkSelectField(e, operand, sel.FieldName(), false)
 	if sel.IsTestOnly() {
 		resultType = types.BoolType
 	}
@@ -152,12 +154,12 @@ func (c *checker) checkOptSelect(e ast.Expr) {
 		}
 		c.errors.notAnOptionalFieldSelectionCall(e.ID(), c.location(e),
 			fmt.Sprintf(
-				"incorrect signature.%s argument count: %d", t, len(call.Args())))
+				"incorrect signature.%s argument count: %d%s", t, len(call.Args())))
 		return
 	}
 
-	operand := call.Args()[0]
-	field := call.Args()[1]
+	operand := maybeFetchExprFromAnnotationCall(call.Args()[0])
+	field := maybeFetchExprFromAnnotationCall(call.Args()[1])
 	fieldName, isString := maybeUnwrapString(field)
 	if !isString {
 		c.errors.notAnOptionalFieldSelection(field.ID(), c.location(field), field)
@@ -226,9 +228,12 @@ func (c *checker) checkCall(e ast.Expr) {
 	}
 
 	args := call.Args()
+	var unaugmentedArgs []ast.Expr
 	// Traverse arguments.
 	for _, arg := range args {
+		arg = maybeFetchExprFromAnnotationCall(arg)
 		c.check(arg)
+		unaugmentedArgs = append(unaugmentedArgs, arg)
 	}
 
 	// Regular static call with simple name.
@@ -243,7 +248,7 @@ func (c *checker) checkCall(e ast.Expr) {
 		// Overwrite the function name with its fully qualified resolved name.
 		e.SetKindCase(c.NewCall(e.ID(), fn.Name(), args...))
 		// Check to see whether the overload resolves.
-		c.resolveOverloadOrError(e, fn, nil, args)
+		c.resolveOverloadOrError(e, fn, nil, unaugmentedArgs)
 		return
 	}
 
@@ -252,7 +257,7 @@ func (c *checker) checkCall(e ast.Expr) {
 	// target a.b.
 	//
 	// Check whether the target is a namespaced function name.
-	target := call.Target()
+	target := maybeFetchExprFromAnnotationCall(call.Target())
 	qualifiedPrefix, maybeQualified := containers.ToQualifiedName(target)
 	if maybeQualified {
 		maybeQualifiedName := qualifiedPrefix + "." + fnName
@@ -262,7 +267,7 @@ func (c *checker) checkCall(e ast.Expr) {
 			// be an inaccurate representation of the desired evaluation behavior.
 			// Overwrite with fully-qualified resolved function name sans receiver target.
 			e.SetKindCase(c.NewCall(e.ID(), fn.Name(), args...))
-			c.resolveOverloadOrError(e, fn, nil, args)
+			c.resolveOverloadOrError(e, fn, nil, unaugmentedArgs)
 			return
 		}
 	}
@@ -272,7 +277,7 @@ func (c *checker) checkCall(e ast.Expr) {
 	fn := c.env.LookupFunction(fnName)
 	// Function found, attempt overload resolution.
 	if fn != nil {
-		c.resolveOverloadOrError(e, fn, target, args)
+		c.resolveOverloadOrError(e, fn, target, unaugmentedArgs)
 		return
 	}
 	// Function name not declared, record error.
@@ -389,6 +394,7 @@ func (c *checker) checkCreateList(e ast.Expr) {
 		optionals[optInd] = true
 	}
 	for i, e := range create.Elements() {
+		e = maybeFetchExprFromAnnotationCall(e)
 		c.check(e)
 		elemType := c.getType(e)
 		if optionals[int32(i)] {
@@ -413,11 +419,11 @@ func (c *checker) checkCreateMap(e ast.Expr) {
 	var mapValueType *types.Type
 	for _, e := range mapVal.Entries() {
 		entry := e.AsMapEntry()
-		key := entry.Key()
+		key := maybeFetchExprFromAnnotationCall(entry.Key())
 		c.check(key)
 		mapKeyType = c.joinTypes(key, mapKeyType, c.getType(key))
 
-		val := entry.Value()
+		val := maybeFetchExprFromAnnotationCall(entry.Value())
 		c.check(val)
 		valType := c.getType(val)
 		if entry.IsOptional() {
@@ -480,7 +486,7 @@ func (c *checker) checkCreateStruct(e ast.Expr) {
 	for _, f := range msgVal.Fields() {
 		field := f.AsStructField()
 		fieldName := field.Name()
-		value := field.Value()
+		value := maybeFetchExprFromAnnotationCall(field.Value())
 		c.check(value)
 
 		fieldType := types.ErrorType
@@ -505,13 +511,15 @@ func (c *checker) checkCreateStruct(e ast.Expr) {
 
 func (c *checker) checkComprehension(e ast.Expr) {
 	comp := e.AsComprehension()
-	c.check(comp.IterRange())
-	c.check(comp.AccuInit())
-	rangeType := substitute(c.mappings, c.getType(comp.IterRange()), false)
+	iterRange := maybeFetchExprFromAnnotationCall(comp.IterRange())
+	c.check(iterRange)
+	accuInit := maybeFetchExprFromAnnotationCall(comp.AccuInit())
+	c.check(accuInit)
+	rangeType := substitute(c.mappings, c.getType(iterRange), false)
 
 	// Create a scope for the comprehension since it has a local accumulation variable.
 	// This scope will contain the accumulation variable used to compute the result.
-	accuType := c.getType(comp.AccuInit())
+	accuType := c.getType(accuInit)
 	c.env = c.env.enterScope()
 	c.env.AddIdents(decls.NewVariable(comp.AccuVar(), accuType))
 
@@ -558,16 +566,19 @@ func (c *checker) checkComprehension(e ast.Expr) {
 		c.env.AddIdents(decls.NewVariable(comp.IterVar2(), var2Type))
 	}
 	// Check the variable references in the condition and step.
-	c.check(comp.LoopCondition())
-	c.assertType(comp.LoopCondition(), types.BoolType)
-	c.check(comp.LoopStep())
-	c.assertType(comp.LoopStep(), accuType)
+	loopCondition := maybeFetchExprFromAnnotationCall(comp.LoopCondition())
+	c.check(loopCondition)
+	c.assertType(loopCondition, types.BoolType)
+	loopStep := maybeFetchExprFromAnnotationCall(comp.LoopStep())
+	c.check(loopStep)
+	c.assertType(loopStep, accuType)
 	// Exit the loop's block scope before checking the result.
 	c.env = c.env.exitScope()
-	c.check(comp.Result())
+	result := maybeFetchExprFromAnnotationCall(comp.Result())
+	c.check(result)
 	// Exit the comprehension scope.
 	c.env = c.env.exitScope()
-	c.setType(e, substitute(c.mappings, c.getType(comp.Result()), false))
+	c.setType(e, substitute(c.mappings, c.getType(result), false))
 }
 
 // Checks compatibility of joined types, and returns the most general common type.
@@ -707,6 +718,22 @@ func getWellKnownTypeName(t *types.Type) string {
 		return name
 	}
 	return ""
+}
+
+// isAnnotation returns true if the given expression is an cel.@annotation call,
+// where the first argument is the original expression being annotated and the second argument
+// is the node containing the annotations.
+func isAnnotation(e ast.Expr) bool {
+	return e.Kind() == ast.CallKind && e.AsCall().FunctionName() == "cel.@annotation" && len(e.AsCall().Args()) == 2
+}
+
+// maybeFetchExprFromAnnotationCall returns the first argument of an annotation call, which is the original expression
+// being annotated.
+func maybeFetchExprFromAnnotationCall(e ast.Expr) ast.Expr {
+	if isAnnotation(e) {
+		return e.AsCall().Args()[0]
+	}
+	return e
 }
 
 var (

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -2722,9 +2722,9 @@ func TestCheckAugmentedListElement(t *testing.T) {
 	identX := fac.NewIdent(1, "x")
 	// create a stand-in for an annotation list.
 	// this doesn't have to be a valid annotation, just a list that is wrapped in a call.
-	annotation := fac.NewList(2, []ast.Expr{}, []int32{})
+	annotation := fac.NewList(2, []ast.Expr{}, nil)
 	annotatedX := fac.NewCall(3, "cel.@annotation", identX, annotation)
-	list := fac.NewList(4, []ast.Expr{annotatedX}, []int32{})
+	list := fac.NewList(4, []ast.Expr{annotatedX}, nil)
 
 	// This is not valid syntax, just for illustration purposes.
 	src := common.NewTextSource("[x]")
@@ -2770,7 +2770,7 @@ func TestCheckAugmentedCallArgument(t *testing.T) {
 		// create the expression size(x) where x is a list of ints.
 		identX := fac.NewIdent(1, "x")
 		// create a stand-in for an annotation list.
-		annotation := fac.NewList(2, []ast.Expr{}, []int32{})
+		annotation := fac.NewList(2, []ast.Expr{}, nil)
 		annotatedX := fac.NewCall(3, "cel.@annotation", identX, annotation)
 		// create the call size(annotatedX)
 		call := fac.NewCall(4, "size", annotatedX)
@@ -2804,7 +2804,7 @@ func TestCheckAugmentedCallArgument(t *testing.T) {
 		// test list[annotated_index]
 		listVar := fac.NewIdent(1, "x")
 		indexVar := fac.NewIdent(2, "i")
-		annotation := fac.NewList(3, []ast.Expr{}, []int32{})
+		annotation := fac.NewList(3, []ast.Expr{}, nil)
 		annotatedIndex := fac.NewCall(4, "cel.@annotation", indexVar, annotation)
 		call := fac.NewCall(5, "_[_]", listVar, annotatedIndex)
 
@@ -2850,7 +2850,7 @@ func TestCheckAugmentedMapKeyAndValue(t *testing.T) {
 	identX := fac.NewIdent(1, "x")
 	identY := fac.NewIdent(2, "y")
 	// create a stand-in for an annotation list.
-	annotation := fac.NewList(3, []ast.Expr{}, []int32{})
+	annotation := fac.NewList(3, []ast.Expr{}, nil)
 	annotatedX := fac.NewCall(4, "cel.@annotation", identX, annotation)
 	annotatedY := fac.NewCall(5, "cel.@annotation", identY, annotation)
 
@@ -2923,7 +2923,7 @@ func TestCheckAugmentedStructFields(t *testing.T) {
 	// create the expression TestAllTypes{single_int32: x} where x is an int.
 	identX := fac.NewIdent(1, "x")
 	// create a stand-in for an annotation list.
-	annotation := fac.NewList(2, []ast.Expr{}, []int32{})
+	annotation := fac.NewList(2, []ast.Expr{}, nil)
 	annotatedX := fac.NewCall(3, "cel.@annotation", identX, annotation)
 
 	field := fac.NewStructField(4, "single_int32", annotatedX, false)
@@ -2963,10 +2963,10 @@ func TestCheckAugmentedComprehension(t *testing.T) {
 
 	// create the expression [true].all(i, i == true)
 	// annotations on iterRange, accuInit, loopCond, loopStep, result
-	annotation := fac.NewList(1, []ast.Expr{}, []int32{})
+	annotation := fac.NewList(1, []ast.Expr{}, nil)
 
 	// iterRange: [true]
-	iterRange := fac.NewList(2, []ast.Expr{fac.NewLiteral(3, types.True)}, []int32{})
+	iterRange := fac.NewList(2, []ast.Expr{fac.NewLiteral(3, types.True)}, nil)
 	annotatedIterRange := fac.NewCall(4, "cel.@annotation", iterRange, annotation)
 
 	// accuInit: true
@@ -3018,7 +3018,7 @@ func TestCheckAugmentedSelectOperand(t *testing.T) {
 	// create the expression x.single_int32 where x is a TestAllTypes.
 	identX := fac.NewIdent(1, "x")
 	// create a stand-in for an annotation list.
-	annotation := fac.NewList(2, []ast.Expr{}, []int32{})
+	annotation := fac.NewList(2, []ast.Expr{}, nil)
 	annotatedX := fac.NewCall(3, "cel.@annotation", identX, annotation)
 
 	sel := fac.NewSelect(4, annotatedX, "single_int32")


### PR DESCRIPTION
This PR includes changes in the type-checker to completely bypass the type-checking of annotations. This decision is based on our intention to use only static annotations (injected after policy/expression compilation and before any optimizations) for coverage purposes.