### PR TITLE
parser: parenthesize unary operands that would reparse differently

### DIFF
--- a/parser/unparser.go
+++ b/parser/unparser.go
@@ -519,11 +519,7 @@ func isComplexOperator(expr ast.Expr) bool {
 func isAmbiguousUnaryOperand(expr ast.Expr) bool {
 	switch expr.Kind() {
 	case ast.CallKind:
-		call := expr.AsCall()
-		if call.IsMemberFunction() || len(call.Args()) != 1 {
-			return false
-		}
-		fun := call.FunctionName()
+		fun := expr.AsCall().FunctionName()
 		return fun == operators.LogicalNot || fun == operators.Negate
 	case ast.LiteralKind:
 		switch lit := expr.AsLiteral().(type) {

--- a/parser/unparser.go
+++ b/parser/unparser.go
@@ -17,6 +17,7 @@ package parser
 import (
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -270,7 +271,7 @@ func (un *unparser) visitCallUnary(expr ast.Expr) error {
 		return fmt.Errorf("cannot unmangle operator: %s", fun)
 	}
 	un.str.WriteString(unmangled)
-	nested := isComplexOperator(args[0])
+	nested := isComplexOperator(args[0]) || isAmbiguousUnaryOperand(args[0])
 	return un.visitMaybeNested(args[0], nested)
 }
 
@@ -503,6 +504,34 @@ func isLowerPrecedence(op string, expr ast.Expr) bool {
 func isComplexOperator(expr ast.Expr) bool {
 	if expr.Kind() == ast.CallKind && len(expr.AsCall().Args()) >= 2 {
 		return true
+	}
+	return false
+}
+
+// Indicates whether the operand of a unary operator must be wrapped in parentheses in order for
+// the unparsed expression to parse back to an equivalent AST.
+//
+// The CEL grammar parses a run of leading '!' or '-' tokens as a single unary expression and drops
+// the operators when their count is even, and it also treats a leading '-' as part of an int or
+// double literal. Emitting such an operand without parentheses either changes the expression, e.g.
+// `!(!a)` would unparse to `!!a` which parses back to `a`, or produces output which does not parse
+// at all, e.g. `-(!a)` would unparse to `-!a`.
+func isAmbiguousUnaryOperand(expr ast.Expr) bool {
+	switch expr.Kind() {
+	case ast.CallKind:
+		call := expr.AsCall()
+		if call.IsMemberFunction() || len(call.Args()) != 1 {
+			return false
+		}
+		fun := call.FunctionName()
+		return fun == operators.LogicalNot || fun == operators.Negate
+	case ast.LiteralKind:
+		switch lit := expr.AsLiteral().(type) {
+		case types.Int:
+			return lit < 0
+		case types.Double:
+			return math.Signbit(float64(lit))
+		}
 	}
 	return false
 }

--- a/parser/unparser_test.go
+++ b/parser/unparser_test.go
@@ -113,6 +113,19 @@ func TestUnparse(t *testing.T) {
 		{name: "select_quoted", in: "a.`b-c`"},
 		{name: "opt_select_quoted", in: "a.?`b.c`"},
 		{name: "message_create_quoted", in: "MyType{`in`: false}"},
+		// A unary operator whose operand is another unary operator, or a negative numeric
+		// literal, must keep the operand parenthesized. The grammar parses a run of leading
+		// '!' or '-' tokens as a single unary expression and cancels out pairs of them, and
+		// it also treats a leading '-' as part of an int or double literal.
+		{name: "call_not_not", in: `!(!a)`},
+		{name: "call_neg_neg", in: `-(-a)`},
+		{name: "call_neg_not", in: `-(!a)`},
+		{name: "call_not_neg", in: `!(-a)`},
+		{name: "call_neg_neg_neg", in: `-(-(-a))`},
+		{name: "call_neg_lit_int", in: `-(-1)`},
+		{name: "call_neg_lit_int_min", in: `-(-9223372036854775808)`},
+		{name: "call_neg_lit_double", in: `-(-1.5)`},
+		{name: "call_neg_lit_int_nested", in: `1 + -(-1)`},
 
 		// Equivalent expressions form unparse which do not match the originals.
 		{name: "call_add_equiv", in: `a+b-c`, out: `a + b - c`},


### PR DESCRIPTION
## Summary

`Unparse` does not parenthesize a unary operand that is itself a unary call or a negative numeric literal, so the text it emits either means something different from the AST it came from, or does not parse at all.

## Details

`visitCallUnary` decides whether to wrap its operand using `isComplexOperator`:

```go
un.str.WriteString(unmangled)
nested := isComplexOperator(args[0])
return un.visitMaybeNested(args[0], nested)
```

```go
func isComplexOperator(expr ast.Expr) bool {
	if expr.Kind() == ast.CallKind && len(expr.AsCall().Args()) >= 2 {
		return true
	}
	return false
}
```

It only fires for a call with two or more arguments. That was the right fix for #262 (`-(1 + 2)` unparsing as `- 1 + 2`), but a unary operand has one argument, and a negative literal is not a call at all.

Two grammar rules make this unsound:

- `unary : (ops+='-')+ member | (ops+='!')+ member` — a run of leading `-`/`!` is a single unary expression, and `VisitLogicalNot` / `VisitNegate` drop the operator entirely when the count is even.
- `literal : sign=MINUS? tok=NUM_INT | sign=MINUS? tok=NUM_FLOAT` — a leading `-` binds into the literal, so `-1` is a negative constant rather than `negate(1)`.

Result:

| AST from | emitted | reparses as |
|---|---|---|
| `!(!a)` | `!!a` | `a` |
| `-(-a)` | `--a` | `a` |
| `-(-(-a))` | `---a` | `-a` |
| `-(!a)` | `-!a` | syntax error |
| `!(-a)` | `!-a` | syntax error |
| `-(-1)` | `--1` | `1` |
| `-(-9223372036854775808)` | `--9223372036854775808` | invalid int literal |

## Why it matters

`cel.AstToString` is the public way to render a checked AST back to source, so a stored or logged expression that is round-tripped can change its evaluation result:

```
expr="-(-x)"   x = MinInt64
  original  -> integer overflow
  roundtrip -> -9223372036854775808

expr="!(!a)"   a = 1
  original  -> no such overload
  roundtrip -> 1
```

An expression that failed closed now succeeds. `-(-9223372036854775808)` becomes text that will not compile at all.

## Change

Parenthesize an operand that is a single-argument `!_` or `-_` call, or a negative int or double literal. `math.Signbit` is used for doubles so `-0.0` is covered.

## Testing

Nine cases added to the existing `TestUnparse` table. That harness already parses the input, unparses, compares the text, then reparses and `proto.Equal`s the two ASTs, so it catches both the wrong-text and wrong-AST halves without new scaffolding.

Without the change:

```
--- FAIL: TestUnparse/call_not_not      Unparse() got '!!a', wanted '!(!a)'
    Roundtrip Parse() differs from original. Got '!_(!_(a))', wanted 'a'
--- FAIL: TestUnparse/call_neg_not      Unparse() got '-!a', wanted '-(!a)'
    roundtrip failed: Syntax error: no viable alternative at input '-!'
--- FAIL: TestUnparse/call_neg_lit_int_min
    roundtrip failed: invalid int literal
```
(nine subtests fail in total)

With it, `go test ./parser/...` passes, and so does `go test ./...` in the root module and in the `policy`, `repl`, `tools` and `ext/security` submodules. `conformance/policy` fails identically on a pristine clone (`runfiles: no runfiles found`, bazel-only), so it is pre-existing. `go vet ./parser/` is clean; `gofmt -l parser/` reports only `lexer_test.go`, which is already unformatted upstream and untouched here.

## One note on approach

I fixed the unparser rather than the parser. A maintainer could reasonably argue the parser should not silently cancel `!!` / `--`, but that behaviour is what the ANTLR grammar prescribes, it is long-standing, and the existing `call_not_not_equiv` case (`!!true` → `true`) asserts it. That test still passes unchanged.

Visible side effect worth knowing: `-(-1)` now unparses as `-(-1)` instead of `--1`. That is more faithful, but it is an output change for anyone snapshotting unparsed strings. No test in any module broke.
