### PR TITLE
Preserve runtime error node IDs from Resolve

### DIFF
--- a/common/types/err.go
+++ b/common/types/err.go
@@ -113,6 +113,9 @@ func ValOrErr(val ref.Val, format string, args ...any) ref.Val {
 
 // WrapErr wraps an existing Go error value into a CEL Err value.
 func WrapErr(err error) ref.Val {
+	if err, ok := err.(*Err); ok {
+		return err
+	}
 	return &Err{error: err}
 }
 

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -349,7 +349,7 @@ func (a *absoluteAttribute) Resolve(vars Activation) (any, error) {
 		obj, found := v.ResolveName(nm)
 		if found {
 			if celErr, ok := obj.(*types.Err); ok {
-				return nil, celErr.Unwrap()
+				return nil, celErr
 			}
 			obj, isOpt, err := applyQualifiers(v, obj, a.qualifiers)
 			if err != nil {

--- a/interpreter/attributes_test.go
+++ b/interpreter/attributes_test.go
@@ -1106,6 +1106,21 @@ func TestAttributeStateTracking(t *testing.T) {
 			),
 			out: types.NewUnknown(5, types.QualifyAttribute[string](types.NewAttributeTrail("a"), "b")),
 		},
+		{
+			expr: `['a', b.val, 'c'].filter(i, i + 'b' != 'ab')`,
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("b", types.NewMapType(types.StringType, types.DynType)),
+			},
+			in: partialActivation(
+				map[string]any{
+					"b": map[string]any{
+						"val": 1,
+					},
+				},
+			),
+			// Error node 9 corresponds to the `i + 'b'` expression
+			out: types.LabelErrNode(9, types.NoSuchOverloadErr()),
+		},
 	}
 	for _, test := range tests {
 		tc := test
@@ -1170,8 +1185,18 @@ func TestAttributeStateTracking(t *testing.T) {
 				if !reflect.DeepEqual(tc.out, out) {
 					t.Errorf("got %v, wanted %v", out, tc.out)
 				}
+			} else if types.IsError(tc.out) && types.IsError(out) {
+				if tc.out.(*types.Err).Error() != out.(*types.Err).Error() {
+					t.Errorf("got %v, wanted %v", out, tc.out)
+				}
 			} else if tc.out.Equal(out) != types.True {
 				t.Errorf("got %v, wanted %v", out, tc.out)
+			}
+			if err, isErr := out.(*types.Err); isErr && err.NodeID() != 0 {
+				wantErr := tc.out.(*types.Err)
+				if err.NodeID() != wantErr.NodeID() {
+					t.Errorf("err.NodeID() got %d, wanted %d", err.NodeID(), wantErr.NodeID())
+				}
 			}
 			for id, val := range tc.state {
 				stVal, found := holder.st.Value(id)


### PR DESCRIPTION
# Pull Requests Guidelines

See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details about when to create
a GitHub [Pull Request][1] and when other kinds of contributions or
consultation might be more desirable.

When creating a new pull request, please fork the repo and work within a
development branch.

## Commit Messages

* Most changes should be accompanied by tests.
* Commit messages should explain _why_ the changes were made.
```
Preserve runtime error node IDs from Resolve

When absoluteAttribute.Resolve() encounters a *types.Err variable value,
return it directly rather than calling Unwrap(). The Unwrap call strips
the Err wrapper and its node ID, causing callers to re-label the error
with the observation site's ID instead of the originating expression's ID.

Additionally, make WrapErr pass through existing *types.Err values rather
than double-wrapping them. This ensures that LabelErrNode sees the
original non-zero node ID and preserves it, regardless of the call site.

Fixes #1191
```

## Reviews

* Perform a self-review.
* Make sure the Travis CI build passes.
* Assign a reviewer once both the above have been completed.

## Merging

* If a CEL maintaner approves the change, it may be merged by the author if
  they have write access. Otherwise, the change will be merged by a maintainer.
* Multiple commits should be squashed before merging.
* Please append the line `closes #<issue-num>: description` in the merge message,
  if applicable.

[1]:  https://help.github.com/articles/about-pull-requests