### PR TITLE
HMAC Digest and linear-time Equal functions

### DIFF
--- a/ext/security/hmac/BUILD.bazel
+++ b/ext/security/hmac/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "cel.dev/cel-go/ext/security/hmac",
     deps = [
         "//cel:go_default_library",
+        "//common/cost:go_default_library",
         "//common/types:go_default_library",
         "//common/types/ref:go_default_library",
     ],
@@ -29,6 +30,7 @@ go_test(
     ],
     deps = [
         "//cel:go_default_library",
+        "//common/cost:go_default_library",
         "//ext:go_default_library",
     ],
 )

--- a/ext/security/hmac/README.md
+++ b/ext/security/hmac/README.md
@@ -1,0 +1,201 @@
+# HMAC Extensions
+
+HMAC extensions are a set of functions and constants for computing and
+verifying Hash-based Message Authentication Codes (HMAC) within CEL
+expressions. They are commonly used to authenticate signed webhook payloads
+and other messages carrying a shared-secret signature.
+
+The library is not enabled by default. Configure it with the `Library` option:
+
+    import hmaclib "cel.dev/cel-go/ext/security/hmac"
+
+    env, err := cel.NewEnv(hmaclib.Library())
+
+## HMAC
+
+Note, all functions and constants use the 'hmac' namespace. If you are
+currently using a variable named 'hmac', the functions will likely work as
+intended; however, there is some chance for collision.
+
+Every function takes the hash algorithm as a string. Only algorithms
+registered with the library may be used; see [Algorithms](#algorithms) below.
+Algorithm names are matched case-insensitively, and `-` and `/` are treated as
+`_`, so `'SHA-512/256'`, `'sha512_256'`, and `hmac.SHA512_256` all name the
+same algorithm.
+
+Functions which accept `string` inputs operate on the UTF-8 encoding of the
+string, so the `string` and `bytes` overloads agree for equivalent inputs:
+
+    hmac.digest('payload', hmac.SHA256) == hmac.digest(b'payload', hmac.SHA256)
+
+Note that a `string` secret is used as its literal UTF-8 bytes. If a secret is
+distributed in an encoded form, decode it before use, e.g.
+`hmac.compute(msg, base64.decode(secret), hmac.SHA256)`.
+
+### Hmac.Compute
+
+Computes the HMAC of a message under a secret key, and returns the raw
+authentication code as bytes.
+
+This function will return an error if the algorithm is not registered with the
+library.
+
+    hmac.compute(message: bytes, secret: bytes, algorithm: string) -> bytes
+    hmac.compute(message: string, secret: string, algorithm: string) -> bytes
+
+Examples:
+
+    "%x".format([hmac.compute('payload', 'key', hmac.SHA256)])
+      // return '5d98b45c90a207fa998ce639fea6f02ecc8cc3f36fef81d694fb856b4d0a28ca'
+
+    base64.encode(hmac.compute(b'payload', b'key', hmac.SHA256))
+      // return 'XZi0XJCiB/qZjOY5/qbwLsyMw/Nv74HWlPuFa00KKMo='
+
+    hmac.compute('payload', 'key', 'MD5') // Runtime Error unsupported HMAC hash algorithm
+
+### Hmac.Digest
+
+Computes the unkeyed hash digest of a message and returns it as bytes. This is
+the plain hash of the message, not an authentication code; use `hmac.compute`
+when a secret is involved. It is useful for the payload digests referenced by
+signing schemes, such as an AWS SigV4 content hash or a `Digest` header.
+
+This function will return an error if the algorithm is not registered with the
+library.
+
+    hmac.digest(message: bytes, algorithm: string) -> bytes
+    hmac.digest(message: string, algorithm: string) -> bytes
+
+Examples:
+
+    "%x".format([hmac.digest('payload', hmac.SHA256)])
+      // return '239f59ed55e737c77147cf55ad0c1b030b6d7ee748a7426952f9b852d5a935e5'
+
+    base64.encode(hmac.digest(b'payload', hmac.SHA256))
+      // return 'I59Z7VXnN8dxR89VrQwbAwttfudIp0JpUvm4UtWpNeU='
+
+    hmac.digest('payload', 'MD5') // Runtime Error unsupported HMAC hash algorithm
+
+### Hmac.Equal
+
+Compares two byte sequences in constant time, returning true when they are
+equal. Use this rather than `==` when comparing authentication codes, so that
+the comparison does not leak information about the expected value through its
+running time. Inputs of differing lengths compare as unequal.
+
+    hmac.equal(lhs: bytes, rhs: bytes) -> bool
+
+Examples:
+
+    hmac.equal(b'abc', b'abc') // return true
+    hmac.equal(b'abc', b'abd') // return false
+    hmac.equal(b'abc', b'ab')  // return false
+
+    hmac.equal(hmac.compute(msg, secret, hmac.SHA256), base64.decode(signature))
+
+### Hmac.Verify
+
+Computes the HMAC of a message under a secret key and reports whether it
+matches the supplied signature, comparing in constant time.
+
+    hmac.verify(message: bytes, signature: bytes, secret: bytes, algorithm: string) -> bool
+    hmac.verify(message: string, signature: string, secret: string, algorithm: string) -> bool
+
+The `bytes` overload compares the signature to the computed code directly.
+
+The `string` overload additionally accommodates the signature encodings used by
+common webhook schemes. Surrounding whitespace is ignored, and a leading
+`<prefix>=` marker is stripped when the prefix names a registered algorithm
+(e.g. GitHub's `sha256=...`) or is the version marker `v0=` or `v1=` (e.g.
+Slack's and Stripe's). A stripped algorithm prefix takes precedence over the
+`algorithm` argument. The remaining signature is accepted as hex, standard
+base64, or URL-safe base64, with or without padding.
+
+Unlike `hmac.compute` and `hmac.digest`, this function does not return an
+error. An unregistered algorithm, an unparsable signature, and a genuine
+mismatch all evaluate to false.
+
+Examples:
+
+    hmac.verify(b'payload', signature, b'key', hmac.SHA256)
+
+    // hex, base64, and prefixed encodings of the same code all verify
+    hmac.verify('payload', '5d98b45c90a207fa998ce639fea6f02ecc8cc3f36fef81d694fb856b4d0a28ca',
+                'key', hmac.SHA256)                                   // return true
+    hmac.verify('payload', 'XZi0XJCiB/qZjOY5/qbwLsyMw/Nv74HWlPuFa00KKMo=',
+                'key', hmac.SHA256)                                   // return true
+    hmac.verify('payload', 'sha256=5d98b45c90a207fa998ce639fea6f02ecc8cc3f36fef81d694fb856b4d0a28ca',
+                'key', hmac.SHA256)                                   // return true
+
+    hmac.verify('payload', 'not-a-signature', 'key', hmac.SHA256)     // return false
+    hmac.verify('payload', signature, 'key', 'MD5')                   // return false
+
+## Algorithms
+
+By default the library registers the algorithms below, each under its own name,
+its JOSE/JWT alias, and a string constant for each of those names. The constants
+evaluate to the canonical algorithm name, so `hmac.HS256 == 'SHA256'`.
+
+| Algorithm    | Constants                          |
+| ------------ | ---------------------------------- |
+| SHA-224      | `hmac.SHA224`, `hmac.HS224`        |
+| SHA-256      | `hmac.SHA256`, `hmac.HS256`        |
+| SHA-384      | `hmac.SHA384`, `hmac.HS384`        |
+| SHA-512      | `hmac.SHA512`, `hmac.HS512`        |
+| SHA-512/224  | `hmac.SHA512_224`, `hmac.HS512_224`|
+| SHA-512/256  | `hmac.SHA512_256`, `hmac.HS512_256`|
+
+Referring to an algorithm which is not registered is a compile error when the
+constant does not exist, and a runtime error or a false result when an
+unregistered name is passed as a string.
+
+## Cost
+
+`hmac.digest` and `hmac.equal` report an unbounded cost: their estimated cost has
+a maximum of `math.MaxUint64`, and their tracked runtime cost is `math.MaxUint64`.
+An expression using either function will therefore exceed any `cel.CostLimit`.
+
+This is deliberate. The work these functions perform is driven by input sizes the
+checker cannot bound, so no smaller estimate would be sound. Environments which
+enforce a cost limit should treat these functions as opt-in, and expose them only
+where the inputs are otherwise constrained.
+
+`hmac.compute` and `hmac.verify` do not currently declare cost estimators and are
+charged the default per-call cost.
+
+## Configuration
+
+The `Library` option accepts the following options.
+
+### Algorithm
+
+Registers a `crypto.Hash` with optional aliases, replacing the default set. The
+hash must be linked into the binary, as with the `crypto/sha256` and similar
+blank imports. Both the algorithm's own name and each alias become a string
+constant in the `hmac` namespace.
+
+    hmaclib.Library(
+        hmaclib.Algorithm(crypto.SHA256),               // hmac.SHA256
+        hmaclib.Algorithm(crypto.SHA1, "legacy-sha1"),  // hmac.SHA1, hmac.LEGACY_SHA1
+    )
+
+Registering a specific set of algorithms is a way to keep expressions from
+selecting a hash which is no longer considered acceptable.
+
+### CommonAlgorithms
+
+Registers the default set of algorithms described in [Algorithms](#algorithms).
+This is applied automatically when no `Algorithm` option is supplied, and may
+be named explicitly to extend the defaults rather than replace them.
+
+    hmaclib.Library(
+        hmaclib.CommonAlgorithms(),
+        hmaclib.Algorithm(crypto.SHA1, "SHA1"),
+    )
+
+### MaxPrefixLength
+
+Sets the maximum length of the `<prefix>=` marker which `hmac.verify` will
+parse from a string signature. Defaults to 20.
+
+    hmaclib.Library(hmaclib.MaxPrefixLength(40))

--- a/ext/security/hmac/hmac.go
+++ b/ext/security/hmac/hmac.go
@@ -18,16 +18,16 @@ package hmac
 import (
 	"crypto"
 	"crypto/hmac"
-	_ "crypto/md5"
-	_ "crypto/sha1"
 	_ "crypto/sha256"
 	_ "crypto/sha512"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"strings"
 
 	"cel.dev/cel-go/cel"
+	"cel.dev/cel-go/common/cost"
 	"cel.dev/cel-go/common/types"
 	"cel.dev/cel-go/common/types/ref"
 )
@@ -207,14 +207,88 @@ func (l *hmacLib) CompileOptions() []cel.EnvOption {
 				}),
 			),
 		),
