### PR TITLE
Report every evaluation step to every observer

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -1683,6 +1683,64 @@ func TestVariadicLogicalOperators(t *testing.T) {
 	}
 }
 
+func TestCostTrackingWithStateTracking(t *testing.T) {
+	// Cost tracking and state tracking install separate observers. Every observer has to see
+	// every evaluation step, whichever combination of them is configured.
+	env := testEnv(t, Variable("a", StringType))
+	ast, iss := env.Compile(`a.startsWith("x") && a.contains("yz")`)
+	if iss.Err() != nil {
+		t.Fatalf("env.Compile() failed: %v", iss.Err())
+	}
+	baseline, _ := evalCostAndState(t, env, ast, CostTracking(nil))
+	if baseline == 0 {
+		t.Fatalf("cost tracking alone reported a cost of 0")
+	}
+	tests := []struct {
+		name       string
+		opts       []ProgramOption
+		wantState  bool
+		wantEqCost bool
+	}{
+		{name: "cost", opts: []ProgramOption{CostTracking(nil)}, wantEqCost: true},
+		{name: "cost and state", opts: []ProgramOption{CostTracking(nil), EvalOptions(OptTrackState)},
+			wantState: true, wantEqCost: true},
+		{name: "cost and exhaustive", opts: []ProgramOption{CostTracking(nil), EvalOptions(OptExhaustiveEval)},
+			wantState: true, wantEqCost: true},
+	}
+	for _, tst := range tests {
+		tc := tst
+		t.Run(tc.name, func(t *testing.T) {
+			cost, hasState := evalCostAndState(t, env, ast, tc.opts...)
+			if tc.wantEqCost && cost != baseline {
+				t.Errorf("actual cost got %d, wanted %d", cost, baseline)
+			}
+			if hasState != tc.wantState {
+				t.Errorf("state tracked got %t, wanted %t", hasState, tc.wantState)
+			}
+		})
+	}
+}
+
+// evalCostAndState evaluates the ast and reports the tracked cost along with whether evaluation
+// state was recorded.
+func evalCostAndState(t *testing.T, env *Env, ast *Ast, opts ...ProgramOption) (uint64, bool) {
+	t.Helper()
+	prg, err := env.Program(ast, opts...)
+	if err != nil {
+		t.Fatalf("env.Program() failed: %v", err)
+	}
+	_, det, err := prg.Eval(map[string]any{"a": "xyz-abcdefghij"})
+	if err != nil {
+		t.Fatalf("prg.Eval() failed: %v", err)
+	}
+	cost := det.ActualCost()
+	if cost == nil {
+		t.Fatalf("det.ActualCost() returned nil")
+	}
+	state := det.State()
+	return *cost, state != nil && len(state.IDs()) != 0
+}
+
 func TestParseError(t *testing.T) {
 	env := testEnv(t)
 	_, iss := env.Parse("invalid & logical_and")

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -101,7 +101,6 @@ func EvalStateObserver(opts ...evalStateOption) PlannerOption {
 			return nil, errors.New("eval state factory not configured")
 		}
 		p.observers = append(p.observers, et)
-		p.decorators = append(p.decorators, decObserveEval(et.Observe))
 		return p, nil
 	}
 }

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/cel-go/common/functions"
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
 )
 
 // newPlanner creates an interpretablePlanner which references a Dispatcher, TypeProvider,
@@ -73,6 +74,12 @@ type planBuilder struct {
 // such as state-tracking, expression re-write, and possibly efficient thread-safe memoization of
 // repeated expressions.
 func (p *planner) Plan(expr ast.Expr) (InterpretableV2, error) {
+	if len(p.observers) != 0 {
+		// A single decorator reports to every observer. One decorator per observer would not
+		// work, since the second decorator would find the node already wrapped by the first and
+		// leave it alone, silently dropping the second observer's observations.
+		p.decorators = append(p.decorators, decObserveEval(observeAll(p.observers)))
+	}
 	pb := &planBuilder{planner: p, localVars: make(map[string]int)}
 	i, err := pb.plan(expr)
 	if err != nil {
@@ -82,6 +89,18 @@ func (p *planner) Plan(expr ast.Expr) (InterpretableV2, error) {
 		return i, nil
 	}
 	return &ObservableInterpretable{InterpretableV2: i, observers: p.observers}, nil
+}
+
+// observeAll returns an EvalObserver which reports each observation to all of the observers.
+func observeAll(observers []StatefulObserver) EvalObserver {
+	if len(observers) == 1 {
+		return observers[0].Observe
+	}
+	return func(vars Activation, id int64, programStep any, value ref.Val) {
+		for _, o := range observers {
+			o.Observe(vars, id, programStep, value)
+		}
+	}
 }
 
 func (p *planBuilder) plan(expr ast.Expr) (InterpretableV2, error) {

--- a/interpreter/runtimecost.go
+++ b/interpreter/runtimecost.go
@@ -57,7 +57,6 @@ func CostObserver(opts ...costTrackPlanOption) PlannerOption {
 			return nil, errors.New("cost tracker factory not configured")
 		}
 		p.observers = append(p.observers, ct)
-		p.decorators = append(p.decorators, decObserveEval(ct.Observe))
 		return p, nil
 	}
 }


### PR DESCRIPTION
Cost tracking silently reported a cost of zero whenever state tracking was also enabled:

	cel.CostTracking(nil)                                 -> 5
	cel.CostTracking(nil) + cel.EvalOptions(OptTrackState)   -> 0
	cel.CostTracking(nil) + cel.EvalOptions(OptExhaustiveEval) -> 0

Each observer installed its own decorator, and decObserveEval returns a node which is already wrapped in a watcher untouched. Since the planner applies decorators in order, the state observer's decorator wrapped each node first and the cost observer's decorator then found a watcher and left it alone, so the cost observer's per-node callback was never installed. ObservableInterpretable still ran the tracker's InitState and GetState, so evaluation produced a CostTracker reporting a cost of zero rather than an error or a nil result -- including for programs configured with a cost limit, which then could not be exceeded.

Observers now register only as observers, and the planner installs a single decorator which reports each observation to all of them.