### PR TITLE
Extensions for hasOnly, hasAny, hasAll, and hasExactly

### DIFF
--- a/ext/README.md
+++ b/ext/README.md
@@ -465,6 +465,78 @@ Examples:
     [1,[2,[3,[4]]]].flatten(2) // return [1, 2, 3, [4]]
     [1,[2,[3,[4]]]].flatten(-1) // error
 
+### HasAll
+
+**Introduced in version 5**
+
+Returns whether every element of the argument list is contained within the
+target list, i.e. whether the target is a superset of the argument. Standard
+CEL equality is used to determine whether two elements are equal, and neither
+list is required to contain unique elements. An empty argument list always
+returns true.
+
+	<list(T)>.hasAll(<list(T)>) -> <bool>
+
+Examples:
+
+    [1, 2, 3].hasAll([]) // return true
+    [1, 2, 3, 4].hasAll([2, 3]) // return true
+    [1, 2.0, 3u].hasAll([1.0, 2u, 3]) // return true
+    [1, 2, 3].hasAll([2, 4]) // return false
+
+### HasAny
+
+**Introduced in version 5**
+
+Returns whether the target list has at least one element which is equal to an
+element of the argument list. If either list is empty, the result is false.
+
+	<list(T)>.hasAny(<list(T)>) -> <bool>
+
+Examples:
+
+    [1, 2, 3].hasAny([3, 4]) // return true
+    [[1], [2, 3]].hasAny([[1, 2], [2, 3.0]]) // return true
+    [1, 2].hasAny([3, 4]) // return false
+    [1].hasAny([]) // return false
+
+### HasExactly
+
+**Introduced in version 5**
+
+Returns whether the target and argument lists are set equivalent, i.e. every
+element of the target list is equal to an element of the argument list and vice
+versa. The lists may differ in size since neither is guaranteed to hold unique
+elements, so size does not factor into the computation.
+
+	<list(T)>.hasExactly(<list(T)>) -> <bool>
+
+Examples:
+
+    [].hasExactly([]) // return true
+    [1].hasExactly([1, 1]) // return true
+    [1].hasExactly([1u, 1.0]) // return true
+    [1, 2, 3].hasExactly([3u, 2.0, 1]) // return true
+    [1, 2].hasExactly([1, 2, 3]) // return false
+
+### HasOnly
+
+**Introduced in version 5**
+
+Returns whether every element of the target list is contained within the
+argument list, i.e. whether the target is a subset of the argument. An empty
+target list always returns true.
+
+	<list(T)>.hasOnly(<list(T)>) -> <bool>
+
+Examples:
+
+    [].hasOnly([1, 2]) // return true
+    [1, 1, 2].hasOnly([1, 2, 3]) // return true
+    [1, 2.0, 3u].hasOnly([1.0, 2u, 3]) // return true
+    [1, 4].hasOnly([1, 2, 3]) // return false
+    [1].hasOnly([]) // return false
+
 ### Range
 
 **Introduced in version 2 (cost support in version 3)**

