### PR TITLE
CEL test coverage calculation

### DIFF
--- a/policy/BUILD.bazel
+++ b/policy/BUILD.bazel
@@ -91,6 +91,7 @@ cel_go_test(
     name = "context_pb_policy",
     cel_expr = "testdata/context_pb/policy.yaml",
     config = "testdata/context_pb/config.yaml",
+    enable_coverage = True,
     file_descriptor_set = ":test_all_types_fds",
     test_src = "//policy/test:cel_test_runner.go",
     test_suite = "testdata/context_pb/tests.yaml",
@@ -101,6 +102,7 @@ cel_go_test(
     cel_expr = "testdata/k8s/policy.yaml",
     config = "testdata/k8s/config.yaml",
     deps = ["//policy:go_default_library"],
+    enable_coverage = True,
     test_src = "//policy/test:k8s_cel_test_runner.go",
     test_suite = "testdata/k8s/tests.yaml",
 )
@@ -109,6 +111,7 @@ cel_go_test(
     name = "limits_policy",
     cel_expr = "testdata/limits/policy.yaml",
     config = "testdata/limits/config.yaml",
+    enable_coverage = True,
     test_src = "//policy/test:cel_test_runner.go",
     test_suite = "testdata/limits/tests.yaml",
 )
@@ -117,6 +120,7 @@ cel_go_test(
     name = "nested_rule_policy",
     cel_expr = "testdata/nested_rule/policy.yaml",
     config = "testdata/nested_rule/config.yaml",
+    enable_coverage = True,
     test_src = "//policy/test:cel_test_runner.go",
     test_suite = "testdata/nested_rule/tests.yaml",
 )
@@ -125,6 +129,7 @@ cel_go_test(
     name = "nested_rule2_policy",
     cel_expr = "testdata/nested_rule2/policy.yaml",
     config = "testdata/nested_rule2/config.yaml",
+    enable_coverage = True,
     test_src = "//policy/test:cel_test_runner.go",
     test_suite = "testdata/nested_rule2/tests.yaml",
 )
@@ -133,6 +138,7 @@ cel_go_test(
     name = "nested_rule3_policy",
     cel_expr = "testdata/nested_rule3/policy.yaml",
     config = "testdata/nested_rule3/config.yaml",
+    enable_coverage = True,
     test_src = "//policy/test:cel_test_runner.go",
     test_suite = "testdata/nested_rule3/tests.yaml",
 )
@@ -141,6 +147,7 @@ cel_go_test(
     name = "nested_rule4_policy",
     cel_expr = "testdata/nested_rule4/policy.yaml",
     config = "testdata/nested_rule4/config.yaml",
+    enable_coverage = True,
     test_src = "//policy/test:cel_test_runner.go",
     test_suite = "testdata/nested_rule4/tests.yaml",
 )
@@ -149,6 +156,7 @@ cel_go_test(
     name = "nested_rule5_policy",
     cel_expr = "testdata/nested_rule5/policy.yaml",
     config = "testdata/nested_rule5/config.yaml",
+    enable_coverage = True,
     test_src = "//policy/test:cel_test_runner.go",
     test_suite = "testdata/nested_rule5/tests.yaml",
 )
@@ -157,6 +165,7 @@ cel_go_test(
     name = "nested_rule6_policy",
     cel_expr = "testdata/nested_rule6/policy.yaml",
     config = "testdata/nested_rule6/config.yaml",
+    enable_coverage = True,
     test_src = "//policy/test:cel_test_runner.go",
     test_suite = "testdata/nested_rule6/tests.yaml",
 )
@@ -165,6 +174,7 @@ cel_go_test(
     name = "nested_rule7_policy",
     cel_expr = "testdata/nested_rule7/policy.yaml",
     config = "testdata/nested_rule7/config.yaml",
+    enable_coverage = True,
     test_src = "//policy/test:cel_test_runner.go",
     test_suite = "testdata/nested_rule7/tests.yaml",
 )
@@ -174,6 +184,7 @@ cel_go_test(
     cel_expr = "testdata/pb/policy.yaml",
     config = "testdata/pb/config.yaml",
     file_descriptor_set = ":test_all_types_fds",
+    enable_coverage = True,
     test_src = "//policy/test:cel_test_runner.go",
     test_suite = "testdata/pb/tests.yaml",
 )
@@ -182,6 +193,7 @@ cel_go_test(
     name = "required_labels_policy",
     cel_expr = "testdata/required_labels/policy.yaml",
     config = "testdata/required_labels/config.yaml",
+    enable_coverage = True,
     test_src = "//policy/test:cel_test_runner.go",
     test_suite = "testdata/required_labels/tests.yaml",
 )
@@ -190,6 +202,7 @@ cel_go_test(
     name = "restricted_destinations_policy",
     cel_expr = "testdata/restricted_destinations/policy.yaml",
     config = "testdata/restricted_destinations/config.yaml",
+    enable_coverage = True,
     test_src = "//policy/test:cel_test_runner.go",
     test_suite = "testdata/restricted_destinations/tests.yaml",
 )
@@ -198,6 +211,7 @@ cel_go_test(
     name = "unnest_policy",
     cel_expr = "testdata/unnest/policy.yaml",
     config = "testdata/unnest/config.yaml",
+    enable_coverage = True,
     test_src = "//policy/test:cel_test_runner.go",
     test_suite = "testdata/unnest/tests.yaml",
 )

--- a/test/cel_go_test.bzl
+++ b/test/cel_go_test.bzl
@@ -31,6 +31,7 @@ def cel_go_test(
         test_data_path = "",
         file_descriptor_set = "",
         filegroup = "",
+        enable_coverage = False,
         deps = [],
         data = [],
         **kwargs):
@@ -59,6 +60,7 @@ def cel_go_test(
           this must be in binary format with either a .binarypb or .pb or.fds extension. If you need
           to support a textformat file_descriptor_set, embed it in the environment file. (default None)
       filegroup: str label of a filegroup containing the test suite, config, and cel_expr.
+      enable_coverage: boolean indicating if coverage should be enabled for the test.
       deps: list of dependencies for the go_test rule
       data: list of data dependencies for the go_test rule
       **kwargs: additional arguments to pass to the go_test rule
@@ -104,6 +106,7 @@ def cel_go_test(
         "--test_suite_path=%s" % test_suite,
         "--config_path=%s" % config,
         "--base_config_path=%s" % base_config,
+        "--enable_coverage=%s" % enable_coverage,
     ]
 
     if cel_expr_format == ".cel" or cel_expr_format == ".celpolicy" or cel_expr_format == ".yaml":

--- a/tools/celtest/BUILD.bazel
+++ b/tools/celtest/BUILD.bazel
@@ -23,11 +23,14 @@ package(
 go_library(
     name = "go_default_library",
     srcs = [
+        "test_coverage_reporter.go",
         "test_runner.go",
     ],
     importpath = "github.com/google/cel-go/tools/celtest",
     deps = [
         "//cel:go_default_library",
+        "//common/ast:go_default_library",
+        "//common/operators:go_default_library",
         "//common/types:go_default_library",
         "//common/types/ref:go_default_library",
         "//interpreter:go_default_library",
@@ -54,6 +57,7 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = [
+        "test_coverage_reporter_test.go",
         "test_runner_test.go",
     ],
     data = [
@@ -63,6 +67,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cel:go_default_library",
+        "//common/ast:go_default_library",
         "//common/decls:go_default_library",
         "//common/types:go_default_library",
         "//common/types/ref:go_default_library",
@@ -84,6 +89,7 @@ cel_go_test(
     name = "pb_policy",
     cel_expr = "testdata/pb/policy.yaml",
     config = "testdata/pb/config.yaml",
+    enable_coverage = True,
     file_descriptor_set = "//policy:test_all_types_fds",
     test_data_path = "//policy",
     test_src = "//policy/test:cel_test_runner.go",

--- a/tools/celtest/BUILD.bazel
+++ b/tools/celtest/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//common/types:go_default_library",
         "//common/types/ref:go_default_library",
         "//interpreter:go_default_library",
+        "//parser:go_default_library",
         "//test:go_default_library",
         "//tools/compiler:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",

--- a/tools/celtest/test_coverage_reporter.go
+++ b/tools/celtest/test_coverage_reporter.go
@@ -1,0 +1,143 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package celtest provides functions for testing CEL policies and expressions.
+package celtest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/types"
+)
+
+// reportCoverage reports the coverage information for the provided programs.
+//   - For the node coverage, the coverage is reported as a percentage of the number of nodes which
+//     were evaluated during the test execution and hence are present in the program Coverage report.
+//   - For the branch coverage, every node which has a boolean return type is considered as a branch.
+//     The number of branches which were evaluated during the test execution and hence are present in
+//     the program Coverage report are reported as the branch coverage percentage.
+func reportCoverage(t *testing.T, programs []Program) {
+	t.Helper()
+	for _, p := range programs {
+		exprString, err := cel.AstToString(p.Ast)
+		if err != nil {
+			t.Logf("Error converting AST to string for a program: %v", err)
+			continue
+		}
+		rootNavigableExpr := ast.NavigateAST(p.Ast.NativeRep())
+		// Initialize coverage metrics
+		cr := &coverageReport{
+			nodes:                  0,
+			coveredNodes:           0,
+			branches:               0,
+			coveredBooleanOutcomes: 0,
+			unencounteredNodes:     []string{},
+			unencounteredBranches:  []string{},
+		}
+		traverseAndCalculateCoverage(t, rootNavigableExpr, p, true, "", cr)
+		printCoverageReport(t, exprString, cr)
+	}
+}
+
+type coverageReport struct {
+	nodes                  int64
+	coveredNodes           int64
+	branches               int64
+	coveredBooleanOutcomes int64
+	unencounteredNodes     []string
+	unencounteredBranches  []string
+}
+
+func traverseAndCalculateCoverage(t *testing.T, expr ast.NavigableExpr, p Program, logUnencountered bool,
+	preceedingTabs string, cr *coverageReport) {
+	t.Helper()
+	if expr == nil || len(p.CoverageStats) == 0 {
+		return
+	}
+	nodeID := expr.ID()
+	cr.nodes++
+	interestingBoolNode := expr.Type() == types.BoolType && expr.AsLiteral() == nil && expr.AsCall().FunctionName() != "cel.@block"
+	// Check for Node Coverage
+	if _, isCovered := p.CoverageStats[nodeID]; isCovered {
+		cr.coveredNodes++
+	} else if logUnencountered {
+		if interestingBoolNode {
+			exprText, _ := cel.ExprToString(expr, p.Ast.NativeRep().SourceInfo())
+			cr.unencounteredNodes = append(cr.unencounteredNodes,
+				fmt.Sprintf("\nExpression ID %d ('%s')", nodeID, exprText))
+		}
+		logUnencountered = false
+	}
+	// Check for Branch Coverage if the node is a boolean type
+	if interestingBoolNode {
+		cr.branches += 2
+		exprText, _ := cel.ExprToString(expr, p.Ast.NativeRep().SourceInfo())
+		if info, found := p.CoverageStats[nodeID]; !found {
+			if logUnencountered {
+				cr.unencounteredBranches = append(cr.unencounteredBranches,
+					"\n"+preceedingTabs+fmt.Sprintf("Expression ID %d ('%s'): Never evaluated (neither true nor false)", nodeID, exprText))
+				preceedingTabs = preceedingTabs + "\t\t"
+			}
+		} else {
+			if _, ok := info[types.True]; ok {
+				cr.coveredBooleanOutcomes++
+			} else if logUnencountered {
+				cr.unencounteredBranches = append(cr.unencounteredBranches,
+					"\n"+preceedingTabs+fmt.Sprintf("Expression ID %d ('%s'): Never evaluated to 'true'", nodeID, exprText))
+				preceedingTabs = preceedingTabs + "\t\t"
+
+			}
+			if _, ok := info[types.False]; ok {
+				cr.coveredBooleanOutcomes++
+			} else if logUnencountered {
+				cr.unencounteredBranches = append(cr.unencounteredBranches,
+					"\n"+preceedingTabs+fmt.Sprintf("Expression ID %d ('%s'): Never evaluated to 'false'", nodeID, exprText))
+				preceedingTabs = preceedingTabs + "\t\t"
+			}
+		}
+	}
+	for _, child := range expr.Children() {
+		traverseAndCalculateCoverage(t, child.(ast.NavigableExpr), p, logUnencountered, preceedingTabs, cr)
+	}
+}
+
+func printCoverageReport(t *testing.T, exprString string, cr *coverageReport) {
+	t.Helper()
+	t.Logf("--- Start Coverage Report ---\nExpression: %s", exprString)
+	if cr.nodes == 0 {
+		t.Logf("No coverage stats found")
+		return
+	}
+	// Log Node Coverage results
+	nodeCoverage := float64(cr.coveredNodes) / float64(cr.nodes) * 100.0
+	t.Logf("AST Node Coverage: %.2f%% (%d out of %d nodes covered)", nodeCoverage, cr.coveredNodes, cr.nodes)
+	if len(cr.unencounteredNodes) > 0 {
+		t.Logf("Interesting Unencountered Nodes:\n%s", strings.Join(cr.unencounteredNodes, "\n"))
+	}
+	// Log Branch Coverage results
+	branchCoverage := 0.0
+	if cr.branches > 0 {
+		branchCoverage = float64(cr.coveredBooleanOutcomes) / float64(cr.branches) * 100.0
+	}
+	t.Logf("AST Branch Coverage: %.2f%% (%d out of %d branch outcomes covered)", branchCoverage,
+		cr.coveredBooleanOutcomes, cr.branches)
+	if len(cr.unencounteredBranches) > 0 {
+		t.Logf("Interesting Unencountered Branch Paths:\n%s", strings.Join(cr.unencounteredBranches, "\n"))
+	}
+	t.Logf("--- End Coverage Report ---\n")
+}

--- a/tools/celtest/test_coverage_reporter_test.go
+++ b/tools/celtest/test_coverage_reporter_test.go
@@ -1,0 +1,127 @@
+package celtest
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/tools/compiler"
+)
+
+func TestCoverageStats(t *testing.T) {
+	testCases := []struct {
+		name                       string
+		configPath                 string
+		testSuitePath              string
+		celExpr                    string
+		compilerOpts               []any
+		totalASTNodes              int64
+		coveredBranchNodesComplete []int64
+		coveredBranchNodesPartial  []int64
+		uncoveredNodes             []int64
+	}{
+		{
+			name:                       "restricted destinations policy coverage",
+			configPath:                 "../../policy/testdata/restricted_destinations/config.yaml",
+			testSuitePath:              "../../policy/testdata/restricted_destinations/tests.yaml",
+			celExpr:                    "../../policy/testdata/restricted_destinations/policy.yaml",
+			compilerOpts:               []any{locationCodeEnvOption()},
+			totalASTNodes:              44,
+			coveredBranchNodesComplete: []int64{1, 7, 11, 12, 19, 23, 28, 29, 30, 31, 32, 33, 34, 36, 37, 38, 39, 40, 42},
+			coveredBranchNodesPartial:  []int64{3, 13, 41},
+			uncoveredNodes:             []int64{},
+		},
+		{
+			name:                       "k8s policy coverage",
+			configPath:                 "../../policy/testdata/k8s/config.yaml",
+			testSuitePath:              "../../policy/testdata/k8s/tests.yaml",
+			celExpr:                    "../../policy/testdata/k8s/policy.yaml",
+			compilerOpts:               []any{k8sParserOpts()},
+			totalASTNodes:              38,
+			coveredBranchNodesComplete: []int64{},
+			coveredBranchNodesPartial:  []int64{8, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26, 31},
+			uncoveredNodes:             []int64{5, 6, 7, 11, 12, 38},
+		},
+		{
+			name:                       "policy with custom policy metadata coverage",
+			testSuitePath:              "../../tools/celtest/testdata/custom_policy_tests.yaml",
+			celExpr:                    "../../tools/celtest/testdata/custom_policy.celpolicy",
+			compilerOpts:               []any{customPolicyParserOption(), compiler.PolicyMetadataEnvOption(ParsePolicyVariables)},
+			totalASTNodes:              10,
+			coveredBranchNodesComplete: []int64{1, 2, 3, 6},
+			coveredBranchNodesPartial:  []int64{},
+			uncoveredNodes:             []int64{},
+		},
+		{
+			name:                       "raw expression file with unknowns test coverage",
+			configPath:                 "../../tools/celtest/testdata/config.yaml",
+			testSuitePath:              "../../tools/celtest/testdata/raw_expr_tests.yaml",
+			celExpr:                    "../../tools/celtest/testdata/raw_expr.cel",
+			compilerOpts:               []any{fnEnvOption()},
+			totalASTNodes:              8,
+			coveredBranchNodesComplete: []int64{1, 6, 8},
+			coveredBranchNodesPartial:  []int64{},
+			uncoveredNodes:             []int64{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.compilerOpts = append(tc.compilerOpts, cel.EnableMacroCallTracking())
+			if tc.configPath != "" {
+				envOpt := compiler.EnvironmentFile(tc.configPath)
+				tc.compilerOpts = append(tc.compilerOpts, envOpt)
+			}
+			compilerOpt := TestCompiler(tc.compilerOpts...)
+			testSuiteParserOpt := DefaultTestSuiteParser(tc.testSuitePath)
+			testExprOpt := TestExpression(tc.celExpr)
+			tr, err := NewTestRunner(compilerOpt, testSuiteParserOpt, testExprOpt, EnableCoverage(), PartialEvalProgramOption())
+			if err != nil {
+				t.Fatalf("compiler.NewCompiler() failed: %v", err)
+			}
+			programs, err := tr.Programs(t, tr.testProgramOptions...)
+			if err != nil {
+				t.Fatalf("error creating programs: %v", err)
+			}
+			tests, err := tr.Tests(t)
+			if err != nil {
+				t.Fatalf("error creating tests: %v", err)
+			}
+			for _, test := range tests {
+				err := tr.ExecuteTest(t, programs, test)
+				if err != nil {
+					t.Fatalf("error executing test: %v", err)
+				}
+			}
+			p := programs[0]
+			rootNavigableExpr := ast.NavigateAST(p.Ast.NativeRep())
+			cr := &coverageReport{
+				nodes:                  0,
+				coveredNodes:           0,
+				branches:               0,
+				coveredBooleanOutcomes: 0,
+				unencounteredNodes:     []string{},
+				unencounteredBranches:  []string{},
+			}
+			traverseAndCalculateCoverage(t, rootNavigableExpr, p, true, "", cr)
+			coverageStats := p.CoverageStats
+			if cr.nodes != tc.totalASTNodes {
+				t.Errorf("totalASTNodes = %d, want %d", cr.nodes, tc.totalASTNodes)
+			}
+			for _, id := range tc.coveredBranchNodesComplete {
+				if val, ok := coverageStats[id]; !ok || len(val) < 2 {
+					t.Errorf("id %d is not covered completely", id)
+				}
+			}
+			for _, id := range tc.coveredBranchNodesPartial {
+				if val, ok := coverageStats[id]; !ok || len(val) != 1 {
+					t.Errorf("id %d is not covered partially", id)
+				}
+			}
+			for _, id := range tc.uncoveredNodes {
+				if _, ok := coverageStats[id]; ok {
+					t.Errorf("id %d is covered, expected uncoveredNodes", id)
+				}
+			}
+		})
+	}
+}

--- a/tools/celtest/test_runner_test.go
+++ b/tools/celtest/test_runner_test.go
@@ -103,18 +103,13 @@ func k8sParserOpts() policy.ParserOption {
 	}
 }
 
-// TestTriggerTestsCustomPolicy tests the TriggerTestsFromCompiler function for a custom policy
+// TestTriggerTestsWithRunnerOptions tests the TriggerTestsFromCompiler function for a custom policy
 // by providing test runner and compiler options without setting the flag variables.
 func TestTriggerTestsWithRunnerOptions(t *testing.T) {
 	t.Run("test trigger tests custom policy", func(t *testing.T) {
 		envOpt := compiler.EnvironmentFile("../../policy/testdata/k8s/config.yaml")
 		testSuiteParser := DefaultTestSuiteParser("../../policy/testdata/k8s/tests.yaml")
-		testCELPolicy := TestRunnerOption(func(tr *TestRunner) (*TestRunner, error) {
-			tr.Expressions = append(tr.Expressions, &compiler.FileExpression{
-				Path: "../../policy/testdata/k8s/policy.yaml",
-			})
-			return tr, nil
-		})
+		testCELPolicy := TestExpression("../../policy/testdata/k8s/policy.yaml")
 		c, err := compiler.NewCompiler(envOpt, k8sParserOpts())
 		if err != nil {
 			t.Fatalf("compiler.NewCompiler() failed: %v", err)


### PR DESCRIPTION
This change adds coverage calculation logic for the CEL test runner:
1. The `cel_go_test` bazel macro accepts a new boolean flag `enable_coverage`. When set to `True` the coverage statistics for the test suite are logged.
2. Coverage metrics include:
* AST node coverage - Determines the percentage of AST nodes covered
* AST branch coverage -  Determines the percentage of logical branches covered
For each of the above metrics, an optional set of interesting nodes and branches are logged which can help determine which nodes or logical branches are missed by the tests.

Sample coverage logs for `//policy:restricted_destinations_policy`:
<img width="1563" height="644" alt="restricted_destinations_policy" src="https://github.com/user-attachments/assets/78ec2dd7-4c91-4dcc-a052-9010ab2e2d5a" />

