### PR TITLE
Migrate remaining uses of legacy cost references in top-level packages

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -32,8 +32,8 @@ import (
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
-	"cel.dev/cel-go/checker"
 	celast "cel.dev/cel-go/common/ast"
+	"cel.dev/cel-go/common/cost"
 	"cel.dev/cel-go/common/env"
 	"cel.dev/cel-go/common/operators"
 	"cel.dev/cel-go/common/overloads"
@@ -202,7 +202,7 @@ func TestEval(t *testing.T) {
 	env, err := NewEnv(
 		Variable("input", ListType(IntType)),
 		CostEstimatorOptions(
-			checker.OverloadCostEstimate(overloads.TimestampToYear, estimateTimestampToYear),
+			cost.OverloadCostEstimate(overloads.TimestampToYear, estimateTimestampToYear),
 		),
 	)
 	if err != nil {
@@ -228,7 +228,7 @@ func TestEval(t *testing.T) {
 			prgOpts := []ProgramOption{
 				CostTracking(testRuntimeCostEstimator{}),
 				CostTrackerOptions(
-					interpreter.OverloadCostTracker(overloads.TimestampToYear, trackTimestampToYear),
+					cost.OverloadTracker(overloads.TimestampToYear, trackTimestampToYear),
 				),
 				EvalOptions(OptOptimize, OptTrackCost),
 				InterruptCheckFrequency(100),
@@ -1948,13 +1948,13 @@ func TestCustomInterpreterDecoratorV2(t *testing.T) {
 // TestEstimateCostAndRuntimeCost sanity checks that the cost systems are usable from the program API.
 func TestEstimateCostAndRuntimeCost(t *testing.T) {
 	intList := ListType(IntType)
-	zeroCost := checker.CostEstimate{}
+	zeroCost := cost.CostEstimate{}
 	cases := []struct {
 		name  string
 		expr  string
 		decls []EnvOption
 		hints map[string]uint64
-		want  checker.CostEstimate
+		want  cost.CostEstimate
 		in    any
 	}{
 		{
@@ -1967,7 +1967,7 @@ func TestEstimateCostAndRuntimeCost(t *testing.T) {
 			name:  "identity",
 			expr:  `input`,
 			decls: []EnvOption{Variable("input", intList)},
-			want:  checker.CostEstimate{Min: 1, Max: 1},
+			want:  cost.CostEstimate{Min: 1, Max: 1},
 			in:    map[string]any{"input": []int{1, 2}},
 		},
 		{
@@ -1978,7 +1978,7 @@ func TestEstimateCostAndRuntimeCost(t *testing.T) {
 				Variable("str2", StringType),
 			},
 			hints: map[string]uint64{"str1": 10, "str2": 10},
-			want:  checker.CostEstimate{Min: 2, Max: 6},
+			want:  cost.CostEstimate{Min: 2, Max: 6},
 			in:    map[string]any{"str1": "val1111111", "str2": "val2222222"},
 		},
 	}
@@ -1992,7 +1992,7 @@ func TestEstimateCostAndRuntimeCost(t *testing.T) {
 			}
 			envOpts := []EnvOption{
 				CostEstimatorOptions(
-					checker.OverloadCostEstimate(overloads.TimestampToYear, estimateTimestampToYear),
+					cost.OverloadCostEstimate(overloads.TimestampToYear, estimateTimestampToYear),
 				),
 			}
 			envOpts = append(envOpts, tc.decls...)
@@ -2003,10 +2003,10 @@ func TestEstimateCostAndRuntimeCost(t *testing.T) {
 			}
 			est, err := env.EstimateCost(ast, testCostEstimator{hints: tc.hints})
 			if err != nil {
-				t.Fatalf("Env.EstimateCost(ast *Ast, estimator checker.CostEstimator) failed to estimate cost: %s\n", err)
+				t.Fatalf("Env.EstimateCost(ast *Ast, estimator cost.Estimator) failed to estimate cost: %s\n", err)
 			}
 			if est.Min != tc.want.Min || est.Max != tc.want.Max {
-				t.Fatalf("Env.EstimateCost(ast *Ast, estimator checker.CostEstimator) failed to return the right cost interval. Got [%v, %v], wanted [%v, %v]",
+				t.Fatalf("Env.EstimateCost(ast *Ast, estimator cost.Estimator) failed to return the right cost interval. Got [%v, %v], wanted [%v, %v]",
 					est.Min, est.Max, tc.want.Min, tc.want.Max)
 			}
 
@@ -2018,7 +2018,7 @@ func TestEstimateCostAndRuntimeCost(t *testing.T) {
 			program, err := env.Program(checkedAst,
 				CostTracking(testRuntimeCostEstimator{}),
 				CostTrackerOptions(
-					interpreter.OverloadCostTracker(overloads.TimestampToYear, trackTimestampToYear),
+					cost.OverloadTracker(overloads.TimestampToYear, trackTimestampToYear),
 				),
 			)
 			if err != nil {
@@ -2079,7 +2079,7 @@ func TestCostLimit(t *testing.T) {
 			t.Parallel()
 			envOpts := []EnvOption{
 				CostEstimatorOptions(
-					checker.OverloadCostEstimate(overloads.TimestampToYear, estimateTimestampToYear),
+					cost.OverloadCostEstimate(overloads.TimestampToYear, estimateTimestampToYear),
 				),
 			}
 			envOpts = append(envOpts, tc.decls...)
@@ -2090,7 +2090,7 @@ func TestCostLimit(t *testing.T) {
 			}
 			est, err := env.EstimateCost(ast, testCostEstimator{hints: map[string]uint64{}})
 			if err != nil {
-				t.Fatalf("Env.EstimateCost(ast *Ast, estimator checker.CostEstimator) failed to estimate cost: %s\n", err)
+				t.Fatalf("Env.EstimateCost(ast *Ast, estimator cost.Estimator) failed to estimate cost: %s\n", err)
 			}
 
 			checkedAst, iss := env.Check(ast)
@@ -2101,7 +2101,7 @@ func TestCostLimit(t *testing.T) {
 			program, err := env.Program(checkedAst,
 				CostTracking(testRuntimeCostEstimator{}),
 				CostTrackerOptions(
-					interpreter.OverloadCostTracker(overloads.TimestampToYear, trackTimestampToYear),
+					cost.OverloadTracker(overloads.TimestampToYear, trackTimestampToYear),
 				),
 				CostLimit(tc.costLimit),
 			)
@@ -4019,7 +4019,7 @@ func TestOptionalHasValueCost(t *testing.T) {
 		expr       string
 		hints      map[string]uint64
 		in         map[string]any
-		wantEst    checker.CostEstimate
+		wantEst    cost.CostEstimate
 		wantActual uint64
 	}{
 		{
@@ -4029,7 +4029,7 @@ func TestOptionalHasValueCost(t *testing.T) {
 				"optStr": types.OptionalOf(types.String("val1111111")),
 				"str":    "val2222222",
 			},
-			wantEst:    checker.CostEstimate{Min: 3, Max: 3},
+			wantEst:    cost.CostEstimate{Min: 3, Max: 3},
 			wantActual: 3,
 		},
 		{
@@ -4039,7 +4039,7 @@ func TestOptionalHasValueCost(t *testing.T) {
 				"optStr": types.OptionalOf(types.String(longStr)),
 				"str":    longStr,
 			},
-			wantEst:    checker.CostEstimate{Min: 3, Max: 1002},
+			wantEst:    cost.CostEstimate{Min: 3, Max: 1002},
 			wantActual: 1002,
 		},
 		{
@@ -4050,7 +4050,7 @@ func TestOptionalHasValueCost(t *testing.T) {
 				"optStr": types.OptionalOf(types.String(longStr)),
 				"str":    "val2222222",
 			},
-			wantEst:    checker.CostEstimate{Min: 3, Max: 3},
+			wantEst:    cost.CostEstimate{Min: 3, Max: 3},
 			wantActual: 3,
 		},
 		{
@@ -4062,7 +4062,7 @@ func TestOptionalHasValueCost(t *testing.T) {
 				"optOptStr": types.OptionalOf(types.OptionalOf(types.String(longStr))),
 				"optStr":    types.OptionalOf(types.String(longStr)),
 			},
-			wantEst:    checker.CostEstimate{Min: 3, Max: 1002},
+			wantEst:    cost.CostEstimate{Min: 3, Max: 1002},
 			wantActual: 1002,
 		},
 		{
@@ -4073,7 +4073,7 @@ func TestOptionalHasValueCost(t *testing.T) {
 				"optStr": types.OptionalNone,
 				"str":    longStr,
 			},
-			wantEst:    checker.CostEstimate{Min: 3, Max: 1002},
+			wantEst:    cost.CostEstimate{Min: 3, Max: 1002},
 			wantActual: 3,
 		},
 	}
@@ -4629,19 +4629,19 @@ type testCostEstimator struct {
 	hints map[string]uint64
 }
 
-func (tc testCostEstimator) EstimateSize(element checker.AstNode) *checker.SizeEstimate {
+func (tc testCostEstimator) EstimateSize(element cost.AstNode) *cost.SizeEstimate {
 	if l, ok := tc.hints[strings.Join(element.Path(), ".")]; ok {
-		return &checker.SizeEstimate{Min: 0, Max: l}
+		return &cost.SizeEstimate{Min: 0, Max: l}
 	}
 	return nil
 }
 
-func (tc testCostEstimator) EstimateCallCost(function, overloadID string, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
+func (tc testCostEstimator) EstimateCallCost(function, overloadID string, target *cost.AstNode, args []cost.AstNode) *cost.CallEstimate {
 	return nil
 }
 
-func estimateTimestampToYear(estimator checker.CostEstimator, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
-	return &checker.CallEstimate{CostEstimate: checker.CostEstimate{Min: 7, Max: 7}}
+func estimateTimestampToYear(estimator cost.Estimator, target *cost.AstNode, args []cost.AstNode) *cost.CallEstimate {
+	return &cost.CallEstimate{CostEstimate: cost.CostEstimate{Min: 7, Max: 7}}
 }
 
 type testRuntimeCostEstimator struct{}

--- a/cel/env.go
+++ b/cel/env.go
@@ -28,6 +28,7 @@ import (
 	"cel.dev/cel-go/common"
 	celast "cel.dev/cel-go/common/ast"
 	"cel.dev/cel-go/common/containers"
+	"cel.dev/cel-go/common/cost"
 	"cel.dev/cel-go/common/decls"
 	"cel.dev/cel-go/common/env"
 	"cel.dev/cel-go/common/functions"
@@ -149,7 +150,7 @@ type Env struct {
 	limits          map[limitID]int
 	libraries       map[string]SingletonLibrary
 	validators      []ASTValidator
-	costOptions     []checker.CostOption
+	costOptions     []cost.CostOption
 
 	// Flags for copy-on-write behavior with env.Extend.
 	funcsShared           bool
@@ -399,7 +400,7 @@ func NewCustomEnv(opts ...EnvOption) (*Env, error) {
 		libraries:       map[string]SingletonLibrary{},
 		validators:      []ASTValidator{},
 		progOpts:        []ProgramOption{},
-		costOptions:     []checker.CostOption{},
+		costOptions:     []cost.CostOption{},
 	}).configure(opts)
 }
 
@@ -887,11 +888,11 @@ func (e *Env) ResidualAst(a *Ast, details *EvalDetails) (*Ast, error) {
 
 // EstimateCost estimates the cost of a type checked CEL expression using the length estimates of input data and
 // extension functions provided by estimator.
-func (e *Env) EstimateCost(ast *Ast, estimator checker.CostEstimator, opts ...checker.CostOption) (checker.CostEstimate, error) {
-	extendedOpts := make([]checker.CostOption, 0, len(e.costOptions))
+func (e *Env) EstimateCost(ast *Ast, estimator cost.Estimator, opts ...cost.CostOption) (cost.CostEstimate, error) {
+	extendedOpts := make([]cost.CostOption, 0, len(e.costOptions))
 	extendedOpts = append(extendedOpts, opts...)
 	extendedOpts = append(extendedOpts, e.costOptions...)
-	return checker.Cost(ast.NativeRep(), estimator, extendedOpts...)
+	return cost.Cost(ast.NativeRep(), estimator, extendedOpts...)
 }
 
 // configure applies a series of EnvOptions to the current environment.

--- a/cel/library.go
+++ b/cel/library.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"math"
 
-	"cel.dev/cel-go/checker"
 	"cel.dev/cel-go/common"
 	"cel.dev/cel-go/common/ast"
 	"cel.dev/cel-go/common/cost"
@@ -634,7 +633,7 @@ func (lib *optionalLib) CompileOptions() []EnvOption {
 					return types.Equal(opt.GetValue(), other)
 				}))))
 		opts = append(opts, CostEstimatorOptions(
-			checker.OverloadCostEstimate(optionalHasValueValueOverload, estimateOptionalHasValue)))
+			cost.OverloadCostEstimate(optionalHasValueValueOverload, estimateOptionalHasValue)))
 	}
 
 	return opts
@@ -647,7 +646,7 @@ func (lib *optionalLib) ProgramOptions() []ProgramOption {
 	}
 	if lib.version >= 3 {
 		opts = append(opts, CostTrackerOptions(
-			interpreter.OverloadCostTracker(optionalHasValueValueOverload, trackOptionalHasValue)))
+			cost.OverloadTracker(optionalHasValueValueOverload, trackOptionalHasValue)))
 	}
 	return opts
 }
@@ -657,7 +656,7 @@ func (lib *optionalLib) ProgramOptions() []ProgramOption {
 //
 // The overload is sugar for 'opt.hasValue() ? opt.value() == v : false' where the equality check
 // dominates the cost, so the estimate mirrors the O(min(m, n)) cost of an equality comparison.
-func estimateOptionalHasValue(estimator checker.CostEstimator, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
+func estimateOptionalHasValue(estimator cost.Estimator, target *cost.AstNode, args []cost.AstNode) *cost.CallEstimate {
 	if target == nil || len(args) != 1 {
 		return nil
 	}
@@ -672,19 +671,19 @@ func estimateOptionalHasValue(estimator checker.CostEstimator, target *checker.A
 		// equality of 2 scalar values results in a cost of 1
 		minCost = 1
 	}
-	return &checker.CallEstimate{
-		CostEstimate: checker.CostEstimate{Min: minCost, Max: smallestMax}.
+	return &cost.CallEstimate{
+		CostEstimate: cost.CostEstimate{Min: minCost, Max: smallestMax}.
 			MultiplyByCostFactor(common.StringTraversalCostFactor),
 	}
 }
 
 // sizeOrUnknown returns the size estimate computed for the node, or an unknown size if the node
 // size could not be determined at check time.
-func sizeOrUnknown(node checker.AstNode) checker.SizeEstimate {
+func sizeOrUnknown(node cost.AstNode) cost.SizeEstimate {
 	if sz := node.ComputedSize(); sz != nil {
 		return *sz
 	}
-	return checker.UnknownSizeEstimate()
+	return cost.UnknownSizeEstimate()
 }
 
 // trackOptionalHasValue computes the runtime cost of comparing an optional's value against the

--- a/cel/options.go
+++ b/cel/options.go
@@ -26,8 +26,8 @@ import (
 	"google.golang.org/protobuf/types/dynamicpb"
 
 	"cel.dev/cel-go/cel/async"
-	"cel.dev/cel-go/checker"
 	"cel.dev/cel-go/common/containers"
+	"cel.dev/cel-go/common/cost"
 	"cel.dev/cel-go/common/decls"
 	"cel.dev/cel-go/common/env"
 	"cel.dev/cel-go/common/functions"
@@ -836,7 +836,7 @@ func ConcurrentDrainStrategy(strategy async.DrainStrategy) ProgramOption {
 }
 
 // CostEstimatorOptions configure type-check time options for estimating expression cost.
-func CostEstimatorOptions(costOpts ...checker.CostOption) EnvOption {
+func CostEstimatorOptions(costOpts ...cost.CostOption) EnvOption {
 	return func(e *Env) (*Env, error) {
 		e.costOptions = append(e.costOptions, costOpts...)
 		return e, nil
@@ -846,7 +846,7 @@ func CostEstimatorOptions(costOpts ...checker.CostOption) EnvOption {
 // CostTrackerOptions configures a set of options for cost-tracking.
 //
 // Note, CostTrackerOptions is a no-op unless CostTracking is also enabled.
-func CostTrackerOptions(costOpts ...interpreter.CostTrackerOption) ProgramOption {
+func CostTrackerOptions(costOpts ...cost.TrackerOption) ProgramOption {
 	return func(p *prog) (*prog, error) {
 		p.costOptions = append(p.costOptions, costOpts...)
 		return p, nil
@@ -854,7 +854,7 @@ func CostTrackerOptions(costOpts ...interpreter.CostTrackerOption) ProgramOption
 }
 
 // CostTracking enables cost tracking and registers a ActualCostEstimator that can optionally provide a runtime cost estimate for any function calls.
-func CostTracking(costEstimator interpreter.ActualCostEstimator) ProgramOption {
+func CostTracking(costEstimator cost.ActualCostEstimator) ProgramOption {
 	return func(p *prog) (*prog, error) {
 		p.callCostEstimator = costEstimator
 		p.evalOpts |= OptTrackCost

--- a/cel/program.go
+++ b/cel/program.go
@@ -22,6 +22,7 @@ import (
 
 	"cel.dev/cel-go/cel/async"
 	"cel.dev/cel-go/common/ast"
+	"cel.dev/cel-go/common/cost"
 	"cel.dev/cel-go/common/operators"
 	"cel.dev/cel-go/common/overloads"
 	"cel.dev/cel-go/common/types"
@@ -140,7 +141,7 @@ type AttributePatternType = interpreter.AttributePattern
 // EvalDetails holds additional information observed during the Eval() call.
 type EvalDetails struct {
 	state       interpreter.EvalState
-	costTracker *interpreter.CostTracker
+	costTracker *cost.Tracker
 	memTracker  *types.MemoryTracker
 }
 
@@ -197,8 +198,8 @@ type prog struct {
 	// Interpretable configured from an Ast and aggregate decorator set based on program options.
 	interpretable     interpreter.InterpretableV2
 	observable        *interpreter.ObservableInterpretable
-	callCostEstimator interpreter.ActualCostEstimator
-	costOptions       []interpreter.CostTrackerOption
+	callCostEstimator cost.ActualCostEstimator
+	costOptions       []cost.TrackerOption
 	costLimit         *uint64
 	memoryOptions     []types.MemoryTrackerOption
 	memoryLimit       *uint32
@@ -260,7 +261,7 @@ func newProgram(e *Env, a *ast.AST, opts []ProgramOption) (Program, error) {
 		Env:            e,
 		plannerOptions: []interpreter.PlannerOption{},
 		dispatcher:     disp,
-		costOptions:    []interpreter.CostTrackerOption{},
+		costOptions:    []cost.TrackerOption{},
 		drainStrategy:  async.DrainReady(100 * time.Microsecond),
 		hasAsync:       hasAsync,
 	}
@@ -339,20 +340,20 @@ func newProgram(e *Env, a *ast.AST, opts []ProgramOption) (Program, error) {
 			if p.costLimit != nil {
 				costOptCount++
 			}
-			costOpts := make([]interpreter.CostTrackerOption, 0, costOptCount)
+			costOpts := make([]cost.TrackerOption, 0, costOptCount)
 			costOpts = append(costOpts, p.costOptions...)
 			if p.costLimit != nil {
-				costOpts = append(costOpts, interpreter.CostTrackerLimit(*p.costLimit))
+				costOpts = append(costOpts, cost.TrackerLimit(*p.costLimit))
 			}
 			// Creating a new cost tracker for each evaluation causes significant work that
 			// needs to be repeated for each evaluation even though the cost tracker is
 			// mostly read-only once constructed. Therefore it gets constructed
 			// once now and later a cheap clone is used for each evaluation.
-			tracker, err := interpreter.NewCostTracker(p.callCostEstimator, costOpts...)
+			tracker, err := cost.NewTracker(p.callCostEstimator, costOpts...)
 			if err != nil {
 				return nil, fmt.Errorf("construct cost tracker: %w", err)
 			}
-			trackerFactory := func() (*interpreter.CostTracker, error) {
+			trackerFactory := func() (*cost.Tracker, error) {
 				return tracker.Clone()
 			}
 			plannerOptions = append(plannerOptions, interpreter.CostObserver(interpreter.CostTrackerFactory(trackerFactory)))

--- a/cel/program_async_test.go
+++ b/cel/program_async_test.go
@@ -313,7 +313,7 @@ func TestConcurrentEval(t *testing.T) {
 		// Tests the scenario where there are more async invocations than completion buffer.
 		{
 			name:    "more requests than completion buffer w/ debounce",
-			expr:    `lists.range(1000).exists(i, async_inc(i) == 1000)`,
+			expr:    `lists.range(100).exists(i, async_inc(i) == 100)`,
 			maxConc: 5,
 			opts: []any{
 				ext.Lists(),
@@ -326,7 +326,7 @@ func TestConcurrentEval(t *testing.T) {
 		// Tests the scenario where there are more async invocations than completion buffer.
 		{
 			name:    "more requests than completion buffer w/ drain all",
-			expr:    `lists.range(1000).exists(i, async_inc(i) == 1000)`,
+			expr:    `lists.range(100).exists(i, async_inc(i) == 100)`,
 			maxConc: 5,
 			opts: []any{
 				ext.Lists(),
@@ -338,7 +338,7 @@ func TestConcurrentEval(t *testing.T) {
 		},
 		{
 			name: "more requests than completion buffer w/ drain none",
-			expr: `lists.range(300).exists(i, async_inc(i) == 300)`,
+			expr: `lists.range(100).exists(i, async_inc(i) == 100)`,
 			opts: []any{
 				ext.Lists(),
 				cel.AsyncCompletionBufferSize(1),
@@ -351,7 +351,7 @@ func TestConcurrentEval(t *testing.T) {
 		// Tests the scenario where there are more async invocations than completion buffer across two different comprehensions.
 		{
 			name: "chained comprehensions with drain none",
-			expr: `lists.range(300).map(i, async_inc(i) * 2).exists(j, j == 600)`,
+			expr: `lists.range(100).map(i, async_inc(i) * 2).exists(j, j == 200)`,
 			opts: []any{
 				ext.Lists(),
 				cel.AsyncCompletionBufferSize(4),

--- a/ext/BUILD.bazel
+++ b/ext/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cel:go_default_library",
-        "//checker:go_default_library",
         "//common:go_default_library",
         "//common/ast:go_default_library",
         "//common/cost:go_default_library",
@@ -75,7 +74,6 @@ go_test(
     ],
     deps = [
         "//cel:go_default_library",
-        "//checker:go_default_library",
         "//common:go_default_library",
         "//common/env:go_default_library",
         "//common/types:go_default_library",

--- a/ext/comprehensions_test.go
+++ b/ext/comprehensions_test.go
@@ -22,7 +22,6 @@ import (
 	"cel.dev/cel-go/cel"
 	"cel.dev/cel-go/common/cost"
 	"cel.dev/cel-go/common/types"
-	"cel.dev/cel-go/interpreter"
 )
 
 func TestTwoVarComprehensions(t *testing.T) {
@@ -601,7 +600,7 @@ func TestTwoVarComprehensionsResidualAST(t *testing.T) {
 		name     string
 		in       map[string]any
 		varOpts  []cel.EnvOption
-		unks     []*interpreter.AttributePattern
+		unks     []*cel.AttributePatternType
 		expr     string
 		residual string
 	}{
@@ -614,7 +613,7 @@ func TestTwoVarComprehensionsResidualAST(t *testing.T) {
 			in: map[string]any{
 				"x": []any{0, uint(1)},
 			},
-			unks:     []*interpreter.AttributePattern{cel.AttributePattern("y")},
+			unks:     []*cel.AttributePatternType{cel.AttributePattern("y")},
 			expr:     `x.transformMapEntry(i, v, {v: i}).size() < y`,
 			residual: `2 < y`,
 		},
@@ -627,7 +626,7 @@ func TestTwoVarComprehensionsResidualAST(t *testing.T) {
 			in: map[string]any{
 				"x": []any{0, uint(1)},
 			},
-			unks:     []*interpreter.AttributePattern{cel.AttributePattern("y")},
+			unks:     []*cel.AttributePatternType{cel.AttributePattern("y")},
 			expr:     `x.transformMapEntry(i, v, i < y, {v: i})`,
 			residual: `[0, 1u].transformMapEntry(i, v, i < y, {v: i})`,
 		},
@@ -640,7 +639,7 @@ func TestTwoVarComprehensionsResidualAST(t *testing.T) {
 			in: map[string]any{
 				"x": []any{1, 2, 3},
 			},
-			unks:     []*interpreter.AttributePattern{cel.AttributePattern("y")},
+			unks:     []*cel.AttributePatternType{cel.AttributePattern("y")},
 			expr:     `x.exists(val, y.exists(key, _, key == val))`,
 			residual: `[1, 2, 3].exists(val, y.exists(key, _, key == val))`,
 		},
@@ -653,7 +652,7 @@ func TestTwoVarComprehensionsResidualAST(t *testing.T) {
 			in: map[string]any{
 				"y": map[int]string{1: "hi", 2: "hello", 3: "howdy"},
 			},
-			unks:     []*interpreter.AttributePattern{cel.AttributePattern("x")},
+			unks:     []*cel.AttributePatternType{cel.AttributePattern("x")},
 			expr:     `x.exists(val, y.exists(key, _, key == val))`,
 			residual: `x.exists(val, y.exists(key, _, key == val))`,
 		},
@@ -666,7 +665,7 @@ func TestTwoVarComprehensionsResidualAST(t *testing.T) {
 			in: map[string]any{
 				"y": map[int]string{1: "hi", 2: "hello", 3: "howdy"},
 			},
-			unks:     []*interpreter.AttributePattern{cel.AttributePattern("x")},
+			unks:     []*cel.AttributePatternType{cel.AttributePattern("x")},
 			expr:     `x.exists(val, y.exists(key, _, key == val)) && y.all(key, val, val.startsWith('h'))`,
 			residual: `x.exists(val, y.exists(key, _, key == val))`,
 		},
@@ -680,7 +679,7 @@ func TestTwoVarComprehensionsResidualAST(t *testing.T) {
 				"x": []int{42, 0, 43},
 				"y": map[int]string{1: "hi", 2: "hello", 3: "howdy"},
 			},
-			unks:     []*interpreter.AttributePattern{cel.AttributePattern("x").QualInt(1)},
+			unks:     []*cel.AttributePatternType{cel.AttributePattern("x").QualInt(1)},
 			expr:     `x.exists(val, y.exists(key, _, key == val)) || x[0] == 0 || x[1] == 1 || x[2] == 2`,
 			residual: `x.exists(val, y.exists(key, _, key == val)) || x[1] == 1`,
 		},
@@ -694,7 +693,7 @@ func TestTwoVarComprehensionsResidualAST(t *testing.T) {
 				"x": []int{42, 0, 43},
 				"y": map[int]string{1: "hi", 2: "hello", 3: "howdy"},
 			},
-			unks:     []*interpreter.AttributePattern{cel.AttributePattern("x").QualInt(1)},
+			unks:     []*cel.AttributePatternType{cel.AttributePattern("x").QualInt(1)},
 			expr:     `x.exists(val, y.exists(key, _, key == val)) || (x[?0].hasValue() && x[?1].hasValue())`,
 			residual: `x.exists(val, y.exists(key, _, key == val)) || x[?1].hasValue()`,
 		},
@@ -708,7 +707,7 @@ func TestTwoVarComprehensionsResidualAST(t *testing.T) {
 				"x": []string{"howdy", "hello", "hi"},
 				"y": map[int]string{0: "hi", 1: "hello", 2: "howdy"},
 			},
-			unks:     []*interpreter.AttributePattern{cel.AttributePattern("y").QualInt(1)},
+			unks:     []*cel.AttributePatternType{cel.AttributePattern("y").QualInt(1)},
 			expr:     `x.exists(key, val, y[?key] == optional.of(val))`,
 			residual: `["howdy", "hello", "hi"].exists(key, val, y[?key] == optional.of(val))`,
 		},
@@ -722,7 +721,7 @@ func TestTwoVarComprehensionsResidualAST(t *testing.T) {
 				"x": []string{"howdy"},
 				"y": map[int]string{0: "hello"},
 			},
-			unks:     []*interpreter.AttributePattern{cel.AttributePattern("x").QualInt(0)},
+			unks:     []*cel.AttributePatternType{cel.AttributePattern("x").QualInt(0)},
 			expr:     `y.exists(key, y[?key] == x[?key])`,
 			residual: `{0: "hello"}.exists(key, y[?key] == x[?key])`,
 		},
@@ -734,7 +733,7 @@ func TestTwoVarComprehensionsResidualAST(t *testing.T) {
 			in: map[string]any{
 				"y": map[int]string{0: "hi", 1: "hello", 2: "howdy"},
 			},
-			unks:     []*interpreter.AttributePattern{cel.AttributePattern("y").QualInt(1)},
+			unks:     []*cel.AttributePatternType{cel.AttributePattern("y").QualInt(1)},
 			expr:     `cel.bind(z, y[0], z + y[1])`,
 			residual: `cel.bind(z, "hi", "hi" + y[1])`,
 		},
@@ -748,7 +747,7 @@ func TestTwoVarComprehensionsResidualAST(t *testing.T) {
 				"x": []string{"hi", "hello", "howdy"},
 				"y": map[int]string{0: "hi", 1: "hello", 2: "howdy"},
 			},
-			unks:     []*interpreter.AttributePattern{cel.AttributePattern("y").QualInt(1)},
+			unks:     []*cel.AttributePatternType{cel.AttributePattern("y").QualInt(1)},
 			expr:     `cel.bind(z, y[0], x.all(i, val, val == z || optional.of(val) == y[?i]))`,
 			residual: `cel.bind(z, "hi", ["hi", "hello", "howdy"].all(i, val, val == z || optional.of(val) == y[?i]))`,
 		},

--- a/ext/encoders_test.go
+++ b/ext/encoders_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"cel.dev/cel-go/cel"
-	"cel.dev/cel-go/checker"
+	"cel.dev/cel-go/common/cost"
 )
 
 func TestEncoders(t *testing.T) {
@@ -250,7 +250,7 @@ func TestEncodersCosts(t *testing.T) {
 		vars          []cel.EnvOption
 		in            map[string]any
 		hints         map[string]uint64
-		estimatedCost checker.CostEstimate
+		estimatedCost cost.CostEstimate
 		actualCost    uint64
 		version       int
 	}{
@@ -266,7 +266,7 @@ func TestEncodersCosts(t *testing.T) {
 			hints: map[string]uint64{
 				"x": 100,
 			},
-			estimatedCost: checker.FixedCostEstimate(3), // x lookup (1) + encode (1) + == (1) = 3
+			estimatedCost: cost.FixedCostEstimate(3), // x lookup (1) + encode (1) + == (1) = 3
 			actualCost:    3,
 			version:       0,
 		},
@@ -282,8 +282,8 @@ func TestEncodersCosts(t *testing.T) {
 			hints: map[string]uint64{
 				"x": 100,
 			},
-			estimatedCost: checker.CostEstimate{Min: 3, Max: 13}, // x lookup (1) + encode (100 * 0.1 + 1 = 11) + == (1) = 13
-			actualCost:    4,                                     // x lookup (1) + encode (ceil(5 * 0.1) + 1 = 2) + == (1) = 4
+			estimatedCost: cost.CostEstimate{Min: 3, Max: 13}, // x lookup (1) + encode (100 * 0.1 + 1 = 11) + == (1) = 13
+			actualCost:    4,                                  // x lookup (1) + encode (ceil(5 * 0.1) + 1 = 2) + == (1) = 4
 			version:       1,
 		},
 		{
@@ -298,7 +298,7 @@ func TestEncodersCosts(t *testing.T) {
 			hints: map[string]uint64{
 				"x": 100,
 			},
-			estimatedCost: checker.FixedCostEstimate(3),
+			estimatedCost: cost.FixedCostEstimate(3),
 			actualCost:    3,
 			version:       0,
 		},
@@ -314,42 +314,42 @@ func TestEncodersCosts(t *testing.T) {
 			hints: map[string]uint64{
 				"x": 100,
 			},
-			estimatedCost: checker.CostEstimate{Min: 3, Max: 13}, // x lookup (1) + decode (100 * 0.1 + 1 = 11) + == (1) = 13
-			actualCost:    4,                                     // x lookup (1) + decode (ceil(8 * 0.1) + 1 = 2) + == (1) = 4
+			estimatedCost: cost.CostEstimate{Min: 3, Max: 13}, // x lookup (1) + decode (100 * 0.1 + 1 = 11) + == (1) = 13
+			actualCost:    4,                                  // x lookup (1) + decode (ceil(8 * 0.1) + 1 = 2) + == (1) = 4
 			version:       1,
 		},
 		{
 			name:          "encode_bytes_v1_literal",
 			expr:          "base64.encode(b'hello') == 'aGVsbG8='",
-			estimatedCost: checker.FixedCostEstimate(3),
+			estimatedCost: cost.FixedCostEstimate(3),
 			actualCost:    3,
 			version:       1,
 		},
 		{
 			name:          "decode_string_v1_literal",
 			expr:          "base64.decode('aGVsbG8=') == b'hello'",
-			estimatedCost: checker.FixedCostEstimate(3),
+			estimatedCost: cost.FixedCostEstimate(3),
 			actualCost:    3,
 			version:       1,
 		},
 		{
 			name:          "encode_empty_bytes_v1_literal",
 			expr:          "base64.encode(b'') == ''",
-			estimatedCost: checker.FixedCostEstimate(1),
+			estimatedCost: cost.FixedCostEstimate(1),
 			actualCost:    1,
 			version:       1,
 		},
 		{
 			name:          "decode_empty_string_v1_literal",
 			expr:          "base64.decode('') == b''",
-			estimatedCost: checker.FixedCostEstimate(1),
+			estimatedCost: cost.FixedCostEstimate(1),
 			actualCost:    1,
 			version:       1,
 		},
 		{
 			name:          "encode_non_utf8_bytes_v1_literal",
 			expr:          "base64.encode(b'\xff\xfe\xfd') != '////'",
-			estimatedCost: checker.FixedCostEstimate(3),
+			estimatedCost: cost.FixedCostEstimate(3),
 			actualCost:    3,
 			version:       1,
 		},
@@ -365,7 +365,7 @@ func TestEncodersCosts(t *testing.T) {
 			hints: map[string]uint64{
 				"x": 100,
 			},
-			estimatedCost: checker.CostEstimate{Min: 2, Max: math.MaxUint64},
+			estimatedCost: cost.CostEstimate{Min: 2, Max: math.MaxUint64},
 			actualCost:    math.MaxUint64,
 			version:       1,
 		},
@@ -381,7 +381,7 @@ func TestEncodersCosts(t *testing.T) {
 			hints: map[string]uint64{
 				"x": 100,
 			},
-			estimatedCost: checker.CostEstimate{Min: 3, Max: 13},
+			estimatedCost: cost.CostEstimate{Min: 3, Max: 13},
 			actualCost:    4,
 			version:       2,
 		},
@@ -397,7 +397,7 @@ func TestEncodersCosts(t *testing.T) {
 			hints: map[string]uint64{
 				"x": 100,
 			},
-			estimatedCost: checker.CostEstimate{Min: 3, Max: 13},
+			estimatedCost: cost.CostEstimate{Min: 3, Max: 13},
 			actualCost:    4,
 			version:       2,
 		},
@@ -434,7 +434,7 @@ func TestDecodeNonBase64Error(t *testing.T) {
 	if iss.Err() != nil {
 		t.Fatalf("env.Check() failed: %v", iss.Err())
 	}
-	testCheckCost(t, env, cAst, nil, checker.FixedCostEstimate(2))
+	testCheckCost(t, env, cAst, nil, cost.FixedCostEstimate(2))
 	prgOpts := []cel.ProgramOption{}
 	if cAst.IsChecked() {
 		prgOpts = append(prgOpts, cel.CostTracking(nil))
@@ -459,7 +459,7 @@ func TestDecodeNonBase64UrlError(t *testing.T) {
 	if iss.Err() != nil {
 		t.Fatalf("env.Check() failed: %v", iss.Err())
 	}
-	testCheckCost(t, env, cAst, nil, checker.FixedCostEstimate(2))
+	testCheckCost(t, env, cAst, nil, cost.FixedCostEstimate(2))
 	prgOpts := []cel.ProgramOption{}
 	if cAst.IsChecked() {
 		prgOpts = append(prgOpts, cel.CostTracking(nil))
@@ -489,7 +489,7 @@ func TestJSONEncodeCostUnbounded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("env.EstimateCost() failed: %v", err)
 	}
-	wantEst := checker.CostEstimate{Min: 0, Max: math.MaxUint64}
+	wantEst := cost.CostEstimate{Min: 0, Max: math.MaxUint64}
 	if est != wantEst {
 		t.Errorf("env.EstimateCost() got %v, wanted %v", est, wantEst)
 	}

--- a/ext/formatting_test.go
+++ b/ext/formatting_test.go
@@ -25,7 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"cel.dev/cel-go/cel"
-	"cel.dev/cel-go/checker"
+	"cel.dev/cel-go/common/cost"
 	"cel.dev/cel-go/common/types"
 	"cel.dev/cel-go/common/types/ref"
 
@@ -42,7 +42,7 @@ func TestStringFormat(t *testing.T) {
 		err                   string
 		expectedOutput        string
 		expectedRuntimeCost   uint64
-		expectedEstimatedCost checker.CostEstimate
+		expectedEstimatedCost cost.CostEstimate
 		skipCompileCheck      bool
 	}{
 		{
@@ -50,7 +50,7 @@ func TestStringFormat(t *testing.T) {
 			format:                "no substitution",
 			expectedOutput:        "no substitution",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 
 		{
@@ -59,14 +59,14 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `"filler"`,
 			expectedOutput:        "str is filler and some more",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:                  "percent escaping",
 			format:                "%% and also %%",
 			expectedOutput:        "% and also %",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:                  "substution inside escaped percent signs",
@@ -74,7 +74,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `"text"`,
 			expectedOutput:        "%text%",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "substitution with one escaped percent sign on the right",
@@ -82,7 +82,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `"percent on the right"`,
 			expectedOutput:        "percent on the right%",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "substitution with one escaped percent sign on the left",
@@ -90,7 +90,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `"percent on the left"`,
 			expectedOutput:        "%percent on the left",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "multiple substitutions",
@@ -98,7 +98,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `1, 2, 3, "A", "B", "C", 4, 5, 6, "D", "E", "F"`,
 			expectedOutput:        "1 2 3, A B C, 4 5 6, D E F",
 			expectedRuntimeCost:   14,
-			expectedEstimatedCost: checker.CostEstimate{Min: 14, Max: 14},
+			expectedEstimatedCost: cost.CostEstimate{Min: 14, Max: 14},
 		},
 		{
 			name:                  "percent sign escape sequence support",
@@ -106,7 +106,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `"percent"`,
 			expectedOutput:        "%escaped percent%",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:                  "fixed point formatting clause",
@@ -114,7 +114,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "1.2345",
 			expectedOutput:        "1.234",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 			locale:                "en_US",
 		},
 		{
@@ -123,7 +123,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "5",
 			expectedOutput:        "this is 5 in binary: 101",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:                  "negative binary formatting clause",
@@ -131,7 +131,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "-5",
 			expectedOutput:        "this is -5 in binary: -101",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:                  "uint support for binary formatting",
@@ -139,7 +139,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "uint(64)",
 			expectedOutput:        "unsigned 64 in binary: 1000000",
 			expectedRuntimeCost:   14,
-			expectedEstimatedCost: checker.CostEstimate{Min: 14, Max: 14},
+			expectedEstimatedCost: cost.CostEstimate{Min: 14, Max: 14},
 		},
 		{
 			name:                  "bool support for binary formatting",
@@ -147,7 +147,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "true",
 			expectedOutput:        "bit set from bool: 1",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:                  "octal formatting clause",
@@ -155,7 +155,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "11",
 			expectedOutput:        "13",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "negative octal formatting clause",
@@ -163,7 +163,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "-11",
 			expectedOutput:        "-13",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "uint support for octal formatting clause",
@@ -171,7 +171,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "uint(65535)",
 			expectedOutput:        "this is an unsigned octal: 177777",
 			expectedRuntimeCost:   14,
-			expectedEstimatedCost: checker.CostEstimate{Min: 14, Max: 14},
+			expectedEstimatedCost: cost.CostEstimate{Min: 14, Max: 14},
 		},
 		{
 			name:                  "lowercase hexadecimal formatting clause",
@@ -179,7 +179,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "30",
 			expectedOutput:        "1e is 30 in hexadecimal",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:                  "uppercase hexadecimal formatting clause",
@@ -187,7 +187,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "30",
 			expectedOutput:        "1E is 20 in hexadecimal",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:                  "negative hexadecimal formatting clause",
@@ -195,7 +195,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "-30",
 			expectedOutput:        "-1e is -30 in hexadecimal",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:                  "unsigned support for hexadecimal formatting clause",
@@ -203,7 +203,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "uint(6000)",
 			expectedOutput:        "1770 is 6000 in hexadecimal",
 			expectedRuntimeCost:   14,
-			expectedEstimatedCost: checker.CostEstimate{Min: 14, Max: 14},
+			expectedEstimatedCost: cost.CostEstimate{Min: 14, Max: 14},
 		},
 		{
 			name:                  "string support with hexadecimal formatting clause",
@@ -211,7 +211,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `"Hello world!"`,
 			expectedOutput:        "48656c6c6f20776f726c6421",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "string support with uppercase hexadecimal formatting clause",
@@ -219,7 +219,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `"Hello world!"`,
 			expectedOutput:        "48656C6C6F20776F726C6421",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "byte support with hexadecimal formatting clause",
@@ -227,7 +227,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `b"byte string"`,
 			expectedOutput:        "6279746520737472696e67",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "byte support with hexadecimal formatting clause leading zero",
@@ -235,7 +235,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `b"\x00\x00byte string\x00"`,
 			expectedOutput:        "00006279746520737472696e6700",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "byte support with uppercase hexadecimal formatting clause",
@@ -243,7 +243,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `b"byte string"`,
 			expectedOutput:        "6279746520737472696E67",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "scientific notation formatting clause",
@@ -251,7 +251,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "1052.032911275",
 			expectedOutput:        "1.052033\u202f\u00d7\u202f10\u2070\u00b3",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 			locale:                "en_US",
 		},
 		{
@@ -261,7 +261,7 @@ func TestStringFormat(t *testing.T) {
 			locale:                "fr_FR",
 			expectedOutput:        "3,140",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "default precision for fixed-point clause",
@@ -269,7 +269,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "2.71828",
 			expectedOutput:        "2.718280",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 			locale:                "en_US",
 		},
 		{
@@ -278,7 +278,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "2.71828",
 			expectedOutput:        "2.718280\u202f\u00d7\u202f10\u2070\u2070",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 			locale:                "en_US",
 		},
 		{
@@ -287,7 +287,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "2.71",
 			expectedOutput:        "2.71",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 			locale:                "en_US",
 		},
 		{
@@ -296,7 +296,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "[2.71]",
 			expectedOutput:        "[2.710000]",
 			expectedRuntimeCost:   21,
-			expectedEstimatedCost: checker.CostEstimate{Min: 21, Max: 21},
+			expectedEstimatedCost: cost.CostEstimate{Min: 21, Max: 21},
 			locale:                "en_US",
 		},
 		{
@@ -305,7 +305,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "0.000000002",
 			expectedOutput:        "2e-09",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 			locale:                "en_US",
 		},
 		{
@@ -314,7 +314,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "[0.000000002]",
 			expectedOutput:        "[0.000000]",
 			expectedRuntimeCost:   21,
-			expectedEstimatedCost: checker.CostEstimate{Min: 21, Max: 21},
+			expectedEstimatedCost: cost.CostEstimate{Min: 21, Max: 21},
 			locale:                "en_US",
 		},
 		{
@@ -323,7 +323,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "2.71828, 2.71828",
 			expectedOutput:        "unescaped unicode: 2.718280 × 10⁰⁰, escaped unicode: 2.718280\u202f\u00d7\u202f10\u2070\u2070",
 			expectedRuntimeCost:   15,
-			expectedEstimatedCost: checker.CostEstimate{Min: 15, Max: 15},
+			expectedEstimatedCost: cost.CostEstimate{Min: 15, Max: 15},
 			locale:                "en_US",
 		},
 		{
@@ -332,7 +332,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `"NaN"`,
 			expectedOutput:        "NaN",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 			locale:                "en_US",
 		},
 		{
@@ -341,7 +341,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `"Infinity"`,
 			expectedOutput:        "∞",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 			locale:                "en_US",
 		},
 		{
@@ -350,7 +350,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `"-Infinity"`,
 			expectedOutput:        "-∞",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 			locale:                "en_US",
 		},
 		{
@@ -383,7 +383,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "uint(64)",
 			expectedOutput:        "64",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:                  "null support for string",
@@ -391,7 +391,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            "null",
 			expectedOutput:        "null: null",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "int support for string",
@@ -399,7 +399,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `999999999999`,
 			expectedOutput:        "999999999999",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "bytes support for string",
@@ -407,7 +407,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `b"xyz"`,
 			expectedOutput:        "some bytes: xyz",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:                  "type() support for string",
@@ -415,7 +415,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `type("test string")`,
 			expectedOutput:        "type is string",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:                  "timestamp support for string",
@@ -423,7 +423,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `timestamp("2023-02-03T23:31:20+00:00")`,
 			expectedOutput:        "2023-02-03T23:31:20Z",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:                  "duration support for string",
@@ -431,7 +431,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `duration("1h45m47s")`,
 			expectedOutput:        "6347s",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:                  "small duration support for string",
@@ -439,7 +439,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `duration("2ns")`,
 			expectedOutput:        "0.000000002s",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:                  "list support for string",
@@ -447,7 +447,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `["abc", 3.14, null, [9, 8, 7, 6], timestamp("2023-02-03T23:31:20Z")]`,
 			expectedOutput:        `["abc", 3.140000, null, [9, 8, 7, 6], timestamp("2023-02-03T23:31:20Z")]`,
 			expectedRuntimeCost:   32,
-			expectedEstimatedCost: checker.CostEstimate{Min: 32, Max: 32},
+			expectedEstimatedCost: cost.CostEstimate{Min: 32, Max: 32},
 		},
 		{
 			name:                  "map support for string",
@@ -456,7 +456,7 @@ func TestStringFormat(t *testing.T) {
 			locale:                "nl_NL",
 			expectedOutput:        `{"key1":b"xyz", "key2":duration("7200s"), "key3":2.718280, "key4":true, "key5":null}`,
 			expectedRuntimeCost:   42,
-			expectedEstimatedCost: checker.CostEstimate{Min: 42, Max: 42},
+			expectedEstimatedCost: cost.CostEstimate{Min: 42, Max: 42},
 		},
 		{
 			name:                  "map support (all key types)",
@@ -464,7 +464,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `{1: "value1", uint(2): "value2", true: double("NaN")}`,
 			expectedOutput:        `map with multiple key types: {1:"value1", 2:"value2", true:"NaN"}`,
 			expectedRuntimeCost:   46,
-			expectedEstimatedCost: checker.CostEstimate{Min: 46, Max: 46},
+			expectedEstimatedCost: cost.CostEstimate{Min: 46, Max: 46},
 		},
 		{
 			name:                  "boolean support for %s",
@@ -472,7 +472,7 @@ func TestStringFormat(t *testing.T) {
 			formatArgs:            `true, false`,
 			expectedOutput:        "true bool: true, false bool: false",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:       "dyntype support for string formatting clause",
@@ -483,7 +483,7 @@ func TestStringFormat(t *testing.T) {
 			},
 			expectedOutput:        "dynamic string: a string",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:       "dyntype support for numbers with string formatting clause",
@@ -495,7 +495,7 @@ func TestStringFormat(t *testing.T) {
 			},
 			expectedOutput:        "dynIntStr: 32 dynDoubleStr: 56.8",
 			expectedRuntimeCost:   15,
-			expectedEstimatedCost: checker.CostEstimate{Min: 15, Max: 15},
+			expectedEstimatedCost: cost.CostEstimate{Min: 15, Max: 15},
 			locale:                "en_US",
 		},
 		{
@@ -507,7 +507,7 @@ func TestStringFormat(t *testing.T) {
 			},
 			expectedOutput:        "dynamic int: 128",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:       "dyntype support for integer formatting clause (unsigned)",
@@ -518,7 +518,7 @@ func TestStringFormat(t *testing.T) {
 			},
 			expectedOutput:        "dynamic unsigned int: 256",
 			expectedRuntimeCost:   14,
-			expectedEstimatedCost: checker.CostEstimate{Min: 14, Max: 14},
+			expectedEstimatedCost: cost.CostEstimate{Min: 14, Max: 14},
 		},
 		{
 			name:       "dyntype support for hex formatting clause",
@@ -529,7 +529,7 @@ func TestStringFormat(t *testing.T) {
 			},
 			expectedOutput:        "dynamic hex int: 16",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:       "dyntype support for hex formatting clause (uppercase)",
@@ -540,7 +540,7 @@ func TestStringFormat(t *testing.T) {
 			},
 			expectedOutput:        "dynamic hex int: 1A (uppercase)",
 			expectedRuntimeCost:   15,
-			expectedEstimatedCost: checker.CostEstimate{Min: 15, Max: 15},
+			expectedEstimatedCost: cost.CostEstimate{Min: 15, Max: 15},
 		},
 		{
 			name:       "dyntype support for unsigned hex formatting clause",
@@ -551,7 +551,7 @@ func TestStringFormat(t *testing.T) {
 			},
 			expectedOutput:        "dynamic hex int: 1f4 (unsigned)",
 			expectedRuntimeCost:   14,
-			expectedEstimatedCost: checker.CostEstimate{Min: 14, Max: 14},
+			expectedEstimatedCost: cost.CostEstimate{Min: 14, Max: 14},
 		},
 		{
 			name:       "dyntype support for fixed-point formatting clause",
@@ -562,7 +562,7 @@ func TestStringFormat(t *testing.T) {
 			},
 			expectedOutput:        "dynamic double: 4.500",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 			locale:                "en_US",
 		},
 		{
@@ -574,7 +574,7 @@ func TestStringFormat(t *testing.T) {
 			},
 			expectedOutput:        "dynamic double: 4,500000",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 			locale:                "fr_FR",
 		},
 		{
@@ -586,7 +586,7 @@ func TestStringFormat(t *testing.T) {
 			},
 			expectedOutput:        "(dyntype) e: 2.718280\u202f\u00d7\u202f10\u2070\u2070",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 			locale:                "en_US",
 		},
 		{
@@ -599,7 +599,7 @@ func TestStringFormat(t *testing.T) {
 			},
 			expectedOutput:        "NaN: NaN, infinity: ∞",
 			expectedRuntimeCost:   15,
-			expectedEstimatedCost: checker.CostEstimate{Min: 15, Max: 15},
+			expectedEstimatedCost: cost.CostEstimate{Min: 15, Max: 15},
 		},
 		{
 			name:       "dyntype support for timestamp",
@@ -610,7 +610,7 @@ func TestStringFormat(t *testing.T) {
 			},
 			expectedOutput:        "dyntype timestamp: 2009-11-10T23:00:00Z",
 			expectedRuntimeCost:   14,
-			expectedEstimatedCost: checker.CostEstimate{Min: 14, Max: 14},
+			expectedEstimatedCost: cost.CostEstimate{Min: 14, Max: 14},
 		},
 		{
 			name:       "dyntype support for duration",
@@ -621,7 +621,7 @@ func TestStringFormat(t *testing.T) {
 			},
 			expectedOutput:        "dyntype duration: 8747s",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:       "dyntype support for lists",
@@ -632,7 +632,7 @@ func TestStringFormat(t *testing.T) {
 			},
 			expectedOutput:        `dyntype list: [6, 4.200000, "a string"]`,
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:       "dyntype support for maps",
@@ -647,7 +647,7 @@ func TestStringFormat(t *testing.T) {
 			},
 			expectedOutput:        `dyntype map: {"strKey":"x", 6:duration("422s"), true:42}`,
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:       "message field support",
@@ -875,7 +875,7 @@ func TestStringFormat(t *testing.T) {
 			locale:           "en_US",
 		},
 	}
-	evalExpr := func(env *cel.Env, expr string, evalArgs any, expectedRuntimeCost uint64, expectedEstimatedCost checker.CostEstimate, t *testing.T) (ref.Val, error) {
+	evalExpr := func(env *cel.Env, expr string, evalArgs any, expectedRuntimeCost uint64, expectedEstimatedCost cost.CostEstimate, t *testing.T) (ref.Val, error) {
 		t.Logf("evaluating expr: %s", expr)
 		parsedAst, issues := env.Parse(expr)
 		if issues.Err() != nil {
@@ -975,7 +975,7 @@ func TestStringFormat(t *testing.T) {
 		opts = append(opts, variables...)
 		return opts
 	}
-	runCase := func(format, formatArgs, locale string, dynArgs map[string]any, skipCompileCheck bool, expectedRuntimeCost uint64, expectedEstimatedCost checker.CostEstimate, t *testing.T) (ref.Val, error) {
+	runCase := func(format, formatArgs, locale string, dynArgs map[string]any, skipCompileCheck bool, expectedRuntimeCost uint64, expectedEstimatedCost cost.CostEstimate, t *testing.T) (ref.Val, error) {
 		env, err := cel.NewEnv(buildOpts(skipCompileCheck, locale, buildVariables(dynArgs))...)
 		if err != nil {
 			t.Fatalf("cel.NewEnv() failed: %v", err)

--- a/ext/formatting_v2_test.go
+++ b/ext/formatting_v2_test.go
@@ -25,7 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"cel.dev/cel-go/cel"
-	"cel.dev/cel-go/checker"
+	"cel.dev/cel-go/common/cost"
 	"cel.dev/cel-go/common/types"
 	"cel.dev/cel-go/common/types/ref"
 
@@ -52,7 +52,7 @@ func TestStringFormatV2(t *testing.T) {
 		err                   string
 		expectedOutput        string
 		expectedRuntimeCost   uint64
-		expectedEstimatedCost checker.CostEstimate
+		expectedEstimatedCost cost.CostEstimate
 		skipCompileCheck      bool
 	}{
 		{
@@ -60,7 +60,7 @@ func TestStringFormatV2(t *testing.T) {
 			format:                "no substitution",
 			expectedOutput:        "no substitution",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 
 		{
@@ -69,14 +69,14 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `"filler"`,
 			expectedOutput:        "str is filler and some more",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:                  "percent escaping",
 			format:                "%% and also %%",
 			expectedOutput:        "% and also %",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:                  "substution inside escaped percent signs",
@@ -84,7 +84,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `"text"`,
 			expectedOutput:        "%text%",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "substitution with one escaped percent sign on the right",
@@ -92,7 +92,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `"percent on the right"`,
 			expectedOutput:        "percent on the right%",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "substitution with one escaped percent sign on the left",
@@ -100,7 +100,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `"percent on the left"`,
 			expectedOutput:        "%percent on the left",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "multiple substitutions",
@@ -108,7 +108,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `1, 2, 3, "A", "B", "C", 4, 5, 6, "D", "E", "F"`,
 			expectedOutput:        "1 2 3, A B C, 4 5 6, D E F",
 			expectedRuntimeCost:   14,
-			expectedEstimatedCost: checker.CostEstimate{Min: 14, Max: 14},
+			expectedEstimatedCost: cost.CostEstimate{Min: 14, Max: 14},
 		},
 		{
 			name:                  "percent sign escape sequence support",
@@ -116,7 +116,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `"percent"`,
 			expectedOutput:        "%escaped percent%",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.FixedCostEstimate(12),
+			expectedEstimatedCost: cost.FixedCostEstimate(12),
 		},
 		{
 			name:                  "fixed point formatting clause",
@@ -124,7 +124,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "1.2345",
 			expectedOutput:        "1.234",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.FixedCostEstimate(11),
+			expectedEstimatedCost: cost.FixedCostEstimate(11),
 		},
 		{
 			name:                  "fixed point formatting clause with int",
@@ -132,7 +132,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "1, 1u",
 			expectedOutput:        "1.000 + 1.00",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.FixedCostEstimate(12),
+			expectedEstimatedCost: cost.FixedCostEstimate(12),
 		},
 		{
 			name:                  "binary formatting clause",
@@ -140,7 +140,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "5",
 			expectedOutput:        "this is 5 in binary: 101",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:                  "negative binary formatting clause",
@@ -148,7 +148,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "-5",
 			expectedOutput:        "this is -5 in binary: -101",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:                  "uint support for binary formatting",
@@ -156,7 +156,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "uint(64)",
 			expectedOutput:        "unsigned 64 in binary: 1000000",
 			expectedRuntimeCost:   14,
-			expectedEstimatedCost: checker.CostEstimate{Min: 14, Max: 14},
+			expectedEstimatedCost: cost.CostEstimate{Min: 14, Max: 14},
 		},
 		{
 			name:                  "bool support for binary formatting",
@@ -164,7 +164,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "true",
 			expectedOutput:        "bit set from bool: 1",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:                  "octal formatting clause",
@@ -172,7 +172,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "11",
 			expectedOutput:        "13",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "negative octal formatting clause",
@@ -180,7 +180,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "-11",
 			expectedOutput:        "-13",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "uint support for octal formatting clause",
@@ -188,7 +188,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "uint(65535)",
 			expectedOutput:        "this is an unsigned octal: 177777",
 			expectedRuntimeCost:   14,
-			expectedEstimatedCost: checker.CostEstimate{Min: 14, Max: 14},
+			expectedEstimatedCost: cost.CostEstimate{Min: 14, Max: 14},
 		},
 		{
 			name:                  "lowercase hexadecimal formatting clause",
@@ -196,7 +196,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "30",
 			expectedOutput:        "1e is 30 in hexadecimal",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:                  "uppercase hexadecimal formatting clause",
@@ -204,7 +204,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "30",
 			expectedOutput:        "1E is 20 in hexadecimal",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:                  "negative hexadecimal formatting clause",
@@ -212,7 +212,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "-30",
 			expectedOutput:        "-1e is -30 in hexadecimal",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:                  "unsigned support for hexadecimal formatting clause",
@@ -220,7 +220,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "uint(6000)",
 			expectedOutput:        "1770 is 6000 in hexadecimal",
 			expectedRuntimeCost:   14,
-			expectedEstimatedCost: checker.CostEstimate{Min: 14, Max: 14},
+			expectedEstimatedCost: cost.CostEstimate{Min: 14, Max: 14},
 		},
 		{
 			name:                  "string support with hexadecimal formatting clause",
@@ -228,7 +228,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `"Hello world!"`,
 			expectedOutput:        "48656c6c6f20776f726c6421",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "string support with uppercase hexadecimal formatting clause",
@@ -236,7 +236,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `"Hello world!"`,
 			expectedOutput:        "48656C6C6F20776F726C6421",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "byte support with hexadecimal formatting clause",
@@ -244,7 +244,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `b"byte string"`,
 			expectedOutput:        "6279746520737472696e67",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "byte support with hexadecimal formatting clause leading zero",
@@ -252,7 +252,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `b"\x00\x00byte string\x00"`,
 			expectedOutput:        "00006279746520737472696e6700",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "byte support with uppercase hexadecimal formatting clause",
@@ -260,7 +260,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `b"byte string"`,
 			expectedOutput:        "6279746520737472696E67",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "scientific notation formatting clause",
@@ -268,7 +268,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "1052.032911275",
 			expectedOutput:        "1.052033e+03",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "scientific notation formatting clause with uint",
@@ -276,7 +276,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "1052u",
 			expectedOutput:        "1.0520e+03",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "scientific notation formatting clause with int",
@@ -284,7 +284,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "1052",
 			expectedOutput:        "1.05200e+03",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "default precision for fixed-point clause",
@@ -292,7 +292,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "2.71828",
 			expectedOutput:        "2.718280",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "default precision for scientific notation",
@@ -300,7 +300,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "2.71828",
 			expectedOutput:        "2.718280e+00",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "default precision for string",
@@ -308,7 +308,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "2.71",
 			expectedOutput:        "2.71",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "default list precision for string",
@@ -316,7 +316,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "[2.71]",
 			expectedOutput:        "[2.71]",
 			expectedRuntimeCost:   21,
-			expectedEstimatedCost: checker.CostEstimate{Min: 21, Max: 21},
+			expectedEstimatedCost: cost.CostEstimate{Min: 21, Max: 21},
 		},
 		{
 			name:                  "default format for string",
@@ -324,7 +324,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "0.000000002",
 			expectedOutput:        "0.000000002",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "default list scientific notation for string",
@@ -332,7 +332,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "[0.000000002]",
 			expectedOutput:        "[0.000000002]",
 			expectedRuntimeCost:   21,
-			expectedEstimatedCost: checker.CostEstimate{Min: 21, Max: 21},
+			expectedEstimatedCost: cost.CostEstimate{Min: 21, Max: 21},
 		},
 		{
 			name:                  "NaN support for fixed-point",
@@ -340,7 +340,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `double("NaN")`,
 			expectedOutput:        "NaN",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:                  "positive infinity support for fixed-point",
@@ -348,7 +348,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `double("Infinity")`,
 			expectedOutput:        "Infinity",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:                  "negative infinity support for fixed-point",
@@ -356,7 +356,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `double("-Infinity")`,
 			expectedOutput:        "-Infinity",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:           "NaN support for string",
@@ -388,7 +388,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "uint(64)",
 			expectedOutput:        "64",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:                  "null support for string",
@@ -396,7 +396,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            "null",
 			expectedOutput:        "null: null",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "int support for string",
@@ -404,7 +404,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `999999999999`,
 			expectedOutput:        "999999999999",
 			expectedRuntimeCost:   11,
-			expectedEstimatedCost: checker.CostEstimate{Min: 11, Max: 11},
+			expectedEstimatedCost: cost.CostEstimate{Min: 11, Max: 11},
 		},
 		{
 			name:                  "bytes support for string",
@@ -412,7 +412,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `b"xyz"`,
 			expectedOutput:        "some bytes: xyz",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:                  "type() support for string",
@@ -420,7 +420,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `type("test string")`,
 			expectedOutput:        "type is string",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:                  "timestamp support for string",
@@ -428,7 +428,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `timestamp("2023-02-03T23:31:20+00:00")`,
 			expectedOutput:        "2023-02-03T23:31:20Z",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:                  "duration support for string",
@@ -436,7 +436,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `duration("1h45m47s")`,
 			expectedOutput:        "6347s",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:                  "small duration support for string",
@@ -444,7 +444,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `duration("2ns")`,
 			expectedOutput:        "0.000000002s",
 			expectedRuntimeCost:   12,
-			expectedEstimatedCost: checker.CostEstimate{Min: 12, Max: 12},
+			expectedEstimatedCost: cost.CostEstimate{Min: 12, Max: 12},
 		},
 		{
 			name:                  "list support for string",
@@ -452,7 +452,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `["abc", 3.14, null, [9, 8, 7, 6], timestamp("2023-02-03T23:31:20Z")]`,
 			expectedOutput:        `[abc, 3.14, null, [9, 8, 7, 6], 2023-02-03T23:31:20Z]`,
 			expectedRuntimeCost:   32,
-			expectedEstimatedCost: checker.CostEstimate{Min: 32, Max: 32},
+			expectedEstimatedCost: cost.CostEstimate{Min: 32, Max: 32},
 		},
 		{
 			name:                  "map support for string",
@@ -460,7 +460,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `{"key1": b"xyz", "key5": null, "key2": duration("2h"), "key4": true, "key3": 2.71828}`,
 			expectedOutput:        `{key1: xyz, key2: 7200s, key3: 2.71828, key4: true, key5: null}`,
 			expectedRuntimeCost:   42,
-			expectedEstimatedCost: checker.CostEstimate{Min: 42, Max: 42},
+			expectedEstimatedCost: cost.CostEstimate{Min: 42, Max: 42},
 		},
 		{
 			name:                  "map support (all key types)",
@@ -468,7 +468,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `{1: "value1", uint(2): "value2", true: double("NaN")}`,
 			expectedOutput:        `map with multiple key types: {1: value1, 2: value2, true: NaN}`,
 			expectedRuntimeCost:   46,
-			expectedEstimatedCost: checker.CostEstimate{Min: 46, Max: 46},
+			expectedEstimatedCost: cost.CostEstimate{Min: 46, Max: 46},
 		},
 		{
 			name:                  "boolean support for %s",
@@ -476,7 +476,7 @@ func TestStringFormatV2(t *testing.T) {
 			formatArgs:            `true, false`,
 			expectedOutput:        "true bool: true, false bool: false",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:       "dyntype support for string formatting clause",
@@ -487,7 +487,7 @@ func TestStringFormatV2(t *testing.T) {
 			},
 			expectedOutput:        "dynamic string: a string",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:       "dyntype support for numbers with string formatting clause",
@@ -499,7 +499,7 @@ func TestStringFormatV2(t *testing.T) {
 			},
 			expectedOutput:        "dynIntStr: 32 dynDoubleStr: 56.8",
 			expectedRuntimeCost:   15,
-			expectedEstimatedCost: checker.CostEstimate{Min: 15, Max: 15},
+			expectedEstimatedCost: cost.CostEstimate{Min: 15, Max: 15},
 		},
 		{
 			name:       "dyntype support for integer formatting clause",
@@ -510,7 +510,7 @@ func TestStringFormatV2(t *testing.T) {
 			},
 			expectedOutput:        "dynamic int: 128",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:       "dyntype support for integer formatting clause (unsigned)",
@@ -521,7 +521,7 @@ func TestStringFormatV2(t *testing.T) {
 			},
 			expectedOutput:        "dynamic unsigned int: 256",
 			expectedRuntimeCost:   14,
-			expectedEstimatedCost: checker.CostEstimate{Min: 14, Max: 14},
+			expectedEstimatedCost: cost.CostEstimate{Min: 14, Max: 14},
 		},
 		{
 			name:       "dyntype support for hex formatting clause",
@@ -532,7 +532,7 @@ func TestStringFormatV2(t *testing.T) {
 			},
 			expectedOutput:        "dynamic hex int: 16",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:       "dyntype support for hex formatting clause (uppercase)",
@@ -543,7 +543,7 @@ func TestStringFormatV2(t *testing.T) {
 			},
 			expectedOutput:        "dynamic hex int: 1A (uppercase)",
 			expectedRuntimeCost:   15,
-			expectedEstimatedCost: checker.CostEstimate{Min: 15, Max: 15},
+			expectedEstimatedCost: cost.CostEstimate{Min: 15, Max: 15},
 		},
 		{
 			name:       "dyntype support for unsigned hex formatting clause",
@@ -554,7 +554,7 @@ func TestStringFormatV2(t *testing.T) {
 			},
 			expectedOutput:        "dynamic hex int: 1f4 (unsigned)",
 			expectedRuntimeCost:   14,
-			expectedEstimatedCost: checker.CostEstimate{Min: 14, Max: 14},
+			expectedEstimatedCost: cost.CostEstimate{Min: 14, Max: 14},
 		},
 		{
 			name:       "dyntype support for fixed-point formatting clause",
@@ -565,7 +565,7 @@ func TestStringFormatV2(t *testing.T) {
 			},
 			expectedOutput:        "dynamic double: 4.500",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:       "dyntype support for scientific notation",
@@ -576,7 +576,7 @@ func TestStringFormatV2(t *testing.T) {
 			},
 			expectedOutput:        "(dyntype) e: 2.718280e+00",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:       "dyntype NaN/infinity support for decimal",
@@ -589,7 +589,7 @@ func TestStringFormatV2(t *testing.T) {
 			},
 			expectedOutput:        "NaN: NaN, infinity: Infinity, -infinity: -Infinity",
 			expectedRuntimeCost:   17,
-			expectedEstimatedCost: checker.FixedCostEstimate(17),
+			expectedEstimatedCost: cost.FixedCostEstimate(17),
 		},
 		{
 			name:       "dyntype NaN/infinity support for fixed-point",
@@ -601,7 +601,7 @@ func TestStringFormatV2(t *testing.T) {
 			},
 			expectedOutput:        "NaN: NaN, infinity: Infinity",
 			expectedRuntimeCost:   15,
-			expectedEstimatedCost: checker.CostEstimate{Min: 15, Max: 15},
+			expectedEstimatedCost: cost.CostEstimate{Min: 15, Max: 15},
 		},
 		{
 			name:       "dyntype NaN/infinity support for scientific",
@@ -614,7 +614,7 @@ func TestStringFormatV2(t *testing.T) {
 			},
 			expectedOutput:        "NaN: NaN, infinity: Infinity, -infinity: -Infinity",
 			expectedRuntimeCost:   17,
-			expectedEstimatedCost: checker.FixedCostEstimate(17),
+			expectedEstimatedCost: cost.FixedCostEstimate(17),
 		},
 		{
 			name:       "dyntype support for timestamp",
@@ -625,7 +625,7 @@ func TestStringFormatV2(t *testing.T) {
 			},
 			expectedOutput:        "dyntype timestamp: 2009-11-10T23:00:00Z",
 			expectedRuntimeCost:   14,
-			expectedEstimatedCost: checker.CostEstimate{Min: 14, Max: 14},
+			expectedEstimatedCost: cost.CostEstimate{Min: 14, Max: 14},
 		},
 		{
 			name:       "dyntype support for duration",
@@ -636,7 +636,7 @@ func TestStringFormatV2(t *testing.T) {
 			},
 			expectedOutput:        "dyntype duration: 8747s",
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:       "dyntype support for lists",
@@ -647,7 +647,7 @@ func TestStringFormatV2(t *testing.T) {
 			},
 			expectedOutput:        `dyntype list: [6, 4.2, a string]`,
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:       "dyntype support for maps",
@@ -662,7 +662,7 @@ func TestStringFormatV2(t *testing.T) {
 			},
 			expectedOutput:        `dyntype map: {6: 422s, strKey: x, true: 42}`,
 			expectedRuntimeCost:   13,
-			expectedEstimatedCost: checker.CostEstimate{Min: 13, Max: 13},
+			expectedEstimatedCost: cost.CostEstimate{Min: 13, Max: 13},
 		},
 		{
 			name:       "message field support",
@@ -888,7 +888,7 @@ func TestStringFormatV2(t *testing.T) {
 			err:              "precision 9999999 exceeds maximum allowed precision 100",
 		},
 	}
-	evalExpr := func(env *cel.Env, expr string, evalArgs any, expectedRuntimeCost uint64, expectedEstimatedCost checker.CostEstimate, t *testing.T) (ref.Val, error) {
+	evalExpr := func(env *cel.Env, expr string, evalArgs any, expectedRuntimeCost uint64, expectedEstimatedCost cost.CostEstimate, t *testing.T) (ref.Val, error) {
 		t.Logf("evaluating expr: %s", expr)
 		parsedAst, issues := env.Parse(expr)
 		if issues.Err() != nil {
@@ -988,7 +988,7 @@ func TestStringFormatV2(t *testing.T) {
 		opts = append(opts, variables...)
 		return opts
 	}
-	runCase := func(format, formatArgs string, dynArgs map[string]any, skipCompileCheck bool, expectedRuntimeCost uint64, expectedEstimatedCost checker.CostEstimate, t *testing.T) (ref.Val, error) {
+	runCase := func(format, formatArgs string, dynArgs map[string]any, skipCompileCheck bool, expectedRuntimeCost uint64, expectedEstimatedCost cost.CostEstimate, t *testing.T) (ref.Val, error) {
 		env, err := cel.NewEnv(buildOpts(skipCompileCheck, buildVariables(dynArgs))...)
 		if err != nil {
 			t.Fatalf("cel.NewEnv() failed: %v", err)


### PR DESCRIPTION
While the internals of the checker and interpreter may still refer to local aliases, the top-level packages should be able to remove these dependencies