### PR TITLE
[Pratt parser] Disallow trailing commas in function call argument lists

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2289,10 +2289,7 @@ ERROR: <input>:1:34: expected ']'
 		| ........^`,
 		PrattE: `ERROR: <input>:1:9: unexpected token
 		| foo(a,b,)
-		| ........^
-		ERROR: <input>:1:10: Syntax error: mismatched input <EOF> expecting ')'
-		| foo(a,b,)
-		| .........^`,
+		| ........^`,
 	},
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2282,6 +2282,18 @@ ERROR: <input>:1:34: expected ']'
 				p^#4:*expr.Expr_IdentExpr#
 				  )^#13:filter#`,
 	},
+	{
+		I: `foo(a,b,)`,
+		E: `ERROR: <input>:1:9: Syntax error: mismatched input ')' expecting {'[', '{', '(', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}
+		| foo(a,b,)
+		| ........^`,
+		PrattE: `ERROR: <input>:1:9: unexpected token
+		| foo(a,b,)
+		| ........^
+		ERROR: <input>:1:10: Syntax error: mismatched input <EOF> expecting ')'
+		| foo(a,b,)
+		| .........^`,
+	},
 }
 
 type testInfo struct {

--- a/parser/pratt_parser.go
+++ b/parser/pratt_parser.go
@@ -862,6 +862,10 @@ func (p *prattParserWorker) parseArguments(closeTok tokenKind) []ast.Expr {
 			args = append(args, p.parseExpr())
 			if p.peekTok.kind == tokComma {
 				p.nextToken()
+				if p.peekTok.kind == closeTok {
+					p.reportError(p.peekTok, "unexpected token")
+					break
+				}
 				continue
 			}
 			break

--- a/parser/pratt_parser.go
+++ b/parser/pratt_parser.go
@@ -862,9 +862,6 @@ func (p *prattParserWorker) parseArguments(closeTok tokenKind) []ast.Expr {
 			args = append(args, p.parseExpr())
 			if p.peekTok.kind == tokComma {
 				p.nextToken()
-				if p.peekTok.kind == closeTok {
-					break
-				}
 				continue
 			}
 			break


### PR DESCRIPTION
Disallow trailing commas in function call argument lists in the Pratt parser to match CEL grammar (`exprList`) and ANTLR parser behavior. Added a test case in `parser_test.go` to verify that `foo(a,b,)` produces a syntax error.