### PR TITLE
Scale sizes for strings and bytes

### DIFF
--- a/common/types/list_test.go
+++ b/common/types/list_test.go
@@ -969,7 +969,7 @@ func TestListCalculateSize(t *testing.T) {
 		{
 			name: "string_list",
 			val:  NewStringList(adapter, []string{"hello", "world"}),
-			want: 11,
+			want: 3, // 1 (container) + 1 ("hello" unit) + 1 ("world" unit) = 3
 		},
 		{
 			name: "dynamic_list",

--- a/common/types/map_test.go
+++ b/common/types/map_test.go
@@ -1312,7 +1312,7 @@ func TestMapCalculateSize(t *testing.T) {
 		{
 			name: "string_string_map",
 			val:  NewStringStringMap(adapter, map[string]string{"k1": "v1", "k2": "v2"}),
-			want: 9,
+			want: 5, // 1 (container) + 4 (single-unit keys and values) = 5
 		},
 		{
 			name: "mutable_map_after_insert",

--- a/common/types/native_test.go
+++ b/common/types/native_test.go
@@ -1353,8 +1353,8 @@ func TestNativeObjectCalculateSize(t *testing.T) {
 					NestedListVal: []string{"a", "b"},
 				},
 			},
-			// 1 (root struct) + "hello"(5) + NestedVal(1 container + ["a", "b"](1+2=3) = 4) = 10
-			want: 10,
+			// 1 (root struct) + "hello"(1 unit) + NestedVal(1 container + ["a", "b"](1+2=3) = 4) = 6
+			want: 6,
 		},
 		{
 			name: "bytes_and_time",
@@ -1363,7 +1363,8 @@ func TestNativeObjectCalculateSize(t *testing.T) {
 				DurationVal:  time.Second,
 				TimestampVal: time.Unix(100, 0),
 			},
-			want: 7,
+			// 1 (root struct) + "test"(1 unit) + duration(1) + timestamp(1) = 4
+			want: 4,
 		},
 		{
 			name: "slice_of_structs",

--- a/common/types/size_calc.go
+++ b/common/types/size_calc.go
@@ -18,7 +18,6 @@ import (
 	"math"
 	"reflect"
 	"time"
-	"unicode/utf8"
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -28,8 +27,9 @@ import (
 )
 
 const (
-	defaultSizeCalculatorMaxDepth     = 5
-	defaultSizeCalculatorMaxTraversal = 10000
+	defaultSizeCalculatorMaxDepth         = 5
+	defaultSizeCalculatorMaxTraversal     = 10000
+	defaultSizeCalculatorStringUnitLength = 10
 )
 
 // SizeCalculatorOption configures a SizeCalculator instance.
@@ -49,19 +49,37 @@ func SizeCalculatorMaxTraversal(traversal int) SizeCalculatorOption {
 	}
 }
 
+// SizeCalculatorStringUnitLength sets the number of string or bytes value bytes which count as
+// a single element (default 10). Values less than 1 are treated as 1, meaning each byte counts
+// as a whole element.
+//
+// String sizes are measured in bytes rather than characters so that sizing large values is
+// O(1) rather than a full UTF-8 scan per observation; byte length is never smaller than the
+// character count, so byte-based sizing is conservative for limit enforcement.
+func SizeCalculatorStringUnitLength(length int) SizeCalculatorOption {
+	return func(s *SizeCalculator) {
+		if length < 1 {
+			length = 1
+		}
+		s.stringUnitLength = length
+	}
+}
+
 // SizeCalculator calculates the recursive element size of values.
 type SizeCalculator struct {
-	version      int
-	maxDepth     int
-	maxTraversal int
+	version          int
+	maxDepth         int
+	maxTraversal     int
+	stringUnitLength int
 }
 
 // NewSizeCalculator returns a new SizeCalculator configured with optional SizeCalculatorOption settings.
 func NewSizeCalculator(opts ...SizeCalculatorOption) *SizeCalculator {
 	s := &SizeCalculator{
-		version:      0,
-		maxDepth:     defaultSizeCalculatorMaxDepth,
-		maxTraversal: defaultSizeCalculatorMaxTraversal,
+		version:          0,
+		maxDepth:         defaultSizeCalculatorMaxDepth,
+		maxTraversal:     defaultSizeCalculatorMaxTraversal,
+		stringUnitLength: defaultSizeCalculatorStringUnitLength,
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -105,6 +123,15 @@ func (s *SizeCalculator) AggregateSize(val any) uint32 {
 	return ctx.AggregateSize(val)
 }
 
+// stringSize converts a byte length to an element count where stringUnitLength bytes count
+// as a single element, rounding up with a minimum size of 1.
+func (s *SizeCalculator) stringSize(length int) uint32 {
+	if length <= 0 {
+		return 1
+	}
+	return safeUint32FromInt((length + s.stringUnitLength - 1) / s.stringUnitLength)
+}
+
 // AggregateSize implements the ref.Val interface and allows for the generation of nested
 // child context values which are necessary for correct traversal count tracking.
 func (c sizeContext) AggregateSize(val any) uint32 {
@@ -112,6 +139,10 @@ func (c sizeContext) AggregateSize(val any) uint32 {
 		return math.MaxUint32
 	}
 	switch v := val.(type) {
+	case String:
+		return c.calc.stringSize(len(v))
+	case Bytes:
+		return c.calc.stringSize(len(v))
 	case AggregateSizeVisitor:
 		return v.AggregateSize(c.childContext())
 	case traits.Foldable:
@@ -161,9 +192,9 @@ func (c sizeContext) AggregateSize(val any) uint32 {
 	case reflect.Value:
 		return getReflectValueAggregateSize(c, v)
 	case string:
-		return safeUint32FromInt(utf8.RuneCountInString(v))
+		return c.calc.stringSize(len(v))
 	case []byte:
-		return safeUint32FromInt(len(v))
+		return c.calc.stringSize(len(v))
 	case int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64,
 		float32, float64, bool, time.Time, time.Duration, nil:
@@ -245,11 +276,11 @@ func getReflectValueAggregateSize(c sizeContext, fieldVal reflect.Value) uint32 
 	childCtx := c.childContext()
 	switch fieldVal.Kind() {
 	case reflect.String:
-		return safeUint32FromInt(utf8.RuneCountInString(fieldVal.String()))
+		return c.calc.stringSize(fieldVal.Len())
 	case reflect.Slice, reflect.Array:
 		elemType := fieldVal.Type().Elem()
 		if elemType.Kind() == reflect.Uint8 {
-			return safeUint32FromInt(fieldVal.Len())
+			return c.calc.stringSize(fieldVal.Len())
 		}
 		total := safeAddUint32(1, safeUint32FromInt(fieldVal.Len()))
 		switch elemType.Kind() {

--- a/common/types/size_calc_test.go
+++ b/common/types/size_calc_test.go
@@ -45,12 +45,12 @@ func TestCalculateSize(t *testing.T) {
 		{
 			name: "sizer_string",
 			val:  String("hello"),
-			want: 5,
+			want: 1, // 5 bytes round up to a single 10-byte element unit
 		},
 		{
 			name: "sizer_bytes",
 			val:  Bytes("world"),
-			want: 5,
+			want: 1,
 		},
 		{
 			name: "err_val",
@@ -100,12 +100,12 @@ func TestCalculateSize(t *testing.T) {
 		{
 			name: "proto_value_string",
 			val:  protoreflect.ValueOfString("hello"),
-			want: 5,
+			want: 1,
 		},
 		{
 			name: "proto_value_bytes",
 			val:  protoreflect.ValueOfBytes([]byte("world")),
-			want: 5,
+			want: 1,
 		},
 		{
 			name: "proto_value_int",
@@ -115,12 +115,12 @@ func TestCalculateSize(t *testing.T) {
 		{
 			name: "proto_map_key",
 			val:  protoreflect.MapKey(protoreflect.ValueOfString("key")),
-			want: 3,
+			want: 1,
 		},
 		{
 			name: "proto_message",
 			val:  &proto3pb.TestAllTypes{SingleString: "hello"},
-			want: 6, // 1 (root) + 5 (string) = 6
+			want: 2, // 1 (root) + 1 (string unit) = 2
 		},
 		{
 			name: "proto_message_with_list_and_map",
@@ -153,17 +153,17 @@ func TestCalculateSize(t *testing.T) {
 		{
 			name: "reflect_value",
 			val:  reflect.ValueOf("reflected"),
-			want: 9,
+			want: 1,
 		},
 		{
 			name: "native_string",
 			val:  "hello",
-			want: 5,
+			want: 1,
 		},
 		{
 			name: "native_bytes",
 			val:  []byte("world"),
-			want: 5,
+			want: 1,
 		},
 		{
 			name: "native_int",
@@ -198,7 +198,7 @@ func TestCalculateSize(t *testing.T) {
 		{
 			name: "custom_struct",
 			val:  struct{ Name string }{"cel"},
-			want: 4, // 1 (root) + 3 ("cel") = 4
+			want: 2, // 1 (root) + 1 ("cel") = 2
 		},
 		{
 			name: "custom_lister",
@@ -208,12 +208,12 @@ func TestCalculateSize(t *testing.T) {
 		{
 			name: "custom_mapper",
 			val:  interopFoldableMap{Mapper: NewStringStringMap(DefaultTypeAdapter, map[string]string{"key": "val"})},
-			want: 7, // 1 (container) + 3 ("key") + 3 ("val") = 7
+			want: 3, // 1 (container) + 1 ("key") + 1 ("val") = 3
 		},
 		{
 			name: "custom_pure_mapper",
 			val:  customPureMapper{Mapper: NewStringStringMap(DefaultTypeAdapter, map[string]string{"key": "val"})},
-			want: 7, // 1 (container) + 3 ("key") + 3 ("val") = 7
+			want: 3, // 1 (container) + 1 ("key") + 1 ("val") = 3
 		},
 		{
 			name: "custom_sizer_struct_field",
@@ -791,4 +791,55 @@ func createNestedCustomList(adapter Adapter, depth, width int) ref.Val {
 		elems[i] = createNestedCustomList(adapter, depth-1, width)
 	}
 	return proxyLegacyList{proxy: NewRefValList(adapter, elems)}
+}
+
+func TestSizeCalculatorStringUnitLength(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []SizeCalculatorOption
+		val  any
+		want uint32
+	}{
+		{name: "empty_string_unit", val: String(""), want: 1},
+		{name: "one_unit_exact", val: String("0123456789"), want: 1},
+		{name: "one_unit_plus_one", val: String("0123456789a"), want: 2},
+		{name: "three_units", val: String("0123456789012345678901"), want: 3},
+		{name: "bytes_two_units", val: Bytes("01234567890"), want: 2},
+		{name: "native_string_two_units", val: "01234567890", want: 2},
+		{name: "native_bytes_two_units", val: []byte("01234567890"), want: 2},
+		{name: "reflect_string_two_units", val: reflect.ValueOf("01234567890"), want: 2},
+		{
+			name: "unit_length_one",
+			opts: []SizeCalculatorOption{SizeCalculatorStringUnitLength(1)},
+			val:  String("hello"),
+			want: 5,
+		},
+		{
+			name: "unit_length_below_one_clamped",
+			opts: []SizeCalculatorOption{SizeCalculatorStringUnitLength(0)},
+			val:  String("hello"),
+			want: 5,
+		},
+		{
+			name: "unit_length_large",
+			opts: []SizeCalculatorOption{SizeCalculatorStringUnitLength(100)},
+			val:  String("hello world, hello world, hello world"),
+			want: 1,
+		},
+		{
+			// Sizes are measured in bytes, not characters: four 3-byte CJK characters
+			// occupy 12 bytes and count as two 10-byte units.
+			name: "multibyte_counted_in_bytes",
+			val:  String("日本語字"),
+			want: 2,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			calc := NewSizeCalculator(tc.opts...)
+			if got := calc.AggregateSize(tc.val); got != tc.want {
+				t.Errorf("AggregateSize(%v) got %d, want %d", tc.val, got, tc.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
String and bytes values now count as one element per ten bytes, rounding up with a minimum of one element, configurable via `SizeCalculatorStringUnitLength`. 

Sizes are measured in bytes rather than characters so that sizing large values is O(1) rather than a full UTF-8 scan per observation; byte length is never smaller than the character count, so byte-based sizing is conservative for limit enforcement.