### PR TITLE
Fix panic when sizing counted regex repetitions

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -2681,6 +2681,17 @@ func TestRegexProgramSizeLimit(t *testing.T) {
 			vars: map[string]any{"pattern": "[0-9]+"},
 			want: types.True,
 		},
+		{
+			name:       "constant_counted_repetition_exceeds_limit_ast_validation",
+			expr:       `"123 abc 456".matches('[a-z]{8}')`,
+			compileErr: "regex program size 10 exceeds limit of 5",
+		},
+		{
+			name: "dynamic_counted_repetition_within_limit",
+			expr: `"aa bb".matches(pattern)`,
+			vars: map[string]any{"pattern": "a{2}"},
+			want: types.True,
+		},
 	}
 
 	for _, tc := range tests {

--- a/common/types/regex.go
+++ b/common/types/regex.go
@@ -26,7 +26,7 @@ func RegexProgramSize(pattern string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	prog, err := syntax.Compile(re)
+	prog, err := syntax.Compile(re.Simplify())
 	if err != nil {
 		return 0, err
 	}

--- a/common/types/regex_test.go
+++ b/common/types/regex_test.go
@@ -27,6 +27,9 @@ func TestRegexProgramSize(t *testing.T) {
 		{pattern: "a", minSize: 1},
 		{pattern: "el*", minSize: 3},
 		{pattern: "(a|b)*[0-9]+", minSize: 5},
+		{pattern: "a{3}", minSize: 3},
+		{pattern: "(a|b){2,4}", minSize: 4},
+		{pattern: "[0-9a-f]{8}-[0-9a-f]{4}", minSize: 12},
 		{pattern: "(", hasError: true},
 	}
 
@@ -58,6 +61,8 @@ func TestCompileRegexWithLimit(t *testing.T) {
 		{pattern: "el*", limit: 0},
 		{pattern: "el*", limit: -1},
 		{pattern: "(a|b)*[0-9]+", limit: 5, hasError: true},
+		{pattern: "a{3}", limit: 10},
+		{pattern: "[0-9a-f]{8}", limit: 5, hasError: true},
 		{pattern: "(", limit: 10, hasError: true},
 	}
 


### PR DESCRIPTION
An environment configured with `RegexProgramSizeLimit` cannot handle an expression whose regex contains a counted repetition such as `[0-9]{3}`. `Env.Compile` panics with `"regexp: unhandled case in compile"` when the pattern is a literal, and evaluation fails with `"internal error: regexp: unhandled case in compile"` when the pattern comes from a variable.

The size is computed by parsing the pattern and compiling it with `regexp/syntax`. The standard library's `regexp.Compile` does the same, except that it calls `Simplify` on the parsed tree in between, which rewrites a counted repetition into its expanded form so that `a{3}` becomes `aaa`. That step is not optional: `syntax.Compile` has no case for the `OpRepeat` node the parser produces for `{n}` and panics on it.

Simplify the parsed pattern before compiling it, so the size is measured on the same program `regexp.Compile` builds.