### PR TITLE
costs: Migrate binding and comprehension cost tests to common cost APIs

### DIFF
--- a/ext/bindings_test.go
+++ b/ext/bindings_test.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	"cel.dev/cel-go/cel"
-	"cel.dev/cel-go/checker"
 	"cel.dev/cel-go/common/ast"
+	"cel.dev/cel-go/common/cost"
 	"cel.dev/cel-go/common/operators"
 	"cel.dev/cel-go/common/types"
 	"cel.dev/cel-go/common/types/ref"
@@ -39,14 +39,14 @@ var bindingTests = []struct {
 	vars          []cel.EnvOption
 	in            map[string]any
 	hints         map[string]uint64
-	estimatedCost checker.CostEstimate
+	estimatedCost cost.CostEstimate
 	actualCost    uint64
 }{
 	{
 		name: "single bind",
 		expr: `cel.bind(a, 'hell' + 'o' + '!', "%s, %s, %s".format([a, a, a])) ==
 	                       'hello!, hello!, hello' + '!'`,
-		estimatedCost: checker.CostEstimate{Min: 30, Max: 32},
+		estimatedCost: cost.CostEstimate{Min: 30, Max: 32},
 		actualCost:    32,
 	},
 	{
@@ -54,7 +54,7 @@ var bindingTests = []struct {
 		expr: `cel.bind(a, 'hello!',
 		       cel.bind(b, 'goodbye',
 				a + ' and, ' + b)) == 'hello! and, goodbye'`,
-		estimatedCost: checker.CostEstimate{Min: 27, Max: 28},
+		estimatedCost: cost.CostEstimate{Min: 27, Max: 28},
 		actualCost:    28,
 	},
 	{
@@ -62,7 +62,7 @@ var bindingTests = []struct {
 		expr: `cel.bind(a,
 		       cel.bind(a, 'world', a + '!'),
 		   	    'hello ' + a) == 'hello ' + 'world' + '!'`,
-		estimatedCost: checker.CostEstimate{Min: 30, Max: 31},
+		estimatedCost: cost.CostEstimate{Min: 30, Max: 31},
 		actualCost:    31,
 	},
 	{
@@ -77,7 +77,7 @@ var bindingTests = []struct {
 		hints: map[string]uint64{
 			"x": 3,
 		},
-		estimatedCost: checker.CostEstimate{Min: 39, Max: 39},
+		estimatedCost: cost.CostEstimate{Min: 39, Max: 39},
 		actualCost:    39,
 	},
 	{
@@ -93,7 +93,7 @@ var bindingTests = []struct {
 			"x":        3,
 			"x.@items": 10,
 		},
-		estimatedCost: checker.CostEstimate{Min: 38, Max: 40},
+		estimatedCost: cost.CostEstimate{Min: 38, Max: 40},
 		actualCost:    39,
 	},
 	{
@@ -103,7 +103,7 @@ var bindingTests = []struct {
 		in: map[string]any{
 			"cel.example.x": "1",
 		},
-		estimatedCost: checker.FixedCostEstimate(12),
+		estimatedCost: cost.FixedCostEstimate(12),
 		actualCost:    12,
 	},
 	{
@@ -116,7 +116,7 @@ var bindingTests = []struct {
 		in: map[string]any{
 			"cel.example.x": "1",
 		},
-		estimatedCost: checker.FixedCostEstimate(12),
+		estimatedCost: cost.FixedCostEstimate(12),
 		actualCost:    12,
 	},
 	{
@@ -129,7 +129,7 @@ var bindingTests = []struct {
 		in: map[string]any{
 			"cel.example.x.y": 1,
 		},
-		estimatedCost: checker.FixedCostEstimate(43),
+		estimatedCost: cost.FixedCostEstimate(43),
 		actualCost:    43,
 	},
 	{
@@ -141,7 +141,7 @@ var bindingTests = []struct {
 		in: map[string]any{
 			"x.y": 0,
 		},
-		estimatedCost: checker.FixedCostEstimate(44),
+		estimatedCost: cost.FixedCostEstimate(44),
 		actualCost:    44,
 	},
 	{
@@ -153,13 +153,13 @@ var bindingTests = []struct {
 		in: map[string]any{
 			"y": 1,
 		},
-		estimatedCost: checker.FixedCostEstimate(13),
+		estimatedCost: cost.FixedCostEstimate(13),
 		actualCost:    13,
 	},
 	{
 		name:          "nesting shadowing",
 		expr:          `cel.bind(y, 0, cel.bind(y, 1, y != 0))`,
-		estimatedCost: checker.FixedCostEstimate(22),
+		estimatedCost: cost.FixedCostEstimate(22),
 		actualCost:    22,
 	},
 }

--- a/ext/comprehensions_test.go
+++ b/ext/comprehensions_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"cel.dev/cel-go/cel"
-	"cel.dev/cel-go/checker"
+	"cel.dev/cel-go/common/cost"
 	"cel.dev/cel-go/common/types"
 	"cel.dev/cel-go/interpreter"
 )
@@ -222,25 +222,25 @@ func TestTwoVarComprehensionsCost(t *testing.T) {
 		vars          []cel.EnvOption
 		in            map[string]any
 		hints         map[string]uint64
-		estimatedCost checker.CostEstimate
+		estimatedCost cost.CostEstimate
 		actualCost    uint64
 	}{
 		{
 			name:          "all list literal",
 			expr:          `[1, 2, 3, 4].all(i, v, i < 5 && v > 0)`,
-			estimatedCost: checker.CostEstimate{Min: 23, Max: 39},
+			estimatedCost: cost.CostEstimate{Min: 23, Max: 39},
 			actualCost:    39,
 		},
 		{
 			name:          "all map literal - true",
 			expr:          `{1: 1, 2: 2, 3: 3}.all(i, v, i < 5 && v > 0)`,
-			estimatedCost: checker.CostEstimate{Min: 40, Max: 52},
+			estimatedCost: cost.CostEstimate{Min: 40, Max: 52},
 			actualCost:    52,
 		},
 		{
 			name:          "all map literal - false",
 			expr:          `!{0: 0}.all(i, v, i < 5 && v > 0)`,
-			estimatedCost: checker.CostEstimate{Min: 35, Max: 39},
+			estimatedCost: cost.CostEstimate{Min: 35, Max: 39},
 			actualCost:    39,
 		},
 		{
@@ -253,7 +253,7 @@ func TestTwoVarComprehensionsCost(t *testing.T) {
 			in: map[string]any{
 				"m": map[int]int{1: 1, 2: 2},
 			},
-			estimatedCost: checker.CostEstimate{Min: 2, Max: 23},
+			estimatedCost: cost.CostEstimate{Min: 2, Max: 23},
 			actualCost:    16,
 		},
 		{
@@ -268,56 +268,56 @@ func TestTwoVarComprehensionsCost(t *testing.T) {
 			in: map[string]any{
 				"m": map[string]string{"he": "hello", "go": "goodbye"},
 			},
-			estimatedCost: checker.CostEstimate{Min: 2, Max: 23},
+			estimatedCost: cost.CostEstimate{Min: 2, Max: 23},
 			actualCost:    14,
 		},
 		{
 			name:          "transformList empty",
 			expr:          `[].transformList(i, v, v) == []`,
-			estimatedCost: checker.FixedCostEstimate(31),
+			estimatedCost: cost.FixedCostEstimate(31),
 			actualCost:    31,
 		},
 		{
 			name:          "transformList single element",
 			expr:          `[1].transformList(i, v, i) == [0]`,
-			estimatedCost: checker.FixedCostEstimate(45),
+			estimatedCost: cost.FixedCostEstimate(45),
 			actualCost:    45,
 		},
 		{
 			name:          "transformList with filter",
 			expr:          `[3, 2, 1].transformList(i, v, v > i, v) == [3, 2]`,
-			estimatedCost: checker.CostEstimate{Min: 44, Max: 80},
+			estimatedCost: cost.CostEstimate{Min: 44, Max: 80},
 			actualCost:    67,
 		},
 		{
 			name:          "transformMap empty list",
 			expr:          `[].transformMap(k, v, v + 1) == {}`,
-			estimatedCost: checker.FixedCostEstimate(71),
+			estimatedCost: cost.FixedCostEstimate(71),
 			actualCost:    71,
 		},
 		{
 			name:          "transformMap empty map",
 			expr:          `{}.transformMap(k, v, v + 1) == {}`,
-			estimatedCost: checker.FixedCostEstimate(91),
+			estimatedCost: cost.FixedCostEstimate(91),
 			actualCost:    91,
 		},
 		{
 			name:          "transformMap literal scalar map",
 			expr:          `{1: 2}.transformMap(k, v, v + 1) == {1: 3}`,
-			estimatedCost: checker.FixedCostEstimate(97),
+			estimatedCost: cost.FixedCostEstimate(97),
 			actualCost:    97,
 		},
 		{
 			name: "transformMap local bind",
 			expr: `cel.bind(m, {"hello": "hello"},
 			                m.transformMap(k, v, v + "world")) == {"hello": "helloworld"}`,
-			estimatedCost: checker.FixedCostEstimate(108),
+			estimatedCost: cost.FixedCostEstimate(108),
 			actualCost:    108,
 		},
 		{
 			name:          "transformMap filter map",
 			expr:          `{1: 2, 3: 4, 5: 6}.transformMap(k, v, k % 3 == 0, v + 1) == {3: 5}`,
-			estimatedCost: checker.CostEstimate{Min: 104, Max: 116},
+			estimatedCost: cost.CostEstimate{Min: 104, Max: 116},
 			actualCost:    106,
 		},
 		{
@@ -338,13 +338,13 @@ func TestTwoVarComprehensionsCost(t *testing.T) {
 				"m.@values":        10,
 				"m.@values.@items": 2,
 			},
-			estimatedCost: checker.CostEstimate{Min: 73, Max: 173},
+			estimatedCost: cost.CostEstimate{Min: 73, Max: 173},
 			actualCost:    98,
 		},
 		{
 			name:          "transformMapEntry literal input",
 			expr:          `{1: 2}.transformMapEntry(k, v, {v: k}) == {2: 1}`,
-			estimatedCost: checker.FixedCostEstimate(126),
+			estimatedCost: cost.FixedCostEstimate(126),
 			actualCost:    126,
 		},
 		{
@@ -364,7 +364,7 @@ func TestTwoVarComprehensionsCost(t *testing.T) {
 				"m.@keys":   16,
 				"m.@values": 10,
 			},
-			estimatedCost: checker.CostEstimate{Min: 65, Max: 405},
+			estimatedCost: cost.CostEstimate{Min: 65, Max: 405},
 			actualCost:    201,
 		},
 	}


### PR DESCRIPTION
Migrate binding and comprehension cost tests to common cost APIs