### PR TITLE
mem-track: Fix data race for aggregate size computation

### DIFF
--- a/common/types/list.go
+++ b/common/types/list.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync/atomic"
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -109,8 +110,12 @@ func NewMutableList(adapter Adapter) traits.MutableLister {
 // The `Adapter` enables native type to CEL type conversions.
 type baseList struct {
 	Adapter
-	value   any
-	size    int
+	value any
+	size  int
+	// aggSize memoizes the aggregate size computed by the first completed sizing of this
+	// list. Accessed atomically since immutable lists may be shared across concurrent
+	// evaluations; zero means not yet computed. See the SizeCalculator documentation for
+	// the memoization contract.
 	aggSize uint32
 	get     func(int) any
 }
@@ -266,14 +271,16 @@ func (l *baseList) Size() ref.Val {
 
 // AggregateSize implements the AggregateSizeVisitor interface method.
 func (l *baseList) AggregateSize(sizer AggregateSizer) uint32 {
-	if l.aggSize != 0 {
-		return l.aggSize
+	if sz := atomic.LoadUint32(&l.aggSize); sz != 0 {
+		return sz
 	}
 	total := uint32(1)
 	for i := range l.size {
 		total = safeAddUint32(total, sizer.AggregateSize(l.get(i)))
 	}
-	l.aggSize = total
+	if cacheableAggregateSize(sizer) {
+		atomic.StoreUint32(&l.aggSize, total)
+	}
 	return total
 }
 
@@ -330,13 +337,13 @@ func (l *mutableList) Add(other ref.Val) ref.Val {
 	case *mutableList:
 		l.mutableValues = append(l.mutableValues, otherList.mutableValues...)
 		l.size += len(otherList.mutableValues)
-		l.aggSize = 0
+		atomic.StoreUint32(&l.aggSize, 0)
 	case traits.Lister:
 		for i := IntZero; i < otherList.Size().(Int); i++ {
 			l.size++
 			l.mutableValues = append(l.mutableValues, otherList.Get(i))
 		}
-		l.aggSize = 0
+		atomic.StoreUint32(&l.aggSize, 0)
 	default:
 		return MaybeNoSuchOverloadErr(otherList)
 	}

--- a/common/types/map.go
+++ b/common/types/map.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"unicode"
 
 	"google.golang.org/protobuf/proto"
@@ -142,7 +143,12 @@ type baseMap struct {
 	// value is the native Go value upon which the map type operators.
 	value any
 
-	size    int
+	size int
+
+	// aggSize memoizes the aggregate size computed by the first completed sizing of this
+	// map. Accessed atomically since immutable maps may be shared across concurrent
+	// evaluations; zero means not yet computed. See the SizeCalculator documentation for
+	// the memoization contract.
 	aggSize uint32
 }
 
@@ -305,12 +311,14 @@ func (m *baseMap) Size() ref.Val {
 
 // AggregateSize implements the AggregateSizeVisitor interface method.
 func (m *baseMap) AggregateSize(sizer AggregateSizer) uint32 {
-	if m.aggSize != 0 {
-		return m.aggSize
+	if sz := atomic.LoadUint32(&m.aggSize); sz != 0 {
+		return sz
 	}
 	f := foldableAggregateSizer{sizer: sizer, total: 1}
 	m.Fold(&f)
-	m.aggSize = f.total
+	if cacheableAggregateSize(sizer) {
+		atomic.StoreUint32(&m.aggSize, f.total)
+	}
 	return f.total
 }
 
@@ -392,7 +400,7 @@ func (m *mutableMap) Insert(k, v ref.Val) ref.Val {
 	}
 	m.mutableValues[k] = v
 	m.size++
-	m.aggSize = 0
+	atomic.StoreUint32(&m.aggSize, 0)
 	return m
 }
 

--- a/common/types/size_calc.go
+++ b/common/types/size_calc.go
@@ -66,6 +66,15 @@ func SizeCalculatorStringUnitLength(length int) SizeCalculatorOption {
 }
 
 // SizeCalculator calculates the recursive element size of values.
+//
+// Aggregate values may memoize their computed size on first calculation as an optimization
+// for repeated sizing of shared structures. The memoized size reflects the configuration of
+// the calculator which first sized the value; hosts requiring differently configured
+// calculators, e.g. distinct depth or traversal limits, should not share value instances
+// across them. Memoized totals are also a snapshot of the value's contents at first sizing:
+// hosts which mutate data underlying a sized aggregate, e.g. a proto message held as a list
+// element, will observe the total computed before the mutation. Sizes computed from
+// calculations aborted at the depth or traversal limits are never memoized.
 type SizeCalculator struct {
 	version          int
 	maxDepth         int
@@ -96,6 +105,7 @@ type sizeContext struct {
 	calc           *SizeCalculator
 	depth          int
 	traversalCount *int
+	limitExceeded  *bool
 }
 
 func (c sizeContext) childContext() sizeContext {
@@ -106,21 +116,67 @@ func (c sizeContext) childContext() sizeContext {
 func (c sizeContext) visitNode() bool {
 	*c.traversalCount++
 	if *c.traversalCount > c.calc.maxTraversal || c.depth > c.calc.maxDepth {
+		*c.limitExceeded = true
 		return false
 	}
 	return true
 }
 
+// aggregateSizeStatus exposes whether the in-flight size computation has exceeded the
+// calculator's depth or traversal limits.
+type aggregateSizeStatus interface {
+	aggregateSizeLimitExceeded() bool
+}
+
+// aggregateSizeLimitExceeded implements the aggregateSizeStatus interface method.
+func (c sizeContext) aggregateSizeLimitExceeded() bool {
+	return *c.limitExceeded
+}
+
+// cacheableAggregateSize reports whether a size computed with the given sizer is safe to
+// memoize on the value. Only totals from computations which verifiably stayed within the
+// calculator's depth and traversal limits are stable properties of the value; totals from
+// aborted computations depend on where in the traversal the value was encountered and would
+// poison the memoized size.
+func cacheableAggregateSize(sizer AggregateSizer) bool {
+	status, ok := sizer.(aggregateSizeStatus)
+	return ok && !status.aggregateSizeLimitExceeded()
+}
+
+// AggregateSizeEstimate captures the outcome of an aggregate size computation.
+//
+// The Size saturates at math.MaxUint32 when the accumulated element count overflows uint32.
+// LimitExceeded reports the computation was aborted because the value was too expensive to
+// traverse (too deep, or too many nodes visited); in that case Size is also math.MaxUint32,
+// but the value's true size may be smaller — the two conditions are distinguishable by the flag.
+type AggregateSizeEstimate struct {
+	Size          uint32
+	LimitExceeded bool
+}
+
 // AggregateSize returns the size of the input value, if known.
 // Otherwise, a unit size of 1 is returned.
+//
+// When the calculator's depth or traversal limits are exceeded, the size saturates to
+// math.MaxUint32. Use EstimateAggregateSize to distinguish limit-exceeded results from
+// genuine uint32 saturation.
 func (s *SizeCalculator) AggregateSize(val any) uint32 {
+	return s.EstimateAggregateSize(val).Size
+}
+
+// EstimateAggregateSize returns the aggregate size of the input value along with an indication
+// of whether the computation was aborted due to the calculator's depth or traversal limits.
+func (s *SizeCalculator) EstimateAggregateSize(val any) AggregateSizeEstimate {
 	traversals := 0
+	exceeded := false
 	ctx := sizeContext{
 		calc:           s,
 		depth:          1,
 		traversalCount: &traversals,
+		limitExceeded:  &exceeded,
 	}
-	return ctx.AggregateSize(val)
+	size := ctx.AggregateSize(val)
+	return AggregateSizeEstimate{Size: size, LimitExceeded: exceeded}
 }
 
 // stringSize converts a byte length to an element count where stringUnitLength bytes count

--- a/common/types/size_calc_test.go
+++ b/common/types/size_calc_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -842,4 +843,122 @@ func TestSizeCalculatorStringUnitLength(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEstimateAggregateSize(t *testing.T) {
+	adapter := DefaultTypeAdapter
+
+	t.Run("within_limits", func(t *testing.T) {
+		calc := NewSizeCalculator()
+		est := calc.EstimateAggregateSize(NewRefValList(adapter, []ref.Val{Int(1), Int(2)}))
+		if est.Size != 3 || est.LimitExceeded {
+			t.Errorf("EstimateAggregateSize() got %+v, want {Size: 3, LimitExceeded: false}", est)
+		}
+	})
+
+	t.Run("traversal_limit_exceeded", func(t *testing.T) {
+		calc := NewSizeCalculator(SizeCalculatorMaxTraversal(2))
+		list := NewRefValList(adapter, []ref.Val{Int(1), Int(2), Int(3)})
+		est := calc.EstimateAggregateSize(list)
+		if est.Size != math.MaxUint32 || !est.LimitExceeded {
+			t.Errorf("EstimateAggregateSize() got %+v, want {Size: MaxUint32, LimitExceeded: true}", est)
+		}
+	})
+
+	t.Run("depth_limit_exceeded", func(t *testing.T) {
+		calc := NewSizeCalculator(SizeCalculatorMaxDepth(1))
+		list := NewRefValList(adapter, []ref.Val{NewRefValList(adapter, []ref.Val{Int(1)})})
+		est := calc.EstimateAggregateSize(list)
+		if est.Size != math.MaxUint32 || !est.LimitExceeded {
+			t.Errorf("EstimateAggregateSize() got %+v, want {Size: MaxUint32, LimitExceeded: true}", est)
+		}
+	})
+
+	t.Run("saturation_without_limit", func(t *testing.T) {
+		// Two custom sizers each reporting MaxUint32 elements saturate the sum without
+		// tripping the depth or traversal limits.
+		calc := NewSizeCalculator()
+		val := struct{ A, B traits.Sizer }{
+			A: customSizerVal(math.MaxUint32),
+			B: customSizerVal(math.MaxUint32),
+		}
+		est := calc.EstimateAggregateSize(val)
+		if est.Size != math.MaxUint32 || est.LimitExceeded {
+			t.Errorf("EstimateAggregateSize() got %+v, want {Size: MaxUint32, LimitExceeded: false}", est)
+		}
+	})
+}
+
+func TestAggregateSizeConcurrentAccess(t *testing.T) {
+	// Immutable lists and maps may be shared across concurrent evaluations; the aggregate
+	// size memoization must be race-free (validated under `go test -race`).
+	adapter := DefaultTypeAdapter
+	sharedList := NewRefValList(adapter, []ref.Val{Int(1), Int(2), Int(3)})
+	sharedMap := NewRefValMap(adapter, map[ref.Val]ref.Val{String("k"): String("v")})
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			calc := NewSizeCalculator()
+			if got := calc.AggregateSize(sharedList); got != 4 {
+				t.Errorf("AggregateSize(list) got %d, want 4", got)
+			}
+			if got := calc.AggregateSize(sharedMap); got != 3 {
+				t.Errorf("AggregateSize(map) got %d, want 3", got)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestAggregateSizeAbortedComputationNotMemoized(t *testing.T) {
+	// A sizing aborted at the calculator's limits depends on where in the traversal the
+	// value was encountered and must not be memoized: a later sizing within limits must
+	// return the true size with no limit-exceeded signal.
+	adapter := DefaultTypeAdapter
+
+	t.Run("list", func(t *testing.T) {
+		shared := NewRefValList(adapter, []ref.Val{Int(1), Int(2), Int(3), Int(4), Int(5)})
+		strict := NewSizeCalculator(SizeCalculatorMaxTraversal(2))
+		if est := strict.EstimateAggregateSize(shared); !est.LimitExceeded {
+			t.Fatalf("strict EstimateAggregateSize() got %+v, want LimitExceeded", est)
+		}
+		generous := NewSizeCalculator()
+		est := generous.EstimateAggregateSize(shared)
+		if est.Size != 6 || est.LimitExceeded {
+			t.Errorf("generous EstimateAggregateSize() got %+v, want {Size: 6, LimitExceeded: false}", est)
+		}
+	})
+
+	t.Run("map", func(t *testing.T) {
+		shared := NewRefValMap(adapter, map[ref.Val]ref.Val{
+			Int(1): Int(2),
+			Int(3): Int(4),
+		})
+		strict := NewSizeCalculator(SizeCalculatorMaxTraversal(2))
+		if est := strict.EstimateAggregateSize(shared); !est.LimitExceeded {
+			t.Fatalf("strict EstimateAggregateSize() got %+v, want LimitExceeded", est)
+		}
+		generous := NewSizeCalculator()
+		est := generous.EstimateAggregateSize(shared)
+		if est.Size != 5 || est.LimitExceeded {
+			t.Errorf("generous EstimateAggregateSize() got %+v, want {Size: 5, LimitExceeded: false}", est)
+		}
+	})
+
+	t.Run("completed_computation_is_memoized", func(t *testing.T) {
+		shared := NewRefValList(adapter, []ref.Val{Int(1), Int(2)})
+		calc := NewSizeCalculator()
+		if got := calc.AggregateSize(shared); got != 3 {
+			t.Fatalf("AggregateSize() got %d, want 3", got)
+		}
+		// A subsequent sizing under a stricter budget serves the memoized total rather
+		// than recomputing (and aborting).
+		strict := NewSizeCalculator(SizeCalculatorMaxTraversal(2))
+		est := strict.EstimateAggregateSize(shared)
+		if est.Size != 3 || est.LimitExceeded {
+			t.Errorf("strict EstimateAggregateSize() after memoization got %+v, want {Size: 3, LimitExceeded: false}", est)
+		}
+	})
 }


### PR DESCRIPTION
The aggregate size is now accessed atomically to avoid data races.

EstimateAggregateSize additionally distinguishes uint32 saturation from computations
aborted at the limits.