### PR TITLE
Bazel fixes for import

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "gazelle",
-    version = "0.44.0",
+    version = "0.47.0",
     repo_name = "bazel_gazelle",
 )
 bazel_dep(
@@ -27,13 +27,14 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_go",
-    version = "0.57.0",
+    version = "0.59.0",
     repo_name = "io_bazel_rules_go",
 )
 bazel_dep(
     name = "rules_proto",
     version = "7.0.2",
 )
+bazel_dep(name = "rules_shell", version = "0.6.1")
 
 # local_path_override(
 #     module_name = "cel-spec",

--- a/conformance/conformance_test.bzl
+++ b/conformance/conformance_test.bzl
@@ -16,6 +16,8 @@
 This module contains build rules for generating the conformance test targets.
 """
 
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
 # Converts the list of tests to skip from the format used by the original Go test runner to a single
 # flag value where each test is separated by a comma. It also performs expansion, for example
 # `foo/bar,baz` becomes two entries which are `foo/bar` and `foo/baz`.
@@ -38,13 +40,13 @@ def _expand_tests_to_skip(tests_to_skip):
 def _conformance_test_args(data, skip_tests, dashboard):
     args = []
     args.append("--skip_tests={}".format(",".join(_expand_tests_to_skip(skip_tests))))
-    args.append("--tests={}".format(",".join(["$(location " + test + ")" for test in data])))
+    args.append("--tests={}".format(",".join(["$(rlocationpath " + test + ")" for test in data])))
     if dashboard:
         args.append("--dashboard")
     return args
 
 def conformance_test(name, data, dashboard, skip_tests = []):
-    native.sh_test(
+    sh_test(
         name = name,
         size = "small",
         srcs = ["//conformance:conformance_test.sh"],


### PR DESCRIPTION
- fixes for bazel 8+
- version bump rules_go/gazelle
- switch to rules_shell repo instead of native.rules_shell