### PR TITLE
Support unwrapping unknown implementations of `proto.Message`

### DIFF
--- a/common/types/pb/type.go
+++ b/common/types/pb/type.go
@@ -472,7 +472,7 @@ func unwrap(desc description, msg proto.Message) (any, bool, error) {
 		}
 		return v.GetValue(), true, nil
 	}
-	return msg, false, nil
+	return unwrapDynamic(desc, msg.ProtoReflect())
 }
 
 // unwrapDynamic unwraps a reflected protobuf Message value.

--- a/common/types/pb/type_test.go
+++ b/common/types/pb/type_test.go
@@ -430,6 +430,10 @@ func TestTypeDescriptionMaybeUnwrap(t *testing.T) {
 			in:  dpb.New(time.Duration(345)),
 			out: time.Duration(345),
 		},
+		{
+			in:  struct{ proto.Message }{wrapperspb.Int32(1234)},
+			out: int32(1234),
+		},
 	}
 	for _, tc := range tests {
 		typeName := string(tc.in.ProtoReflect().Descriptor().FullName())


### PR DESCRIPTION
`proto.Message` can have implementations outside of protobuf module, all such cases should be treated as a dynamic message.