### PR TITLE
mem-track: Add memory tracker, scale-down string and byte sizes

### DIFF
--- a/common/types/memory_tracker.go
+++ b/common/types/memory_tracker.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+const (
+	defaultMemoryTrackerSampleInterval = 1
+)
+
+// MemoryTrackerOption configures a MemoryTracker instance.
+type MemoryTrackerOption func(*MemoryTracker)
+
+// MemoryTrackerLimit sets a limit on the peak aggregate memory observed during tracking.
+//
+// The tracker does not enforce the limit itself; callers should consult ExceedsLimit after
+// tracking observations and terminate evaluation as appropriate.
+func MemoryTrackerLimit(limit uint32) MemoryTrackerOption {
+	return func(t *MemoryTracker) {
+		t.limit = &limit
+	}
+}
+
+// MemoryTrackerSampleInterval configures how frequently Sample observations compute a size.
+//
+// An interval of N means every Nth call to Sample performs a size computation; intervening
+// calls are skipped. Values less than 1 are treated as 1, meaning every sample is computed.
+// Sampling bounds the tracking overhead for high-frequency observation points such as
+// comprehension loops and bind initializers.
+func MemoryTrackerSampleInterval(interval uint32) MemoryTrackerOption {
+	return func(t *MemoryTracker) {
+		if interval < 1 {
+			interval = 1
+		}
+		t.sampleInterval = interval
+	}
+}
+
+// MemoryTrackerSizeCalculator overrides the SizeCalculator used to compute value sizes.
+func MemoryTrackerSizeCalculator(calc *SizeCalculator) MemoryTrackerOption {
+	return func(t *MemoryTracker) {
+		t.calc = calc
+	}
+}
+
+// MemoryTracker records the peak aggregate memory observed during an evaluation.
+//
+// Memory is measured in aggregate element counts as computed by a SizeCalculator, with all
+// arithmetic saturating at math.MaxUint32. The tracker is independent of any interpreter
+// implementation; evaluators feed it observations at points where values materialize:
+//
+//   - inputs to a call (e.g. the target and arguments of a.join(', '))
+//   - the output of a call (e.g. the result of a + a)
+//   - resolved attribute values (e.g. the value of a.b.c)
+//   - sampled values built up within comprehensions or bind initializers
+//
+// The peak is the largest single observation, where one Track call observes a set of
+// coexistent values as a single watermark.
+//
+// A MemoryTracker is stateful and intended for use by a single evaluation at a time; it is
+// not safe for concurrent use.
+type MemoryTracker struct {
+	version        int
+	calc           *SizeCalculator
+	limit          *uint32
+	sampleInterval uint32
+
+	sampleCount       uint32
+	peak              uint32
+	calcLimitExceeded bool
+}
+
+// NewMemoryTracker returns a new MemoryTracker configured with optional MemoryTrackerOption
+// settings, using a default SizeCalculator when one is not provided.
+func NewMemoryTracker(opts ...MemoryTrackerOption) *MemoryTracker {
+	t := &MemoryTracker{
+		version:        0,
+		sampleInterval: defaultMemoryTrackerSampleInterval,
+	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	if t.calc == nil {
+		t.calc = NewSizeCalculator()
+	}
+	return t
+}
+
+// Version returns the tracking version.
+func (t *MemoryTracker) Version() int {
+	return t.version
+}
+
+// Track observes a set of coexistent values as a single watermark, returning their combined
+// aggregate size with saturation at math.MaxUint32.
+//
+// Call sites with multiple live values, such as the input arguments to a function call,
+// should be tracked in a single call so the watermark reflects their combined footprint.
+func (t *MemoryTracker) Track(vals ...any) uint32 {
+	total := uint32(0)
+	for _, val := range vals {
+		est := t.calc.EstimateAggregateSize(val)
+		if est.LimitExceeded {
+			t.calcLimitExceeded = true
+		}
+		total = safeAddUint32(total, est.Size)
+	}
+	if total > t.peak {
+		t.peak = total
+	}
+	return total
+}
+
+// Sample observes a value subject to the tracker's sample interval, returning the value's
+// aggregate size when computed, or zero when the observation is skipped.
+//
+// Sample is intended for high-frequency observation points, such as accumulator values built
+// up by comprehension loops or bind initializers, where sizing every iteration would be
+// prohibitively expensive.
+func (t *MemoryTracker) Sample(val any) uint32 {
+	t.sampleCount++
+	if t.sampleInterval > 1 && t.sampleCount%t.sampleInterval != 0 {
+		return 0
+	}
+	return t.Track(val)
+}
+
+// Peak returns the largest single watermark observed, saturating at math.MaxUint32.
+func (t *MemoryTracker) Peak() uint32 {
+	return t.peak
+}
+
+// ExceedsLimit indicates whether the peak observed memory exceeds the configured limit.
+// When no limit is configured, ExceedsLimit always returns false.
+func (t *MemoryTracker) ExceedsLimit() bool {
+	return t.limit != nil && t.peak > *t.limit
+}
+
+// CalculationLimitExceeded indicates whether any tracked value was too expensive to size,
+// causing the size computation to abort at the SizeCalculator's depth or traversal limits.
+//
+// Such observations saturate to math.MaxUint32; this signal distinguishes values which were
+// too costly to measure from values whose measured size genuinely saturated uint32.
+func (t *MemoryTracker) CalculationLimitExceeded() bool {
+	return t.calcLimitExceeded
+}

--- a/common/types/memory_tracker.go
+++ b/common/types/memory_tracker.go
@@ -59,10 +59,9 @@ func MemoryTrackerSizeCalculator(calc *SizeCalculator) MemoryTrackerOption {
 // arithmetic saturating at math.MaxUint32. The tracker is independent of any interpreter
 // implementation; evaluators feed it observations at points where values materialize:
 //
-//   - inputs to a call (e.g. the target and arguments of a.join(', '))
-//   - the output of a call (e.g. the result of a + a)
+//   - inputs and outputs of calls (e.g. the target and arguments of a.join(', '))
 //   - resolved attribute values (e.g. the value of a.b.c)
-//   - sampled values built up within comprehensions or bind initializers
+//   - values built up within literal blocks, comprehensions, and bind initializers
 //
 // The peak is the largest single observation, where one Track call observes a set of
 // coexistent values as a single watermark.
@@ -106,6 +105,9 @@ func (t *MemoryTracker) Version() int {
 //
 // Call sites with multiple live values, such as the input arguments to a function call,
 // should be tracked in a single call so the watermark reflects their combined footprint.
+//
+// Within observers, consider whether to choose the aggregated argument sizes, the result size,
+// or both when working with allocating operations.
 func (t *MemoryTracker) Track(vals ...any) uint32 {
 	total := uint32(0)
 	for _, val := range vals {

--- a/common/types/memory_tracker_test.go
+++ b/common/types/memory_tracker_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+)
+
+func TestMemoryTrackerTrack(t *testing.T) {
+	adapter := DefaultTypeAdapter
+
+	t.Run("single_value_watermark", func(t *testing.T) {
+		tracker := NewMemoryTracker()
+		list := NewRefValList(adapter, []ref.Val{Int(1), Int(2)})
+		if got := tracker.Track(list); got != 3 {
+			t.Errorf("Track() got %d, want 3", got)
+		}
+		if got := tracker.Peak(); got != 3 {
+			t.Errorf("Peak() got %d, want 3", got)
+		}
+	})
+
+	t.Run("call_inputs_combined_watermark", func(t *testing.T) {
+		// Models the inputs to a.join(', ') where the list and separator coexist.
+		tracker := NewMemoryTracker()
+		list := NewRefValList(adapter, []ref.Val{String("a"), String("b")})
+		sep := String(", ")
+		if got := tracker.Track(list, sep); got != 4 {
+			t.Errorf("Track(list, sep) got %d, want 4 (3 list + 1 separator)", got)
+		}
+		if got := tracker.Peak(); got != 4 {
+			t.Errorf("Peak() got %d, want 4", got)
+		}
+	})
+
+	t.Run("peak_retains_max", func(t *testing.T) {
+		tracker := NewMemoryTracker()
+		tracker.Track(NewRefValList(adapter, []ref.Val{Int(1), Int(2), Int(3)}))
+		tracker.Track(Int(1))
+		if got := tracker.Peak(); got != 4 {
+			t.Errorf("Peak() got %d, want 4", got)
+		}
+	})
+
+	t.Run("call_output_watermark", func(t *testing.T) {
+		// Models the output of a + a, a string twice the size of its inputs.
+		tracker := NewMemoryTracker()
+		in := String(strings.Repeat("a", 50))
+		tracker.Track(in, in)
+		out := String(strings.Repeat("a", 100))
+		tracker.Track(out)
+		if got := tracker.Peak(); got != 10 {
+			t.Errorf("Peak() got %d, want 10 (100-char output at 10 chars per unit)", got)
+		}
+	})
+
+	t.Run("saturating_sum", func(t *testing.T) {
+		tracker := NewMemoryTracker()
+		big := customSizerVal(math.MaxUint32)
+		if got := tracker.Track(big, big); got != math.MaxUint32 {
+			t.Errorf("Track() got %d, want MaxUint32", got)
+		}
+		if got := tracker.Peak(); got != math.MaxUint32 {
+			t.Errorf("Peak() got %d, want MaxUint32", got)
+		}
+		if tracker.CalculationLimitExceeded() {
+			t.Error("CalculationLimitExceeded() got true, want false for pure saturation")
+		}
+	})
+
+	t.Run("calculation_limit_exceeded", func(t *testing.T) {
+		tracker := NewMemoryTracker(
+			MemoryTrackerSizeCalculator(NewSizeCalculator(SizeCalculatorMaxTraversal(2))))
+		list := NewRefValList(adapter, []ref.Val{Int(1), Int(2), Int(3)})
+		if got := tracker.Track(list); got != math.MaxUint32 {
+			t.Errorf("Track() got %d, want MaxUint32", got)
+		}
+		if !tracker.CalculationLimitExceeded() {
+			t.Error("CalculationLimitExceeded() got false, want true")
+		}
+	})
+}
+
+func TestMemoryTrackerSample(t *testing.T) {
+	adapter := DefaultTypeAdapter
+
+	t.Run("default_interval_samples_every_value", func(t *testing.T) {
+		tracker := NewMemoryTracker()
+		for i := 0; i < 3; i++ {
+			if got := tracker.Sample(Int(i)); got != 1 {
+				t.Errorf("Sample() got %d, want 1", got)
+			}
+		}
+		if got := tracker.Peak(); got != 1 {
+			t.Errorf("Peak() got %d, want 1", got)
+		}
+	})
+
+	t.Run("interval_skips_intermediate_samples", func(t *testing.T) {
+		tracker := NewMemoryTracker(MemoryTrackerSampleInterval(3))
+		list := NewRefValList(adapter, []ref.Val{Int(1), Int(2)})
+		if got := tracker.Sample(list); got != 0 {
+			t.Errorf("Sample() #1 got %d, want 0 (skipped)", got)
+		}
+		if got := tracker.Sample(list); got != 0 {
+			t.Errorf("Sample() #2 got %d, want 0 (skipped)", got)
+		}
+		if got := tracker.Sample(list); got != 3 {
+			t.Errorf("Sample() #3 got %d, want 3 (computed)", got)
+		}
+		if got := tracker.Peak(); got != 3 {
+			t.Errorf("Peak() got %d, want 3", got)
+		}
+	})
+
+	t.Run("zero_interval_clamped_to_one", func(t *testing.T) {
+		tracker := NewMemoryTracker(MemoryTrackerSampleInterval(0))
+		if got := tracker.Sample(Int(1)); got != 1 {
+			t.Errorf("Sample() got %d, want 1", got)
+		}
+	})
+}
+
+func TestMemoryTrackerLimit(t *testing.T) {
+	t.Run("no_limit", func(t *testing.T) {
+		tracker := NewMemoryTracker()
+		tracker.Track(customSizerVal(math.MaxUint32))
+		if tracker.ExceedsLimit() {
+			t.Error("ExceedsLimit() got true, want false when no limit configured")
+		}
+	})
+
+	t.Run("under_limit", func(t *testing.T) {
+		tracker := NewMemoryTracker(MemoryTrackerLimit(10))
+		tracker.Track(customSizerVal(10))
+		if tracker.ExceedsLimit() {
+			t.Error("ExceedsLimit() got true, want false at exactly the limit")
+		}
+	})
+
+	t.Run("over_limit", func(t *testing.T) {
+		tracker := NewMemoryTracker(MemoryTrackerLimit(10))
+		tracker.Track(customSizerVal(11))
+		if !tracker.ExceedsLimit() {
+			t.Error("ExceedsLimit() got false, want true")
+		}
+	})
+}
+
+func TestMemoryTrackerVersion(t *testing.T) {
+	if got := NewMemoryTracker().Version(); got != 0 {
+		t.Errorf("Version() got %d, want 0", got)
+	}
+}
+
+// Interface conformance check: the tracker's calculator remains usable as an AggregateSizer
+// by visitor implementations.
+var _ traits.Sizer = customSizerVal(0)

--- a/common/types/memory_tracker_test.go
+++ b/common/types/memory_tracker_test.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/cel-go/common/types/ref"
-	"github.com/google/cel-go/common/types/traits"
+	"cel.dev/cel-go/common/types/ref"
+	"cel.dev/cel-go/common/types/traits"
 )
 
 func TestMemoryTrackerTrack(t *testing.T) {

--- a/common/types/size_calc.go
+++ b/common/types/size_calc.go
@@ -179,8 +179,8 @@ func (s *SizeCalculator) EstimateAggregateSize(val any) AggregateSizeEstimate {
 	return AggregateSizeEstimate{Size: size, LimitExceeded: exceeded}
 }
 
-// stringSize converts a byte length to an element count where stringUnitLength bytes count
-// as a single element, rounding up with a minimum size of 1.
+// stringSize converts a character or byte length to an element count where stringUnitLength
+// characters count as a single element, rounding up with a minimum size of 1.
 func (s *SizeCalculator) stringSize(length int) uint32 {
 	if length <= 0 {
 		return 1

--- a/common/types/size_calc_test.go
+++ b/common/types/size_calc_test.go
@@ -46,7 +46,7 @@ func TestCalculateSize(t *testing.T) {
 		{
 			name: "sizer_string",
 			val:  String("hello"),
-			want: 1, // 5 bytes round up to a single 10-byte element unit
+			want: 1, // 5 chars round up to a single 10-char element unit
 		},
 		{
 			name: "sizer_bytes",


### PR DESCRIPTION
Simple peak memory tracker and scale down the string & bytes costs.

Future changes will hook up the tracker to a memory limiter, and make aggregate
computations atomic on a given object. The caveat for proper use is that the
`SizeCalculator` should not change between environment configurations.