### PR TITLE
docs: document EnableMacroCallTracking requirement for ResidualAst

### DIFF
--- a/cel/env.go
+++ b/cel/env.go
@@ -855,6 +855,12 @@ func (e *Env) PartialVars(vars any) (PartialActivation, error) {
 //
 // See the PartialVars helper for how to construct a PartialActivation.
 //
+// Note: if the original Ast contains a comprehension macro (e.g. all, exists, exists_one,
+// filter, map) whose range or predicate cannot be fully resolved by partial evaluation, the
+// Env must have been created with the EnableMacroCallTracking() option. Without it, this method
+// returns an error when it cannot re-serialize the unresolved comprehension's expanded internal
+// representation back into CEL source syntax.
+//
 // TODO: Consider adding an option to generate a Program.Residual to avoid round-tripping to an
 // Ast format and then Program again.
 func (e *Env) ResidualAst(a *Ast, details *EvalDetails) (*Ast, error) {

--- a/cel/options.go
+++ b/cel/options.go
@@ -987,6 +987,11 @@ func ContextProtoVars(ctx proto.Message, opts ...types.RegistryOption) (Activati
 
 // EnableMacroCallTracking ensures that call expressions which are replaced by macros
 // are tracked in the `SourceInfo` of parsed and checked expressions.
+//
+// This is required for Env.ResidualAst to succeed when the residual Ast contains an
+// unresolved comprehension macro (all, exists, exists_one, filter, map): without it,
+// ResidualAst cannot re-serialize the macro's expanded internal representation back
+// into CEL source syntax and returns an error instead of the residual expression.
 func EnableMacroCallTracking() EnvOption {
 	return features(featureEnableMacroCallTracking, true)
 }


### PR DESCRIPTION
# doc: document EnableMacroCallTracking requirement for ResidualAst with comprehensions

## What

Documents, on both `Env.ResidualAst()` and `EnableMacroCallTracking()`, a
functional dependency between the two that is not currently mentioned in
either doc comment: `ResidualAst()` cannot serialize a residual AST back into
CEL source if it retains an unresolved comprehension macro (`all`, `exists`,
`filter`, `map`) unless `EnableMacroCallTracking()` was enabled on the `Env`
at construction time. Without it, `ResidualAst()` returns an opaque
`unsupported expression: <pointer>` error instead of the residual expression.

See issue #1444 for the full reproduction, root-cause analysis, and
external corroboration (`authzed/spicedb` independently discovered and
worked around this same requirement).

## Why a docs-only PR

This is filed as a minimal, low-risk documentation fix rather than a
behavioral change, so it can land quickly and unblock integrators hitting
this today. A more complete fix (e.g. making `ResidualAst()` retain
macro-call metadata unconditionally, or returning a clearer error message)
is a larger, more opinionated change that I'd rather leave to the
maintainers' judgment — happy to attempt it in a follow-up if there's
interest.

## Diff

```diff
--- a/cel/env.go
+++ b/cel/env.go
@@ -855,6 +855,12 @@
 //
 // See the PartialVars helper for how to construct a PartialActivation.
 //
+// Note: if the original Ast contains a comprehension macro (e.g. all, exists, exists_one,
+// filter, map) whose range or predicate cannot be fully resolved by partial evaluation, the
+// Env must have been created with the EnableMacroCallTracking() option. Without it, this method
+// returns an error when it cannot re-serialize the unresolved comprehension's expanded internal
+// representation back into CEL source syntax.
+//
 // TODO: Consider adding an option to generate a Program.Residual to avoid round-tripping to an
 // Ast format and then Program again.
 func (e *Env) ResidualAst(a *Ast, details *EvalDetails) (*Ast, error) {
```

```diff
--- a/cel/options.go
+++ b/cel/options.go
@@ -987,6 +987,11 @@
 
 // EnableMacroCallTracking ensures that call expressions which are replaced by macros
 // are tracked in the `SourceInfo` of parsed and checked expressions.
+//
+// This is required for Env.ResidualAst to succeed when the residual Ast contains an
+// unresolved comprehension macro (all, exists, exists_one, filter, map): without it,
+// ResidualAst cannot re-serialize the macro's expanded internal representation back
+// into CEL source syntax and returns an error instead of the residual expression.
 func EnableMacroCallTracking() EnvOption {
 	return features(featureEnableMacroCallTracking, true)
 }
```

## Testing

Comment-only change; verified with `gofmt -l` that both files remain
correctly formatted, and confirmed the surrounding functions are otherwise
byte-for-byte unchanged from `master`.
