### PR TITLE
Fuzzing: add FuzzMacros for comprehension macro coverage

### DIFF
--- a/cel/fuzz_macros.go
+++ b/cel/fuzz_macros.go
@@ -1,0 +1,66 @@
+package cel
+
+// FuzzMacros targets comprehension macros (all, exists, filter, map)
+// and optional field selection which are not covered by FuzzCompile or FuzzEval.
+func FuzzMacros(data []byte) int {
+	if len(data) < 2 {
+		return 0
+	}
+
+	macroType := int(data[0]) % 6
+	expr := string(data[1:])
+
+	var fullExpr string
+	switch macroType {
+	case 0:
+		fullExpr = "[1,2,3,4,5].all(x, " + expr + ")"
+	case 1:
+		fullExpr = "[1,2,3,4,5].exists(x, " + expr + ")"
+	case 2:
+		fullExpr = "[1,2,3,4,5].filter(x, " + expr + ")"
+	case 3:
+		fullExpr = "[1,2,3,4,5].map(x, " + expr + ")"
+	case 4:
+		fullExpr = "[1,2,3,4,5].exists_one(x, " + expr + ")"
+	case 5:
+		fullExpr = expr
+	}
+
+	env, err := getCELFuzzEnv()
+	if err != nil {
+		return 0
+	}
+
+	env, err = env.Extend(
+		Variable("x", IntType),
+		Variable("s", StringType),
+		Variable("items", ListType(IntType)),
+	)
+	if err != nil {
+		return 0
+	}
+
+	ast, iss := env.Parse(fullExpr)
+	if iss != nil && iss.Err() != nil {
+		return 0
+	}
+
+	checked, iss := env.Check(ast)
+	if iss != nil && iss.Err() != nil {
+		return 0
+	}
+
+	prg, err := env.Program(checked)
+	if err != nil {
+		return 0
+	}
+
+	prg.Eval(map[string]any{
+		"x":     int64(3),
+		"s":     "test",
+		"items": []int64{1, 2, 3, 4, 5},
+	})
+
+	return 1
+}
+```


### PR DESCRIPTION
Add FuzzMacros fuzzer targeting comprehension macros (all, exists,
filter, map, exists_one) which are not covered by the existing
FuzzCompile or FuzzEval fuzzers.

The fuzzer wraps randomly generated expressions inside comprehension
contexts to increase coverage of macro expansion and type-checking
code paths in the CEL parser and checker.

This fuzzer is intended for use with OSS-Fuzz integration.