### PR TITLE
Update missed checker -> cost changes

### DIFF
--- a/ext/lists.go
+++ b/ext/lists.go
@@ -502,11 +502,11 @@ func (lib listsLib) CompileOptions() []cel.EnvOption {
 				),
 			),
 			cel.CostEstimatorOptions(
-				checker.OverloadCostEstimate("list_hasOnly_list", estimateListSetOp(1)),
-				checker.OverloadCostEstimate("list_hasAny_list", estimateListSetOp(1)),
-				checker.OverloadCostEstimate("list_hasAll_list", estimateListSetOp(1)),
+				cost.OverloadCostEstimate("list_hasOnly_list", estimateListSetOp(1)),
+				cost.OverloadCostEstimate("list_hasAny_list", estimateListSetOp(1)),
+				cost.OverloadCostEstimate("list_hasAll_list", estimateListSetOp(1)),
 				// set equivalence requires up to two m*n comparisons to ensure each list contains the other
-				checker.OverloadCostEstimate("list_hasExactly_list", estimateListSetOp(2)),
+				cost.OverloadCostEstimate("list_hasExactly_list", estimateListSetOp(2)),
 			),
 		)
 	}
@@ -549,10 +549,10 @@ func (lib *listsLib) ProgramOptions() []cel.ProgramOption {
 		}
 		if lib.version >= 5 {
 			trackers = append(trackers,
-				interpreter.OverloadCostTracker("list_hasOnly_list", trackSetsCost(1)),
-				interpreter.OverloadCostTracker("list_hasAny_list", trackSetsCost(1)),
-				interpreter.OverloadCostTracker("list_hasAll_list", trackSetsCost(1)),
-				interpreter.OverloadCostTracker("list_hasExactly_list", trackSetsCost(2)),
+				cost.OverloadTracker("list_hasOnly_list", trackSetsCost(1)),
+				cost.OverloadTracker("list_hasAny_list", trackSetsCost(1)),
+				cost.OverloadTracker("list_hasAll_list", trackSetsCost(1)),
+				cost.OverloadTracker("list_hasExactly_list", trackSetsCost(2)),
 			)
 		}
 		opts = append(opts, cel.CostTrackerOptions(trackers...))
@@ -795,8 +795,8 @@ func templatedOverloads(types []*cel.Type, template func(t *cel.Type) cel.Functi
 
 // estimateListSetOp computes an O(m*n) comparison between the target list and its argument, scaled
 // by the number of passes the operation makes over the pair of lists.
-func estimateListSetOp(costFactor float64) checker.FunctionEstimator {
-	return func(estimator checker.CostEstimator, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
+func estimateListSetOp(costFactor float64) cost.FunctionEstimator {
+	return func(estimator cost.Estimator, target *cost.AstNode, args []cost.AstNode) *cost.CallEstimate {
 		if target == nil || len(args) != 1 {
 			return nil
 		}

--- a/ext/lists_test.go
+++ b/ext/lists_test.go
@@ -747,25 +747,25 @@ func TestListsCosts(t *testing.T) {
 		{
 			name:          "list_hasOnly",
 			expr:          `[1, 2].hasOnly([1, 2, 3])`,
-			estimatedCost: checker.FixedCostEstimate(27),
+			estimatedCost: cost.FixedCostEstimate(27),
 			actualCost:    27,
 		},
 		{
 			name:          "list_hasAny",
 			expr:          `[1, 2].hasAny([2, 3])`,
-			estimatedCost: checker.FixedCostEstimate(25),
+			estimatedCost: cost.FixedCostEstimate(25),
 			actualCost:    25,
 		},
 		{
 			name:          "list_hasAll",
 			expr:          `[1, 2, 3].hasAll([1, 2])`,
-			estimatedCost: checker.FixedCostEstimate(27),
+			estimatedCost: cost.FixedCostEstimate(27),
 			actualCost:    27,
 		},
 		{
 			name:          "list_hasExactly",
 			expr:          `[1, 2].hasExactly([2, 1])`,
-			estimatedCost: checker.FixedCostEstimate(29),
+			estimatedCost: cost.FixedCostEstimate(29),
 			actualCost:    29,
 		},
 		{
@@ -774,7 +774,7 @@ func TestListsCosts(t *testing.T) {
 			vars:          []cel.EnvOption{cel.Variable("x", cel.ListType(cel.StringType))},
 			in:            map[string]any{"x": []string{"a", "b", "c"}},
 			hints:         map[string]uint64{"x": 10},
-			estimatedCost: checker.CostEstimate{Min: 12, Max: 32},
+			estimatedCost: cost.CostEstimate{Min: 12, Max: 32},
 			actualCost:    18,
 		},
 	}


### PR DESCRIPTION
Some of the changes from the previous conversion didn't appear to get saved, convert remaining `checker` references to `cost`