--- a/ext/lists.go
+++ b/ext/lists.go
@@ -153,6 +153,78 @@ var comparableTypes = []*cel.Type{
 //	  Player { name: "baz", score: 1000 },
 //	].sortBy(e, e.score).map(e, e.name)
 //	== ["bar", "foo", "baz"]
+//
+// # HasOnly
+//
+// Introduced in version: 5
+//
+// Returns whether every element of the target list is contained within the
+// argument list, i.e. whether the target is a subset of the argument. Standard
+// CEL equality is used to determine whether two elements are equal, and neither
+// list is required to contain unique elements. An empty target list always
+// returns true.
+//
+//	<list(T)>.hasOnly(<list(T)>) -> <bool>
+//
+// Examples:
+//
+//	[].hasOnly([1, 2]) // return true
+//	[1, 1, 2].hasOnly([1, 2, 3]) // return true
+//	[1, 2.0, 3u].hasOnly([1.0, 2u, 3]) // return true
+//	[1, 4].hasOnly([1, 2, 3]) // return false
+//	[1].hasOnly([]) // return false
+//
+// # HasAny
+//
+// Introduced in version: 5
+//
+// Returns whether the target list has at least one element which is equal to an
+// element of the argument list. If either list is empty, the result is false.
+//
+//	<list(T)>.hasAny(<list(T)>) -> <bool>
+//
+// Examples:
+//
+//	[1, 2, 3].hasAny([3, 4]) // return true
+//	[[1], [2, 3]].hasAny([[1, 2], [2, 3.0]]) // return true
+//	[1, 2].hasAny([3, 4]) // return false
+//	[1].hasAny([]) // return false
+//
+// # HasAll
+//
+// Introduced in version: 5
+//
+// Returns whether every element of the argument list is contained within the
+// target list, i.e. whether the target is a superset of the argument. An empty
+// argument list always returns true.
+//
+//	<list(T)>.hasAll(<list(T)>) -> <bool>
+//
+// Examples:
+//
+//	[1, 2, 3].hasAll([]) // return true
+//	[1, 2, 3, 4].hasAll([2, 3]) // return true
+//	[1, 2.0, 3u].hasAll([1.0, 2u, 3]) // return true
+//	[1, 2, 3].hasAll([2, 4]) // return false
+//
+// # HasExactly
+//
+// Introduced in version: 5
+//
+// Returns whether the target and argument lists are set equivalent, i.e. every
+// element of the target list is equal to an element of the argument list and
+// vice versa. The lists may differ in size since neither is guaranteed to hold
+// unique elements, so size does not factor into the computation.
+//
+//	<list(T)>.hasExactly(<list(T)>) -> <bool>
+//
+// Examples:
+//
+//	[].hasExactly([]) // return true
+//	[1].hasExactly([1, 1]) // return true
+//	[1].hasExactly([1u, 1.0]) // return true
+//	[1, 2, 3].hasExactly([3u, 2.0, 1]) // return true
+//	[1, 2].hasExactly([1, 2, 3]) // return false
 func Lists(options ...ListsOption) cel.EnvOption {
 	l := &listsLib{version: math.MaxUint32, maxRangeSize: defaultMaxRangeSize}
 	for _, o := range options {
@@ -406,6 +478,41 @@ func (lib listsLib) CompileOptions() []cel.EnvOption {
 		}
 		opts = append(opts, cel.CostEstimatorOptions(estimators...))
 	}
+	if lib.version >= 5 {
+		opts = append(opts,
+			cel.Function("hasOnly",
+				cel.MemberOverload("list_hasOnly_list",
+					[]*cel.Type{listType, listType}, cel.BoolType,
+					cel.BinaryBinding(listHasOnly),
+				),
+			),
+			cel.Function("hasAny",
+				cel.MemberOverload("list_hasAny_list",
+					[]*cel.Type{listType, listType}, cel.BoolType,
+					cel.BinaryBinding(listHasAny),
+				),
+			),
+			cel.Function("hasAll",
+				cel.MemberOverload("list_hasAll_list",
+					[]*cel.Type{listType, listType}, cel.BoolType,
+					cel.BinaryBinding(listHasAll),
+				),
+			),
+			cel.Function("hasExactly",
+				cel.MemberOverload("list_hasExactly_list",
+					[]*cel.Type{listType, listType}, cel.BoolType,
+					cel.BinaryBinding(listHasExactly),
+				),
+			),
+			cel.CostEstimatorOptions(
+				checker.OverloadCostEstimate("list_hasOnly_list", estimateListSetOp(1)),
+				checker.OverloadCostEstimate("list_hasAny_list", estimateListSetOp(1)),
+				checker.OverloadCostEstimate("list_hasAll_list", estimateListSetOp(1)),
+				// set equivalence requires up to two m*n comparisons to ensure each list contains the other
+				checker.OverloadCostEstimate("list_hasExactly_list", estimateListSetOp(2)),
+			),
+		)
+	}
 
 	return opts
 }
@@ -441,6 +548,14 @@ func (lib *listsLib) ProgramOptions() []cel.ProgramOption {
 					fmt.Sprintf("list_%s_sortByAssociatedKeys", t.TypeName()),
 					trackListSortBy,
 				),
+			)
+		}
+		if lib.version >= 5 {
+			trackers = append(trackers,
+				interpreter.OverloadCostTracker("list_hasOnly_list", trackSetsCost(1)),
+				interpreter.OverloadCostTracker("list_hasAny_list", trackSetsCost(1)),
+				interpreter.OverloadCostTracker("list_hasAll_list", trackSetsCost(1)),
+				interpreter.OverloadCostTracker("list_hasExactly_list", trackSetsCost(2)),
 			)
 		}
 		opts = append(opts, cel.CostTrackerOptions(trackers...))
