### PR TITLE
Check for unknown before traversal through qualifiers of an attribute

### DIFF
--- a/ext/bindings_test.go
+++ b/ext/bindings_test.go
@@ -28,6 +28,7 @@ import (
 	"cel.dev/cel-go/common/types/ref"
 	"cel.dev/cel-go/interpreter"
 	"cel.dev/cel-go/test"
+	proto3pb "cel.dev/cel-go/test/proto3pb"
 )
 
 var bindingTests = []struct {
@@ -626,5 +627,38 @@ func TestValidateBindNestingLimit(t *testing.T) {
 				t.Fatalf("env.Compile(%v) failed: %v", tc.expr, iss.Err())
 			}
 		})
+	}
+}
+
+func TestSyncSelect_ProtoInBind(t *testing.T) {
+	e, err := cel.NewEnv(
+		Bindings(),
+		cel.Types(&proto3pb.TestAllTypes{}),
+		cel.Function("resp",
+			cel.Overload("resp_proto", nil, cel.ObjectType("google.expr.proto3.test.TestAllTypes"),
+				cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+					return types.NewUnknown(1, types.NewAttributeTrail("resp"))
+				}),
+			),
+		),
+	)
+	if err != nil {
+		t.Fatalf("NewEnv() failed: %v", err)
+	}
+
+	astBind, iss := e.Compile(`cel.bind(r, resp(), r.single_int32 == 0)`)
+	if iss.Err() != nil {
+		t.Fatalf("Compile() failed: %v", iss.Err())
+	}
+	prgBind, err := e.Program(astBind)
+	if err != nil {
+		t.Fatalf("Program() failed: %v", err)
+	}
+	valBind, _, errBind := prgBind.Eval(cel.NoVars())
+	if errBind != nil {
+		t.Fatalf("Eval() failed: %v", errBind)
+	}
+	if !types.IsUnknown(valBind) {
+		t.Fatalf("Eval() got %v (%T), wanted unknown", valBind, valBind)
 	}
 }

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -351,6 +351,10 @@ func (a *absoluteAttribute) Resolve(vars Activation) (any, error) {
 			if celErr, ok := obj.(*types.Err); ok {
 				return nil, celErr
 			}
+			_, isUnknown := obj.(*types.Unknown)
+			if isUnknown {
+				return obj, nil
+			}
 			obj, isOpt, err := applyQualifiers(v, obj, a.qualifiers)
 			if err != nil {
 				return nil, err

--- a/interpreter/attributes_test.go
+++ b/interpreter/attributes_test.go
@@ -299,6 +299,80 @@ func TestAttributesRelativeAttrRelativeQualifier(t *testing.T) {
 	}
 }
 
+func TestAttributesRelativeAttrUnknown(t *testing.T) {
+	reg := newTestRegistry(t)
+	attrs := NewAttributeFactory(containers.DefaultContainer, reg, reg)
+
+	unk := types.NewUnknown(1, types.NewAttributeTrail("a"))
+	op := NewConstValue(1, unk)
+	attr := attrs.RelativeAttribute(1, op)
+	qualB := makeQualifier(t, attrs, nil, 2, "b")
+	attr.AddQualifier(qualB)
+
+	out, err := attr.Resolve(EmptyActivation())
+	if err != nil {
+		t.Fatalf("attr.Resolve() failed: %v", err)
+	}
+	if !types.IsUnknown(out.(ref.Val)) {
+		t.Fatalf("attr.Resolve() got %v (%T), wanted unknown", out, out)
+	}
+	if !reflect.DeepEqual(out, unk) {
+		t.Errorf("attr.Resolve() got %v, wanted %v", out, unk)
+	}
+
+	partialAttrs := NewPartialAttributeFactory(containers.DefaultContainer, reg, reg)
+	absAttr := partialAttrs.AbsoluteAttribute(1, "a")
+	evalOp := &evalAttr{adapter: reg, attr: absAttr}
+	relAttr := partialAttrs.RelativeAttribute(2, evalOp)
+	qualC := makeQualifier(t, partialAttrs, nil, 3, "c")
+	relAttr.AddQualifier(qualC)
+
+	vars, err := NewPartialActivation(map[string]any{}, NewAttributePattern("a"))
+	if err != nil {
+		t.Fatalf("NewPartialActivation() failed: %v", err)
+	}
+	out, err = relAttr.Resolve(vars)
+	if err != nil {
+		t.Fatalf("relAttr.Resolve() failed: %v", err)
+	}
+	unkVal, isUnk := out.(*types.Unknown)
+	if !isUnk {
+		t.Fatalf("relAttr.Resolve() got %v (%T), wanted unknown", out, out)
+	}
+	wantedUnk := types.NewUnknown(1, types.NewAttributeTrail("a"))
+	if !reflect.DeepEqual(unkVal, wantedUnk) {
+		t.Errorf("relAttr.Resolve() got %v, wanted %v", unkVal, wantedUnk)
+	}
+}
+
+func TestAttributesAbsoluteAttrUnknown(t *testing.T) {
+	reg := newTestRegistry(t)
+	attrs := NewAttributeFactory(containers.DefaultContainer, reg, reg)
+
+	unk := types.NewUnknown(1, types.NewAttributeTrail("a"))
+	vars, err := NewActivation(map[string]any{
+		"a": unk,
+	})
+	if err != nil {
+		t.Fatalf("NewActivation() failed: %v", err)
+	}
+
+	attr := attrs.AbsoluteAttribute(1, "a")
+	qualB := makeQualifier(t, attrs, nil, 2, "b")
+	attr.AddQualifier(qualB)
+
+	out, err := attr.Resolve(vars)
+	if err != nil {
+		t.Fatalf("attr.Resolve() failed: %v", err)
+	}
+	if !types.IsUnknown(out.(ref.Val)) {
+		t.Fatalf("attr.Resolve() got %v (%T), wanted unknown", out, out)
+	}
+	if !reflect.DeepEqual(out, unk) {
+		t.Errorf("attr.Resolve() got %v, wanted %v", out, unk)
+	}
+}
+
 func TestAttributesOneofAttr(t *testing.T) {
 	reg := newTestRegistry(t)
 	cont, err := containers.NewContainer(containers.Name("acme.ns"))


### PR DESCRIPTION
Fix the scenario where traversing through a `cel.bind(x, <unk>, x.y)` results in an error rather than the original unknown.