+
+		cel.Function("hmac.digest",
+			cel.Overload("hmac_digest_bytes_string",
+				[]*cel.Type{cel.BytesType, cel.StringType},
+				cel.BytesType,
+				cel.BinaryBinding(func(msgVal, algVal ref.Val) ref.Val {
+					msg := msgVal.(types.Bytes)
+					alg := algVal.(types.String)
+					sum, err := l.digest(msg, string(alg))
+					if err != nil {
+						return types.ValOrErr(msgVal, "%v", err)
+					}
+					return types.Bytes(sum)
+				}),
+			),
+			cel.Overload("hmac_digest_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.BytesType,
+				cel.BinaryBinding(func(msgVal, algVal ref.Val) ref.Val {
+					msg := msgVal.(types.String)
+					alg := algVal.(types.String)
+					sum, err := l.digest([]byte(string(msg)), string(alg))
+					if err != nil {
+						return types.ValOrErr(msgVal, "%v", err)
+					}
+					return types.Bytes(sum)
+				}),
+			),
+		),
+
+		cel.Function("hmac.equal",
+			cel.Overload("hmac_equal_bytes_bytes",
+				[]*cel.Type{cel.BytesType, cel.BytesType},
+				cel.BoolType,
+				cel.BinaryBinding(func(lhs, rhs ref.Val) ref.Val {
+					x := lhs.(types.Bytes)
+					y := rhs.(types.Bytes)
+					return types.Bool(hmac.Equal(x, y))
+				}),
+			),
+		),
 	)