@@ -653,12 +768,45 @@ func distinctList(list traits.Lister) (ref.Val, error) {
 	return types.DefaultTypeAdapter.NativeToValue(uniqueList), nil
 }
 
+// listHasOnly returns true if every element of the target list is contained within the argument list.
+func listHasOnly(list, other ref.Val) ref.Val {
+	return setsContains(other, list)
+}
+
+// listHasAny returns true if the target list and the argument list share at least one element.
+func listHasAny(list, other ref.Val) ref.Val {
+	return setsIntersects(list, other)
+}
+
+// listHasAll returns true if every element of the argument list is contained within the target list.
+func listHasAll(list, other ref.Val) ref.Val {
+	return setsContains(list, other)
+}
+
+// listHasExactly returns true if the target list and the argument list are set equivalent.
+func listHasExactly(list, other ref.Val) ref.Val {
+	return setsEquivalent(list, other)
+}
+
 func templatedOverloads(types []*cel.Type, template func(t *cel.Type) cel.FunctionOpt) []cel.FunctionOpt {
 	overloads := make([]cel.FunctionOpt, len(types))
 	for i, t := range types {
 		overloads[i] = template(t)
 	}
 	return overloads
+}
+
+// estimateListSetOp computes an O(m*n) comparison between the target list and its argument, scaled
+// by the number of passes the operation makes over the pair of lists.
+func estimateListSetOp(costFactor float64) checker.FunctionEstimator {
+	return func(estimator checker.CostEstimator, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
+		if target == nil || len(args) != 1 {
+			return nil
+		}
+		targetSize := estimateSize(estimator, *target)
+		argSize := estimateSize(estimator, args[0])
+		return callEstimate(targetSize.Multiply(argSize).MultiplyByCostFactor(costFactor).Add(callCostEstimate), nil)
+	}
 }
 
 // estimateListSlice computes an O(n) slice operation with a cost factor of 1.

--- a/ext/lists_test.go
+++ b/ext/lists_test.go
@@ -74,6 +74,53 @@ func TestLists(t *testing.T) {
 		{expr: `[1, 1.0, 2].distinct() == [1, 2]`},
 		{expr: `[[1], [1], [2]].distinct() == [[1], [2]]`},
 		{expr: `[ExampleType{name: 'a'}, ExampleType{name: 'b'}, ExampleType{name: 'a'}].distinct() == [ExampleType{name: 'a'}, ExampleType{name: 'b'}]`},
+
+		{expr: `[].hasOnly([])`},
+		{expr: `[].hasOnly([1, 2])`},
+		{expr: `![1].hasOnly([])`},
+		{expr: `[1, 1, 2].hasOnly([1, 2, 3])`},
+		{expr: `[1, 2, 3].hasOnly([1, 2, 3])`},
+		{expr: `![1, 4].hasOnly([1, 2, 3])`},
+		{expr: `[1, 2.0, 3u].hasOnly([1.0, 2u, 3])`},
+		{expr: `[[1], [2, 3]].hasOnly([[2, 3], [1], [4]])`},
+		{expr: `['a', 'b'].hasOnly(['b', 'a', 'c'])`},
+		{expr: `[ExampleType{name: 'a'}].hasOnly([ExampleType{name: 'a'}, ExampleType{name: 'b'}])`},
+
+		{expr: `![].hasAny([])`},
+		{expr: `![].hasAny([1, 2])`},
+		{expr: `![1].hasAny([])`},
+		{expr: `[1, 2, 3].hasAny([3, 4])`},
+		{expr: `![1, 2].hasAny([3, 4])`},
+		{expr: `[1].hasAny([1u, 1.0])`},
+		{expr: `[[1], [2, 3]].hasAny([[1, 2], [2, 3.0]])`},
+		{expr: `['a', 'b'].hasAny(['c', 'b'])`},
+
+		{expr: `[].hasAll([])`},
+		{expr: `[1, 2, 3].hasAll([])`},
+		{expr: `![].hasAll([1])`},
+		{expr: `[1, 2, 3, 4].hasAll([2, 3])`},
+		{expr: `[1, 2, 3].hasAll([2, 2, 2])`},
+		{expr: `![1, 2, 3].hasAll([2, 4])`},
+		{expr: `[1, 2.0, 3u].hasAll([1.0, 2u, 3])`},
+		{expr: `[[1], [2, 3]].hasAll([[2, 3.0]])`},
+		{expr: `[ExampleType{name: 'a'}, ExampleType{name: 'b'}].hasAll([ExampleType{name: 'b'}])`},
+
+		{expr: `[].hasExactly([])`},
+		{expr: `![].hasExactly([1])`},
+		{expr: `![1].hasExactly([])`},
+		{expr: `[1].hasExactly([1, 1])`},
+		{expr: `[1, 1].hasExactly([1])`},
+		{expr: `[1].hasExactly([1u, 1.0])`},
+		{expr: `[1, 2, 3].hasExactly([3u, 2.0, 1])`},
+		{expr: `![1, 2].hasExactly([1, 2, 3])`},
+		{expr: `![1, 2, 3].hasExactly([1, 2])`},
+		{expr: `[[1], [2, 3]].hasExactly([[2, 3.0], [1]])`},
+		{expr: `['a', 'b', 'a'].hasExactly(['b', 'a'])`},
+
+		{expr: `dyn(1).hasOnly([1])`, err: "no such overload: hasOnly(int, list)"},
+		{expr: `[1].hasAny(dyn(1))`, err: "no such overload: hasAny(list, int)"},
+		{expr: `dyn([1]).hasAll(dyn('a'))`, err: "no such overload: hasAll(list, string)"},
+		{expr: `dyn({}).hasExactly([1])`, err: "no such overload: hasExactly(map, list)"},
 	}
 
 	env := testListsEnv(t, 0)
