### PR TITLE
Consolidate saturating cost arithmetic into common/cost

### DIFF
--- a/checker/BUILD.bazel
+++ b/checker/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//common:go_default_library",
         "//common/ast:go_default_library",
         "//common/containers:go_default_library",
+        "//common/cost:go_default_library",
         "//common/debug:go_default_library",
         "//common/decls:go_default_library",
         "//common/operators:go_default_library",

--- a/checker/cost.go
+++ b/checker/cost.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/cost"
 	"github.com/google/cel-go/common/overloads"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/parser"
@@ -115,8 +116,8 @@ func FixedSizeEstimate(size uint64) SizeEstimate {
 // If add would result in an uint64 overflow, the result is math.MaxUint64.
 func (se SizeEstimate) Add(sizeEstimate SizeEstimate) SizeEstimate {
 	return SizeEstimate{
-		addUint64NoOverflow(se.Min, sizeEstimate.Min),
-		addUint64NoOverflow(se.Max, sizeEstimate.Max),
+		cost.SafeAdd(se.Min, sizeEstimate.Min),
+		cost.SafeAdd(se.Max, sizeEstimate.Max),
 	}
 }
 
@@ -124,8 +125,8 @@ func (se SizeEstimate) Add(sizeEstimate SizeEstimate) SizeEstimate {
 // If multiply would result in an uint64 overflow, the result is math.MaxUint64.
 func (se SizeEstimate) Multiply(sizeEstimate SizeEstimate) SizeEstimate {
 	return SizeEstimate{
-		multiplyUint64NoOverflow(se.Min, sizeEstimate.Min),
-		multiplyUint64NoOverflow(se.Max, sizeEstimate.Max),
+		cost.SafeMultiply(se.Min, sizeEstimate.Min),
+		cost.SafeMultiply(se.Max, sizeEstimate.Max),
 	}
 }
 
@@ -133,17 +134,17 @@ func (se SizeEstimate) Multiply(sizeEstimate SizeEstimate) SizeEstimate {
 // nearest integer of the result, rounded up.
 func (se SizeEstimate) MultiplyByCostFactor(costPerUnit float64) CostEstimate {
 	return CostEstimate{
-		multiplyByCostFactor(se.Min, costPerUnit),
-		multiplyByCostFactor(se.Max, costPerUnit),
+		cost.SafeMultiplyByFactor(se.Min, costPerUnit),
+		cost.SafeMultiplyByFactor(se.Max, costPerUnit),
 	}
 }
 
 // MultiplyByCost multiplies by the cost and returns the product.
 // If multiply would result in an uint64 overflow, the result is math.MaxUint64.
-func (se SizeEstimate) MultiplyByCost(cost CostEstimate) CostEstimate {
+func (se SizeEstimate) MultiplyByCost(estimate CostEstimate) CostEstimate {
 	return CostEstimate{
-		multiplyUint64NoOverflow(se.Min, cost.Min),
-		multiplyUint64NoOverflow(se.Max, cost.Max),
+		cost.SafeMultiply(se.Min, estimate.Min),
+		cost.SafeMultiply(se.Max, estimate.Max),
 	}
 }
 
@@ -176,25 +177,25 @@ func UnknownCostEstimate() CostEstimate {
 }
 
 // FixedCostEstimate returns a cost with a fixed min and max range.
-func FixedCostEstimate(cost uint64) CostEstimate {
-	return CostEstimate{Min: cost, Max: cost}
+func FixedCostEstimate(fixedCost uint64) CostEstimate {
+	return CostEstimate{Min: fixedCost, Max: fixedCost}
 }
 
 // Add adds the costs and returns the sum.
 // If add would result in an uint64 overflow for the min or max, the value is set to math.MaxUint64.
-func (ce CostEstimate) Add(cost CostEstimate) CostEstimate {
+func (ce CostEstimate) Add(estimate CostEstimate) CostEstimate {
 	return CostEstimate{
-		Min: addUint64NoOverflow(ce.Min, cost.Min),
-		Max: addUint64NoOverflow(ce.Max, cost.Max),
+		Min: cost.SafeAdd(ce.Min, estimate.Min),
+		Max: cost.SafeAdd(ce.Max, estimate.Max),
 	}
 }
 
 // Multiply multiplies by the cost and returns the product.
 // If multiply would result in an uint64 overflow, the result is math.MaxUint64.
-func (ce CostEstimate) Multiply(cost CostEstimate) CostEstimate {
+func (ce CostEstimate) Multiply(estimate CostEstimate) CostEstimate {
 	return CostEstimate{
-		Min: multiplyUint64NoOverflow(ce.Min, cost.Min),
-		Max: multiplyUint64NoOverflow(ce.Max, cost.Max),
+		Min: cost.SafeMultiply(ce.Min, estimate.Min),
+		Max: cost.SafeMultiply(ce.Max, estimate.Max),
 	}
 }
 
@@ -202,8 +203,8 @@ func (ce CostEstimate) Multiply(cost CostEstimate) CostEstimate {
 // nearest integer of the result, rounded up.
 func (ce CostEstimate) MultiplyByCostFactor(costPerUnit float64) CostEstimate {
 	return CostEstimate{
-		Min: multiplyByCostFactor(ce.Min, costPerUnit),
-		Max: multiplyByCostFactor(ce.Max, costPerUnit),
+		Min: cost.SafeMultiplyByFactor(ce.Min, costPerUnit),
+		Max: cost.SafeMultiplyByFactor(ce.Max, costPerUnit),
 	}
 }
 
@@ -217,37 +218,6 @@ func (ce CostEstimate) Union(size CostEstimate) CostEstimate {
 		result.Max = size.Max
 	}
 	return result
-}
-
-// addUint64NoOverflow adds non-negative ints. If the result is exceeds math.MaxUint64, math.MaxUint64
-// is returned.
-func addUint64NoOverflow(x, y uint64) uint64 {
-	if y > 0 && x > math.MaxUint64-y {
-		return math.MaxUint64
-	}
-	return x + y
-}
-
-// multiplyUint64NoOverflow multiplies non-negative ints. If the result is exceeds math.MaxUint64, math.MaxUint64
-// is returned.
-func multiplyUint64NoOverflow(x, y uint64) uint64 {
-	if y != 0 && x > math.MaxUint64/y {
-		return math.MaxUint64
-	}
-	return x * y
-}
-
-// multiplyByFactor multiplies an integer by a cost factor float and returns the nearest integer value, rounded up.
-func multiplyByCostFactor(x uint64, y float64) uint64 {
-	xFloat := float64(x)
-	if xFloat > 0 && y > 0 && xFloat > math.MaxUint64/y {
-		return math.MaxUint64
-	}
-	ceil := math.Ceil(xFloat * y)
-	if ceil >= doubleTwoTo64 {
-		return math.MaxUint64
-	}
-	return uint64(ceil)
 }
 
 // CostOption configures flags which affect cost computations.
@@ -465,32 +435,32 @@ func (c *coster) cost(e ast.Expr) CostEstimate {
 	if e == nil {
 		return CostEstimate{}
 	}
-	var cost CostEstimate
+	var estimate CostEstimate
 	switch e.Kind() {
 	case ast.LiteralKind:
-		cost = constCost
+		estimate = constCost
 	case ast.IdentKind:
-		cost = c.costIdent(e)
+		estimate = c.costIdent(e)
 	case ast.SelectKind:
-		cost = c.costSelect(e)
+		estimate = c.costSelect(e)
 	case ast.CallKind:
-		cost = c.costCall(e)
+		estimate = c.costCall(e)
 	case ast.ListKind:
-		cost = c.costCreateList(e)
+		estimate = c.costCreateList(e)
 	case ast.MapKind:
-		cost = c.costCreateMap(e)
+		estimate = c.costCreateMap(e)
 	case ast.StructKind:
-		cost = c.costCreateStruct(e)
+		estimate = c.costCreateStruct(e)
 	case ast.ComprehensionKind:
 		if c.isBind(e) {
-			cost = c.costBind(e)
+			estimate = c.costBind(e)
 		} else {
-			cost = c.costComprehension(e)
+			estimate = c.costComprehension(e)
 		}
 	default:
 		return CostEstimate{}
 	}
-	return cost
+	return estimate
 }
 
 func (c *coster) costIdent(e ast.Expr) CostEstimate {
@@ -1013,14 +983,14 @@ func computeExprSize(expr ast.Expr) *SizeEstimate {
 	default:
 		return nil
 	}
-	cost := FixedSizeEstimate(v)
-	return &cost
+	size := FixedSizeEstimate(v)
+	return &size
 }
 
 func computeTypeSize(t *types.Type) *SizeEstimate {
 	if isScalar(t) {
-		cost := FixedSizeEstimate(1)
-		return &cost
+		size := FixedSizeEstimate(1)
+		return &size
 	}
 	return nil
 }
@@ -1041,8 +1011,6 @@ func isScalar(t *types.Type) bool {
 }
 
 var (
-	doubleTwoTo64 = math.Ldexp(1.0, 64)
-
 	unknownSizeEstimate = SizeEstimate{Min: 0, Max: math.MaxUint64}
 	unknownCostEstimate = unknownSizeEstimate.MultiplyByCostFactor(1)
 

--- a/common/cost/BUILD.bazel
+++ b/common/cost/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "cost.go",
+    ],
+    importpath = "github.com/google/cel-go/common/cost",
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = [
+        "cost_test.go",
+    ],
+    embed = [
+        ":go_default_library",
+    ],
+)

--- a/common/cost/cost.go
+++ b/common/cost/cost.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cost provides the saturating arithmetic shared by cost estimation and cost tracking.
+//
+// Costs and sizes are unsigned 64-bit values where math.MaxUint64 doubles as the representation
+// of an unbounded, or unknown, quantity. Every operation in this package saturates at
+// math.MaxUint64 rather than wrapping so that an unbounded input remains unbounded through any
+// sequence of operations.
+package cost
+
+import "math"
+
+// maxUint64AsFloat is the smallest float64 value greater than math.MaxUint64.
+//
+// Conversion of a float64 to a uint64 is undefined when the value is out of range, so float
+// results are compared against this bound before conversion.
+var maxUint64AsFloat = math.Ldexp(1.0, 64)
+
+// SafeAdd returns the sum of the input values, saturating at math.MaxUint64.
+func SafeAdd(x, y uint64, rest ...uint64) uint64 {
+	sum := x
+	if y > 0 && sum > math.MaxUint64-y {
+		return math.MaxUint64
+	}
+	sum += y
+	for _, r := range rest {
+		if r > 0 && sum > math.MaxUint64-r {
+			return math.MaxUint64
+		}
+		sum += r
+	}
+	return sum
+}
+
+// SafeMultiply returns the product of the input values, saturating at math.MaxUint64.
+func SafeMultiply(x, y uint64) uint64 {
+	if y != 0 && x > math.MaxUint64/y {
+		return math.MaxUint64
+	}
+	return x * y
+}
+
+// SafeMultiplyByFactor multiplies a value by a cost factor and returns the nearest integer
+// value, rounded up, saturating at math.MaxUint64.
+func SafeMultiplyByFactor(x uint64, factor float64) uint64 {
+	xFloat := float64(x)
+	if xFloat > 0 && factor > 0 && xFloat > math.MaxUint64/factor {
+		return math.MaxUint64
+	}
+	return SafeCeil(xFloat * factor)
+}
+
+// SafeCeil returns the smallest integer value greater than or equal to the input, saturating at
+// math.MaxUint64 and flooring at zero.
+//
+// Negative and NaN inputs return zero.
+func SafeCeil(x float64) uint64 {
+	if math.IsNaN(x) || x <= 0 {
+		return 0
+	}
+	ceil := math.Ceil(x)
+	if ceil >= maxUint64AsFloat {
+		return math.MaxUint64
+	}
+	return uint64(ceil)
+}

--- a/common/cost/cost_test.go
+++ b/common/cost/cost_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cost
+
+import (
+	"math"
+	"testing"
+)
+
+func TestSafeAdd(t *testing.T) {
+	tests := []struct {
+		name string
+		x, y uint64
+		rest []uint64
+		want uint64
+	}{
+		{name: "zero", x: 0, y: 0, want: 0},
+		{name: "simple", x: 2, y: 3, want: 5},
+		{name: "variadic", x: 1, y: 2, rest: []uint64{3, 4}, want: 10},
+		{name: "max plus zero", x: math.MaxUint64, y: 0, want: math.MaxUint64},
+		{name: "overflow", x: math.MaxUint64, y: 1, want: math.MaxUint64},
+		{name: "overflow near max", x: math.MaxUint64 - 5, y: 10, want: math.MaxUint64},
+		{name: "overflow in rest", x: 1, y: 2, rest: []uint64{math.MaxUint64}, want: math.MaxUint64},
+		{name: "saturated stays saturated", x: math.MaxUint64, y: math.MaxUint64,
+			rest: []uint64{math.MaxUint64}, want: math.MaxUint64},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SafeAdd(tc.x, tc.y, tc.rest...); got != tc.want {
+				t.Errorf("SafeAdd(%d, %d, %v) got %d, want %d", tc.x, tc.y, tc.rest, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSafeMultiply(t *testing.T) {
+	tests := []struct {
+		name string
+		x, y uint64
+		want uint64
+	}{
+		{name: "zero", x: 0, y: 0, want: 0},
+		{name: "max by zero", x: math.MaxUint64, y: 0, want: 0},
+		{name: "simple", x: 3, y: 4, want: 12},
+		{name: "max by one", x: math.MaxUint64, y: 1, want: math.MaxUint64},
+		{name: "overflow", x: math.MaxUint64, y: 2, want: math.MaxUint64},
+		{name: "overflow squared", x: math.MaxUint32, y: math.MaxUint32 * 2, want: math.MaxUint64},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SafeMultiply(tc.x, tc.y); got != tc.want {
+				t.Errorf("SafeMultiply(%d, %d) got %d, want %d", tc.x, tc.y, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSafeMultiplyByFactor(t *testing.T) {
+	tests := []struct {
+		name   string
+		x      uint64
+		factor float64
+		want   uint64
+	}{
+		{name: "zero value", x: 0, factor: 0.1, want: 0},
+		{name: "zero factor", x: 100, factor: 0, want: 0},
+		{name: "rounds up", x: 15, factor: 0.1, want: 2},
+		{name: "exact", x: 10, factor: 0.1, want: 1},
+		{name: "whole factor", x: 10, factor: 3, want: 30},
+		{name: "max saturates", x: math.MaxUint64, factor: 2, want: math.MaxUint64},
+		{name: "max scaled down", x: math.MaxUint64, factor: 0.1, want: 1844674407370955264},
+		{name: "negative factor", x: 10, factor: -1, want: 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SafeMultiplyByFactor(tc.x, tc.factor); got != tc.want {
+				t.Errorf("SafeMultiplyByFactor(%d, %f) got %d, want %d", tc.x, tc.factor, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSafeCeil(t *testing.T) {
+	tests := []struct {
+		name string
+		x    float64
+		want uint64
+	}{
+		{name: "zero", x: 0, want: 0},
+		{name: "negative", x: -1.5, want: 0},
+		{name: "nan", x: math.NaN(), want: 0},
+		{name: "fraction", x: 0.1, want: 1},
+		{name: "rounds up", x: 2.5, want: 3},
+		{name: "whole", x: 3.0, want: 3},
+		{name: "infinity", x: math.Inf(1), want: math.MaxUint64},
+		{name: "out of range", x: math.Ldexp(1.0, 64), want: math.MaxUint64},
+		{name: "largest in range", x: math.Ldexp(1.0, 63), want: 1 << 63},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SafeCeil(tc.x); got != tc.want {
+				t.Errorf("SafeCeil(%f) got %d, want %d", tc.x, got, tc.want)
+			}
+		})
+	}
+}

--- a/ext/BUILD.bazel
+++ b/ext/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//checker:go_default_library",
         "//common:go_default_library",
         "//common/ast:go_default_library",
+        "//common/cost:go_default_library",
         "//common/decls:go_default_library",
         "//common/env:go_default_library",
         "//common/operators:go_default_library",

--- a/ext/costs.go
+++ b/ext/costs.go
@@ -66,6 +66,8 @@ func actualSize(value ref.Val) uint64 {
 	return 1
 }
 
+// nodeAsUintValue returns the value of a literal int node as a uint64, or the default value if the
+// node is not a non-negative int literal.
 func nodeAsUintValue(node checker.AstNode, defaultVal uint64) uint64 {
 	if node.Expr().Kind() != ast.LiteralKind {
 		return defaultVal
@@ -101,22 +103,4 @@ func atLeastOne(size checker.SizeEstimate) checker.SizeEstimate {
 		size.Max = 1
 	}
 	return size
-}
-
-func safeAdd(x, y uint64, rest ...uint64) uint64 {
-	if y > 0 && x > math.MaxUint64-y {
-		return math.MaxUint64
-	}
-	next := x + y
-	if len(rest) == 0 {
-		return next
-	}
-	return safeAdd(next, rest[0], rest[1:]...)
-}
-
-func safeMul(x, y uint64) uint64 {
-	if y != 0 && x > math.MaxUint64/y {
-		return math.MaxUint64
-	}
-	return x * y
 }

--- a/ext/encoders.go
+++ b/ext/encoders.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker"
+	"github.com/google/cel-go/common/cost"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter"
@@ -184,8 +185,8 @@ func estimateDecode(estimator checker.CostEstimator, target *checker.AstNode, ar
 
 func trackEncode(args []ref.Val, _ ref.Val) *uint64 {
 	sz := actualSize(args[0])
-	cost := uint64(math.Ceil(float64(sz)*stringCostFactor)) + callCost
-	return &cost
+	total := cost.SafeAdd(cost.SafeMultiplyByFactor(sz, stringCostFactor), callCost)
+	return &total
 }
 
 func trackJSONEncode(args []ref.Val, _ ref.Val) *uint64 {
@@ -195,8 +196,8 @@ func trackJSONEncode(args []ref.Val, _ ref.Val) *uint64 {
 
 func trackDecode(args []ref.Val, _ ref.Val) *uint64 {
 	sz := actualSize(args[0])
-	cost := uint64(math.Ceil(float64(sz)*stringCostFactor)) + callCost
-	return &cost
+	total := cost.SafeAdd(cost.SafeMultiplyByFactor(sz, stringCostFactor), callCost)
+	return &total
 }
 
 func estimateEncodeSize(sz checker.SizeEstimate) checker.SizeEstimate {

--- a/ext/lists.go
+++ b/ext/lists.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/cost"
 	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
@@ -893,7 +894,7 @@ func trackListSelfCompare(l traits.Lister) *uint64 {
 	if elem.Type() == types.StringType || elem.Type() == types.BytesType {
 		costFactor += common.StringTraversalCostFactor
 	}
-	return trackAllocatingListCall(costFactor, safeMul(sz, sz))
+	return trackAllocatingListCall(costFactor, cost.SafeMultiply(sz, sz))
 }
 
 // trackAllocatingListCall computes costs as a function of the size of the result list with a baseline cost
@@ -902,8 +903,8 @@ func trackAllocatingListCall(costFactor float64, size uint64) *uint64 {
 	if costFactor < 0.0 {
 		costFactor = 1.0
 	}
-	cost := safeAdd(uint64(float64(size)*costFactor), callCost, common.ListCreateBaseCost)
-	return &cost
+	total := cost.SafeAdd(uint64(float64(size)*costFactor), callCost, common.ListCreateBaseCost)
+	return &total
 }
 
 func estimateListDistinctLegacy(estimator checker.CostEstimator, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {

--- a/ext/math.go
+++ b/ext/math.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/cost"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
@@ -982,6 +983,6 @@ func estimateMathListCost(estimator checker.CostEstimator, target *checker.AstNo
 
 func trackMathListCost(args []ref.Val, _ ref.Val) *uint64 {
 	sz := actualSize(args[0])
-	cost := safeAdd(sz, callCost)
-	return &cost
+	total := cost.SafeAdd(sz, callCost)
+	return &total
 }

--- a/ext/network.go
+++ b/ext/network.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/cost"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter"
@@ -766,13 +767,13 @@ func estimateNetworkContainsCIDRStringCost(estimator checker.CostEstimator, targ
 // Runtime cost tracking functions for network extensions.
 
 func trackNetworkParseCost(args []ref.Val, result ref.Val) *uint64 {
-	cost := uint64(math.Ceil(float64(actualSize(args[0])) * stringCostFactor))
-	return &cost
+	total := cost.SafeMultiplyByFactor(actualSize(args[0]), stringCostFactor)
+	return &total
 }
 
 func trackIPIsCanonicalCost(args []ref.Val, result ref.Val) *uint64 {
-	cost := uint64(math.Ceil(float64(actualSize(args[0])) * 2 * stringCostFactor))
-	return &cost
+	total := cost.SafeMultiplyByFactor(actualSize(args[0]), 2*stringCostFactor)
+	return &total
 }
 
 func trackNetworkNominalCost(args []ref.Val, result ref.Val) *uint64 {
@@ -781,30 +782,30 @@ func trackNetworkNominalCost(args []ref.Val, result ref.Val) *uint64 {
 
 func trackNetworkContainsIPIPCost(args []ref.Val, result ref.Val) *uint64 {
 	cidrSize := actualSize(args[0])
-	cost := uint64(math.Ceil(float64(cidrSize+cidrSize) * stringCostFactor))
-	return &cost
+	total := cost.SafeMultiplyByFactor(cost.SafeAdd(cidrSize, cidrSize), stringCostFactor)
+	return &total
 }
 
 func trackNetworkContainsIPStringCost(args []ref.Val, result ref.Val) *uint64 {
 	cidrSize := actualSize(args[0])
 	otherSize := actualSize(args[1])
-	cost := uint64(math.Ceil(float64(cidrSize+cidrSize) * stringCostFactor))
-	cost = safeAdd(cost, uint64(math.Ceil(float64(otherSize)*stringCostFactor)))
-	return &cost
+	total := cost.SafeMultiplyByFactor(cost.SafeAdd(cidrSize, cidrSize), stringCostFactor)
+	total = cost.SafeAdd(total, cost.SafeMultiplyByFactor(otherSize, stringCostFactor))
+	return &total
 }
 
 func trackNetworkContainsCIDRCIDRCost(args []ref.Val, result ref.Val) *uint64 {
 	cidrSize := actualSize(args[0])
-	cost := uint64(math.Ceil(float64(cidrSize+cidrSize) * stringCostFactor))
-	cost = safeAdd(cost, uint64(math.Ceil(float64(cidrSize)*stringCostFactor)), 1)
-	return &cost
+	total := cost.SafeMultiplyByFactor(cost.SafeAdd(cidrSize, cidrSize), stringCostFactor)
+	total = cost.SafeAdd(total, cost.SafeMultiplyByFactor(cidrSize, stringCostFactor), 1)
+	return &total
 }
 
 func trackNetworkContainsCIDRStringCost(args []ref.Val, result ref.Val) *uint64 {
 	cidrSize := actualSize(args[0])
 	otherSize := actualSize(args[1])
-	cost := uint64(math.Ceil(float64(cidrSize+cidrSize) * stringCostFactor))
-	cost = safeAdd(cost, uint64(math.Ceil(float64(cidrSize)*stringCostFactor)), 1)
-	cost = safeAdd(cost, uint64(math.Ceil(float64(otherSize)*stringCostFactor)))
-	return &cost
+	total := cost.SafeMultiplyByFactor(cost.SafeAdd(cidrSize, cidrSize), stringCostFactor)
+	total = cost.SafeAdd(total, cost.SafeMultiplyByFactor(cidrSize, stringCostFactor), 1)
+	total = cost.SafeAdd(total, cost.SafeMultiplyByFactor(otherSize, stringCostFactor))
+	return &total
 }

--- a/ext/regex.go
+++ b/ext/regex.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/common"
+	"github.com/google/cel-go/common/cost"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter"
@@ -411,8 +412,8 @@ func estimateReplaceCost() checker.FunctionEstimator {
 
 func extractCostTracker() interpreter.FunctionTracker {
 	return func(args []ref.Val, result ref.Val) *uint64 {
-		targetCost := float64(safeAdd(actualSize(args[0]), 1)) * common.StringTraversalCostFactor
-		regexCost := float64(safeAdd(actualSize(args[1]), 1)) * common.RegexStringLengthCostFactor
+		targetCost := float64(cost.SafeAdd(actualSize(args[0]), 1)) * common.StringTraversalCostFactor
+		regexCost := float64(cost.SafeAdd(actualSize(args[1]), 1)) * common.RegexStringLengthCostFactor
 		// Actual search cost calculation = targetCost + regexCost
 		searchCost := targetCost * regexCost
 		// The total cost is the base call cost + search cost + result string allocation.

--- a/ext/sets.go
+++ b/ext/sets.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/cost"
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
@@ -248,7 +249,7 @@ func trackSetsCost(costFactor float64) interpreter.FunctionTracker {
 	return func(args []ref.Val, _ ref.Val) *uint64 {
 		lhsSize := actualSize(args[0])
 		rhsSize := actualSize(args[1])
-		cost := safeAdd(callCost, uint64(float64(lhsSize*rhsSize)*costFactor))
-		return &cost
+		total := cost.SafeAdd(callCost, uint64(float64(lhsSize*rhsSize)*costFactor))
+		return &total
 	}
 }

--- a/ext/strings.go
+++ b/ext/strings.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/common"
+	"github.com/google/cel-go/common/cost"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
@@ -972,7 +973,7 @@ func estimateStringReplaceCost(estimator checker.CostEstimator, target *checker.
 	searchCost := atLeastOne(targetSize).Multiply(needleSize).MultiplyByCostFactor(stringCostFactor)
 
 	replacementSize := estimateSize(estimator, args[1]).Add(fixedSizeEstimate(1))
-	allReplacedSize := safeMul(safeAdd(targetSize.Max, 1), replacementSize.Max)
+	allReplacedSize := cost.SafeMultiply(cost.SafeAdd(targetSize.Max, 1), replacementSize.Max)
 	resultMinSize := targetSize.Min
 	if resultMinSize > replacementSize.Min {
 		resultMinSize = replacementSize.Min
@@ -1017,10 +1018,10 @@ func estimateStringJoinCost(estimator checker.CostEstimator, target *checker.Ast
 	traversalCost := targetSize.Add(fixedSizeEstimate(1)).MultiplyByCostFactor(stringCostFactor)
 	// Result size: sum of element sizes + (n-1) * separator size.
 	// Worst case estimate: use list size * max element size + list size * separator size.
-	maxResultSize := safeAdd(safeMul(targetSize.Max, (safeAdd(1, sepSize.Max))), sepSize.Max)
+	maxResultSize := cost.SafeAdd(cost.SafeMultiply(targetSize.Max, cost.SafeAdd(1, sepSize.Max)), sepSize.Max)
 	resultSize := rangedSizeEstimate(0, maxResultSize)
-	cost := traversalCost.Add(resultSize.MultiplyByCostFactor(1)).Add(callCostEstimate)
-	return callEstimate(cost, &resultSize)
+	estimate := traversalCost.Add(resultSize.MultiplyByCostFactor(1)).Add(callCostEstimate)
+	return callEstimate(estimate, &resultSize)
 }
 
 // Runtime cost tracking functions for string extensions.
@@ -1030,24 +1031,23 @@ func estimateStringJoinCost(estimator checker.CostEstimator, target *checker.Ast
 
 // trackStringCharAtCost tracks runtime cost for O(n) string operations.
 func trackStringCharAtCost(args []ref.Val, result ref.Val) *uint64 {
-	size := float64(actualSize(args[0])) * stringCostFactor
-	cost := safeAdd(callCost, uint64(math.Ceil(size)), 1)
-	return &cost
+	total := cost.SafeAdd(callCost, cost.SafeMultiplyByFactor(actualSize(args[0]), stringCostFactor), 1)
+	return &total
 }
 
 // trackStringTransformCost tracks runtime cost for O(n) string operations.
 func trackStringTransformCost(args []ref.Val, result ref.Val) *uint64 {
-	transformCost := math.Ceil(float64(actualSize(args[0])) * stringCostFactor)
+	transformCost := cost.SafeMultiplyByFactor(actualSize(args[0]), stringCostFactor)
 	resultSize := actualSize(result)
-	cost := safeAdd(callCost, uint64(transformCost), resultSize)
-	return &cost
+	total := cost.SafeAdd(callCost, transformCost, resultSize)
+	return &total
 }
 
 // trackStringSearchCost tracks runtime cost for O(n*m) string search operations.
 func trackStringSearchCost(args []ref.Val, _ ref.Val) *uint64 {
-	searchCost := float64(actualSize(args[0])*actualSize(args[1])) * stringCostFactor
-	cost := safeAdd(uint64(math.Ceil(searchCost)), callCost)
-	return &cost
+	searchSize := cost.SafeMultiply(actualSize(args[0]), actualSize(args[1]))
+	total := cost.SafeAdd(cost.SafeMultiplyByFactor(searchSize, stringCostFactor), callCost)
+	return &total
 }
 
 // trackStringReplaceCost tracks runtime cost for string replace operations,
@@ -1061,24 +1061,24 @@ func trackStringReplaceCost(args []ref.Val, result ref.Val) *uint64 {
 	if needleSize == 0 {
 		needleSize = 1
 	}
-	searchCost := uint64(math.Ceil(float64(targetSize*needleSize) * stringCostFactor))
-	cost := safeAdd(callCost, searchCost, actualSize(result))
-	return &cost
+	searchCost := cost.SafeMultiplyByFactor(cost.SafeMultiply(targetSize, needleSize), stringCostFactor)
+	total := cost.SafeAdd(callCost, searchCost, actualSize(result))
+	return &total
 }
 
 // trackStringSplitCost tracks runtime cost for string split operations,
 // accounting for traversal and list allocation.
 func trackStringSplitCost(args []ref.Val, result ref.Val) *uint64 {
-	traversalCost := float64(safeAdd(actualSize(args[0]), 1)) * stringCostFactor
+	traversalCost := cost.SafeMultiplyByFactor(cost.SafeAdd(actualSize(args[0]), 1), stringCostFactor)
 	resultSize := actualSize(result)
-	cost := safeAdd(callCost, uint64(math.Ceil(traversalCost)), resultSize, common.ListCreateBaseCost)
-	return &cost
+	total := cost.SafeAdd(callCost, traversalCost, resultSize, common.ListCreateBaseCost)
+	return &total
 }
 
 // trackStringJoinCost tracks runtime cost for string join operations,
 // accounting for traversal and the size of the result.
 func trackStringJoinCost(args []ref.Val, result ref.Val) *uint64 {
-	traversalCost := float64(safeAdd(actualSize(args[0]), 1)) * stringCostFactor
-	cost := safeAdd(callCost, uint64(math.Ceil(traversalCost)), actualSize(result))
-	return &cost
+	traversalCost := cost.SafeMultiplyByFactor(cost.SafeAdd(actualSize(args[0]), 1), stringCostFactor)
+	total := cost.SafeAdd(callCost, traversalCost, actualSize(result))
+	return &total
 }

--- a/interpreter/BUILD.bazel
+++ b/interpreter/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//common:go_default_library",
         "//common/ast:go_default_library",
         "//common/containers:go_default_library",
+        "//common/cost:go_default_library",
         "//common/functions:go_default_library",
         "//common/operators:go_default_library",
         "//common/overloads:go_default_library",

--- a/interpreter/runtimecost.go
+++ b/interpreter/runtimecost.go
@@ -16,9 +16,9 @@ package interpreter
 
 import (
 	"errors"
-	"math"
 
 	"github.com/google/cel-go/common"
+	"github.com/google/cel-go/common/cost"
 	"github.com/google/cel-go/common/overloads"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
@@ -254,21 +254,21 @@ func (c *CostTracker) ActualCost() uint64 {
 }
 
 func (c *CostTracker) costCall(call InterpretableCall, args []ref.Val, result ref.Val) uint64 {
-	var cost uint64
+	var total uint64
 	if len(c.overloadTrackers) != 0 {
 		if tracker, found := c.overloadTrackers[call.OverloadID()]; found {
 			callCost := tracker(args, result)
 			if callCost != nil {
-				cost = safeAdd(cost, *callCost)
-				return cost
+				total = cost.SafeAdd(total, *callCost)
+				return total
 			}
 		}
 	}
 	if c.Estimator != nil {
 		callCost := c.Estimator.CallCost(call.Function(), call.OverloadID(), args, result)
 		if callCost != nil {
-			cost = safeAdd(cost, *callCost)
-			return cost
+			total = cost.SafeAdd(total, *callCost)
+			return total
 		}
 	}
 	// if user didn't specify, the default way of calculating runtime cost would be used.
@@ -276,13 +276,13 @@ func (c *CostTracker) costCall(call InterpretableCall, args []ref.Val, result re
 	switch call.OverloadID() {
 	// O(n) functions
 	case overloads.StartsWithString, overloads.EndsWithString:
-		cost = safeAdd(cost, uint64(math.Ceil(float64(actualSize(args[1]))*common.StringTraversalCostFactor)))
+		total = cost.SafeAdd(total, cost.SafeMultiplyByFactor(actualSize(args[1]), common.StringTraversalCostFactor))
 	case overloads.StringToBytes, overloads.BytesToString, overloads.ExtQuoteString, overloads.ExtFormatString:
-		cost = safeAdd(cost, uint64(math.Ceil(float64(actualSize(args[0]))*common.StringTraversalCostFactor)))
+		total = cost.SafeAdd(total, cost.SafeMultiplyByFactor(actualSize(args[0]), common.StringTraversalCostFactor))
 	case overloads.InList:
 		// If a list is composed entirely of constant values this is O(1), but we don't account for that here.
 		// We just assume all list containment checks are O(n).
-		cost = safeAdd(cost, actualSize(args[1]))
+		total = cost.SafeAdd(total, actualSize(args[1]))
 	// O(min(m, n)) functions
 	case overloads.LessString, overloads.GreaterString, overloads.LessEqualsString, overloads.GreaterEqualsString,
 		overloads.LessBytes, overloads.GreaterBytes, overloads.LessEqualsBytes, overloads.GreaterEqualsBytes,
@@ -293,28 +293,29 @@ func (c *CostTracker) costCall(call InterpretableCall, args []ref.Val, result re
 		lhsSize := actualSize(args[0])
 		rhsSize := actualSize(args[1])
 		minSize := min(rhsSize, lhsSize)
-		cost = safeAdd(cost, uint64(math.Ceil(float64(minSize)*common.StringTraversalCostFactor)))
+		total = cost.SafeAdd(total, cost.SafeMultiplyByFactor(minSize, common.StringTraversalCostFactor))
 	// O(m+n) functions
 	case overloads.AddString, overloads.AddBytes:
 		// In the worst case scenario, we would need to reallocate a new backing store and copy both operands over.
-		cost = safeAdd(cost, uint64(math.Ceil(float64(actualSize(args[0])+actualSize(args[1]))*common.StringTraversalCostFactor)))
+		argSize := cost.SafeAdd(actualSize(args[0]), actualSize(args[1]))
+		total = cost.SafeAdd(total, cost.SafeMultiplyByFactor(argSize, common.StringTraversalCostFactor))
 	// O(nm) functions
 	case overloads.Matches, overloads.MatchesString:
 		// https://swtch.com/~rsc/regexp/regexp1.html applies to RE2 implementation supported by CEL
 		// Add one to string length for purposes of cost calculation to prevent product of string and regex to be 0
 		// in case where string is empty but regex is still expensive.
-		strCost := uint64(math.Ceil((1.0 + float64(actualSize(args[0]))) * common.StringTraversalCostFactor))
+		strCost := cost.SafeMultiplyByFactor(cost.SafeAdd(1, actualSize(args[0])), common.StringTraversalCostFactor)
 		// We don't know how many expressions are in the regex, just the string length (a huge
 		// improvement here would be to somehow get a count the number of expressions in the regex or
 		// how many states are in the regex state machine and use that to measure regex cost).
 		// For now, we're making a guess that each expression in a regex is typically at least 4 chars
 		// in length.
-		regexCost := uint64(math.Ceil(float64(actualSize(args[1])) * common.RegexStringLengthCostFactor))
-		cost = safeAdd(cost, strCost*regexCost)
+		regexCost := cost.SafeMultiplyByFactor(actualSize(args[1]), common.RegexStringLengthCostFactor)
+		total = cost.SafeAdd(total, cost.SafeMultiply(strCost, regexCost))
 	case overloads.ContainsString:
-		strCost := uint64(math.Ceil(float64(actualSize(args[0])) * common.StringTraversalCostFactor))
-		substrCost := uint64(math.Ceil(float64(actualSize(args[1])) * common.StringTraversalCostFactor))
-		cost = safeAdd(cost, strCost*substrCost)
+		strCost := cost.SafeMultiplyByFactor(actualSize(args[0]), common.StringTraversalCostFactor)
+		substrCost := cost.SafeMultiplyByFactor(actualSize(args[1]), common.StringTraversalCostFactor)
+		total = cost.SafeAdd(total, cost.SafeMultiply(strCost, substrCost))
 
 	default:
 		// The following operations are assumed to have O(1) complexity.
@@ -324,10 +325,10 @@ func (c *CostTracker) costCall(call InterpretableCall, args []ref.Val, result re
 		// - Computing the size of strings, byte sequences, lists and maps.
 		// - Logical operations and all operators on fixed width scalars (comparisons, equality)
 		// - Any functions that don't have a declared cost either here or in provided ActualCostEstimator.
-		cost = safeAdd(cost, 1)
+		total = cost.SafeAdd(total, 1)
 
 	}
-	return cost
+	return total
 }
 
 // actualSize returns the size of the value for all traits.Sizer values, a fixed size for all proto-based
@@ -394,22 +395,4 @@ argloop:
 		return nil, false
 	}
 	return result, true
-}
-
-func safeAdd(x, y uint64, rest ...uint64) uint64 {
-	if y > 0 && x > math.MaxUint64-y {
-		return math.MaxUint64
-	}
-	next := x + y
-	if len(rest) == 0 {
-		return next
-	}
-	return safeAdd(next, rest[0], rest[1:]...)
-}
-
-func safeMul(x, y uint64) uint64 {
-	if y != 0 && x > math.MaxUint64/y {
-		return math.MaxUint64
-	}
-	return x * y
 }


### PR DESCRIPTION
Introduce `common/cost` to handle saturation-safe numeric computations related to cost estimation / tracking. 

Locals named `cost` in the touched functions were renamed to `total`/`estimate` so the package identifier is not shadowed.