### PR TITLE
Add logic to unwrap activiations and return evalState for the underlying activations

### DIFF
--- a/ext/bindings.go
+++ b/ext/bindings.go
@@ -248,6 +248,11 @@ type dynamicSlotActivation struct {
 	slotVals  []*slotVal
 }
 
+// Unwrap returns the underlying activation.
+func (sa *dynamicSlotActivation) Unwrap() cel.Activation {
+	return sa.Activation
+}
+
 // ResolveName implements the Activation interface method but handles variables prefixed with `@index`
 // as special variables which exist within the slot-based memory of the cel.@block() where each slot
 // refers to an expression which must be computed only once.
@@ -304,6 +309,11 @@ type constantSlotActivation struct {
 	cel.Activation
 	slots     traits.Lister
 	slotCount int
+}
+
+// Unwrap returns the underlying activation.
+func (sa *constantSlotActivation) Unwrap() cel.Activation {
+	return sa.Activation
 }
 
 // ResolveName implements Activation interface method and proxies @index prefixed lookups into the slot

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -137,6 +137,11 @@ func (esa evalStateActivation) asEvalState() EvalState {
 	return esa.state
 }
 
+// activationWrapper identifies an object that can be unwrapped to access the underlying activation.
+type activationWrapper interface {
+	Unwrap() Activation
+}
+
 // asEvalState walks the Activation hierarchy and returns the first EvalState found, if present.
 func asEvalState(vars Activation) (EvalState, bool) {
 	if conv, ok := vars.(evalStateConverter); ok {
@@ -146,9 +151,6 @@ func asEvalState(vars Activation) (EvalState, bool) {
 	// wrappers such as the @block() activation which may be composed of a dynamicSlotActivation or a
 	// constantSlotActivation. In this case, the underlying activation is the portion which interacts
 	// with the EvalState.
-	type activationWrapper interface {
-		Unwrap() Activation
-	}
 	if wrapper, ok := vars.(activationWrapper); ok {
 		unwrapped := wrapper.Unwrap()
 		// Recursively call asEvalState on the unwrapped activation. This will check the unwrapped value and its parents.


### PR DESCRIPTION
This change adds an inline `activationWrapper` interface to the `asEvalState` function. This can be implemented by composite objects like  `dynamicSlotActivation` and `constantSlotActivation` to return the contained `Activations`. 
This will fix state observation for ternary conditional expressions which are added as part of the composition optimizer during policy compilation when state tracking is enabled.