+
+	// The digest and equal functions are unbounded in cost: the work is driven by
+	// input sizes the checker cannot bound, so they are reported as unknown at
+	// check time and as the maximum cost at runtime.
+	estimators := make([]cost.CostOption, 0, len(unboundedCostOverloads))
+	for _, overloadID := range unboundedCostOverloads {
+		estimators = append(estimators, cost.OverloadCostEstimate(overloadID, estimateUnboundedCost))
+	}
+	opts = append(opts, cel.CostEstimatorOptions(estimators...))
 
 	return opts
 }
 
 // ProgramOptions returns program options for HMAC extensions.
 func (l *hmacLib) ProgramOptions() []cel.ProgramOption {
-	return nil
+	trackers := make([]cost.TrackerOption, 0, len(unboundedCostOverloads))
+	for _, overloadID := range unboundedCostOverloads {
+		trackers = append(trackers, cost.OverloadTracker(overloadID, trackUnboundedCost))
+	}
+	return []cel.ProgramOption{cel.CostTrackerOptions(trackers...)}
+}
+
+// unboundedCostOverloads are the overload identifiers reported as having an
+// unbounded estimated and actual cost.
+var unboundedCostOverloads = []string{
+	"hmac_digest_bytes_string",
+	"hmac_digest_string_string",
+	"hmac_equal_bytes_bytes",
+}
+
+// estimateUnboundedCost reports an unknown cost estimate, whose maximum is
+// math.MaxUint64, for the overload under estimation.
+func estimateUnboundedCost(estimator cost.Estimator, target *cost.AstNode, args []cost.AstNode) *cost.CallEstimate {
+	return &cost.CallEstimate{CostEstimate: cost.UnknownCostEstimate()}
+}
+
+// trackUnboundedCost reports the maximum actual cost for the overload invoked.
+func trackUnboundedCost(args []ref.Val, result ref.Val) *uint64 {
+	maxCost := uint64(math.MaxUint64)
+	return &maxCost
 }
 
 func (l *hmacLib) compute(msg, secret []byte, alg string) ([]byte, error) {
@@ -223,6 +297,14 @@ func (l *hmacLib) compute(msg, secret []byte, alg string) ([]byte, error) {
 		return nil, err
 	}
 	return computeHMAC(msg, secret, hType)
+}
+
+func (l *hmacLib) digest(msg []byte, alg string) ([]byte, error) {
+	hType, err := l.resolveHash(alg)
+	if err != nil {
+		return nil, err
+	}
+	return computeDigest(msg, hType)
 }
 
 func (l *hmacLib) verifyBytes(msg, sig, secret []byte, alg string) bool {
@@ -338,6 +420,15 @@ func computeHMAC(msg, secret []byte, hType crypto.Hash) ([]byte, error) {
 	mac := hmac.New(hType.New, secret)
 	mac.Write(msg)
 	return mac.Sum(nil), nil
+}
+
+func computeDigest(msg []byte, hType crypto.Hash) ([]byte, error) {
+	if !hType.Available() {
+		return nil, fmt.Errorf("hash algorithm %v is not available", hType)
+	}
+	h := hType.New()
+	h.Write(msg)
+	return h.Sum(nil), nil
 }
 
 // decodeBase64URLSegment decodes a URL-safe base64 string with or without padding.

--- a/ext/security/hmac/hmac_test.go
+++ b/ext/security/hmac/hmac_test.go
@@ -21,10 +21,13 @@ import (
 	"crypto/sha512"
 	"encoding/base64"
 	"encoding/hex"
+	"math"
 	"reflect"
+	"strings"
 	"testing"
 
 	"cel.dev/cel-go/cel"
+	"cel.dev/cel-go/common/cost"
 	"cel.dev/cel-go/ext"
 	hmaclib "cel.dev/cel-go/ext/security/hmac"
 )
@@ -526,4 +529,564 @@ func TestHMACMaxPrefixLengthOption(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHMACDigest(t *testing.T) {
+	msgStr := `{"action":"push","ref":"refs/heads/main"}`
+	msgBytes := []byte(msgStr)
+
+	unicodeStr := "h\u00e9llo \u4e16\u754c"
+
+	sha256Sum := sha256.Sum256(msgBytes)
+	sha512Sum := sha512.Sum512(msgBytes)
+	emptySum := sha256.Sum256(nil)
+	unicodeSum := sha256.Sum256([]byte(unicodeStr))
+
+	env, err := cel.NewEnv(
+		hmaclib.Library(),
+		ext.Encoders(),
+		ext.Strings(),
+		cel.Variable("msgStr", cel.StringType),
+		cel.Variable("msgBytes", cel.BytesType),
+		cel.Variable("msgUnicode", cel.StringType),
+		cel.Variable("secretBytes", cel.BytesType),
+	)
+	if err != nil {
+		t.Fatalf("cel.NewEnv failed: %v", err)
+	}
+
+	vars := map[string]any{
+		"msgStr":      msgStr,
+		"msgBytes":    msgBytes,
+		"msgUnicode":  unicodeStr,
+		"secretBytes": []byte("my-shared-secret-key"),
+	}
+
+	tests := []struct {
+		name string
+		expr string
+		want any
+	}{
+		{
+			name: "digest_sha256",
+			expr: `hmac.digest(msgBytes, hmac.SHA256)`,
+			want: sha256Sum[:],
+		},
+		{
+			name: "digest_sha512",
+			expr: `hmac.digest(msgBytes, hmac.SHA512)`,
+			want: sha512Sum[:],
+		},
+		{
+			name: "digest_alias_alg",
+			expr: `hmac.digest(msgBytes, 'HS256')`,
+			want: sha256Sum[:],
+		},
+		{
+			name: "digest_literal_alg",
+			expr: `hmac.digest(msgBytes, 'SHA-256')`,
+			want: sha256Sum[:],
+		},
+		{
+			name: "digest_empty_message",
+			expr: `hmac.digest(b'', hmac.SHA256)`,
+			want: emptySum[:],
+		},
+		{
+			name: "digest_is_unkeyed",
+			expr: `hmac.digest(msgBytes, hmac.SHA256) != hmac.compute(msgBytes, secretBytes, hmac.SHA256)`,
+			want: true,
+		},
+		{
+			name: "digest_string_sha256",
+			expr: `hmac.digest(msgStr, hmac.SHA256)`,
+			want: sha256Sum[:],
+		},
+		{
+			name: "digest_string_sha512",
+			expr: `hmac.digest(msgStr, hmac.SHA512)`,
+			want: sha512Sum[:],
+		},
+		{
+			name: "digest_string_alias_alg",
+			expr: `hmac.digest(msgStr, 'HS256')`,
+			want: sha256Sum[:],
+		},
+		{
+			name: "digest_string_empty_message",
+			expr: `hmac.digest('', hmac.SHA256)`,
+			want: emptySum[:],
+		},
+		{
+			// The string overload hashes the UTF-8 encoding of the message,
+			// so it must agree with the bytes overload for every input.
+			name: "digest_string_matches_bytes",
+			expr: `hmac.digest(msgStr, hmac.SHA256) == hmac.digest(msgBytes, hmac.SHA256)`,
+			want: true,
+		},
+		{
+			name: "digest_string_multibyte_utf8",
+			expr: `hmac.digest(msgUnicode, hmac.SHA256)`,
+			want: unicodeSum[:],
+		},
+		{
+			name: "digest_string_multibyte_matches_bytes",
+			expr: `hmac.digest(msgUnicode, hmac.SHA256) == hmac.digest(bytes(msgUnicode), hmac.SHA256)`,
+			want: true,
+		},
+		{
+			name: "digest_composes_with_encoders",
+			expr: `base64.encode(hmac.digest(msgBytes, hmac.SHA256))`,
+			want: base64.StdEncoding.EncodeToString(sha256Sum[:]),
+		},
+		{
+			name: "digest_composes_with_format",
+			expr: `"%x".format([hmac.digest(msgBytes, hmac.SHA256)])`,
+			want: hex.EncodeToString(sha256Sum[:]),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := evalExpr(t, env, tc.expr, vars)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("evalExpr(%q) got %v, wanted %v", tc.expr, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHMACDigestUnsupportedAlgorithm(t *testing.T) {
+	env, err := cel.NewEnv(
+		hmaclib.Library(hmaclib.Algorithm(crypto.SHA256)),
+		cel.Variable("msgBytes", cel.BytesType),
+	)
+	if err != nil {
+		t.Fatalf("cel.NewEnv failed: %v", err)
+	}
+	for _, expr := range []string{
+		`hmac.digest(msgBytes, 'SHA512')`,
+		`hmac.digest('msg', 'SHA512')`,
+	} {
+		t.Run(expr, func(t *testing.T) {
+			ast, issues := env.Compile(expr)
+			if issues != nil && issues.Err() != nil {
+				t.Fatalf("Compile(%q) failed: %v", expr, issues.Err())
+			}
+			prg, err := env.Program(ast)
+			if err != nil {
+				t.Fatalf("Program(%q) failed: %v", expr, err)
+			}
+			_, _, err = prg.Eval(map[string]any{"msgBytes": []byte("msg")})
+			if err == nil {
+				t.Fatalf("Eval(%q) got nil error, wanted unsupported HMAC hash algorithm error", expr)
+			}
+			if !strings.Contains(err.Error(), "unsupported HMAC hash algorithm") {
+				t.Errorf("Eval(%q) got error %v, wanted unsupported HMAC hash algorithm error", expr, err)
+			}
+		})
+	}
+}
+
+func TestHMACEqual(t *testing.T) {
+	secretBytes := []byte("my-shared-secret-key")
+	msgBytes := []byte(`{"action":"push","ref":"refs/heads/main"}`)
+
+	h256 := hmac.New(sha256.New, secretBytes)
+	h256.Write(msgBytes)
+	mac256Bytes := h256.Sum(nil)
+
+	env, err := cel.NewEnv(
+		hmaclib.Library(),
+		ext.Encoders(),
+		cel.Variable("msgBytes", cel.BytesType),
+		cel.Variable("secretBytes", cel.BytesType),
+		cel.Variable("sigBytes", cel.BytesType),
+		cel.Variable("sigHex", cel.StringType),
+	)
+	if err != nil {
+		t.Fatalf("cel.NewEnv failed: %v", err)
+	}
+
+	vars := map[string]any{
+		"msgBytes":    msgBytes,
+		"secretBytes": secretBytes,
+		"sigBytes":    mac256Bytes,
+		"sigHex":      hex.EncodeToString(mac256Bytes),
+	}
+
+	tests := []struct {
+		name string
+		expr string
+		want any
+	}{
+		{
+			name: "equal_identical_literals",
+			expr: `hmac.equal(b'abc', b'abc')`,
+			want: true,
+		},
+		{
+			name: "equal_differing_literals",
+			expr: `hmac.equal(b'abc', b'abd')`,
+			want: false,
+		},
+		{
+			name: "equal_differing_lengths",
+			expr: `hmac.equal(b'abc', b'abcd')`,
+			want: false,
+		},
+		{
+			name: "equal_both_empty",
+			expr: `hmac.equal(b'', b'')`,
+			want: true,
+		},
+		{
+			name: "equal_empty_and_non_empty",
+			expr: `hmac.equal(b'', b'a')`,
+			want: false,
+		},
+		{
+			name: "equal_computed_mac",
+			expr: `hmac.equal(hmac.compute(msgBytes, secretBytes, hmac.SHA256), sigBytes)`,
+			want: true,
+		},
+		{
+			name: "equal_computed_mac_wrong_algorithm",
+			expr: `hmac.equal(hmac.compute(msgBytes, secretBytes, hmac.SHA512), sigBytes)`,
+			want: false,
+		},
+		{
+			name: "equal_computed_mac_wrong_secret",
+			expr: `hmac.equal(hmac.compute(msgBytes, b'wrong-secret', hmac.SHA256), sigBytes)`,
+			want: false,
+		},
+		{
+			name: "equal_decoded_hex_signature",
+			expr: `hmac.equal(hmac.compute(msgBytes, secretBytes, hmac.SHA256), base64.decode(base64.encode(sigBytes)))`,
+			want: true,
+		},
+		{
+			name: "equal_agrees_with_verify",
+			expr: `hmac.equal(hmac.compute(msgBytes, secretBytes, hmac.SHA256), sigBytes) == hmac.verify(msgBytes, sigBytes, secretBytes, hmac.SHA256)`,
+			want: true,
+		},
+		{
+			name: "equal_digests",
+			expr: `hmac.equal(hmac.digest(msgBytes, hmac.SHA256), hmac.digest(msgBytes, hmac.SHA256))`,
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := evalExpr(t, env, tc.expr, vars)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("evalExpr(%q) got %v, wanted %v", tc.expr, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHMACEqualStringsUnsupported(t *testing.T) {
+	env, err := cel.NewEnv(hmaclib.Library())
+	if err != nil {
+		t.Fatalf("cel.NewEnv failed: %v", err)
+	}
+	if _, issues := env.Compile(`hmac.equal('abc', 'abc')`); issues == nil || issues.Err() == nil {
+		t.Error("Compile(`hmac.equal('abc', 'abc')`) got nil error, wanted no matching overload")
+	}
+}
+
+// TestHMACREADMEExamples evaluates the examples documented in README.md so that
+// the documented values cannot drift from the implementation.
+func TestHMACREADMEExamples(t *testing.T) {
+	const sigHex = "5d98b45c90a207fa998ce639fea6f02ecc8cc3f36fef81d694fb856b4d0a28ca"
+
+	env, err := cel.NewEnv(
+		hmaclib.Library(),
+		ext.Encoders(),
+		ext.Strings(),
+		cel.Variable("signature", cel.StringType),
+	)
+	if err != nil {
+		t.Fatalf("cel.NewEnv failed: %v", err)
+	}
+	vars := map[string]any{"signature": sigHex}
+
+	tests := []struct {
+		name string
+		expr string
+		want any
+	}{
+		// Overloads agree on equivalent inputs.
+		{
+			name: "string_and_bytes_digests_agree",
+			expr: `hmac.digest('payload', hmac.SHA256) == hmac.digest(b'payload', hmac.SHA256)`,
+			want: true,
+		},
+
+		// Hmac.Compute
+		{
+			name: "compute_hex",
+			expr: `"%x".format([hmac.compute('payload', 'key', hmac.SHA256)])`,
+			want: sigHex,
+		},
+		{
+			name: "compute_base64",
+			expr: `base64.encode(hmac.compute(b'payload', b'key', hmac.SHA256))`,
+			want: "XZi0XJCiB/qZjOY5/qbwLsyMw/Nv74HWlPuFa00KKMo=",
+		},
+
+		// Hmac.Digest
+		{
+			name: "digest_hex",
+			expr: `"%x".format([hmac.digest('payload', hmac.SHA256)])`,
+			want: "239f59ed55e737c77147cf55ad0c1b030b6d7ee748a7426952f9b852d5a935e5",
+		},
+		{
+			name: "digest_base64",
+			expr: `base64.encode(hmac.digest(b'payload', hmac.SHA256))`,
+			want: "I59Z7VXnN8dxR89VrQwbAwttfudIp0JpUvm4UtWpNeU=",
+		},
+
+		// Hmac.Equal
+		{
+			name: "equal_same",
+			expr: `hmac.equal(b'abc', b'abc')`,
+			want: true,
+		},
+		{
+			name: "equal_differs",
+			expr: `hmac.equal(b'abc', b'abd')`,
+			want: false,
+		},
+		{
+			name: "equal_shorter",
+			expr: `hmac.equal(b'abc', b'ab')`,
+			want: false,
+		},
+
+		// Hmac.Verify signature encodings.
+		{
+			name: "verify_hex",
+			expr: `hmac.verify('payload', '` + sigHex + `', 'key', hmac.SHA256)`,
+			want: true,
+		},
+		{
+			name: "verify_base64",
+			expr: `hmac.verify('payload', 'XZi0XJCiB/qZjOY5/qbwLsyMw/Nv74HWlPuFa00KKMo=', 'key', hmac.SHA256)`,
+			want: true,
+		},
+		{
+			name: "verify_algorithm_prefix",
+			expr: `hmac.verify('payload', 'sha256=` + sigHex + `', 'key', hmac.SHA256)`,
+			want: true,
+		},
+		{
+			name: "verify_version_prefix",
+			expr: `hmac.verify('payload', 'v1=` + sigHex + `', 'key', hmac.SHA256)`,
+			want: true,
+		},
+		{
+			name: "verify_surrounding_whitespace",
+			expr: `hmac.verify('payload', '  ` + sigHex + `  ', 'key', hmac.SHA256)`,
+			want: true,
+		},
+		{
+			// A recognized algorithm prefix wins over the algorithm argument.
+			name: "verify_prefix_overrides_algorithm_argument",
+			expr: `hmac.verify('payload', 'sha512=' + "%x".format([hmac.compute('payload', 'key', hmac.SHA512)]), 'key', hmac.SHA256)`,
+			want: true,
+		},
+		{
+			name: "verify_unparsable_signature",
+			expr: `hmac.verify('payload', 'not-a-signature', 'key', hmac.SHA256)`,
+			want: false,
+		},
+		{
+			// verify reports false rather than erroring on an unregistered algorithm.
+			name: "verify_unregistered_algorithm",
+			expr: `hmac.verify('payload', signature, 'key', 'MD5')`,
+			want: false,
+		},
+
+		// Algorithm name matching and constant values.
+		{
+			name: "constant_alias_value",
+			expr: `hmac.HS256 == 'SHA256'`,
+			want: true,
+		},
+		{
+			name: "constant_alias_value_sha512_256",
+			expr: `hmac.HS512_256 == 'SHA512_256'`,
+			want: true,
+		},
+		{
+			name: "algorithm_name_case_and_separator_insensitive",
+			expr: `hmac.digest('payload', 'sha-256') == hmac.digest('payload', hmac.SHA256)`,
+			want: true,
+		},
+		{
+			name: "algorithm_name_slash_separator",
+			expr: `hmac.digest('payload', 'SHA-512/256') == hmac.digest('payload', hmac.SHA512_256)`,
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := evalExpr(t, env, tc.expr, vars)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("evalExpr(%q) got %v, wanted %v", tc.expr, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHMACREADMEConfiguration exercises the Configuration section of README.md.
+func TestHMACREADMEConfiguration(t *testing.T) {
+	t.Run("Algorithm_replaces_defaults", func(t *testing.T) {
+		env, err := cel.NewEnv(hmaclib.Library(
+			hmaclib.Algorithm(crypto.SHA256),
+			hmaclib.Algorithm(crypto.SHA1, "legacy-sha1"),
+		))
+		if err != nil {
+			t.Fatalf("cel.NewEnv failed: %v", err)
+		}
+		for expr, want := range map[string]string{
+			`hmac.SHA256`:      "SHA256",
+			`hmac.SHA1`:        "SHA1",
+			`hmac.LEGACY_SHA1`: "SHA1",
+		} {
+			if got := evalExpr(t, env, expr, nil); got != want {
+				t.Errorf("evalExpr(%q) got %v, wanted %v", expr, got, want)
+			}
+		}
+		if _, issues := env.Compile(`hmac.SHA512`); issues == nil || issues.Err() == nil {
+			t.Error("Compile(`hmac.SHA512`) got nil error, wanted undeclared reference")
+		}
+	})
+
+	t.Run("CommonAlgorithms_extends_defaults", func(t *testing.T) {
+		env, err := cel.NewEnv(hmaclib.Library(
+			hmaclib.CommonAlgorithms(),
+			hmaclib.Algorithm(crypto.SHA1, "SHA1"),
+		))
+		if err != nil {
+			t.Fatalf("cel.NewEnv failed: %v", err)
+		}
+		for _, expr := range []string{`hmac.SHA256`, `hmac.HS512`, `hmac.SHA1`} {
+			if _, issues := env.Compile(expr); issues != nil && issues.Err() != nil {
+				t.Errorf("Compile(%q) failed: %v", expr, issues.Err())
+			}
+		}
+	})
+}
+
+// TestHMACUnboundedCosts verifies that hmac.digest and hmac.equal report an unbounded
+// estimated cost and an unbounded actual cost, including when combined with cost accrued
+// elsewhere in the expression, and that they trip a cost limit.
+func TestHMACUnboundedCosts(t *testing.T) {
+	env, err := cel.NewEnv(
+		hmaclib.Library(),
+		cel.Variable("msgStr", cel.StringType),
+		cel.Variable("msgBytes", cel.BytesType),
+		cel.Variable("sigBytes", cel.BytesType),
+		cel.Variable("secretBytes", cel.BytesType),
+	)
+	if err != nil {
+		t.Fatalf("cel.NewEnv failed: %v", err)
+	}
+	vars := map[string]any{
+		"msgStr":      "payload",
+		"msgBytes":    []byte("payload"),
+		"sigBytes":    []byte("signature"),
+		"secretBytes": []byte("key"),
+	}
+
+	unbounded := []string{
+		`hmac.digest(msgBytes, hmac.SHA256)`,
+		`hmac.digest(msgStr, hmac.SHA256)`,
+		`hmac.equal(msgBytes, sigBytes)`,
+		`hmac.equal(hmac.digest(msgBytes, hmac.SHA256), sigBytes)`,
+		`size(msgBytes) > 0 && hmac.equal(hmac.digest(msgStr, hmac.SHA256), sigBytes)`,
+	}
+	for _, expr := range unbounded {
+		t.Run(expr, func(t *testing.T) {
+			ast, issues := env.Compile(expr)
+			if issues != nil && issues.Err() != nil {
+				t.Fatalf("Compile(%q) failed: %v", expr, issues.Err())
+			}
+			est, err := env.EstimateCost(ast, unboundedCostTestEstimator{})
+			if err != nil {
+				t.Fatalf("EstimateCost(%q) failed: %v", expr, err)
+			}
+			if est.Max != math.MaxUint64 {
+				t.Errorf("EstimateCost(%q) got max %d, wanted %d", expr, est.Max, uint64(math.MaxUint64))
+			}
+
+			prg, err := env.Program(ast, cel.CostTracking(nil))
+			if err != nil {
+				t.Fatalf("Program(%q) failed: %v", expr, err)
+			}
+			_, det, err := prg.Eval(vars)
+			if err != nil {
+				t.Fatalf("Eval(%q) failed: %v", expr, err)
+			}
+			if det.ActualCost() == nil {
+				t.Fatalf("Eval(%q) got nil actual cost, wanted a value", expr)
+			}
+			if *det.ActualCost() != math.MaxUint64 {
+				t.Errorf("Eval(%q) got actual cost %d, wanted %d", expr, *det.ActualCost(), uint64(math.MaxUint64))
+			}
+
+			limited, err := env.Program(ast, cel.CostLimit(1000))
+			if err != nil {
+				t.Fatalf("Program(%q) failed: %v", expr, err)
+			}
+			if _, _, err := limited.Eval(vars); err == nil {
+				t.Errorf("Eval(%q) under a cost limit got nil error, wanted cost limit exceeded", expr)
+			}
+		})
+	}
+
+	// compute and verify are unchanged and remain bounded.
+	bounded := []string{
+		`hmac.compute(msgBytes, secretBytes, hmac.SHA256)`,
+		`hmac.verify(msgBytes, sigBytes, secretBytes, hmac.SHA256)`,
+	}
+	for _, expr := range bounded {
+		t.Run(expr, func(t *testing.T) {
+			ast, issues := env.Compile(expr)
+			if issues != nil && issues.Err() != nil {
+				t.Fatalf("Compile(%q) failed: %v", expr, issues.Err())
+			}
+			est, err := env.EstimateCost(ast, unboundedCostTestEstimator{})
+			if err != nil {
+				t.Fatalf("EstimateCost(%q) failed: %v", expr, err)
+			}
+			if est.Max == math.MaxUint64 {
+				t.Errorf("EstimateCost(%q) got an unbounded max, wanted a bounded estimate", expr)
+			}
+			prg, err := env.Program(ast, cel.CostTracking(nil))
+			if err != nil {
+				t.Fatalf("Program(%q) failed: %v", expr, err)
+			}
+			if _, det, err := prg.Eval(vars); err != nil {
+				t.Fatalf("Eval(%q) failed: %v", expr, err)
+			} else if *det.ActualCost() == math.MaxUint64 {
+				t.Errorf("Eval(%q) got an unbounded actual cost, wanted a bounded cost", expr)
+			}
+		})
+	}
+}
+
+type unboundedCostTestEstimator struct{}
+
+func (unboundedCostTestEstimator) EstimateSize(cost.AstNode) *cost.SizeEstimate {
+	return nil
+}
+
+func (unboundedCostTestEstimator) EstimateCallCost(function, overloadID string, target *cost.AstNode, args []cost.AstNode) *cost.CallEstimate {
+	return nil
 }


### PR DESCRIPTION
Support digest computation without secret material, and linear-time equality checks.