### PR TITLE
Fix panic in native object traversal with nil valued struct pointers

### DIFF
--- a/common/types/native.go
+++ b/common/types/native.go
@@ -371,7 +371,7 @@ func (o *nativeObj) AggregateSize(sizer AggregateSizer) uint32 {
 	}
 	total := uint32(1)
 	for _, fieldType := range o.valType.fieldsByName {
-		fieldValue := refVal.FieldByIndex(fieldType.Index)
+		fieldValue := safeGetFieldByIndex(refVal, fieldType.Index)
 		if !fieldValue.IsValid() || fieldValue.IsZero() {
 			continue
 		}

--- a/common/types/native_test.go
+++ b/common/types/native_test.go
@@ -1308,6 +1308,7 @@ func TestNativeObjectCalculateSize(t *testing.T) {
 		ext.NativeTypes(
 			reflect.TypeOf(TestAllTypes{}),
 			reflect.TypeOf(TestNestedType{}),
+			reflect.TypeOf(TestEmbeddedPointerTypes{}),
 		),
 	)
 	if err != nil {
@@ -1324,6 +1325,11 @@ func TestNativeObjectCalculateSize(t *testing.T) {
 			name: "empty_struct",
 			val:  &TestNestedType{},
 			want: 1, // 1 (container)
+		},
+		{
+			name: "nil_embedded_pointer",
+			val:  &TestEmbeddedPointerTypes{},
+			want: 1, // 1 (container); promoted fields through the nil embedded pointer count as unset
 		},
 		{
 			name: "struct_with_scalar_and_list",


### PR DESCRIPTION
Missed one field traversal with the 'safe' field access updates.