### PR TITLE
Updates to JSON handling in Native Types

### DIFF
--- a/common/types/native.go
+++ b/common/types/native.go
@@ -90,15 +90,11 @@ func ParseStructField(handler NativeTypesFieldNameHandler) NativeTypeOption {
 
 func fieldNameByTag(structTagToParse string) func(field reflect.StructField) string {
 	return func(field reflect.StructField) string {
-		tag, found := field.Tag.Lookup(structTagToParse)
-		if found {
-			splits := strings.Split(tag, ",")
-			if len(splits) > 0 {
-				name := splits[0]
-				return name
-			}
+		tagInfo := parseStructTag(field, structTagToParse, field.Name)
+		if tagInfo.Skip {
+			return "-"
 		}
-		return field.Name
+		return tagInfo.Name
 	}
 }
 
@@ -106,11 +102,19 @@ func isSkippedFieldName(name string) bool {
 	return name == "" || name == "-"
 }
 
+type nativeJSONField struct {
+	index     []int
+	jsonName  string
+	omitEmpty bool
+	hasTag    bool
+}
+
 // NativeType represents a CEL struct type descriptor generated from a native Go struct.
 type NativeType struct {
 	typeName     string
 	refType      reflect.Type
 	fieldsByName map[string]reflect.StructField
+	jsonFields   []nativeJSONField
 }
 
 // ReflectType implements StructTypeDescriptor.
@@ -279,22 +283,60 @@ func (o *nativeObj) ConvertToNative(typeDesc reflect.Type) (any, error) {
 		return structpb.NewStructValue(jsonStruct.(*structpb.Struct)), nil
 	case jsonStructType:
 		refVal := reflect.Indirect(o.refValue)
-		fields := make(map[string]*structpb.Value, refVal.NumField())
-		for fieldName, fieldType := range o.valType.fieldsByName {
-			fieldValue := safeGetFieldByIndex(refVal, fieldType.Index)
-			if !fieldValue.IsValid() || fieldValue.IsZero() {
+		fields := make(map[string]*structpb.Value, len(o.valType.jsonFields))
+		for _, jf := range o.valType.jsonFields {
+			fieldValue := safeGetFieldByIndex(refVal, jf.index)
+			if !fieldValue.IsValid() {
 				continue
+			}
+			if fieldValue.IsZero() {
+				if !jf.hasTag || jf.omitEmpty || fieldValue.Kind() == reflect.Pointer || fieldValue.Kind() == reflect.Slice || fieldValue.Kind() == reflect.Map || fieldValue.Kind() == reflect.Interface {
+					continue
+				}
 			}
 			fieldCELVal := o.NativeToValue(fieldValue.Interface())
 			fieldJSONVal, err := fieldCELVal.ConvertToNative(jsonValueType)
 			if err != nil {
 				return nil, err
 			}
-			fields[fieldName] = fieldJSONVal.(*structpb.Value)
+			fields[jf.jsonName] = fieldJSONVal.(*structpb.Value)
 		}
 		return &structpb.Struct{Fields: fields}, nil
 	}
 	return nil, fmt.Errorf("type conversion error from '%v' to '%v'", o.Type(), typeDesc)
+}
+
+type structTagInfo struct {
+	Name      string
+	OmitEmpty bool
+	Skip      bool
+	HasTag    bool
+}
+
+func parseStructTag(field reflect.StructField, tagName, defaultName string) structTagInfo {
+	tag, found := field.Tag.Lookup(tagName)
+	if !found {
+		return structTagInfo{Name: defaultName}
+	}
+	if tag == "-" {
+		return structTagInfo{Skip: true, HasTag: true}
+	}
+	parts := strings.Split(tag, ",")
+	name := parts[0]
+	if name == "" {
+		name = defaultName
+	}
+	omitEmpty := false
+	for _, opt := range parts[1:] {
+		if opt == "omitempty" {
+			omitEmpty = true
+		}
+	}
+	return structTagInfo{
+		Name:      name,
+		OmitEmpty: omitEmpty,
+		HasTag:    true,
+	}
 }
 
 func (o *nativeObj) ConvertToType(typeVal ref.Type) ref.Val {
@@ -462,10 +504,49 @@ func newNativeType(rawType reflect.Type, fieldNameHandler NativeTypesFieldNameHa
 		fieldsByName[fieldName] = field
 	}
 
+	var jsonFields []nativeJSONField
+	for _, field := range reflect.VisibleFields(refType) {
+		if !field.IsExported() || !isSupportedType(field.Type) {
+			continue
+		}
+		fieldName := toFieldName(field, fieldNameHandler)
+		if isSkippedFieldName(fieldName) {
+			continue
+		}
+		// If anonymous embedded field without explicit tag, skip
+		if field.Anonymous {
+			tagInfo := parseStructTag(field, "json", fieldName)
+			if !tagInfo.HasTag || tagInfo.Skip || tagInfo.Name == "" {
+				continue
+			}
+		}
+		// If promoted subfield from embedded struct (len(Index) > 1), check if parent has tag
+		if len(field.Index) > 1 {
+			parentField := refType.Field(field.Index[0])
+			if parentField.Anonymous {
+				tagInfo := parseStructTag(parentField, "json", "")
+				if tagInfo.HasTag && !tagInfo.Skip && tagInfo.Name != "" {
+					continue
+				}
+			}
+		}
+		tagInfo := parseStructTag(field, "json", fieldName)
+		if tagInfo.Skip {
+			continue
+		}
+		jsonFields = append(jsonFields, nativeJSONField{
+			index:     field.Index,
+			jsonName:  tagInfo.Name,
+			omitEmpty: tagInfo.OmitEmpty,
+			hasTag:    tagInfo.HasTag,
+		})
+	}
+
 	return &NativeType{
 		typeName:     fmt.Sprintf("%s.%s", simplePkgAlias(refType.PkgPath()), refType.Name()),
 		refType:      refType,
 		fieldsByName: fieldsByName,
+		jsonFields:   jsonFields,
 	}, nil
 }
 
@@ -490,6 +571,18 @@ func safeSetFieldByIndex(v reflect.Value, index []int) reflect.Value {
 }
 
 func safeGetFieldByIndex(v reflect.Value, index []int) reflect.Value {
+	if len(index) == 1 {
+		if v.Kind() == reflect.Pointer {
+			if v.IsNil() {
+				return reflect.Value{}
+			}
+			v = v.Elem()
+		}
+		if v.Kind() != reflect.Struct || index[0] >= v.NumField() {
+			return reflect.Value{}
+		}
+		return v.Field(index[0])
+	}
 	for _, i := range index {
 		if v.Kind() == reflect.Pointer {
 			if v.IsNil() {

--- a/common/types/native.go
+++ b/common/types/native.go
@@ -68,6 +68,9 @@ type NativeTypeOption func(*NativeTypeOptions) error
 
 // ParseStructTags configures if native types field names should be overridable by CEL struct tags.
 // This is equivalent to ParseStructTag("cel").
+//
+// A tag starting with "-" (e.g. `cel:"-"` or `cel:"-,"`) marks the field as skipped.
+// A literal "-" can be specified by single-quoting the name (e.g. `cel:"'-'"`).
 func ParseStructTags(enabled bool) NativeTypeOption {
 	if enabled {
 		return ParseStructTag("cel")
@@ -76,6 +79,9 @@ func ParseStructTags(enabled bool) NativeTypeOption {
 }
 
 // ParseStructTag configures the struct tag to parse. The 0th item in the tag is used as the name of the CEL field.
+//
+// A tag starting with "-" (e.g. `cel:"-"` or `cel:"-,"`) marks the field as skipped.
+// A literal "-" can be specified by single-quoting the name (e.g. `cel:"'-'"`).
 func ParseStructTag(tag string) NativeTypeOption {
 	return ParseStructField(fieldNameByTag(tag))
 }
@@ -313,16 +319,21 @@ type structTagInfo struct {
 	HasTag    bool
 }
 
+// parseStructTag parses a struct field's tag for the given tagName (e.g. "cel" or "json").
+//
+// If the tag name or leading comma-separated segment is "-" (such as `json:"-"` or `json:"-,"`),
+// the field is marked as skipped. To specify a literal "-" as the field name, single quotes
+// can be used, such as `json:"'-'"`.
 func parseStructTag(field reflect.StructField, tagName, defaultName string) structTagInfo {
 	tag, found := field.Tag.Lookup(tagName)
 	if !found {
 		return structTagInfo{Name: defaultName}
 	}
-	if tag == "-" {
+	parts := strings.Split(tag, ",")
+	if parts[0] == "-" {
 		return structTagInfo{Skip: true, HasTag: true}
 	}
-	parts := strings.Split(tag, ",")
-	name := parts[0]
+	name := strings.Trim(parts[0], "'")
 	if name == "" {
 		name = defaultName
 	}

--- a/common/types/native_test.go
+++ b/common/types/native_test.go
@@ -504,6 +504,7 @@ func TestNativeTypesJsonSerialization(t *testing.T) {
 			expr: `TestSpecialJSONTags{
 				ignored: "sensitive",
 				hyphen_name: "hyphen-val",
+				quoted_hyphen: "quoted-val",
 				renamed: "renamed-val",
 				empty_int: 0,
 				empty_str: "",
@@ -514,7 +515,7 @@ func TestNativeTypesJsonSerialization(t *testing.T) {
 				cel_field: "divergent-val",
 			}`,
 			out: `{
-				"-": "hyphen-val",
+				"-": "quoted-val",
 				"custom_json_name": "renamed-val",
 				"json_field": "divergent-val",
 				"keep_empty": "",
@@ -1749,6 +1750,7 @@ type TestEmbeddedPointerTypes struct {
 type TestSpecialJSONTags struct {
 	Ignored              string `json:"-" cel:"ignored"`
 	HyphenName           string `json:"-," cel:"hyphen_name"`
+	QuotedHyphen         string `json:"'-'" cel:"quoted_hyphen"`
 	Renamed              string `json:"custom_json_name" cel:"renamed"`
 	OmitEmptyInt         int    `json:"empty_int,omitempty" cel:"empty_int"`
 	OmitEmptyStr         string `json:"empty_str,omitempty" cel:"empty_str"`

--- a/common/types/native_test.go
+++ b/common/types/native_test.go
@@ -437,7 +437,6 @@ func TestNativeTypesJsonSerialization(t *testing.T) {
 				CustomName: "name",
 			}`,
 			out: `{
-				"BoolVal":  true,
 				"CustomName":  "name",
 				"DoubleVal":  1.5,
 				"DurationVal":  "5s",
@@ -446,16 +445,17 @@ func TestNativeTypesJsonSerialization(t *testing.T) {
 				"Int64Val":  64,
 				"MapVal": {
 	              "map-key": {
-    	            "BoolVal": true
+    	            "boolVal": true
         	      }
             	},
-				"NestedVal": {
+				"StringVal":  "string",
+				"boolVal":  true,
+				"nestedVal": {
 					"NestedListVal": [
 					  "first",
 					  "second"
 					]
-				},
-				"StringVal":  "string"
+				}
 			  }`,
 		},
 		{
@@ -478,7 +478,6 @@ func TestNativeTypesJsonSerialization(t *testing.T) {
                 custom_name: "name",
 			}`,
 			out: `{
-				"BoolVal":  true,
 				"DoubleVal":  1.5,
 				"DurationVal":  "5s",
 				"FloatVal":  2,
@@ -486,18 +485,92 @@ func TestNativeTypesJsonSerialization(t *testing.T) {
 				"Int64Val":  64,
 				"MapVal": {
 	              "map-key": {
-    	            "BoolVal": true
+    	            "boolVal": true
         	      }
             	},
-				"NestedVal": {
+				"StringVal":  "string",
+				"boolVal":  true,
+				"custom_name": "name",
+				"nestedVal": {
 					"NestedListVal": [
 					  "first",
 					  "second"
 					]
-				},
-				"StringVal":  "string",
-                "custom_name": "name"
+				}
 			  }`,
+			additionalEnvOptions: []any{types.ParseStructTags(true)},
+		},
+		{
+			expr: `TestSpecialJSONTags{
+				ignored: "sensitive",
+				hyphen_name: "hyphen-val",
+				renamed: "renamed-val",
+				empty_int: 0,
+				empty_str: "",
+				pop_int: 42,
+				keep_zero: 0,
+				keep_empty: "",
+				keep_false: false,
+				cel_field: "divergent-val",
+			}`,
+			out: `{
+				"-": "hyphen-val",
+				"custom_json_name": "renamed-val",
+				"json_field": "divergent-val",
+				"keep_empty": "",
+				"keep_false": false,
+				"keep_zero": 0,
+				"pop_int": 42
+			}`,
+			additionalEnvOptions: []any{types.ParseStructTags(true)},
+		},
+		{
+			expr: `TestEmbeddedTypes{
+				name: "alice",
+				Skipped: "secret",
+				NestedListVal: ["a", "b"],
+				custom_name: "nested",
+			}`,
+			out: `{
+				"embedded": {
+					"NestedListVal": [
+						"a",
+						"b"
+					],
+					"custom_name": "nested"
+				},
+				"name": "alice"
+			}`,
+			additionalEnvOptions: []any{types.ParseStructTags(true)},
+		},
+		{
+			expr: `TestEmbeddedTypes{
+				name: "bob",
+				Skipped: "secret",
+			}`,
+			out: `{
+				"name": "bob"
+			}`,
+			additionalEnvOptions: []any{types.ParseStructTags(true)},
+		},
+		{
+			expr: `TestEmbeddedPointerTypes{
+				NestedListVal: ["x"],
+				custom_name: "ptr_nested",
+			}`,
+			out: `{
+				"embedded": {
+					"NestedListVal": [
+						"x"
+					],
+					"custom_name": "ptr_nested"
+				}
+			}`,
+			additionalEnvOptions: []any{types.ParseStructTags(true)},
+		},
+		{
+			expr:                 `TestEmbeddedPointerTypes{}`,
+			out:                  `{}`,
 			additionalEnvOptions: []any{types.ParseStructTags(true)},
 		},
 	}
@@ -1572,6 +1645,9 @@ func testNativeEnv(t testing.TB, opts ...any) *cel.Env {
 	nativeOpts := []any{
 		reflect.ValueOf(&TestAllTypes{}),
 		reflect.ValueOf(&TestRefValFieldType{}),
+		reflect.ValueOf(&TestEmbeddedTypes{}),
+		reflect.ValueOf(&TestEmbeddedPointerTypes{}),
+		reflect.ValueOf(&TestSpecialJSONTags{}),
 	}
 	for _, o := range opts {
 		switch opt := o.(type) {
@@ -1617,12 +1693,12 @@ type TestStructWithMultipleSameNames struct {
 type TestNestedType struct {
 	NestedListVal    []string
 	NestedMapVal     map[int64]bool
-	NestedCustomName string `cel:"custom_name" json:"custom_name"`
+	NestedCustomName string `cel:"custom_name" json:"custom_name,omitempty"`
 }
 
 type TestAllTypes struct {
 	NestedVal       *TestNestedType `json:"nestedVal,omitempty"`
-	NestedStructVal TestNestedType  `json:"nestedStructVal"`
+	NestedStructVal TestNestedType  `json:"nestedStructVal,omitempty"`
 	BoolVal         bool            `json:"boolVal"`
 	BytesVal        []byte
 	DurationVal     time.Duration
@@ -1668,6 +1744,19 @@ type TestEmbeddedTypes struct {
 
 type TestEmbeddedPointerTypes struct {
 	*TestNestedType `json:"embedded,omitempty"`
+}
+
+type TestSpecialJSONTags struct {
+	Ignored              string `json:"-" cel:"ignored"`
+	HyphenName           string `json:"-," cel:"hyphen_name"`
+	Renamed              string `json:"custom_json_name" cel:"renamed"`
+	OmitEmptyInt         int    `json:"empty_int,omitempty" cel:"empty_int"`
+	OmitEmptyStr         string `json:"empty_str,omitempty" cel:"empty_str"`
+	PopulatedInt         int    `json:"pop_int,omitempty" cel:"pop_int"`
+	NonOmitEmptyZero     int    `json:"keep_zero" cel:"keep_zero"`
+	NonOmitEmptyEmptyStr string `json:"keep_empty" cel:"keep_empty"`
+	NonOmitEmptyFalse    bool   `json:"keep_false" cel:"keep_false"`
+	DivergentField       string `cel:"cel_field" json:"json_field"`
 }
 
 type TestRefValFieldType struct {

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -387,6 +387,9 @@ func (p *Registry) FindIdent(identName string) (ref.Val, bool) {
 	if t, found := p.revTypeMap[identName]; found {
 		return t, true
 	}
+	if t, found := p.revTypeMap[sanitizeStructTypeName(identName)]; found {
+		return t, true
+	}
 	if enumVal, found := p.pbdb.DescribeEnum(identName); found {
 		return Int(enumVal.Value()), true
 	}
@@ -496,7 +499,8 @@ func (p *Registry) RegisterMessage(message proto.Message) error {
 // to CEL, even when they're not based on protobuf types.
 func (p *Registry) RegisterType(types ...ref.Type) error {
 	for _, t := range types {
-		existing, found := p.revTypeMap[t.TypeName()]
+		typeName := sanitizeStructTypeName(t.TypeName())
+		existing, found := p.revTypeMap[typeName]
 		celType := maybeForeignType(t)
 		if found {
 			if !existing.IsEquivalentType(celType) {
@@ -511,7 +515,6 @@ func (p *Registry) RegisterType(types ...ref.Type) error {
 		}
 
 		p.ensureMutable()
-		typeName := t.TypeName()
 		p.revTypeMap[typeName] = celType
 		if st, ok := t.(StructTypeDescriptor); ok {
 			// Conflicts are gated above so if we see a struct here, it's safe to register.

--- a/common/types/provider_test.go
+++ b/common/types/provider_test.go
@@ -1360,9 +1360,11 @@ func TestRegistryStructTypeDescriptor_FindStructFieldType(t *testing.T) {
 
 func TestRegistryStructTypeDescriptor_FindIdent(t *testing.T) {
 	reg := newTestStructTypeRegistry(t)
-	ident, found := reg.FindIdent("custom.MyStruct")
-	if !found || ident == nil {
-		t.Fatalf("FindIdent('custom.MyStruct') not found")
+	for _, identName := range []string{"custom.MyStruct", ".custom.MyStruct"} {
+		ident, found := reg.FindIdent(identName)
+		if !found || ident == nil {
+			t.Fatalf("FindIdent(%q) not found", identName)
+		}
 	}
 }
 

--- a/common/types/provider_test.go
+++ b/common/types/provider_test.go
@@ -2706,3 +2706,106 @@ func TestRegistry_NativeReflectTypes(t *testing.T) {
 		}
 	})
 }
+
+func TestParseStructTag(t *testing.T) {
+	tests := []struct {
+		name        string
+		tag         string
+		tagName     string
+		defaultName string
+		want        structTagInfo
+	}{
+		{
+			name:        "no_tag",
+			tag:         ``,
+			tagName:     "json",
+			defaultName: "DefaultField",
+			want:        structTagInfo{Name: "DefaultField", OmitEmpty: false, Skip: false, HasTag: false},
+		},
+		{
+			name:        "hyphen_skip",
+			tag:         `json:"-"`,
+			tagName:     "json",
+			defaultName: "DefaultField",
+			want:        structTagInfo{Name: "", OmitEmpty: false, Skip: true, HasTag: true},
+		},
+		{
+			name:        "hyphen_with_trailing_comma_skip",
+			tag:         `json:"-,"`,
+			tagName:     "json",
+			defaultName: "DefaultField",
+			want:        structTagInfo{Name: "", OmitEmpty: false, Skip: true, HasTag: true},
+		},
+		{
+			name:        "hyphen_with_omitempty_skip",
+			tag:         `json:"-,omitempty"`,
+			tagName:     "json",
+			defaultName: "DefaultField",
+			want:        structTagInfo{Name: "", OmitEmpty: false, Skip: true, HasTag: true},
+		},
+		{
+			name:        "quoted_hyphen_literal",
+			tag:         `json:"'-'"`,
+			tagName:     "json",
+			defaultName: "DefaultField",
+			want:        structTagInfo{Name: "-", OmitEmpty: false, Skip: false, HasTag: true},
+		},
+		{
+			name:        "quoted_hyphen_with_omitempty",
+			tag:         `json:"'-',omitempty"`,
+			tagName:     "json",
+			defaultName: "DefaultField",
+			want:        structTagInfo{Name: "-", OmitEmpty: true, Skip: false, HasTag: true},
+		},
+		{
+			name:        "custom_name",
+			tag:         `json:"custom_name"`,
+			tagName:     "json",
+			defaultName: "DefaultField",
+			want:        structTagInfo{Name: "custom_name", OmitEmpty: false, Skip: false, HasTag: true},
+		},
+		{
+			name:        "custom_name_omitempty",
+			tag:         `json:"custom_name,omitempty"`,
+			tagName:     "json",
+			defaultName: "DefaultField",
+			want:        structTagInfo{Name: "custom_name", OmitEmpty: true, Skip: false, HasTag: true},
+		},
+		{
+			name:        "empty_name_with_omitempty",
+			tag:         `json:",omitempty"`,
+			tagName:     "json",
+			defaultName: "DefaultField",
+			want:        structTagInfo{Name: "DefaultField", OmitEmpty: true, Skip: false, HasTag: true},
+		},
+		{
+			name:        "cel_tag_hyphen_skip",
+			tag:         `cel:"-"`,
+			tagName:     "cel",
+			defaultName: "DefaultField",
+			want:        structTagInfo{Name: "", OmitEmpty: false, Skip: true, HasTag: true},
+		},
+		{
+			name:        "cel_tag_quoted_hyphen",
+			tag:         `cel:"'-'"`,
+			tagName:     "cel",
+			defaultName: "DefaultField",
+			want:        structTagInfo{Name: "-", OmitEmpty: false, Skip: false, HasTag: true},
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			field := reflect.StructField{
+				Name: "DefaultField",
+				Tag:  reflect.StructTag(tc.tag),
+			}
+			got := parseStructTag(field, tc.tagName, tc.defaultName)
+			if got != tc.want {
+				t.Errorf("parseStructTag(%q, %q, %q) = %+v, want %+v", tc.tag, tc.tagName, tc.defaultName, got, tc.want)
+			}
+		})
+	}
+}
+

--- a/ext/native_test.go
+++ b/ext/native_test.go
@@ -436,7 +436,6 @@ func TestNativeTypesJsonSerialization(t *testing.T) {
         CustomName: "name",
 			}`,
 			out: `{
-				"BoolVal":  true,
 				"CustomName":  "name",
 				"DoubleVal":  1.5,
 				"DurationVal":  "5s",
@@ -445,16 +444,17 @@ func TestNativeTypesJsonSerialization(t *testing.T) {
 				"Int64Val":  64,
 				"MapVal": {
 	              "map-key": {
-    	            "BoolVal": true
+    	            "boolVal": true
         	      }
             	},
-				"NestedVal": {
+				"StringVal":  "string",
+				"boolVal":  true,
+				"nestedVal": {
 					"NestedListVal": [
 					  "first",
 					  "second"
 					]
-				},
-				"StringVal":  "string"
+				}
 			  }`,
 		},
 		{
@@ -477,7 +477,6 @@ func TestNativeTypesJsonSerialization(t *testing.T) {
                 custom_name: "name",
 			}`,
 			out: `{
-				"BoolVal":  true,
 				"DoubleVal":  1.5,
 				"DurationVal":  "5s",
 				"FloatVal":  2,
@@ -485,17 +484,18 @@ func TestNativeTypesJsonSerialization(t *testing.T) {
 				"Int64Val":  64,
 				"MapVal": {
 	              "map-key": {
-    	            "BoolVal": true
+    	            "boolVal": true
         	      }
             	},
-				"NestedVal": {
+				"StringVal":  "string",
+				"boolVal":  true,
+				"custom_name": "name",
+				"nestedVal": {
 					"NestedListVal": [
 					  "first",
 					  "second"
 					]
-				},
-				"StringVal":  "string",
-                "custom_name": "name"
+				}
 			  }`,
 			additionalEnvOptions: []any{ParseStructTags(true)},
 		},
@@ -1328,12 +1328,12 @@ type TestStructWithMultipleSameNames struct {
 type TestNestedType struct {
 	NestedListVal    []string
 	NestedMapVal     map[int64]bool
-	NestedCustomName string `cel:"custom_name" json:"custom_name"`
+	NestedCustomName string `cel:"custom_name" json:"custom_name,omitempty"`
 }
 
 type TestAllTypes struct {
 	NestedVal       *TestNestedType `json:"nestedVal,omitempty"`
-	NestedStructVal TestNestedType  `json:"nestedStructVal"`
+	NestedStructVal TestNestedType  `json:"nestedStructVal,omitempty"`
 	BoolVal         bool            `json:"boolVal"`
 	BytesVal        []byte
 	DurationVal     time.Duration


### PR DESCRIPTION
Improved JSON handling of quoted tags and improperly structured tags.

JSON tag name handling now propagates down to `ConvertToNative` properly as well.