@@ -186,6 +233,25 @@ func TestListsVersion(t *testing.T) {
 				"reverse":  "[1, 2, 3].reverse() == [3, 2, 1]",
 				"sort":     "[2, 1, 3].sort() == [1, 2, 3]",
 				"sortBy":   "[{'field': 'lo'}, {'field': 'hi'}].sortBy(m, m.field) == [{'field': 'hi'}, {'field': 'lo'}]",
+			},
+		},
+		{
+			// Versions 3 and 4 only introduce cost support for existing functions, but they are
+			// declared here to assert that later function additions are not visible to them.
+			version:            3,
+			supportedFunctions: map[string]string{},
+		},
+		{
+			version:            4,
+			supportedFunctions: map[string]string{},
+		},
+		{
+			version: 5,
+			supportedFunctions: map[string]string{
+				"hasOnly":    "[1, 2].hasOnly([1, 2, 3])",
+				"hasAny":     "[1, 2].hasAny([2, 3])",
+				"hasAll":     "[1, 2, 3].hasAll([1, 2])",
+				"hasExactly": "[1, 2].hasExactly([2, 1, 1])",
 			},
 		},
 	}
@@ -677,6 +743,39 @@ func TestListsCosts(t *testing.T) {
 			hints:         map[string]uint64{"x": 3, "x.@items": 1},
 			estimatedCost: checker.CostEstimate{Min: 136, Max: 196},
 			actualCost:    196,
+		},
+		{
+			name:          "list_hasOnly",
+			expr:          `[1, 2].hasOnly([1, 2, 3])`,
+			estimatedCost: checker.FixedCostEstimate(27),
+			actualCost:    27,
+		},
+		{
+			name:          "list_hasAny",
+			expr:          `[1, 2].hasAny([2, 3])`,
+			estimatedCost: checker.FixedCostEstimate(25),
+			actualCost:    25,
+		},
+		{
+			name:          "list_hasAll",
+			expr:          `[1, 2, 3].hasAll([1, 2])`,
+			estimatedCost: checker.FixedCostEstimate(27),
+			actualCost:    27,
+		},
+		{
+			name:          "list_hasExactly",
+			expr:          `[1, 2].hasExactly([2, 1])`,
+			estimatedCost: checker.FixedCostEstimate(29),
+			actualCost:    29,
+		},
+		{
+			name:          "list_hasAll_var",
+			expr:          `x.hasAll(['a', 'b'])`,
+			vars:          []cel.EnvOption{cel.Variable("x", cel.ListType(cel.StringType))},
+			in:            map[string]any{"x": []string{"a", "b", "c"}},
+			hints:         map[string]uint64{"x": 10},
+			estimatedCost: checker.CostEstimate{Min: 12, Max: 32},
+			actualCost:    18,
 		},
 	}
 


### PR DESCRIPTION
Create member functions to support simpler to remember, chainable, list content checks.