### PR TITLE
Support for json.parse with extensive round-trip tests

### DIFF
--- a/common/types/native_test.go
+++ b/common/types/native_test.go
@@ -1750,7 +1750,10 @@ type TestEmbeddedPointerTypes struct {
 type TestSpecialJSONTags struct {
 	Ignored              string `json:"-" cel:"ignored"`
 	HyphenName           string `json:"-," cel:"hyphen_name"`
+<<<<<<< HEAD
 	QuotedHyphen         string `json:"'-'" cel:"quoted_hyphen"`
+=======
+>>>>>>> 99d5973f (Update provider and native types to better support JSON conversion and type resolution)
 	Renamed              string `json:"custom_json_name" cel:"renamed"`
 	OmitEmptyInt         int    `json:"empty_int,omitempty" cel:"empty_int"`
 	OmitEmptyStr         string `json:"empty_str,omitempty" cel:"empty_str"`

--- a/common/types/native_test.go
+++ b/common/types/native_test.go
@@ -1750,10 +1750,7 @@ type TestEmbeddedPointerTypes struct {
 type TestSpecialJSONTags struct {
 	Ignored              string `json:"-" cel:"ignored"`
 	HyphenName           string `json:"-," cel:"hyphen_name"`
-<<<<<<< HEAD
 	QuotedHyphen         string `json:"'-'" cel:"quoted_hyphen"`
-=======
->>>>>>> 99d5973f (Update provider and native types to better support JSON conversion and type resolution)
 	Renamed              string `json:"custom_json_name" cel:"renamed"`
 	OmitEmptyInt         int    `json:"empty_int,omitempty" cel:"empty_int"`
 	OmitEmptyStr         string `json:"empty_str,omitempty" cel:"empty_str"`

--- a/ext/BUILD.bazel
+++ b/ext/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
     ],
     deps = [
         "//cel:go_default_library",
+        "//checker:go_default_library",
         "//common:go_default_library",
         "//common/env:go_default_library",
         "//common/types:go_default_library",

--- a/ext/design/encoders.md
+++ b/ext/design/encoders.md
@@ -1,0 +1,199 @@
+# CEL Encoders Extension Library Design
+
+## 1. Overview
+
+The `encoders` extension library provides standard encoding, decoding, and parsing functions for Common Expression Language (CEL). It allows expressions to safely interact with serialized data representations like Base64 and JSON without compromising execution safety, determinism, or resource boundaries.
+
+The library defines functions under two primary namespaces:
+- `base64`: For standard Base64 binary-to-text encoding and decoding.
+- `json`: For serializing CEL values to JSON and parsing JSON payloads into dynamic or strongly-typed CEL representations.
+
+---
+
+## 2. Design Decisions & Precedents
+
+### 2.1. Terminology: `encode` vs. `decode` vs. `parse`
+
+Across the CEL standard library and extension ecosystem, function naming follows distinct semantic conventions:
+
+| Operation | Canonical Signature Pattern | Precedent | Semantic Meaning | Error Handling |
+| :--- | :--- | :--- | :--- | :--- |
+| **`encode`** | `<Type>.encode(val) -> string` | `base64.encode`, `json.encode` | Converts in-memory structured data / bytes / CEL values into a serialized text format. | Produces valid serialized string or returns a CEL error on serialization failure. |
+| **`decode`** | `<Type>.decode(string) -> bytes` | `base64.decode` | Inverts a fixed-shape binary-to-text encoding where target shape is well-known (typically `bytes`). | Returns CEL evaluation error on malformed inputs. |
+| **`parse`** | `<Type>.parse(string[, type(T)]) -> optional_type(T)` | `json.parse`, `jwt.parse` | Deserializes text containing structured schemas or dynamic payloads into structured CEL values. | Returns `optional.none()` on malformed inputs or schema mismatches, avoiding hard evaluation errors on untrusted input. |
+
+#### Why `json.parse` returns `optional_type(T)` instead of throwing errors:
+In CEL evaluation pipelines (e.g., authorization, admission control, policy enforcement), input JSON payloads are frequently untrusted. Raising runtime evaluation errors would short-circuit entire policy evaluations and abort rule checking. Returning `optional_type(T)` empowers authors to use CEL's `optional` macros (`opt.hasValue()`, `opt.orValue(default)`, `opt.optMap(...)`) to handle absent or malformed data gracefully.
+
+---
+
+## 3. Function Signatures & Behavior
+
+### 3.1. Base64 Functions
+
+```text
+base64.encode(bytes) -> string
+base64.decode(string) -> bytes
+```
+
+- **`base64.encode`**: Converts `bytes` into standard Base64 encoded string with standard padding (`=`).
+- **`base64.decode`**: Decodes Base64 string into `bytes`. Supports both standard padding and unpadded / raw Base64 strings.
+
+### 3.2. JSON Functions
+
+```text
+json.encode(dyn) -> string
+json.parse(string) -> optional_type(dyn)
+json.parse(string, type(T)) -> optional_type(T)
+```
+
+#### `json.encode(val)`
+- Converts any CEL value (primitives, lists, maps, protobuf messages, native structs) into a compact JSON string.
+- Uses a single-pass `protojson.Marshal` on `types.JSONValueType` (`structpb.Value`), eliminating double-marshaling overhead.
+- **Key Ordering**: Maps and structs in Go iterate non-deterministically; thus JSON object key ordering is non-deterministic. Equality checks against JSON outputs in tests and policies should parse back to objects or verify membership across valid permutations.
+
+#### `json.parse(string)`
+- Parses any valid JSON payload into a dynamic CEL representation (`optional_type(dyn)`):
+  - JSON objects $\rightarrow$ CEL `map(string, dyn)`
+  - JSON arrays $\rightarrow$ CEL `list(dyn)`
+  - JSON numbers $\rightarrow$ CEL `int` (if integer) or `double` (if float/exponent), using `json.Number` for precision preservation.
+  - JSON booleans $\rightarrow$ CEL `bool`
+  - JSON strings $\rightarrow$ CEL `string`
+  - JSON `null` $\rightarrow$ CEL `null_type`
+- Returns `optional.none()` if input is not valid JSON or has unexpected trailing data.
+
+#### `json.parse(string, type(T))`
+- Strongly-typed JSON parsing into target type `T`:
+  - **Primitives**: `int`, `uint`, `double`, `bool`, `string`, `bytes` (decodes base64 string), `null_type`, `timestamp` (RFC3339 string), `duration` (e.g. `"5s"`).
+  - **Collections**: `list(T)` and `map(string, T)`.
+  - **Protobuf Types**: `google.protobuf.Struct`, `google.protobuf.Value`, `google.protobuf.ListValue`, and arbitrary registered `proto.Message` types.
+  - **Go Native Structs**: Instantiated via `types.Provider.NewValue(typeName, ...)` and Go reflection, respecting struct tags:
+    - `json:"<custom_name>"`: maps JSON field `<custom_name>` to the struct field.
+    - `json:"-"`: ignores and omits the field.
+    - `json:",omitempty"`: omits zero-value fields during serialization.
+- Returns `optional.none()` if the JSON value does not match the expected target schema or type.
+
+---
+
+## 4. Security & Resource Bounds
+
+### 4.1. Payload Size Limit
+To prevent memory exhaustion attacks (e.g., billion-laughs-style JSON bombs, deeply nested objects, or multi-gigabyte payloads), `json.parse` enforces a strict 10MB maximum input size:
+```go
+const maxJSONSize = 10 * 1024 * 1024 // 10MB
+```
+Inputs exceeding this limit immediately return a CEL runtime error.
+
+### 4.2. Cost Modeling
+JSON parsing and serialization complexity cannot be statically bounded without inspecting runtime payloads and target schema depths. Therefore:
+- **Cost Estimation**: Overload cost estimators return `checker.UnknownCostEstimate()` (`CostEstimate{Min: 0, Max: math.MaxUint64}`).
+- **Cost Tracking**: Runtime cost trackers return `math.MaxUint64`.
+
+---
+
+### 5.1. Instantiation via `Provider.NewValue`
+
+`json.parse` utilizes `types.Provider.NewValue(typeName, map[string]ref.Val{})` to instantiate target types:
+1. **Protobuf Messages**: `NewValue` returns a proto value whose underlying `proto.Message` is cloned and populated using `protojson.Unmarshal`.
+2. **Native Go Objects**: `NewValue` returns a native struct value whose `reflect.Type` is used to instantiate a pointer (`reflect.New(rt)`) and populated via standard `json.Unmarshal`.
+3. **No Private Registry Exposure**: Avoids leaking internal registry structures or requiring custom reflection getters on `Registry`.
+
+### 5.2. Separation of Concerns & Format Extensibility (YAML, XML)
+
+To maintain a clean separation of concerns:
+- **`common/types/native.go` & `ext/native.go`**: Contain all Go struct reflection, struct tag inspection (`json:"..."`, `cel:"..."`, `omitempty`, `json:"-"`), anonymous embedded struct promotion, and zero-value omission rules. `nativeObj.ConvertToNative(types.JSONValueType)` / `nativeObj.ConvertToNative(types.JSONStructType)` transforms native objects into standard structured representations.
+- **`ext/encoders.go`**: Acts as a format-level encoder/decoder. It performs payload size verification, invokes `val.ConvertToNative(types.JSONValueType)`, and calls the format-specific marshal/unmarshal engine (`protojson`).
+- **Future Format Support (YAML, XML)**: Adding support for formats such as YAML or XML will follow the exact same architecture: format encoders in `ext/` remain lightweight wrappers over `ConvertToNative` / `NewValue`, while native type reflection and tag mappings reside centrally in `common/types/native.go` and `ext/native.go`.
+
+---
+
+## 6. Test Matrix & Edge Cases
+
+### 6.1. Positive Test Cases
+
+| Scenario | Input Expression | Expected Output |
+| :--- | :--- | :--- |
+| Dynamic Primitive String | `json.parse('"hello"')` | `optional.of('hello')` |
+| Dynamic Negative Int | `json.parse('-42')` | `optional.of(-42)` |
+| Dynamic Float & Scientific | `json.parse('1.25e2')` | `optional.of(125.0)` |
+| Dynamic Boolean & Null | `json.parse('true')`, `json.parse('null')` | `optional.of(true)`, `optional.of(null)` |
+| Dynamic Nested Structure | `json.parse('{"items": [1, true, "a"]}')` | `optional.of({'items': [1, true, 'a']})` |
+| Typed Unsigned Int | `json.parse('18446744073709551615', uint)` | `optional.of(18446744073709551615u)` |
+| Typed Base64 Bytes | `json.parse('"aGVsbG8="', bytes)` | `optional.of(b'hello')` |
+| Typed RFC3339 Timestamp | `json.parse('"2023-01-01T00:00:00Z"', type(timestamp('...')))` | `optional.of(timestamp('2023-01-01T00:00:00Z'))` |
+| Typed Duration | `json.parse('"5s"', type(duration('5s')))` | `optional.of(duration('5s'))` |
+| Typed Generic List | `json.parse('[1, 2, 3]', type([1]))` | `optional.of([1, 2, 3])` |
+| Typed Generic Map | `json.parse('{"a": 1}', type({'': 1}))` | `optional.of({'a': 1})` |
+| Native Struct with Tags | `json.parse('{"user_name":"Alice","age":25}', ext.testNativeUser)` | `optional.of(testNativeUser{Username: 'Alice', Age: 25})` |
+| Roundtrip Identity | `json.parse(json.encode({'a': 1, 'b': 2}))` | `optional.of({'a': 1, 'b': 2})` |
+
+### 6.2. Edge Cases (Formatting & Syntax)
+
+| Scenario | Input Expression | Expected Output | Notes |
+| :--- | :--- | :--- | :--- |
+| Leading / Trailing Whitespace | `json.parse('  \t\n {"a": 1} \r\n ')` | `optional.of({'a': 1})` | Strips outer whitespace properly. |
+| Unicode Escape Sequences | `json.parse('"\\u003chello\\u003e"')` | `optional.of('<hello>')` | Decodes hex escapes. |
+| Multibyte Emojis / UTF-8 | `json.parse('"🚀"')` | `optional.of('🚀')` | Valid UTF-8 preserved. |
+| Double Coercion from Integer | `json.parse('42', double)` | `optional.of(42.0)` | Integer JSON literal valid for double. |
+| Empty Collections | `json.parse('{}')`, `json.parse('[]')` | `optional.of({})`, `optional.of([])` | Empty structures preserved. |
+| Raw vs Padded Base64 | `base64.decode('aGVsbG8=')`, `base64.decode('aGVsbG8')` | `b'hello'` | Supports both padding modes. |
+| Non-deterministic Key Order | `json.encode({'a': 1, 'b': 2})` | `'{"a":1, "b":2}'` or `'{"b":2, "a":1}'` | Validated using `in [...]` or roundtrip parse. |
+
+### 6.3. Negative Test Cases
+
+| Scenario | Input Expression | Expected Output | Notes |
+| :--- | :--- | :--- | :--- |
+| Malformed JSON: Unclosed Brackets | `json.parse('{')`, `json.parse('[1, 2')` | `optional.none()` | Syntax error returns none. |
+| Malformed JSON: Unquoted Key | `json.parse('{key: "value"}')` | `optional.none()` | Invalid JSON syntax. |
+| Malformed JSON: Trailing Comma | `json.parse('[1, 2,]')`, `json.parse('{"a": 1,}')` | `optional.none()` | Trailing comma is invalid JSON. |
+| Multiple Root Values | `json.parse('{"a": 1} {"b": 2}')` | `optional.none()` | Unexpected trailing token. |
+| Trailing Junk Tokens | `json.parse('123 abc')` | `optional.none()` | Trailing garbage returns none. |
+| Empty String Input | `json.parse('')` | `optional.none()` | EOF returns none. |
+| Type Mismatch: String to Int | `json.parse('"123"', int)` | `optional.none()` | String is not a number. |
+| Type Mismatch: Negative to Uint | `json.parse('-1', uint)` | `optional.none()` | Negative not allowable for uint. |
+| Type Mismatch: Float to Int | `json.parse('1.5', int)` | `optional.none()` | Fractional number invalid for int. |
+| Type Mismatch: Number to Bool | `json.parse('1', bool)` | `optional.none()` | Number is not boolean. |
+| Type Mismatch: Object to List | `json.parse('{"a": 1}', type([1]))` | `optional.none()` | Map cannot parse into list. |
+| Type Mismatch: Null to Non-Null | `json.parse('null', int)`, `json.parse('null', string)` | `optional.none()` | Null only valid for null_type / dyn. |
+| Invalid Base64 in Bytes | `json.parse('"not valid base64 %%%"', bytes)` | `optional.none()` | Corrupt base64 string. |
+| Invalid RFC3339 in Timestamp | `json.parse('"invalid-time"', type(timestamp(...)))` | `optional.none()` | Invalid timestamp format. |
+| Invalid Duration Unit | `json.parse('"10x"', type(duration('5s')))` | `optional.none()` | Invalid duration format. |
+| Size Limit Exceeded (> 10MB) | `json.parse(largeJsonString)` | CEL Runtime Error | String size exceeds 10MB limit. |
+
+---
+
+## 7. Performance Benchmarks & Roundtrip Analysis
+
+### 7.1. Conversion Benchmark Metrics (Apple Silicon M1 Pro)
+
+| Benchmark Scenario | Execution Time (`ns/op`) | Memory Allocated (`B/op`) | Allocs (`allocs/op`) |
+| :--- | :--- | :--- | :--- |
+| `BenchmarkBase64/EncodeShort` | 65.5 ns | 32 B | 2 |
+| `BenchmarkBase64/DecodeShort` | 73.9 ns | 40 B | 2 |
+| `BenchmarkJSONEncode/ScalarInt` | 46.6 ns | 16 B | 1 |
+| `BenchmarkJSONEncode/ScalarString` | 139.4 ns | 32 B | 2 |
+| `BenchmarkJSONEncode/ListSmall` | 316.8 ns | 272 B | 10 |
+| `BenchmarkJSONEncode/MapSmall` | 1,102 ns | 841 B | 24 |
+| `BenchmarkJSONEncode/MapNested` | 1,563 ns | 1,682 B | 37 |
+| `BenchmarkJSONEncode/NativeStruct` | 665.3 ns | 568 B | 9 |
+| `BenchmarkJSONEncode/ProtoMessage` | 1,317 ns | 1,441 B | 26 |
+| `BenchmarkJSONParse/DynamicScalar` | 88.1 ns | 32 B | 2 |
+| `BenchmarkJSONParse/DynamicString` | 73.4 ns | 48 B | 3 |
+| `BenchmarkJSONParse/DynamicMap` | 1,335 ns | 1,156 B | 21 |
+| `BenchmarkJSONParse/DynamicNested` | 1,846 ns | 1,629 B | 31 |
+| `BenchmarkJSONParse/TypedInt` | 77.9 ns | 16 B | 1 |
+| `BenchmarkJSONParse/TypedString` | 95.8 ns | 48 B | 3 |
+| `BenchmarkJSONParse/TypedNativeStruct` | 705.1 ns | 619 B | 8 |
+| `BenchmarkJSONParse/TypedProto` | 1,092 ns | 928 B | 18 |
+| `BenchmarkJSONParse/TypedMap` | 1,240 ns | 1,397 B | 21 |
+| `BenchmarkJSONParse/TypedList` | 1,393 ns | 1,089 B | 28 |
+
+### 7.2. Edge-Case Roundtrip Behavior
+
+1. **64-bit Integers & Safe Float Range**:
+   - Integers in $[-2^{53}+1, 2^{53}-1]$ encode as JSON numbers (`42`, `9007199254740991`) and roundtrip directly via `json.parse(json.encode(n)) == optional.of(n)`.
+   - Integers outside this range encode as JSON decimal strings (`"9223372036854775807"`) to prevent IEEE 754 precision loss in downstream JSON consumers. When parsed dynamically, they return a CEL string which can be coerced with `int(...)`. When parsed with explicit schema `json.parse(str, int)`, numbers in the JSON number representation are strictly required to reject raw string mismatches like `json.parse('"123"', int) == optional.none()`.
+2. **Binary Data**:
+   - `bytes` (`b'...'`) serializes to standard Base64 string and roundtrips faithfully using `json.parse(json.encode(b), bytes) == optional.of(b)`.
+3. **Escapes & Unicode**:
+   - Quotes (`"hello\"world"`), control characters (`\n`, `\t`, `\r`), and UTF-8 symbols (`🚀`, `\u003c\u003e`) maintain identity across roundtrips.

--- a/ext/encoders.go
+++ b/ext/encoders.go
@@ -18,15 +18,25 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
 
 	"cel.dev/cel-go/cel"
 	"cel.dev/cel-go/common/cost"
 	"cel.dev/cel-go/common/types"
 	"cel.dev/cel-go/common/types/ref"
+	"cel.dev/cel-go/common/types/traits"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
+
+const maxJSONSize = 10 * 1024 * 1024 // 10MB maximum allowed JSON string size
 
 // Encoders returns a cel.EnvOption to configure extended functions for string, byte, and object
 // encodings.
@@ -94,6 +104,20 @@ import (
 // Examples:
 //
 //	json.encode({'hello': 'world'}) // return '{"hello":"world"}'
+//
+// # JSON.Parse
+//
+// Introduced at version: 1
+//
+// Parses a JSON string to a CEL value or a specific type.
+//
+//	json.parse(<string>) -> <optional_type(dyn)>
+//	json.parse(<string>, <type(T)>) -> <optional_type(T)>
+//
+// Examples:
+//
+//	json.parse('{"hello":"world"}') // return optional.of({'hello': 'world'})
+//	json.parse('123', int) // return optional.of(123)
 func Encoders(options ...EncodersOption) cel.EnvOption {
 	l := &encoderLib{version: math.MaxUint32}
 	for _, o := range options {
@@ -137,18 +161,47 @@ func (lib *encoderLib) CompileOptions() []cel.EnvOption {
 				}))),
 	}
 	if lib.version >= 1 {
+		var adapt types.Adapter = types.DefaultTypeAdapter
+		var prov types.Provider
 		estimators := []cost.CostOption{
 			cost.OverloadCostEstimate("base64_decode_string", estimateDecode),
 			cost.OverloadCostEstimate("base64_encode_bytes", estimateEncode),
 			cost.OverloadCostEstimate("json_encode_dyn", estimateJSONEncode),
+			cost.OverloadCostEstimate("json_parse_string", estimateJSONParse),
+			cost.OverloadCostEstimate("json_parse_string_type", estimateJSONParse),
 		}
-		opts = append(opts, cel.CostEstimatorOptions(estimators...))
 		opts = append(opts,
+			cel.OptionalTypes(),
+			func(e *cel.Env) (*cel.Env, error) {
+				adapt = e.CELTypeAdapter()
+				prov = e.CELTypeProvider()
+				return e, nil
+			},
+			cel.CostEstimatorOptions(estimators...),
 			cel.Function("json.encode",
 				cel.Overload("json_encode_dyn", []*cel.Type{cel.DynType}, cel.StringType,
 					cel.UnaryBinding(func(val ref.Val) ref.Val {
 						return stringOrError(jsonEncodeValue(val))
 					}))),
+			cel.Function("json.parse",
+				cel.Overload("json_parse_string",
+					[]*cel.Type{cel.StringType},
+					cel.OptionalType(cel.DynType),
+					cel.UnaryBinding(func(val ref.Val) ref.Val {
+						str := val.(types.String)
+						return jsonParseString(adapt, string(str))
+					}),
+				),
+				cel.Overload("json_parse_string_type",
+					[]*cel.Type{cel.StringType, types.NewTypeTypeWithParam(cel.TypeParamType("T"))},
+					cel.OptionalType(cel.TypeParamType("T")),
+					cel.BinaryBinding(func(strVal, typeVal ref.Val) ref.Val {
+						str := strVal.(types.String)
+						targetType := typeVal.(ref.Type)
+						return jsonParseWithType(adapt, prov, string(str), targetType)
+					}),
+				),
+			),
 		)
 	}
 	if lib.version >= 2 {
@@ -182,6 +235,8 @@ func (lib *encoderLib) ProgramOptions() []cel.ProgramOption {
 			cost.OverloadTracker("base64_decode_string", trackDecode),
 			cost.OverloadTracker("base64_encode_bytes", trackEncode),
 			cost.OverloadTracker("json_encode_dyn", trackJSONEncode),
+			cost.OverloadTracker("json_parse_string", trackJSONParse),
+			cost.OverloadTracker("json_parse_string_type", trackJSONParse),
 		}
 		opts = append(opts, cel.CostTrackerOptions(trackers...))
 	}
@@ -195,15 +250,62 @@ func (lib *encoderLib) ProgramOptions() []cel.ProgramOption {
 	return opts
 }
 
+// JSONEncode encodes a CEL ref.Val to its JSON string representation.
+func JSONEncode(val ref.Val) (string, error) {
+	return jsonEncodeValue(val)
+}
+
+// JSONParse parses a JSON string into a dynamic CEL ref.Val using the given type adapter.
+// If adapter is nil, types.DefaultTypeAdapter is used.
+func JSONParse(adapter types.Adapter, str string) (ref.Val, error) {
+	if adapter == nil {
+		adapter = types.DefaultTypeAdapter
+	}
+	if len(str) > maxJSONSize {
+		return nil, fmt.Errorf("json parse error: string size exceeds maximum allowed limit of %d bytes", maxJSONSize)
+	}
+	obj, ok := jsonParseDynamic(str)
+	if !ok {
+		return nil, fmt.Errorf("json parse error: invalid JSON input")
+	}
+	return adapter.NativeToValue(obj), nil
+}
+
+// JSONParseWithType parses a JSON string into a typed CEL ref.Val conforming to targetType.
+// If adapter is nil, types.DefaultTypeAdapter is used. If provider implements types.Adapter, it will be used as the adapter.
+func JSONParseWithType(adapter types.Adapter, provider types.Provider, str string, targetType ref.Type) (ref.Val, error) {
+	if adapter == nil {
+		adapter = types.DefaultTypeAdapter
+	}
+	if provAdapter, ok := provider.(types.Adapter); ok && provAdapter != nil {
+		adapter = provAdapter
+	}
+	if len(str) > maxJSONSize {
+		return nil, fmt.Errorf("json parse error: string size exceeds maximum allowed limit of %d bytes", maxJSONSize)
+	}
+	val, ok := jsonParseValue(adapter, provider, str, targetType)
+	if !ok {
+		return nil, fmt.Errorf("json parse error: failed to parse JSON to type %v", targetType)
+	}
+	return adapter.NativeToValue(val), nil
+}
+
+// Base64Encode encodes a byte slice into a standard base64 string.
+func Base64Encode(bytes []byte) string {
+	return base64.StdEncoding.EncodeToString(bytes)
+}
+
+// Base64Decode decodes a base64 encoded string into a byte slice.
+func Base64Decode(str string) ([]byte, error) {
+	return base64DecodeString(str)
+}
+
 func base64DecodeString(str string) ([]byte, error) {
 	b, err := base64.StdEncoding.DecodeString(str)
 	if err == nil {
 		return b, nil
 	}
-	if _, tryAltEncoding := err.(base64.CorruptInputError); tryAltEncoding {
-		return base64.RawStdEncoding.DecodeString(str)
-	}
-	return nil, err
+	return base64.RawStdEncoding.DecodeString(str)
 }
 
 func base64DecodeURLString(str string) ([]byte, error) {
@@ -243,6 +345,14 @@ func estimateJSONEncode(estimator cost.Estimator, target *cost.AstNode, args []c
 	return &cost.CallEstimate{CostEstimate: cost.UnknownCostEstimate(), ResultSize: &size}
 }
 
+func estimateJSONParse(estimator cost.Estimator, target *cost.AstNode, args []cost.AstNode) *cost.CallEstimate {
+	if len(args) < 1 || len(args) > 2 {
+		return nil
+	}
+	size := cost.UnknownSizeEstimate()
+	return &cost.CallEstimate{CostEstimate: cost.UnknownCostEstimate(), ResultSize: &size}
+}
+
 func estimateDecode(estimator cost.Estimator, target *cost.AstNode, args []cost.AstNode) *cost.CallEstimate {
 	if len(args) != 1 {
 		return nil
@@ -260,6 +370,11 @@ func trackEncode(args []ref.Val, _ ref.Val) *uint64 {
 }
 
 func trackJSONEncode(args []ref.Val, _ ref.Val) *uint64 {
+	maxCost := uint64(math.MaxUint64)
+	return &maxCost
+}
+
+func trackJSONParse(args []ref.Val, _ ref.Val) *uint64 {
 	maxCost := uint64(math.MaxUint64)
 	return &maxCost
 }
@@ -291,6 +406,59 @@ func estimateDecodeSize(sz cost.SizeEstimate) cost.SizeEstimate {
 }
 
 func jsonEncodeValue(val ref.Val) (string, error) {
+	switch v := val.(type) {
+	case types.Bool:
+		if v {
+			return "true", nil
+		}
+		return "false", nil
+	case types.Null:
+		return "null", nil
+	case types.Int:
+		if v >= -9007199254740991 && v <= 9007199254740991 {
+			return strconv.FormatInt(int64(v), 10), nil
+		}
+		return strconv.Quote(strconv.FormatInt(int64(v), 10)), nil
+	case types.Uint:
+		if v <= 9007199254740991 {
+			return strconv.FormatUint(uint64(v), 10), nil
+		}
+		return strconv.Quote(strconv.FormatUint(uint64(v), 10)), nil
+	case types.Double:
+		f := float64(v)
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return "", fmt.Errorf("json encode error: NaN and Inf are not supported in JSON")
+		}
+		b, _ := json.Marshal(f)
+		return string(b), nil
+	case types.String:
+		str := string(v)
+		if len(str) < 128 && !strings.ContainsAny(str, "\"\\\n\r\t\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f<>&") {
+			return strconv.Quote(str), nil
+		}
+		b, _ := json.Marshal(str)
+		return string(b), nil
+	case types.Bytes:
+		return strconv.Quote(base64.StdEncoding.EncodeToString([]byte(v))), nil
+	}
+	if msg, ok := getProtoMessage(val); ok {
+		jsonBytes, err := protojson.Marshal(msg)
+		if err != nil {
+			return "", err
+		}
+		return string(jsonBytes), nil
+	}
+	if val.Type().HasTrait(traits.FieldTesterType) {
+		if encoded, ok := jsonEncodeNativeStruct(val.Value()); ok {
+			return encoded, nil
+		}
+	}
+	if lister, ok := val.(traits.Lister); ok {
+		return jsonEncodeList(lister)
+	}
+	if mapper, ok := val.(traits.Mapper); ok {
+		return jsonEncodeMap(mapper)
+	}
 	native, err := val.ConvertToNative(types.JSONValueType)
 	if err != nil {
 		return "", err
@@ -303,14 +471,485 @@ func jsonEncodeValue(val ref.Val) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	var obj interface{}
-	if err := json.Unmarshal(jsonBytes, &obj); err != nil {
-		return "", fmt.Errorf("unmarshaling protojson: %w", err)
-	}
-	// Re-marshal with standard json.Marshal for deterministic compact output
-	jsonBytes, err = json.Marshal(obj)
-	if err != nil {
-		return "", fmt.Errorf("re-marshaling value: %w", err)
-	}
 	return string(jsonBytes), nil
+}
+
+func getProtoMessage(val ref.Val) (proto.Message, bool) {
+	if msg, ok := val.(proto.Message); ok && msg != nil {
+		return msg, true
+	}
+	if msg, ok := val.Value().(proto.Message); ok && msg != nil {
+		return msg, true
+	}
+	return nil, false
+}
+
+func jsonEncodeNativeStruct(nativeVal any) (string, bool) {
+	if nativeVal == nil {
+		return "", false
+	}
+	if _, isProto := nativeVal.(proto.Message); isProto {
+		return "", false
+	}
+	rt := reflect.TypeOf(nativeVal)
+	if rt.Kind() == reflect.Pointer {
+		rt = rt.Elem()
+	}
+	if rt.Kind() == reflect.Struct {
+		jsonBytes, err := json.Marshal(nativeVal)
+		if err == nil {
+			return string(jsonBytes), true
+		}
+	}
+	return "", false
+}
+
+func jsonEncodeList(lister traits.Lister) (string, error) {
+	szVal := lister.Size()
+	szInt, ok := szVal.(types.Int)
+	if !ok {
+		return "", fmt.Errorf("invalid list size: %v", szVal)
+	}
+	sz := int(szInt)
+	if sz == 0 {
+		return "[]", nil
+	}
+	var sb strings.Builder
+	sb.WriteByte('[')
+	for i := 0; i < sz; i++ {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		elem := lister.Get(types.Int(i))
+		elemStr, err := jsonEncodeValue(elem)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(elemStr)
+	}
+	sb.WriteByte(']')
+	return sb.String(), nil
+}
+
+func jsonEncodeMap(mapper traits.Mapper) (string, error) {
+	szVal := mapper.Size()
+	szInt, ok := szVal.(types.Int)
+	if !ok {
+		return "", fmt.Errorf("invalid map size: %v", szVal)
+	}
+	sz := int(szInt)
+	if sz == 0 {
+		return "{}", nil
+	}
+	var sb strings.Builder
+	sb.WriteByte('{')
+	it := mapper.Iterator()
+	first := true
+	for it.HasNext() == types.True {
+		k := it.Next()
+		kStr, ok := k.(types.String)
+		if !ok {
+			kStrVal, err := jsonEncodeValue(k)
+			if err != nil {
+				return "", err
+			}
+			kStr = types.String(kStrVal)
+		}
+		kQuoted, _ := json.Marshal(string(kStr))
+		v := mapper.Get(k)
+		vStr, err := jsonEncodeValue(v)
+		if err != nil {
+			return "", err
+		}
+		if !first {
+			sb.WriteByte(',')
+		}
+		first = false
+		sb.Write(kQuoted)
+		sb.WriteByte(':')
+		sb.WriteString(vStr)
+	}
+	sb.WriteByte('}')
+	return sb.String(), nil
+}
+
+func jsonUnmarshalExact(str string, out any) error {
+	dec := json.NewDecoder(strings.NewReader(str))
+	if err := dec.Decode(out); err != nil {
+		return err
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		return fmt.Errorf("unexpected trailing data")
+	}
+	return nil
+}
+
+func jsonParsePrimitive[T any](str string, convert func(any) (T, bool)) (T, bool) {
+	dec := json.NewDecoder(strings.NewReader(str))
+	dec.UseNumber()
+	tok, err := dec.Token()
+	if err != nil {
+		var zero T
+		return zero, false
+	}
+	val, ok := convert(tok)
+	if !ok {
+		var zero T
+		return zero, false
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		var zero T
+		return zero, false
+	}
+	return val, true
+}
+
+func jsonParseDynamic(str string) (any, bool) {
+	trimmed := strings.TrimSpace(str)
+	if len(trimmed) == 0 {
+		return nil, false
+	}
+	if len(trimmed) >= 2 && trimmed[0] == '"' && trimmed[len(trimmed)-1] == '"' && !strings.ContainsRune(trimmed, '\\') {
+		return trimmed[1 : len(trimmed)-1], true
+	}
+	if trimmed == "true" {
+		return true, true
+	}
+	if trimmed == "false" {
+		return false, true
+	}
+	if trimmed == "null" {
+		return types.NullValue, true
+	}
+	if len(trimmed) > 0 && (trimmed[0] == '-' || (trimmed[0] >= '0' && trimmed[0] <= '9')) {
+		if !strings.ContainsAny(trimmed, " \t\r\n,[]{}:") {
+			if _, err := strconv.ParseInt(trimmed, 10, 64); err == nil {
+				return json.Number(trimmed), true
+			}
+			if _, err := strconv.ParseUint(trimmed, 10, 64); err == nil {
+				return json.Number(trimmed), true
+			}
+			if f, err := strconv.ParseFloat(trimmed, 64); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
+				return json.Number(trimmed), true
+			}
+		}
+	}
+	dec := json.NewDecoder(strings.NewReader(str))
+	dec.UseNumber()
+	var obj any
+	if err := dec.Decode(&obj); err != nil {
+		return nil, false
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		return nil, false
+	}
+	return obj, true
+}
+
+func jsonParseString(adapter types.Adapter, str string) ref.Val {
+	if len(str) > maxJSONSize {
+		return types.NewErr("json parse error: string size exceeds maximum allowed limit of %d bytes", maxJSONSize)
+	}
+	obj, ok := jsonParseDynamic(str)
+	if !ok {
+		return types.OptionalNone
+	}
+	return types.OptionalOf(adapter.NativeToValue(obj))
+}
+
+func jsonParseWithType(adapter types.Adapter, provider types.Provider, str string, targetType ref.Type) ref.Val {
+	if adapter == nil {
+		adapter = types.DefaultTypeAdapter
+	}
+	if provAdapter, ok := provider.(types.Adapter); ok && provAdapter != nil {
+		adapter = provAdapter
+	}
+	if len(str) > maxJSONSize {
+		return types.NewErr("json parse error: string size exceeds maximum allowed limit of %d bytes", maxJSONSize)
+	}
+	val, ok := jsonParseValue(adapter, provider, str, targetType)
+	if !ok {
+		return types.OptionalNone
+	}
+	return types.OptionalOf(adapter.NativeToValue(val))
+}
+
+func jsonParseValue(adapter types.Adapter, provider types.Provider, str string, targetType ref.Type) (any, bool) {
+	switch t := targetType.(type) {
+	case *types.Type:
+		switch t.Kind() {
+		case types.DynKind, types.AnyKind:
+			return jsonParseDynamic(str)
+		case types.StringKind:
+			trimmed := strings.TrimSpace(str)
+			if len(trimmed) >= 2 && trimmed[0] == '"' && trimmed[len(trimmed)-1] == '"' && !strings.ContainsRune(trimmed, '\\') {
+				return trimmed[1 : len(trimmed)-1], true
+			}
+			return jsonParsePrimitive(str, func(t any) (any, bool) { s, ok := t.(string); return s, ok })
+		case types.BoolKind:
+			trimmed := strings.TrimSpace(str)
+			if trimmed == "true" {
+				return true, true
+			}
+			if trimmed == "false" {
+				return false, true
+			}
+			return false, false
+		case types.IntKind:
+			trimmed := strings.TrimSpace(str)
+			if i, err := strconv.ParseInt(trimmed, 10, 64); err == nil {
+				return i, true
+			}
+			return false, false
+		case types.UintKind:
+			trimmed := strings.TrimSpace(str)
+			if u, err := strconv.ParseUint(trimmed, 10, 64); err == nil {
+				return u, true
+			}
+			return false, false
+		case types.DoubleKind:
+			trimmed := strings.TrimSpace(str)
+			if len(trimmed) > 0 && (trimmed[0] == '-' || (trimmed[0] >= '0' && trimmed[0] <= '9')) {
+				if f, err := strconv.ParseFloat(trimmed, 64); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
+					return f, true
+				}
+			}
+			return false, false
+		case types.BytesKind:
+			return jsonParsePrimitive(str, func(t any) (any, bool) {
+				s, ok := t.(string)
+				if !ok {
+					return nil, false
+				}
+				b, err := base64DecodeString(s)
+				return b, err == nil
+			})
+		case types.NullTypeKind:
+			trimmed := strings.TrimSpace(str)
+			if trimmed == "null" {
+				return types.NullValue, true
+			}
+			return false, false
+		case types.TimestampKind:
+			return jsonParsePrimitive(str, func(t any) (any, bool) {
+				s, ok := t.(string)
+				if !ok {
+					return nil, false
+				}
+				ts, err := types.ParseTimestamp(s)
+				return ts, err == nil
+			})
+		case types.DurationKind:
+			return jsonParsePrimitive(str, func(t any) (any, bool) {
+				s, ok := t.(string)
+				if !ok {
+					return nil, false
+				}
+				dur, err := time.ParseDuration(s)
+				return dur, err == nil
+			})
+		case types.ListKind:
+			elemType := types.DynType
+			if len(t.Parameters()) > 0 {
+				elemType = t.Parameters()[0]
+			}
+			return jsonParseTypedList(adapter, provider, str, elemType)
+		case types.MapKind:
+			elemType := types.DynType
+			if len(t.Parameters()) >= 2 {
+				elemType = t.Parameters()[1]
+			}
+			return jsonParseTypedMap(adapter, provider, str, elemType)
+		case types.StructKind:
+			return jsonParseStructNative(provider, str, t.TypeName())
+		}
+	default:
+		if st, ok := targetType.(types.StructTypeDescriptor); ok {
+			if rt := st.ReflectType(); rt != nil {
+				return jsonUnmarshalNative(str, rt)
+			}
+		}
+		return jsonParseStructNative(provider, str, targetType.TypeName())
+	}
+	return nil, false
+}
+
+func jsonParseTypedList(adapter types.Adapter, provider types.Provider, str string, elemType *types.Type) (any, bool) {
+	switch elemType.Kind() {
+	case types.StringKind:
+		var l []string
+		if jsonUnmarshalExact(str, &l) == nil {
+			return l, true
+		}
+		return nil, false
+	case types.IntKind:
+		var l []int64
+		if jsonUnmarshalExact(str, &l) == nil {
+			return l, true
+		}
+		return nil, false
+	case types.UintKind:
+		var l []uint64
+		if jsonUnmarshalExact(str, &l) == nil {
+			return l, true
+		}
+		return nil, false
+	case types.DoubleKind:
+		var l []float64
+		if jsonUnmarshalExact(str, &l) == nil {
+			return l, true
+		}
+		return nil, false
+	case types.BoolKind:
+		var l []bool
+		if jsonUnmarshalExact(str, &l) == nil {
+			return l, true
+		}
+		return nil, false
+	case types.DynKind, types.AnyKind:
+		var l []any
+		if jsonUnmarshalExact(str, &l) == nil {
+			return l, true
+		}
+		return nil, false
+	}
+	var rawList []json.RawMessage
+	if jsonUnmarshalExact(str, &rawList) != nil {
+		return nil, false
+	}
+	elements := make([]any, len(rawList))
+	for i, rawElem := range rawList {
+		elem, ok := jsonParseValue(adapter, provider, string(rawElem), elemType)
+		if !ok {
+			return nil, false
+		}
+		elements[i] = elem
+	}
+	return elements, true
+}
+
+func jsonParseTypedMap(adapter types.Adapter, provider types.Provider, str string, valType *types.Type) (any, bool) {
+	switch valType.Kind() {
+	case types.StringKind:
+		var m map[string]string
+		if jsonUnmarshalExact(str, &m) == nil {
+			return m, true
+		}
+		return nil, false
+	case types.IntKind:
+		var m map[string]int64
+		if jsonUnmarshalExact(str, &m) == nil {
+			return m, true
+		}
+		return nil, false
+	case types.UintKind:
+		var m map[string]uint64
+		if jsonUnmarshalExact(str, &m) == nil {
+			return m, true
+		}
+		return nil, false
+	case types.DoubleKind:
+		var m map[string]float64
+		if jsonUnmarshalExact(str, &m) == nil {
+			return m, true
+		}
+		return nil, false
+	case types.BoolKind:
+		var m map[string]bool
+		if jsonUnmarshalExact(str, &m) == nil {
+			return m, true
+		}
+		return nil, false
+	case types.DynKind, types.AnyKind:
+		var m map[string]any
+		if jsonUnmarshalExact(str, &m) == nil {
+			return m, true
+		}
+		return nil, false
+	}
+	var rawMap map[string]json.RawMessage
+	if jsonUnmarshalExact(str, &rawMap) != nil {
+		return nil, false
+	}
+	entries := make(map[string]any, len(rawMap))
+	for k, rawVal := range rawMap {
+		val, ok := jsonParseValue(adapter, provider, string(rawVal), valType)
+		if !ok {
+			return nil, false
+		}
+		entries[k] = val
+	}
+	return entries, true
+}
+
+func jsonUnmarshalNative(str string, rt reflect.Type) (any, bool) {
+	if rt.Kind() == reflect.Pointer {
+		rt = rt.Elem()
+	}
+	if rt.Kind() == reflect.Struct {
+		ptr := reflect.New(rt)
+		if jsonUnmarshalExact(str, ptr.Interface()) != nil {
+			return nil, false
+		}
+		return ptr.Interface(), true
+	}
+	return nil, false
+}
+
+func jsonUnmarshalProto(str string, template proto.Message) (proto.Message, bool) {
+	newMsg := template.ProtoReflect().New().Interface()
+	if err := protojson.Unmarshal([]byte(str), newMsg); err != nil {
+		return nil, false
+	}
+	return newMsg, true
+}
+
+type structPrototype struct {
+	protoMsg proto.Message
+	refType  reflect.Type
+}
+
+var (
+	structPrototypeCache sync.Map // map[string]structPrototype
+)
+
+func jsonParseStructNative(provider types.Provider, str string, typeName string) (any, bool) {
+	switch typeName {
+	case "google.protobuf.Value":
+		return jsonUnmarshalProto(str, &structpb.Value{})
+	case "google.protobuf.Struct":
+		return jsonUnmarshalProto(str, &structpb.Struct{})
+	case "google.protobuf.ListValue":
+		return jsonUnmarshalProto(str, &structpb.ListValue{})
+	}
+	if protoVal, ok := structPrototypeCache.Load(typeName); ok {
+		p := protoVal.(structPrototype)
+		if p.protoMsg != nil {
+			return jsonUnmarshalProto(str, p.protoMsg)
+		}
+		if p.refType != nil {
+			return jsonUnmarshalNative(str, p.refType)
+		}
+	}
+	if provider != nil {
+		zeroVal := provider.NewValue(typeName, map[string]ref.Val{})
+		if types.IsError(zeroVal) {
+			return nil, false
+		}
+		nativeVal := zeroVal.Value()
+		if nativeVal == nil {
+			return nil, false
+		}
+		if msg, ok := nativeVal.(proto.Message); ok {
+			structPrototypeCache.Store(typeName, structPrototype{protoMsg: msg})
+			return jsonUnmarshalProto(str, msg)
+		}
+		rt := reflect.TypeOf(nativeVal)
+		if rt.Kind() == reflect.Pointer {
+			rt = rt.Elem()
+		}
+		structPrototypeCache.Store(typeName, structPrototype{refType: rt})
+		return jsonUnmarshalNative(str, rt)
+	}
+	return nil, false
 }

--- a/ext/encoders_test.go
+++ b/ext/encoders_test.go
@@ -15,13 +15,22 @@
 package ext
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
+	"reflect"
 	"strings"
 	"testing"
 
 	"cel.dev/cel-go/cel"
+	"cel.dev/cel-go/checker"
 	"cel.dev/cel-go/common/cost"
+	"cel.dev/cel-go/common/types"
+	"cel.dev/cel-go/common/types/ref"
+	"cel.dev/cel-go/common/types/traits"
+	proto2pb "cel.dev/cel-go/test/proto2pb"
+	proto3pb "cel.dev/cel-go/test/proto3pb"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestEncoders(t *testing.T) {
@@ -30,14 +39,20 @@ func TestEncoders(t *testing.T) {
 		err       string
 		parseOnly bool
 	}{
+		// Base64 Positive & Edge Cases
 		{expr: "base64.decode('aGVsbG8=') == b'hello'"},
 		{expr: "base64.decode('aGVsbG8') == b'hello'"},
+		{expr: "base64.decode('') == b''"},
+		{expr: "base64.decode('AQIDBAU=') == b'\\x01\\x02\\x03\\x04\\x05'"},
+		{expr: "base64.encode(b'hello') == 'aGVsbG8='"},
+		{expr: "base64.encode(b'') == ''"},
+		{expr: "base64.encode(b'\\x01\\x02\\x03\\x04\\x05') == 'AQIDBAU='"},
+		// Base64 Overload Errors
 		{
 			expr:      "base64.decode(b'aGVsbG8=') == b'hello'",
 			err:       "no such overload",
 			parseOnly: true,
 		},
-		{expr: "base64.encode(b'hello') == 'aGVsbG8='"},
 		{
 			expr:      "base64.encode('hello') == b'aGVsbG8='",
 			err:       "no such overload",
@@ -143,9 +158,117 @@ func TestEncoders(t *testing.T) {
 		{expr: "base64.decode('+w==') == base64.decodeUrl('-w==')"},
 		{expr: "base64.decode('++++') == base64.decodeUrl('----')"},
 		{expr: "base64.decode('+//+') == base64.decodeUrl('-__-')"},
+		// JSON Encode Positive & Edge Cases
 		{expr: "json.encode('hello') == '\"hello\"'"},
-		{expr: `json.encode([1, 'two', true]) == '[1,"two",true]'`},
-		{expr: `json.encode({'items': [1, 'two', false]}) == '{"items":[1,"two",false]}'`},
+		{expr: "json.encode(123) == '123'"},
+		{expr: "json.encode(-42) == '-42'"},
+		{expr: "json.encode(0) == '0'"},
+		{expr: "json.encode(true) == 'true'"},
+		{expr: "json.encode(false) == 'false'"},
+		{expr: "json.encode(null) == 'null'"},
+		{expr: "json.encode([]) == '[]'"},
+		{expr: "json.encode({}) == '{}'"},
+		{expr: "json.parse(json.encode([1, 'two', true])) == optional.of([1, 'two', true])"},
+		{expr: "json.parse(json.encode({'items': [1, 'two', false]})) == optional.of({'items': [1, 'two', false]})"},
+		{expr: "json.parse(json.encode({'a': 1, 'b': 2})) == optional.of({'a': 1, 'b': 2})"},
+		{expr: `json.parse(json.encode('hello\nworld\t"')) == optional.of("hello\nworld\t\"")`},
+		// JSON Parse Dynamic Positive & Edge Cases
+		{expr: `json.parse('"hello"') == optional.of('hello')`},
+		{expr: `json.parse('123') == optional.of(123)`},
+		{expr: `json.parse('-42') == optional.of(-42)`},
+		{expr: `json.parse('0') == optional.of(0)`},
+		{expr: `json.parse('123.5') == optional.of(123.5)`},
+		{expr: `json.parse('-3.14') == optional.of(-3.14)`},
+		{expr: `json.parse('1e2') == optional.of(100.0)`},
+		{expr: `json.parse('1.25e2') == optional.of(125.0)`},
+		{expr: `json.parse('true') == optional.of(true)`},
+		{expr: `json.parse('false') == optional.of(false)`},
+		{expr: `json.parse('null') == optional.of(null)`},
+		{expr: `json.parse('[]') == optional.of([])`},
+		{expr: `json.parse('{}') == optional.of({})`},
+		{expr: `json.parse('[1, "two", true]') == optional.of([1, 'two', true])`},
+		{expr: `json.parse('{"items":[1,"two",false]}') == optional.of({'items': [1, 'two', false]})`},
+		{expr: `json.parse('{"a": [1, {"b": true}, "three"]}') == optional.of({'a': [1, {'b': true}, 'three']})`},
+		{expr: `json.parse('"hello\\nworld\\t\\\""') == optional.of("hello\nworld\t\"")`},
+		{expr: `json.parse('"\\u003chello\\u003e"') == optional.of('<hello>')`},
+		{expr: `json.parse('"🚀"') == optional.of('🚀')`},
+		{expr: `json.parse('  \n\t {"a": 1} \r\n ') == optional.of({'a': 1})`},
+		{expr: `json.parse('  \t 42 \n ') == optional.of(42)`},
+		{expr: `json.parse(json.encode({'a': 1, 'b': 2})) == optional.of({'a': 1, 'b': 2})`},
+		// JSON Parse Typed Positive & Edge Cases
+		{expr: `json.parse('123', int) == optional.of(123)`},
+		{expr: `json.parse('-100', int) == optional.of(-100)`},
+		{expr: `json.parse('0', int) == optional.of(0)`},
+		{expr: `json.parse('9223372036854775807', int) == optional.of(9223372036854775807)`},
+		{expr: `json.parse('-9223372036854775808', int) == optional.of(-9223372036854775808)`},
+		{expr: `json.parse('123', uint) == optional.of(123u)`},
+		{expr: `json.parse('0', uint) == optional.of(0u)`},
+		{expr: `json.parse('18446744073709551615', uint) == optional.of(18446744073709551615u)`},
+		{expr: `json.parse('1.5', double) == optional.of(1.5)`},
+		{expr: `json.parse('-2.5', double) == optional.of(-2.5)`},
+		{expr: `json.parse('42', double) == optional.of(42.0)`},
+		{expr: `json.parse('true', bool) == optional.of(true)`},
+		{expr: `json.parse('false', bool) == optional.of(false)`},
+		{expr: `json.parse('"hello"', string) == optional.of('hello')`},
+		{expr: `json.parse('""', string) == optional.of('')`},
+		{expr: `json.parse('"aGVsbG8="', bytes) == optional.of(b'hello')`},
+		{expr: `json.parse('"AQID"', bytes) == optional.of(b'\x01\x02\x03')`},
+		{expr: `json.parse('""', bytes) == optional.of(b'')`},
+		{expr: `json.parse('null', null_type) == optional.of(null)`},
+		{expr: `json.parse('"2023-01-01T00:00:00Z"', type(timestamp('2023-01-01T00:00:00Z'))) == optional.of(timestamp('2023-01-01T00:00:00Z'))`},
+		{expr: `json.parse('"5s"', type(duration('5s'))) == optional.of(duration('5s'))`},
+		{expr: `json.parse('"1h30m"', type(duration('5s'))) == optional.of(duration('1h30m'))`},
+		{expr: `json.parse('[1, 2, 3]', type([1])) == optional.of([1, 2, 3])`},
+		{expr: `json.parse('[]', type([1])) == optional.of([])`},
+		{expr: `json.parse('{"a": 1}', type({'': 1})) == optional.of({'a': 1})`},
+		{expr: `json.parse('{}', type({'': 1})) == optional.of({})`},
+		{expr: `json.parse('  \t 42 \n ', int) == optional.of(42)`},
+		// JSON Parse Negative Cases (Malformed Syntax)
+		{expr: `json.parse('invalid') == optional.none()`},
+		{expr: `json.parse('') == optional.none()`},
+		{expr: `json.parse('   ') == optional.none()`},
+		{expr: `json.parse('{') == optional.none()`},
+		{expr: `json.parse('[1, 2') == optional.none()`},
+		{expr: `json.parse('"unterminated') == optional.none()`},
+		{expr: `json.parse('{key: "value"}') == optional.none()`},
+		{expr: `json.parse("'single_quote'") == optional.none()`},
+		{expr: `json.parse('[1, 2,]') == optional.none()`},
+		{expr: `json.parse('{"a": 1,}') == optional.none()`},
+		{expr: `json.parse('123 abc') == optional.none()`},
+		{expr: `json.parse('{"a": 1} {"b": 2}') == optional.none()`},
+		{expr: `json.parse('true false') == optional.none()`},
+		// JSON Parse Negative Cases (Type Mismatches)
+		{expr: `json.parse('"not_an_int"', int) == optional.none()`},
+		{expr: `json.parse('1.5', int) == optional.none()`},
+		{expr: `json.parse('"123"', int) == optional.none()`},
+		{expr: `json.parse('true', int) == optional.none()`},
+		{expr: `json.parse('null', int) == optional.none()`},
+		{expr: `json.parse('{"a": 1}', int) == optional.none()`},
+		{expr: `json.parse('-1', uint) == optional.none()`},
+		{expr: `json.parse('1.5', uint) == optional.none()`},
+		{expr: `json.parse('"123"', uint) == optional.none()`},
+		{expr: `json.parse('null', uint) == optional.none()`},
+		{expr: `json.parse('"1.5"', double) == optional.none()`},
+		{expr: `json.parse('true', double) == optional.none()`},
+		{expr: `json.parse('null', double) == optional.none()`},
+		{expr: `json.parse('123', bool) == optional.none()`},
+		{expr: `json.parse('"true"', bool) == optional.none()`},
+		{expr: `json.parse('null', bool) == optional.none()`},
+		{expr: `json.parse('123', string) == optional.none()`},
+		{expr: `json.parse('true', string) == optional.none()`},
+		{expr: `json.parse('null', string) == optional.none()`},
+		{expr: `json.parse('123', bytes) == optional.none()`},
+		{expr: `json.parse('"not valid base64 %%%"', bytes) == optional.none()`},
+		{expr: `json.parse('123', null_type) == optional.none()`},
+		{expr: `json.parse('"null"', null_type) == optional.none()`},
+		{expr: `json.parse('123', type(timestamp('2023-01-01T00:00:00Z'))) == optional.none()`},
+		{expr: `json.parse('"invalid-time"', type(timestamp('2023-01-01T00:00:00Z'))) == optional.none()`},
+		{expr: `json.parse('123', type(duration('5s'))) == optional.none()`},
+		{expr: `json.parse('"10x"', type(duration('5s'))) == optional.none()`},
+		{expr: `json.parse('123', type([1])) == optional.none()`},
+		{expr: `json.parse('{"a": 1}', type([1])) == optional.none()`},
+		{expr: `json.parse('123', type({'': 1})) == optional.none()`},
+		{expr: `json.parse('[1, 2]', type({'': 1})) == optional.none()`},
 	}
 
 	env, err := cel.NewEnv(Encoders())
@@ -206,6 +329,9 @@ func TestEncodersVersion(t *testing.T) {
 	if _, iss := env.Compile("base64.encodeUrl(b'hello')"); iss.Err() == nil {
 		t.Fatal("base64.encodeUrl() got no error, wanted version-gated function to be unavailable")
 	}
+	if _, iss := env.Compile("json.parse('\"hello\"')"); iss.Err() == nil {
+		t.Fatal("json.parse() got no error, wanted version-gated function to be unavailable")
+	}
 
 	env, err = cel.NewEnv(Encoders(EncodersVersion(1)))
 	if err != nil {
@@ -227,6 +353,12 @@ func TestEncodersVersion(t *testing.T) {
 	}
 	if _, iss := env.Compile("base64.decodeUrl('aGVsbG8=')"); iss.Err() != nil {
 		t.Fatalf("base64.decodeUrl() got %v, wanted no error", iss.Err())
+	}
+	if _, iss := env.Compile("json.parse('\"hello\"')"); iss.Err() != nil {
+		t.Fatalf("json.parse() got %v, wanted no error", iss.Err())
+	}
+	if _, iss := env.Compile("json.parse('123', int)"); iss.Err() != nil {
+		t.Fatalf("json.parse(str, int) got %v, wanted no error", iss.Err())
 	}
 }
 
@@ -401,6 +533,22 @@ func TestEncodersCosts(t *testing.T) {
 			actualCost:    4,
 			version:       2,
 		},
+		{
+			name: "json_parse_string_type",
+			expr: "json.parse(x, string) == optional.of('hello')",
+			vars: []cel.EnvOption{
+				cel.Variable("x", cel.StringType),
+			},
+			in: map[string]any{
+				"x": "\"hello\"",
+			},
+			hints: map[string]uint64{
+				"x": 100,
+			},
+			estimatedCost: checker.CostEstimate{Min: 4, Max: math.MaxUint64},
+			actualCost:    math.MaxUint64,
+			version:       1,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -509,4 +657,1160 @@ func TestJSONEncodeCostUnbounded(t *testing.T) {
 	if *det.ActualCost() != math.MaxUint64 {
 		t.Errorf("det.ActualCost() got %d, wanted %d", *det.ActualCost(), uint64(math.MaxUint64))
 	}
+}
+
+func TestJSONParseCostUnbounded(t *testing.T) {
+	env, err := cel.NewEnv(Encoders(EncodersVersion(1)))
+	if err != nil {
+		t.Fatalf("cel.NewEnv() failed: %v", err)
+	}
+	ast, iss := env.Compile("json.parse('\"hello\"')")
+	if iss.Err() != nil {
+		t.Fatalf("env.Compile() failed: %v", iss.Err())
+	}
+
+	// 1. Check Cost Estimate is unbounded: Max is MaxUint64
+	est, err := env.EstimateCost(ast, testCostHintEstimator{})
+	if err != nil {
+		t.Fatalf("env.EstimateCost() failed: %v", err)
+	}
+	wantEst := checker.CostEstimate{Min: 0, Max: math.MaxUint64}
+	if est != wantEst {
+		t.Errorf("env.EstimateCost() got %v, wanted %v", est, wantEst)
+	}
+
+	// 2. Check Actual Cost is math.MaxUint64
+	prg, err := env.Program(ast, cel.CostTracking(nil))
+	if err != nil {
+		t.Fatalf("env.Program() failed: %v", err)
+	}
+	_, det, err := prg.Eval(cel.NoVars())
+	if err != nil {
+		t.Fatalf("prg.Eval() failed: %v", err)
+	}
+	if det.ActualCost() == nil {
+		t.Fatal("det.ActualCost() got nil, wanted a value")
+	}
+	if *det.ActualCost() != math.MaxUint64 {
+		t.Errorf("det.ActualCost() got %d, wanted %d", *det.ActualCost(), uint64(math.MaxUint64))
+	}
+}
+
+type testNativeUser struct {
+	Username string `json:"user_name" cel:"username"`
+	Age      int    `json:"age,omitempty" cel:"age"`
+	Secret   string `json:"-" cel:"secret"`
+}
+
+func TestJSONParseNativeTypes(t *testing.T) {
+	nativeType, err := types.NewNativeType(reflect.TypeFor[testNativeUser](), types.ParseStructTag("cel"))
+	if err != nil {
+		t.Fatalf("types.NewNativeType failed: %v", err)
+	}
+	env, err := cel.NewEnv(
+		Encoders(),
+		cel.Types(nativeType),
+		cel.Variable("userJson", cel.StringType),
+	)
+	if err != nil {
+		t.Fatalf("cel.NewEnv failed: %v", err)
+	}
+	tests := []struct {
+		expr string
+		vars map[string]any
+	}{
+		{
+			expr: "json.parse(userJson, ext.testNativeUser).value().username == 'Alice' && json.parse(userJson, ext.testNativeUser).value().age == 25",
+			vars: map[string]any{
+				"userJson": `{"user_name":"Alice","age":25,"secret":"supersecret"}`,
+			},
+		},
+		{
+			expr: "json.parse(userJson, ext.testNativeUser).value().secret == ''",
+			vars: map[string]any{
+				"userJson": `{"user_name":"Alice","age":25,"secret":"supersecret"}`,
+			},
+		},
+		{
+			expr: "json.parse(json.encode(json.parse(userJson, ext.testNativeUser).value()), ext.testNativeUser).value().username == 'Alice' && json.parse(json.encode(json.parse(userJson, ext.testNativeUser).value()), ext.testNativeUser).value().age == 25",
+			vars: map[string]any{
+				"userJson": `{"user_name":"Alice","age":25,"secret":"supersecret"}`,
+			},
+		},
+		{
+			expr: "json.encode(json.parse(userJson, ext.testNativeUser).value()) == '{\"user_name\":\"Alice\"}'",
+			vars: map[string]any{
+				"userJson": `{"user_name":"Alice"}`,
+			},
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
+			ast, iss := env.Compile(tc.expr)
+			if iss.Err() != nil {
+				t.Fatalf("env.Compile(%q) failed: %v", tc.expr, iss.Err())
+			}
+			prg, err := env.Program(ast)
+			if err != nil {
+				t.Fatalf("env.Program() failed: %v", err)
+			}
+			out, _, err := prg.Eval(tc.vars)
+			if err != nil {
+				t.Fatalf("prg.Eval() failed: %v", err)
+			}
+			if out.Value() != true {
+				t.Errorf("got %v, wanted true for expr: %s", out.Value(), tc.expr)
+			}
+		})
+	}
+}
+
+func TestJSONParseLimits(t *testing.T) {
+	env, err := cel.NewEnv(
+		Encoders(),
+		cel.Variable("largeJson", cel.StringType),
+	)
+	if err != nil {
+		t.Fatalf("cel.NewEnv() failed: %v", err)
+	}
+	ast, iss := env.Compile("json.parse(largeJson)")
+	if iss.Err() != nil {
+		t.Fatalf("env.Compile() failed: %v", iss.Err())
+	}
+	prg, err := env.Program(ast)
+	if err != nil {
+		t.Fatalf("env.Program() failed: %v", err)
+	}
+	largeStr := `"` + strings.Repeat("a", maxJSONSize) + `"`
+	_, _, err = prg.Eval(map[string]any{
+		"largeJson": largeStr,
+	})
+	if err == nil {
+		t.Fatal("expected size limit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum allowed limit") {
+		t.Errorf("expected exceeds limit error, got: %v", err)
+	}
+}
+
+func TestJSONParseProtobufTypes(t *testing.T) {
+	envProto3, err := cel.NewEnv(
+		Encoders(),
+		cel.Container("google.expr.proto3.test"),
+		cel.Types(
+			&structpb.Struct{},
+			&structpb.ListValue{},
+			&proto3pb.TestAllTypes{},
+		),
+	)
+	if err != nil {
+		t.Fatalf("cel.NewEnv failed: %v", err)
+	}
+
+	proto3Tests := []string{
+		`json.parse('{"k": "v"}', type(google.protobuf.Struct{})).hasValue()`,
+		`json.parse('{"hello": "world"}', type(google.protobuf.Struct{})).value().hello == 'world'`,
+		`json.parse('[1, "two"]', type(google.protobuf.ListValue{})).value()[0] == 1`,
+		`json.parse('[1, "two"]', type(google.protobuf.ListValue{})).value()[1] == 'two'`,
+		`json.parse('invalid', type(google.protobuf.Struct{})) == optional.none()`,
+		`json.parse('{"single_int32": 42, "single_string": "cel"}', TestAllTypes).value().single_int32 == 42`,
+		`json.parse('{"single_int32": 42, "single_string": "cel"}', TestAllTypes).value().single_string == 'cel'`,
+		`json.parse('{"single_int32": 42, "single_string": "cel"}', TestAllTypes).value() == TestAllTypes{single_int32: 42, single_string: 'cel'}`,
+		`json.parse('{"single_int32": 42, "single_string": "cel", "single_bool": false, "single_int64": 0}', TestAllTypes).value() == TestAllTypes{single_int32: 42, single_string: 'cel'}`,
+		`json.parse('{"single_int32": 42, "single_string": "cel", "single_bool": false, "single_int64": 0}', TestAllTypes).value() == TestAllTypes{single_int32: 42, single_string: 'cel', single_bool: false, single_int64: 0}`,
+		`json.parse('invalid', TestAllTypes) == optional.none()`,
+		`json.parse(json.encode(TestAllTypes{single_int32: 42, single_string: 'cel'}), TestAllTypes).value() == TestAllTypes{single_int32: 42, single_string: 'cel'}`,
+	}
+	for i, expr := range proto3Tests {
+		t.Run(fmt.Sprintf("proto3[%d]", i), func(t *testing.T) {
+			ast, iss := envProto3.Compile(expr)
+			if iss.Err() != nil {
+				t.Fatalf("env.Compile(%q) failed: %v", expr, iss.Err())
+			}
+			prg, err := envProto3.Program(ast)
+			if err != nil {
+				t.Fatalf("env.Program() failed: %v", err)
+			}
+			out, _, err := prg.Eval(cel.NoVars())
+			if err != nil {
+				t.Fatalf("prg.Eval() failed: %v", err)
+			}
+			if out.Value() != true {
+				t.Errorf("got %v, wanted true for expr: %s", out.Value(), expr)
+			}
+		})
+	}
+
+	envProto2, err := cel.NewEnv(
+		Encoders(),
+		cel.Container("google.expr.proto2.test"),
+		cel.Types(
+			&proto2pb.TestAllTypes{},
+		),
+	)
+	if err != nil {
+		t.Fatalf("cel.NewEnv failed: %v", err)
+	}
+
+	proto2Tests := []string{
+		`json.parse('{"single_int32": 42, "single_string": "cel"}', TestAllTypes).value().single_int32 == 42`,
+		`json.parse('{"single_int32": 42, "single_string": "cel"}', TestAllTypes).value().single_string == 'cel'`,
+		`json.parse('{"single_int32": 42, "single_string": "cel"}', TestAllTypes).value() == TestAllTypes{single_int32: 42, single_string: 'cel'}`,
+		`json.parse('{"single_int32": 42, "single_string": "cel", "single_bool": false, "single_int64": 0}', TestAllTypes).value() == TestAllTypes{single_int32: 42, single_string: 'cel', single_bool: false, single_int64: 0}`,
+		`json.parse('invalid', TestAllTypes) == optional.none()`,
+		`json.parse(json.encode(TestAllTypes{single_int32: 42, single_string: 'cel'}), TestAllTypes).value() == TestAllTypes{single_int32: 42, single_string: 'cel'}`,
+	}
+	for i, expr := range proto2Tests {
+		t.Run(fmt.Sprintf("proto2[%d]", i), func(t *testing.T) {
+			ast, iss := envProto2.Compile(expr)
+			if iss.Err() != nil {
+				t.Fatalf("env.Compile(%q) failed: %v", expr, iss.Err())
+			}
+			prg, err := envProto2.Program(ast)
+			if err != nil {
+				t.Fatalf("env.Program() failed: %v", err)
+			}
+			out, _, err := prg.Eval(cel.NoVars())
+			if err != nil {
+				t.Fatalf("prg.Eval() failed: %v", err)
+			}
+			if out.Value() != true {
+				t.Errorf("got %v, wanted true for expr: %s", out.Value(), expr)
+			}
+		})
+	}
+}
+
+func TestEncodersRoundtrip(t *testing.T) {
+	nativeType, err := types.NewNativeType(reflect.TypeFor[testNativeUser](), types.ParseStructTag("cel"))
+	if err != nil {
+		t.Fatalf("types.NewNativeType failed: %v", err)
+	}
+	env, err := cel.NewEnv(
+		Encoders(),
+		cel.Container("google.expr.proto3.test"),
+		cel.Types(
+			nativeType,
+			&proto3pb.TestAllTypes{},
+		),
+	)
+	if err != nil {
+		t.Fatalf("cel.NewEnv failed: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		expr string
+	}{
+		{name: "string_simple", expr: `json.parse(json.encode('hello world')) == optional.of('hello world')`},
+		{name: "string_escapes", expr: `json.parse(json.encode("hello\n\t\"\\world")) == optional.of("hello\n\t\"\\world")`},
+		{name: "string_unicode", expr: `json.parse(json.encode('<hello>&"world"')) == optional.of('<hello>&"world"')`},
+		{name: "string_emoji", expr: `json.parse(json.encode('🎉 🚀 CEL')) == optional.of('🎉 🚀 CEL')`},
+		{name: "string_empty", expr: `json.parse(json.encode('')) == optional.of('')`},
+		{name: "int_zero", expr: `json.parse(json.encode(0)) == optional.of(0)`},
+		{name: "int_pos", expr: `json.parse(json.encode(42)) == optional.of(42)`},
+		{name: "int_neg", expr: `json.parse(json.encode(-42)) == optional.of(-42)`},
+		{name: "int_safe_max", expr: `json.parse(json.encode(9007199254740991)) == optional.of(9007199254740991)`},
+		{name: "int_safe_min", expr: `json.parse(json.encode(-9007199254740991)) == optional.of(-9007199254740991)`},
+		{name: "int_64bit_overflow", expr: `json.encode(9223372036854775807) == '"9223372036854775807"' && int(json.parse(json.encode(9223372036854775807)).value()) == 9223372036854775807`},
+		{name: "uint_zero", expr: `json.parse(json.encode(0u), uint) == optional.of(0u)`},
+		{name: "uint_val", expr: `json.parse(json.encode(42u), uint) == optional.of(42u)`},
+		{name: "uint_safe_max", expr: `json.parse(json.encode(9007199254740991u), uint) == optional.of(9007199254740991u)`},
+		{name: "uint_64bit_overflow", expr: `json.encode(18446744073709551615u) == '"18446744073709551615"' && uint(json.parse(json.encode(18446744073709551615u)).value()) == 18446744073709551615u`},
+		{name: "double_zero", expr: `json.parse(json.encode(0.0), double) == optional.of(0.0)`},
+		{name: "double_pos", expr: `json.parse(json.encode(1.5), double) == optional.of(1.5)`},
+		{name: "double_neg", expr: `json.parse(json.encode(-3.14), double) == optional.of(-3.14)`},
+		{name: "bool_true", expr: `json.parse(json.encode(true)) == optional.of(true)`},
+		{name: "bool_false", expr: `json.parse(json.encode(false)) == optional.of(false)`},
+		{name: "null_val", expr: `json.parse(json.encode(null)) == optional.of(null)`},
+		{name: "bytes_empty", expr: `json.parse(json.encode(b''), bytes) == optional.of(b'')`},
+		{name: "bytes_val", expr: `json.parse(json.encode(b'hello'), bytes) == optional.of(b'hello')`},
+		{name: "bytes_binary", expr: `json.parse(json.encode(b'\x00\x01\x02\xff'), bytes) == optional.of(b'\x00\x01\x02\xff')`},
+		{name: "timestamp_val", expr: `json.parse(json.encode(timestamp('2023-01-01T00:00:00Z')), type(timestamp('2023-01-01T00:00:00Z'))) == optional.of(timestamp('2023-01-01T00:00:00Z'))`},
+		{name: "duration_val", expr: `json.parse(json.encode(duration('5s')), type(duration('5s'))) == optional.of(duration('5s'))`},
+		{name: "list_empty", expr: `json.parse(json.encode([])) == optional.of([])`},
+		{name: "list_primitives", expr: `json.parse(json.encode([1, 2, 3])) == optional.of([1, 2, 3])`},
+		{name: "list_heterogeneous", expr: `json.parse(json.encode([1, 'two', true, null])) == optional.of([1, 'two', true, null])`},
+		{name: "list_nested", expr: `json.parse(json.encode([[1, 2], [3, 4]])) == optional.of([[1, 2], [3, 4]])`},
+		{name: "map_empty", expr: `json.parse(json.encode({})) == optional.of({})`},
+		{name: "map_simple", expr: `json.parse(json.encode({'a': 1, 'b': 2})) == optional.of({'a': 1, 'b': 2})`},
+		{name: "map_nested", expr: `json.parse(json.encode({'items': [1, {'nested': true}], 'count': 42})) == optional.of({'items': [1, {'nested': true}], 'count': 42})`},
+		{name: "base64_roundtrip_empty", expr: `base64.decode(base64.encode(b'')) == b''`},
+		{name: "base64_roundtrip_simple", expr: `base64.decode(base64.encode(b'hello world')) == b'hello world'`},
+		{name: "proto_roundtrip", expr: `json.parse(json.encode(TestAllTypes{single_int32: 42, single_string: 'cel'}), TestAllTypes).value().single_int32 == 42`},
+		{name: "proto_enum_roundtrip", expr: `json.parse(json.encode(TestAllTypes{single_nested_enum: TestAllTypes.NestedEnum.BAR}), TestAllTypes).value().single_nested_enum == TestAllTypes.NestedEnum.BAR`},
+		{name: "proto_nested_roundtrip", expr: `json.parse(json.encode(TestAllTypes{single_nested_message: TestAllTypes.NestedMessage{bb: 100}}), TestAllTypes).value().single_nested_message.bb == 100`},
+		{name: "proto_repeated_roundtrip", expr: `json.parse(json.encode(TestAllTypes{repeated_int32: [1, 2, 3]}), TestAllTypes).value().repeated_int32 == [1, 2, 3]`},
+		{name: "proto_map_roundtrip", expr: `json.parse(json.encode(TestAllTypes{map_string_string: {'k': 'v'}}), TestAllTypes).value().map_string_string['k'] == 'v'`},
+		{name: "proto_structpb_roundtrip", expr: `json.parse(json.encode(TestAllTypes{single_struct: {'hello': 'world'}}), TestAllTypes).value().single_struct['hello'] == 'world'`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ast, iss := env.Compile(tc.expr)
+			if iss.Err() != nil {
+				t.Fatalf("env.Compile(%q) failed: %v", tc.expr, iss.Err())
+			}
+			prg, err := env.Program(ast)
+			if err != nil {
+				t.Fatalf("env.Program() failed: %v", err)
+			}
+			out, _, err := prg.Eval(cel.NoVars())
+			if err != nil {
+				t.Fatalf("prg.Eval() failed: %v", err)
+			}
+			if out.Value() != true {
+				t.Errorf("got %v, wanted true for expr: %s", out.Value(), tc.expr)
+			}
+		})
+	}
+}
+
+func BenchmarkJSONEncode(b *testing.B) {
+	nativeType, _ := types.NewNativeType(reflect.TypeFor[testNativeUser](), types.ParseStructTag("cel"))
+	env, err := cel.NewEnv(
+		Encoders(),
+		cel.Types(
+			nativeType,
+			&proto3pb.TestAllTypes{},
+			types.NewObjectType("google.expr.proto3.test.TestAllTypes"),
+		),
+	)
+	if err != nil {
+		b.Fatalf("cel.NewEnv failed: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		expr string
+	}{
+		{name: "ScalarInt", expr: "json.encode(42)"},
+		{name: "ScalarString", expr: "json.encode('hello world')"},
+		{name: "ListSmall", expr: "json.encode([1, 'two', true, null])"},
+		{name: "MapSmall", expr: "json.encode({'a': 1, 'b': 'two', 'c': true})"},
+		{name: "MapNested", expr: "json.encode({'items': [1, {'nested': true}], 'count': 42})"},
+		{name: "ProtoMessage", expr: "json.encode(google.expr.proto3.test.TestAllTypes{single_int32: 42, single_string: 'cel'})"},
+		{name: "NativeStruct", expr: "json.encode(ext.testNativeUser{username: 'Alice', age: 25})"},
+	}
+
+	for _, c := range cases {
+		ast, iss := env.Compile(c.expr)
+		if iss.Err() != nil {
+			b.Fatalf("env.Compile(%q) failed: %v", c.expr, iss.Err())
+		}
+		prg, err := env.Program(ast)
+		if err != nil {
+			b.Fatalf("env.Program() failed: %v", err)
+		}
+		b.Run(c.name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _, err := prg.Eval(cel.NoVars())
+				if err != nil {
+					b.Fatalf("prg.Eval() failed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkJSONParse(b *testing.B) {
+	nativeType, _ := types.NewNativeType(reflect.TypeFor[testNativeUser](), types.ParseStructTag("cel"))
+	env, err := cel.NewEnv(
+		Encoders(),
+		cel.Types(
+			nativeType,
+			&proto3pb.TestAllTypes{},
+			types.NewObjectType("google.expr.proto3.test.TestAllTypes"),
+		),
+	)
+	if err != nil {
+		b.Fatalf("cel.NewEnv failed: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		expr string
+	}{
+		{name: "DynamicScalar", expr: "json.parse('42')"},
+		{name: "DynamicString", expr: "json.parse('\"hello world\"')"},
+		{name: "DynamicMap", expr: "json.parse('{\"a\": 1, \"b\": \"two\", \"c\": true}')"},
+		{name: "DynamicNested", expr: "json.parse('{\"items\": [1, {\"nested\": true}], \"count\": 42}')"},
+		{name: "TypedInt", expr: "json.parse('42', int)"},
+		{name: "TypedString", expr: "json.parse('\"hello world\"', string)"},
+		{name: "TypedList", expr: "json.parse('[1, 2, 3, 4, 5]', type([1]))"},
+		{name: "TypedMap", expr: "json.parse('{\"a\": 1, \"b\": 2}', type({'': 1}))"},
+		{name: "TypedProto", expr: "json.parse('{\"single_int32\": 42, \"single_string\": \"cel\"}', google.expr.proto3.test.TestAllTypes)"},
+		{name: "TypedNativeStruct", expr: "json.parse('{\"user_name\": \"Alice\", \"age\": 25}', ext.testNativeUser)"},
+	}
+
+	for _, c := range cases {
+		ast, iss := env.Compile(c.expr)
+		if iss.Err() != nil {
+			b.Fatalf("env.Compile(%q) failed: %v", c.expr, iss.Err())
+		}
+		prg, err := env.Program(ast)
+		if err != nil {
+			b.Fatalf("env.Program() failed: %v", err)
+		}
+		b.Run(c.name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _, err := prg.Eval(cel.NoVars())
+				if err != nil {
+					b.Fatalf("prg.Eval() failed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkBase64(b *testing.B) {
+	env, err := cel.NewEnv(Encoders())
+	if err != nil {
+		b.Fatalf("cel.NewEnv failed: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		expr string
+	}{
+		{name: "EncodeShort", expr: "base64.encode(b'hello world')"},
+		{name: "EncodeBinary", expr: "base64.encode(b'\\x00\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08\\x09')"},
+		{name: "DecodeShort", expr: "base64.decode('aGVsbG8gd29ybGQ=')"},
+		{name: "DecodeBinary", expr: "base64.decode('AAECAwQFBgcICQ==')"},
+	}
+
+	for _, c := range cases {
+		ast, iss := env.Compile(c.expr)
+		if iss.Err() != nil {
+			b.Fatalf("env.Compile(%q) failed: %v", c.expr, iss.Err())
+		}
+		prg, err := env.Program(ast)
+		if err != nil {
+			b.Fatalf("env.Program() failed: %v", err)
+		}
+		b.Run(c.name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _, err := prg.Eval(cel.NoVars())
+				if err != nil {
+					b.Fatalf("prg.Eval() failed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestEncodersStringConformance(t *testing.T) {
+	env, err := cel.NewEnv(Encoders())
+	if err != nil {
+		t.Fatalf("cel.NewEnv failed: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		expr string
+	}{
+		// Valid escapes in json.parse
+		{name: "escaped_quote", expr: `json.parse('"hello \\"world\\""') == optional.of('hello "world"')`},
+		{name: "escaped_backslash", expr: `json.parse('"hello\\\\world"') == optional.of('hello\\world')`},
+		{name: "escaped_slash", expr: `json.parse('"hello\\/world"') == optional.of('hello/world')`},
+		{name: "escaped_backspace", expr: `json.parse('"hello\\bworld"') == optional.of("hello\bworld")`},
+		{name: "escaped_formfeed", expr: `json.parse('"hello\\fworld"') == optional.of("hello\fworld")`},
+		{name: "escaped_newline", expr: `json.parse('"hello\\nworld"') == optional.of("hello\nworld")`},
+		{name: "escaped_carriage_return", expr: `json.parse('"hello\\rworld"') == optional.of("hello\rworld")`},
+		{name: "escaped_tab", expr: `json.parse('"hello\\tworld"') == optional.of("hello\tworld")`},
+		{name: "escaped_unicode_ascii", expr: `json.parse('"\\u0041\\u0042\\u0043"') == optional.of('ABC')`},
+		{name: "escaped_unicode_cjk", expr: `json.parse('"\\u4e16\\u754c"') == optional.of('世界')`},
+		{name: "escaped_unicode_surrogates", expr: `json.parse('"\\ud83d\\ude80"') == optional.of('🚀')`},
+		{name: "escaped_null_byte", expr: `json.parse('"hello\\u0000world"') == optional.of("hello\x00world")`},
+		// Typed string variants
+		{name: "typed_escaped_quote", expr: `json.parse('"hello \\"world\\""', string) == optional.of('hello "world"')`},
+		{name: "typed_escaped_unicode", expr: `json.parse('"\\u4e16\\u754c"', string) == optional.of('世界')`},
+		{name: "typed_escaped_surrogates", expr: `json.parse('"\\ud83d\\ude80"', string) == optional.of('🚀')`},
+		// Roundtrip with json.encode
+		{name: "encode_quotes", expr: `json.parse(json.encode('"hello"')) == optional.of('"hello"')`},
+		{name: "encode_backslashes", expr: `json.parse(json.encode('a\\b\\c')) == optional.of('a\\b\\c')`},
+		{name: "encode_newlines_tabs", expr: `json.parse(json.encode("line1\nline2\ttab")) == optional.of("line1\nline2\ttab")`},
+		{name: "encode_unicode_cjk", expr: `json.parse(json.encode('你好世界')) == optional.of('你好世界')`},
+		{name: "encode_unicode_emojis", expr: `json.parse(json.encode('👋 🌍 🚀')) == optional.of('👋 🌍 🚀')`},
+		// Negative / Malformed string parsing
+		{name: "invalid_hex_escape", expr: `json.parse('"\\x41"') == optional.none()`},
+		{name: "invalid_alert_escape", expr: `json.parse('"\\a"') == optional.none()`},
+		{name: "invalid_vertical_tab", expr: `json.parse('"\\v"') == optional.none()`},
+		{name: "incomplete_unicode_escape", expr: `json.parse('"\\u123"') == optional.none()`},
+		{name: "unclosed_string", expr: `json.parse('"unclosed') == optional.none()`},
+		{name: "trailing_data", expr: `json.parse('"valid" trailing') == optional.none()`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ast, iss := env.Compile(tc.expr)
+			if iss.Err() != nil {
+				t.Fatalf("env.Compile(%q) failed: %v", tc.expr, iss.Err())
+			}
+			prg, err := env.Program(ast)
+			if err != nil {
+				t.Fatalf("env.Program() failed: %v", err)
+			}
+			out, _, err := prg.Eval(cel.NoVars())
+			if err != nil {
+				t.Fatalf("prg.Eval() failed: %v", err)
+			}
+			if out.Value() != true {
+				t.Errorf("got %v, wanted true for expr: %s", out.Value(), tc.expr)
+			}
+		})
+	}
+}
+
+func TestPublicAPI(t *testing.T) {
+	// Base64 Encode & Decode
+	encodedB64 := Base64Encode([]byte("hello world"))
+	if encodedB64 != "aGVsbG8gd29ybGQ=" {
+		t.Errorf("got %q, wanted %q", encodedB64, "aGVsbG8gd29ybGQ=")
+	}
+	decodedB64, err := Base64Decode(encodedB64)
+	if err != nil || string(decodedB64) != "hello world" {
+		t.Errorf("Base64Decode failed: %v, got %q", err, string(decodedB64))
+	}
+
+	// JSON Encode
+	intVal := types.Int(42)
+	encodedInt, err := JSONEncode(intVal)
+	if err != nil || encodedInt != "42" {
+		t.Errorf("JSONEncode(42) failed: %v, got %q", err, encodedInt)
+	}
+
+	mapVal := types.DefaultTypeAdapter.NativeToValue(map[string]any{"hello": "world"})
+	encodedMap, err := JSONEncode(mapVal)
+	if err != nil || encodedMap != `{"hello":"world"}` {
+		t.Errorf("JSONEncode(map) failed: %v, got %q", err, encodedMap)
+	}
+
+	// JSON Parse Dynamic
+	decodedVal, err := JSONParse(nil, `{"a": 1, "b": "two"}`)
+	if err != nil {
+		t.Fatalf("JSONParse failed: %v", err)
+	}
+	if mapper, ok := decodedVal.(traits.Mapper); !ok || mapper.Size().(types.Int) != 2 {
+		t.Errorf("unexpected decodedVal: %v", decodedVal)
+	}
+
+	// JSON Parse Typed
+	typedVal, err := JSONParseWithType(nil, nil, `[1, 2, 3]`, types.NewListType(types.IntType))
+	if err != nil {
+		t.Fatalf("JSONParseWithType failed: %v", err)
+	}
+	if lister, ok := typedVal.(traits.Lister); !ok || lister.Size().(types.Int) != 3 {
+		t.Errorf("unexpected typedVal: %v", typedVal)
+	}
+
+	// JSON Parse with Proto
+	reg, err := types.NewRegistry(&proto3pb.TestAllTypes{})
+	if err != nil {
+		t.Fatalf("types.NewRegistry failed: %v", err)
+	}
+	protoVal, err := JSONParseWithType(nil, reg, `{"single_int32": 42}`, types.NewObjectType("google.expr.proto3.test.TestAllTypes"))
+	if err != nil {
+		t.Fatalf("JSONParseWithType proto failed: %v", err)
+	}
+	if fieldVal := protoVal.(traits.Indexer).Get(types.String("single_int32")); fieldVal != types.Int(42) {
+		t.Errorf("got %v, wanted 42", fieldVal)
+	}
+	pbMsgAny, err := protoVal.ConvertToNative(reflect.TypeFor[*proto3pb.TestAllTypes]())
+	if err != nil {
+		t.Fatalf("ConvertToNative failed: %v", err)
+	}
+	if pbMsg, ok := pbMsgAny.(*proto3pb.TestAllTypes); !ok || pbMsg.GetSingleInt32() != 42 {
+		t.Errorf("unexpected pbMsg: %v", pbMsgAny)
+	}
+
+	// Max size error checks
+	hugeStr := strings.Repeat("x", maxJSONSize+1)
+	if _, err := JSONParse(nil, hugeStr); err == nil {
+		t.Errorf("expected error on huge string in JSONParse, got nil")
+	}
+	if _, err := JSONParseWithType(nil, nil, hugeStr, types.IntType); err == nil {
+		t.Errorf("expected error on huge string in JSONParseWithType, got nil")
+	}
+
+	// Double NaN and Inf encoding errors
+	if _, err := JSONEncode(types.Double(math.NaN())); err == nil {
+		t.Errorf("expected error encoding NaN, got nil")
+	}
+	if _, err := JSONEncode(types.Double(math.Inf(1))); err == nil {
+		t.Errorf("expected error encoding +Inf, got nil")
+	}
+
+	// Map with non-string keys
+	intKeyMapVal := types.DefaultTypeAdapter.NativeToValue(map[int]string{1: "one"})
+	if enc, err := JSONEncode(intKeyMapVal); err != nil || enc != `{"1":"one"}` {
+		t.Errorf("JSONEncode int key map failed: %v, got %q", err, enc)
+	}
+
+	// Base64 invalid decode
+	if _, err := Base64Decode("!!!"); err == nil {
+		t.Errorf("expected Base64Decode error on invalid input, got nil")
+	}
+
+	// Unmarshal native struct errors
+	if _, ok := jsonUnmarshalNative("{}", reflect.TypeOf(123)); ok {
+		t.Errorf("expected jsonUnmarshalNative to fail on non-struct int type")
+	}
+	if _, ok := jsonUnmarshalNative("invalid", reflect.TypeOf(testNativeUser{})); ok {
+		t.Errorf("expected jsonUnmarshalNative to fail on invalid JSON")
+	}
+}
+
+func TestEncodersTypedCollections(t *testing.T) {
+	// Typed Lists via JSONParseWithType
+	if val, err := JSONParseWithType(nil, nil, `[1, 2]`, types.NewListType(types.UintType)); err != nil || val.Value().([]uint64)[0] != 1 {
+		t.Errorf("uint list parse failed: %v", err)
+	}
+	if val, err := JSONParseWithType(nil, nil, `[1.5, 2.5]`, types.NewListType(types.DoubleType)); err != nil || val.Value().([]float64)[0] != 1.5 {
+		t.Errorf("double list parse failed: %v", err)
+	}
+	if val, err := JSONParseWithType(nil, nil, `[true, false]`, types.NewListType(types.BoolType)); err != nil || val.Value().([]bool)[0] != true {
+		t.Errorf("bool list parse failed: %v", err)
+	}
+	if val, err := JSONParseWithType(nil, nil, `["a", "b"]`, types.NewListType(types.StringType)); err != nil || val.Value().([]string)[0] != "a" {
+		t.Errorf("string list parse failed: %v", err)
+	}
+	if val, err := JSONParseWithType(nil, nil, `[1, "two"]`, types.NewListType(types.DynType)); err != nil || len(val.Value().([]any)) != 2 {
+		t.Errorf("dyn list parse failed: %v", err)
+	}
+	if _, err := JSONParseWithType(nil, nil, `["bad"]`, types.NewListType(types.UintType)); err == nil {
+		t.Errorf("expected uint list to fail on string element")
+	}
+	if _, err := JSONParseWithType(nil, nil, `["bad"]`, types.NewListType(types.DoubleType)); err == nil {
+		t.Errorf("expected double list to fail on string element")
+	}
+	if _, err := JSONParseWithType(nil, nil, `["bad"]`, types.NewListType(types.BoolType)); err == nil {
+		t.Errorf("expected bool list to fail on string element")
+	}
+	if _, err := JSONParseWithType(nil, nil, `["bad"]`, types.NewListType(types.IntType)); err == nil {
+		t.Errorf("expected int list to fail on string element")
+	}
+	if _, err := JSONParseWithType(nil, nil, `invalid`, types.NewListType(types.DynType)); err == nil {
+		t.Errorf("expected dyn list to fail on invalid JSON")
+	}
+
+	// Typed Maps via JSONParseWithType
+	if val, err := JSONParseWithType(nil, nil, `{"a": 1, "b": 2}`, types.NewMapType(types.StringType, types.UintType)); err != nil || val.Value().(map[string]uint64)["a"] != 1 {
+		t.Errorf("uint map parse failed: %v", err)
+	}
+	if val, err := JSONParseWithType(nil, nil, `{"a": 1.5}`, types.NewMapType(types.StringType, types.DoubleType)); err != nil || val.Value().(map[string]float64)["a"] != 1.5 {
+		t.Errorf("double map parse failed: %v", err)
+	}
+	if val, err := JSONParseWithType(nil, nil, `{"a": true}`, types.NewMapType(types.StringType, types.BoolType)); err != nil || val.Value().(map[string]bool)["a"] != true {
+		t.Errorf("bool map parse failed: %v", err)
+	}
+	if val, err := JSONParseWithType(nil, nil, `{"a": "b"}`, types.NewMapType(types.StringType, types.StringType)); err != nil || val.Value().(map[string]string)["a"] != "b" {
+		t.Errorf("string map parse failed: %v", err)
+	}
+	if val, err := JSONParseWithType(nil, nil, `{"a": 1}`, types.NewMapType(types.StringType, types.DynType)); err != nil || val.Value().(map[string]any)["a"] == nil {
+		t.Errorf("dyn map parse failed: %v", err)
+	}
+	if _, err := JSONParseWithType(nil, nil, `{"a": "bad"}`, types.NewMapType(types.StringType, types.UintType)); err == nil {
+		t.Errorf("expected uint map to fail on string value")
+	}
+	if _, err := JSONParseWithType(nil, nil, `{"a": "bad"}`, types.NewMapType(types.StringType, types.DoubleType)); err == nil {
+		t.Errorf("expected double map to fail on string value")
+	}
+	if _, err := JSONParseWithType(nil, nil, `{"a": "bad"}`, types.NewMapType(types.StringType, types.BoolType)); err == nil {
+		t.Errorf("expected bool map to fail on string value")
+	}
+	if _, err := JSONParseWithType(nil, nil, `{"a": "bad"}`, types.NewMapType(types.StringType, types.IntType)); err == nil {
+		t.Errorf("expected int map to fail on string value")
+	}
+	if _, err := JSONParseWithType(nil, nil, `invalid`, types.NewMapType(types.StringType, types.DynType)); err == nil {
+		t.Errorf("expected dyn map to fail on invalid JSON")
+	}
+
+	// Proto Collections
+	reg, _ := types.NewRegistry(&proto3pb.TestAllTypes{})
+	if val, err := JSONParseWithType(nil, reg, `[{"single_int32": 42}]`, types.NewListType(types.NewObjectType("google.expr.proto3.test.TestAllTypes"))); err != nil || len(val.Value().([]any)) != 1 {
+		t.Errorf("proto list parse failed: %v", err)
+	}
+	if _, err := JSONParseWithType(nil, reg, `[{"single_int32": "bad"}]`, types.NewListType(types.NewObjectType("google.expr.proto3.test.TestAllTypes"))); err == nil {
+		t.Errorf("expected proto list to fail on bad field type")
+	}
+	if _, err := JSONParseWithType(nil, reg, `invalid`, types.NewListType(types.NewObjectType("google.expr.proto3.test.TestAllTypes"))); err == nil {
+		t.Errorf("expected proto list to fail on invalid JSON")
+	}
+	if val, err := JSONParseWithType(nil, reg, `{"a": {"single_int32": 42}}`, types.NewMapType(types.StringType, types.NewObjectType("google.expr.proto3.test.TestAllTypes"))); err != nil || val.Value().(map[string]any)["a"] == nil {
+		t.Errorf("proto map parse failed: %v", err)
+	}
+	if _, err := JSONParseWithType(nil, reg, `{"a": {"single_int32": "bad"}}`, types.NewMapType(types.StringType, types.NewObjectType("google.expr.proto3.test.TestAllTypes"))); err == nil {
+		t.Errorf("expected proto map to fail on bad field type")
+	}
+	if _, err := JSONParseWithType(nil, reg, `invalid`, types.NewMapType(types.StringType, types.NewObjectType("google.expr.proto3.test.TestAllTypes"))); err == nil {
+		t.Errorf("expected proto map to fail on invalid JSON")
+	}
+
+	// Well-known types via JSONParseWithType
+	if _, err := JSONParseWithType(nil, nil, `"hello"`, types.NewObjectType("google.protobuf.Value")); err != nil {
+		t.Errorf("Value parse failed: %v", err)
+	}
+	if _, err := JSONParseWithType(nil, nil, `{"k": "v"}`, types.NewObjectType("google.protobuf.Struct")); err != nil {
+		t.Errorf("Struct parse failed: %v", err)
+	}
+	if _, err := JSONParseWithType(nil, nil, `[1, 2]`, types.NewObjectType("google.protobuf.ListValue")); err != nil {
+		t.Errorf("ListValue parse failed: %v", err)
+	}
+	if _, err := JSONParseWithType(nil, nil, `{"bad":}`, types.NewObjectType("google.protobuf.Value")); err == nil {
+		t.Errorf("expected Value parse to fail on malformed JSON")
+	}
+	if _, err := JSONParseWithType(nil, nil, `{"bad":}`, types.NewObjectType("google.protobuf.Struct")); err == nil {
+		t.Errorf("expected Struct parse to fail on malformed JSON")
+	}
+	if _, err := JSONParseWithType(nil, nil, `{"bad":}`, types.NewObjectType("google.protobuf.ListValue")); err == nil {
+		t.Errorf("expected ListValue parse to fail on malformed JSON")
+	}
+}
+
+func TestEncodersEstimatorsAndEdgeCases(t *testing.T) {
+	// Test estimator invalid argument guards
+	if estimateEncode(nil, nil, []checker.AstNode{}) != nil {
+		t.Errorf("expected nil from estimateEncode with empty args")
+	}
+	if estimateDecode(nil, nil, []checker.AstNode{}) != nil {
+		t.Errorf("expected nil from estimateDecode with empty args")
+	}
+	if estimateJSONEncode(nil, nil, []checker.AstNode{}) != nil {
+		t.Errorf("expected nil from estimateJSONEncode with empty args")
+	}
+	if estimateJSONParse(nil, nil, []checker.AstNode{}) != nil {
+		t.Errorf("expected nil from estimateJSONParse with empty args")
+	}
+	if estimateJSONParse(nil, nil, []checker.AstNode{nil, nil, nil}) != nil {
+		t.Errorf("expected nil from estimateJSONParse with 3 args")
+	}
+
+	// Test estimateEncodeSize overflow guard
+	overflowSz := estimateEncodeSize(checker.SizeEstimate{Min: 0, Max: math.MaxUint64})
+	if overflowSz.Max != math.MaxUint64 {
+		t.Errorf("expected MaxUint64, got %v", overflowSz.Max)
+	}
+
+	// Test jsonParsePrimitive errors
+	if _, ok := jsonParsePrimitive("123 trailing", func(t any) (any, bool) { return t, true }); ok {
+		t.Errorf("expected jsonParsePrimitive to fail with trailing data")
+	}
+	if _, ok := jsonParsePrimitive("invalid", func(t any) (any, bool) { return t, true }); ok {
+		t.Errorf("expected jsonParsePrimitive to fail with invalid token")
+	}
+	if _, ok := jsonParsePrimitive("123", func(t any) (any, bool) { return nil, false }); ok {
+		t.Errorf("expected jsonParsePrimitive to fail when convert returns false")
+	}
+
+	// Test jsonParseDynamic uint overflow / numbers
+	if num, ok := jsonParseDynamic("18446744073709551615"); !ok || num != json.Number("18446744073709551615") {
+		t.Errorf("expected uint64 number, got %v, ok=%v", num, ok)
+	}
+
+	// Test jsonParseStructNative with invalid prototype
+	if _, ok := jsonParseStructNative(nil, "{}", "non.existent.Type"); ok {
+		t.Errorf("expected jsonParseStructNative to fail on non-existent type with nil provider")
+	}
+
+	// Test jsonParseStructNative with erroring provider
+	errProvider := &mockErrorProvider{}
+	if _, ok := jsonParseStructNative(errProvider, "{}", "error.Type"); ok {
+		t.Errorf("expected jsonParseStructNative to fail on provider error")
+	}
+	nilProvider := &mockNilProvider{}
+	if _, ok := jsonParseStructNative(nilProvider, "{}", "nil.Type"); ok {
+		t.Errorf("expected jsonParseStructNative to fail on nil value from provider")
+	}
+
+	// Test jsonParseStructNative with cached pointer reflect type
+	ptrTypeVal := &testNativeUser{Username: "Alice", Age: 30}
+	structPrototypeCache.Store("ptr.NativeUser", structPrototype{refType: reflect.TypeOf(ptrTypeVal)})
+	if val, ok := jsonParseStructNative(nil, `{"user_name":"Bob","age":25}`, "ptr.NativeUser"); !ok || val == nil {
+		t.Errorf("expected jsonParseStructNative to parse cached ptr reflect type")
+	}
+
+	// Test direct jsonUnmarshalNative with pointer to struct
+	if val, ok := jsonUnmarshalNative(`{"user_name":"Carol","age":35}`, reflect.TypeOf(&testNativeUser{})); !ok || val == nil {
+		t.Errorf("expected jsonUnmarshalNative with pointer to succeed")
+	}
+	if _, ok := jsonUnmarshalNative(`invalid`, reflect.TypeOf(&testNativeUser{})); ok {
+		t.Errorf("expected jsonUnmarshalNative with pointer to fail on invalid JSON")
+	}
+
+	// Test direct jsonUnmarshalProto
+	if msg, ok := jsonUnmarshalProto(`{"single_int32": 99}`, &proto3pb.TestAllTypes{}); !ok || msg == nil {
+		t.Errorf("expected jsonUnmarshalProto to succeed")
+	}
+	if _, ok := jsonUnmarshalProto(`{"single_int32": "bad"}`, &proto3pb.TestAllTypes{}); ok {
+		t.Errorf("expected jsonUnmarshalProto to fail on invalid field")
+	}
+
+	// Test direct jsonEncodeNativeStruct with nil, proto, pointer, and non-struct
+	if _, ok := jsonEncodeNativeStruct(nil); ok {
+		t.Errorf("expected jsonEncodeNativeStruct(nil) to return false")
+	}
+	if _, ok := jsonEncodeNativeStruct(&proto3pb.TestAllTypes{}); ok {
+		t.Errorf("expected jsonEncodeNativeStruct(proto) to return false")
+	}
+	if enc, ok := jsonEncodeNativeStruct(&testNativeUser{Username: "Dave", Age: 40}); !ok || enc != `{"user_name":"Dave","age":40}` {
+		t.Errorf("expected jsonEncodeNativeStruct(pointer) to succeed, got %q, ok=%v", enc, ok)
+	}
+	if _, ok := jsonEncodeNativeStruct(123); ok {
+		t.Errorf("expected jsonEncodeNativeStruct(int) to return false")
+	}
+
+	// Test direct getProtoMessage
+	if msg, ok := getProtoMessage(mockProtoVal{TestAllTypes: &proto3pb.TestAllTypes{SingleInt32: 42}}); !ok || msg == nil {
+		t.Errorf("expected getProtoMessage(proto.Message) to succeed")
+	}
+	if _, ok := getProtoMessage(types.Int(42)); ok {
+		t.Errorf("expected getProtoMessage(types.Int) to return false")
+	}
+
+	// Test jsonEncodeList and jsonEncodeMap error paths
+	invalidList := mockInvalidList{}
+	if _, err := jsonEncodeList(invalidList); err == nil {
+		t.Errorf("expected jsonEncodeList to fail on non-int size")
+	}
+	elemErrList := types.DefaultTypeAdapter.NativeToValue([]any{math.NaN()}).(traits.Lister)
+	if _, err := jsonEncodeList(elemErrList); err == nil {
+		t.Errorf("expected jsonEncodeList to fail on NaN element")
+	}
+
+	invalidMap := mockInvalidMap{}
+	if _, err := jsonEncodeMap(invalidMap); err == nil {
+		t.Errorf("expected jsonEncodeMap to fail on non-int size")
+	}
+	valErrMap := types.DefaultTypeAdapter.NativeToValue(map[string]any{"a": math.NaN()}).(traits.Mapper)
+	if _, err := jsonEncodeMap(valErrMap); err == nil {
+		t.Errorf("expected jsonEncodeMap to fail on NaN value")
+	}
+
+	// Test jsonEncodeValue error from ConvertToNative
+	mockErr := &mockErrVal{}
+	if _, err := jsonEncodeValue(mockErr); err == nil {
+		t.Errorf("expected jsonEncodeValue to fail on ConvertToNative error")
+	}
+
+	// Test jsonParseWithType string limit and scalar types
+	hugeStr := strings.Repeat("a", maxJSONSize+1)
+	if res := jsonParseWithType(nil, nil, hugeStr, types.IntType); !types.IsError(res) {
+		t.Errorf("expected error from jsonParseWithType on oversized string")
+	}
+	if _, ok := jsonParseValue(nil, nil, `"not-bytes"`, types.BytesType); ok {
+		t.Errorf("expected jsonParseValue to fail on invalid bytes")
+	}
+	if _, ok := jsonParseValue(nil, nil, `"not-timestamp"`, types.TimestampType); ok {
+		t.Errorf("expected jsonParseValue to fail on invalid timestamp")
+	}
+	if _, ok := jsonParseValue(nil, nil, `"not-duration"`, types.DurationType); ok {
+		t.Errorf("expected jsonParseValue to fail on invalid duration")
+	}
+	if _, ok := jsonParseValue(nil, nil, `123`, types.StringType); ok {
+		t.Errorf("expected jsonParseValue to fail on string parse of number token")
+	}
+	if _, ok := jsonParseValue(nil, nil, `123`, types.BytesType); ok {
+		t.Errorf("expected jsonParseValue to fail on bytes parse of number token")
+	}
+	if _, ok := jsonParseValue(nil, nil, `123`, types.TimestampType); ok {
+		t.Errorf("expected jsonParseValue to fail on timestamp parse of number token")
+	}
+	if _, ok := jsonParseValue(nil, nil, `123`, types.DurationType); ok {
+		t.Errorf("expected jsonParseValue to fail on duration parse of number token")
+	}
+
+	// Test jsonUnmarshalExact with trailing data
+	var trailingObj any
+	if err := jsonUnmarshalExact("123 trailing", &trailingObj); err == nil {
+		t.Errorf("expected jsonUnmarshalExact to fail on trailing token")
+	}
+
+	// Test jsonEncodeMap key error
+	keyErrMap := mockKeyErrMap{}
+	if _, err := jsonEncodeMap(keyErrMap); err == nil {
+		t.Errorf("expected jsonEncodeMap to fail on key error")
+	}
+
+	// Test jsonParseValue with ListType and MapType singletons (no parameters)
+	if val, ok := jsonParseValue(nil, nil, `[1, "two"]`, types.ListType); !ok || val == nil {
+		t.Errorf("expected jsonParseValue to succeed for unparameterized ListType")
+	}
+	if _, ok := jsonParseValue(nil, nil, `invalid`, types.ListType); ok {
+		t.Errorf("expected jsonParseValue to fail on invalid json for unparameterized ListType")
+	}
+	if val, ok := jsonParseValue(nil, nil, `{"a": 1}`, types.MapType); !ok || val == nil {
+		t.Errorf("expected jsonParseValue to succeed for unparameterized MapType")
+	}
+	if _, ok := jsonParseValue(nil, nil, `invalid`, types.MapType); ok {
+		t.Errorf("expected jsonParseValue to fail on invalid json for unparameterized MapType")
+	}
+
+	// Test jsonParseValue with NullType and TypeType
+	if _, ok := jsonParseValue(nil, nil, `"not-null"`, types.NullType); ok {
+		t.Errorf("expected jsonParseValue to fail on non-null for NullType")
+	}
+	if _, ok := jsonParseValue(nil, nil, `"not-type"`, types.TypeType); ok {
+		t.Errorf("expected jsonParseValue to fail on non-type for TypeType")
+	}
+
+	// Test jsonParseValue with custom StructTypeDescriptor and NonType
+	if val, ok := jsonParseValue(nil, nil, `{"user_name":"Eve","age":20}`, mockStructTypeDesc{reflectType: reflect.TypeOf(testNativeUser{})}); !ok || val == nil {
+		t.Errorf("expected jsonParseValue to succeed for StructTypeDescriptor")
+	}
+	if val, ok := jsonParseValue(nil, nil, `{"user_name":"Eve","age":20}`, mockCustomTypeDesc{typeName: "ptr.NativeUser"}); !ok || val == nil {
+		t.Errorf("expected jsonParseValue to succeed for custom TypeName")
+	}
+	if _, ok := jsonParseValue(nil, nil, `{}`, mockCustomNonType{}); ok {
+		t.Errorf("expected jsonParseValue to fail for mockCustomNonType")
+	}
+
+	// Test jsonParseTypedList & jsonParseTypedMap nested custom type failures
+	if _, ok := jsonParseTypedList(nil, nil, `[{"bad":}]`, types.NewObjectType("non.existent")); ok {
+		t.Errorf("expected jsonParseTypedList to fail on nested custom type with bad json")
+	}
+	if _, ok := jsonParseTypedMap(nil, nil, `{"a": {"bad":}}`, types.NewObjectType("non.existent")); ok {
+		t.Errorf("expected jsonParseTypedMap to fail on nested custom type with bad json")
+	}
+
+	// Test jsonParseStructNative well-known types
+	if val, ok := jsonParseStructNative(nil, `"hello"`, "google.protobuf.Value"); !ok || val == nil {
+		t.Errorf("expected jsonParseStructNative(Value) to succeed")
+	}
+	if val, ok := jsonParseStructNative(nil, `{"k":"v"}`, "google.protobuf.Struct"); !ok || val == nil {
+		t.Errorf("expected jsonParseStructNative(Struct) to succeed")
+	}
+	if val, ok := jsonParseStructNative(nil, `[1, 2]`, "google.protobuf.ListValue"); !ok || val == nil {
+		t.Errorf("expected jsonParseStructNative(ListValue) to succeed")
+	}
+
+	// Test CompileOptions defaults and binary overload invalid typeVal
+	lib := &encoderLib{version: 1}
+	opts := lib.CompileOptions()
+	if len(opts) == 0 {
+		t.Errorf("expected CompileOptions to return options")
+	}
+	env, _ := cel.NewEnv(opts...)
+	ast, _ := env.Compile(`json.parse("123")`)
+	prg, _ := env.Program(ast)
+	if _, _, err := prg.Eval(cel.NoVars()); err != nil {
+		t.Fatalf("prg.Eval failed: %v", err)
+	}
+
+	// Test jsonParseWithType directly
+	if res := jsonParseWithType(nil, nil, "123", types.IntType); res.Value() != int64(123) {
+		t.Errorf("expected 123, got %v", res)
+	}
+
+	// Test JSONParse invalid JSON
+	if _, err := JSONParse(nil, `{"bad":}`); err == nil {
+		t.Errorf("expected JSONParse error on invalid JSON")
+	}
+
+	// Test Base64Decode padding error
+	if _, err := Base64Decode("=aGVsbG8="); err == nil {
+		t.Errorf("expected Base64Decode error on padding error")
+	}
+
+	// Test string and bytes invalid collections
+	if _, err := JSONParseWithType(nil, nil, "invalid", types.NewListType(types.StringType)); err == nil {
+		t.Errorf("expected string list parse to fail on invalid JSON")
+	}
+	if _, err := JSONParseWithType(nil, nil, "invalid", types.NewMapType(types.StringType, types.StringType)); err == nil {
+		t.Errorf("expected string map parse to fail on invalid JSON")
+	}
+
+	// Test proto message with invalid UTF8 string marshal error
+	invalidProto := &proto3pb.TestAllTypes{SingleString: "\xff\xff"}
+	if _, err := jsonEncodeValue(mockProtoVal{TestAllTypes: invalidProto}); err == nil {
+		t.Errorf("expected jsonEncodeValue error on proto with invalid utf8")
+	}
+	if _, err := jsonEncodeValue(types.DefaultTypeAdapter.NativeToValue(invalidProto)); err == nil {
+		t.Errorf("expected jsonEncodeValue error on proto with invalid utf8")
+	}
+
+	// Test ConvertToNative returning non-structpb.Value and invalid UTF-8 Value
+	if _, err := jsonEncodeValue(mockNonStructPBVal{}); err == nil {
+		t.Errorf("expected jsonEncodeValue error on non-structpb.Value")
+	}
+	if _, err := jsonEncodeValue(mockInvalidUTF8PBVal{}); err == nil {
+		t.Errorf("expected jsonEncodeValue error on invalid UTF-8 Value")
+	}
+
+	// Test int typed collections
+	if val, err := JSONParseWithType(nil, nil, `[1, 2]`, types.NewListType(types.IntType)); err != nil || len(val.Value().([]int64)) != 2 {
+		t.Errorf("expected int list to parse successfully")
+	}
+	if val, err := JSONParseWithType(nil, nil, `{"a": 1}`, types.NewMapType(types.StringType, types.IntType)); err != nil || val.Value().(map[string]int64)["a"] != 1 {
+		t.Errorf("expected int map to parse successfully")
+	}
+	if _, err := JSONParseWithType(nil, nil, `123`, types.NewMapType(types.StringType, types.NewObjectType("google.expr.proto3.test.TestAllTypes"))); err == nil {
+		t.Errorf("expected proto map parse to fail on non-map JSON")
+	}
+}
+
+type mockNonStructPBVal struct {
+	ref.Val
+}
+
+func (mockNonStructPBVal) Type() ref.Type {
+	return types.NewObjectType("mock.NonStructPBVal")
+}
+
+func (mockNonStructPBVal) Value() any {
+	return nil
+}
+
+func (mockNonStructPBVal) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	return "not-structpb-value", nil
+}
+
+type mockInvalidUTF8PBVal struct {
+	ref.Val
+}
+
+func (mockInvalidUTF8PBVal) Type() ref.Type {
+	return types.NewObjectType("mock.InvalidUTF8PBVal")
+}
+
+func (mockInvalidUTF8PBVal) Value() any {
+	return nil
+}
+
+func (mockInvalidUTF8PBVal) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	return &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "\xff\xff"}}, nil
+}
+
+type mockInvalidList struct {
+	traits.Lister
+}
+
+func (mockInvalidList) Size() ref.Val {
+	return types.String("invalid-size")
+}
+
+type mockInvalidMap struct {
+	traits.Mapper
+}
+
+func (mockInvalidMap) Size() ref.Val {
+	return types.String("invalid-size")
+}
+
+type mockKeyErrMap struct {
+	traits.Mapper
+}
+
+func (mockKeyErrMap) Size() ref.Val {
+	return types.Int(1)
+}
+
+func (mockKeyErrMap) Iterator() traits.Iterator {
+	return &mockKeyErrIterator{first: true}
+}
+
+type mockKeyErrIterator struct {
+	traits.Iterator
+	first bool
+}
+
+func (m *mockKeyErrIterator) HasNext() ref.Val {
+	if m.first {
+		m.first = false
+		return types.True
+	}
+	return types.False
+}
+
+func (m *mockKeyErrIterator) Next() ref.Val {
+	return types.Double(math.NaN())
+}
+
+type mockStructTypeDesc struct {
+	types.StructTypeDescriptor
+	reflectType reflect.Type
+}
+
+func (m mockStructTypeDesc) ReflectType() reflect.Type {
+	return m.reflectType
+}
+
+func (m mockStructTypeDesc) TypeName() string {
+	return "mock.StructType"
+}
+
+func (m mockStructTypeDesc) HasTrait(trait int) bool {
+	return false
+}
+
+type mockCustomTypeDesc struct {
+	ref.Type
+	typeName string
+}
+
+func (m mockCustomTypeDesc) TypeName() string {
+	return m.typeName
+}
+
+type mockCustomNonType struct {
+	ref.Type
+}
+
+func (mockCustomNonType) HasTrait(trait int) bool {
+	return false
+}
+
+func (mockCustomNonType) TypeName() string {
+	return "mock.CustomNonType"
+}
+
+type mockErrVal struct {
+	ref.Val
+}
+
+func (mockErrVal) Type() ref.Type {
+	return types.NewObjectType("mock.ErrVal")
+}
+
+func (mockErrVal) Value() any {
+	return nil
+}
+
+func (mockErrVal) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	return nil, fmt.Errorf("mock ConvertToNative error")
+}
+
+type mockErrorProvider struct {
+	types.Provider
+}
+
+func (mockErrorProvider) NewValue(typeName string, fields map[string]ref.Val) ref.Val {
+	return types.NewErr("mock provider error")
+}
+
+type mockNilProvider struct {
+	types.Provider
+}
+
+type mockNilVal struct {
+	ref.Val
+}
+
+func (mockNilVal) Value() any {
+	return nil
+}
+
+func (mockNilProvider) NewValue(typeName string, fields map[string]ref.Val) ref.Val {
+	return mockNilVal{}
+}
+
+type mockProtoVal struct {
+	ref.Val
+	*proto3pb.TestAllTypes
 }


### PR DESCRIPTION
Support for `json.parse` with extensive roundtrip tests. 

If the value can be parsed as JSON, it returns an `optional_type` with a value.
There are two flavors of `json.parse`, one which returns a `dyn` value, and one
which takes a type identifier and attempts to parse the JSON value into the type.

The type-specified version of `json.parse` supports both native and protobuf type
definitions. 

Benchmarks included under `ext/design/encoders.md`