### PR TITLE
Support escaped function names as a parser option

### DIFF
--- a/cel/io.go
+++ b/cel/io.go
@@ -118,18 +118,42 @@ func AstToParsedExpr(a *Ast) (*exprpb.ParsedExpr, error) {
 	}, nil
 }
 
+// ASTFormatOption is a functional option for configuring the output formatting of AstToString and ExprToString.
+type ASTFormatOption func() parser.UnparserOption
+
+// FormatEscapeIdentifiers configures whether non-standard or reserved identifiers are quoted with backticks.
+func FormatEscapeIdentifiers(escape bool) ASTFormatOption {
+	return func() parser.UnparserOption {
+		return parser.EscapeIdentifiers(escape)
+	}
+}
+
+// FormatWrapOnColumn configures expression word-wrapping when the string length exceeds the specified column limit.
+func FormatWrapOnColumn(col int) ASTFormatOption {
+	return func() parser.UnparserOption {
+		return parser.WrapOnColumn(col)
+	}
+}
+
 // AstToString converts an Ast back to a string if possible.
 //
 // Note, the conversion may not be an exact replica of the original expression, but will produce
 // a string that is semantically equivalent and whose textual representation is stable.
-func AstToString(a *Ast) (string, error) {
-	return ExprToString(a.NativeRep().Expr(), a.NativeRep().SourceInfo())
+func AstToString(a *Ast, opts ...ASTFormatOption) (string, error) {
+	if a == nil {
+		return "", errors.New("unsupported expr")
+	}
+	return ExprToString(a.NativeRep().Expr(), a.NativeRep().SourceInfo(), opts...)
 }
 
 // ExprToString converts an AST Expr node back to a string using macro call tracking metadata from
 // source info if any macros are encountered within the expression.
-func ExprToString(e ast.Expr, info *ast.SourceInfo) (string, error) {
-	return parser.Unparse(e, info)
+func ExprToString(e ast.Expr, info *ast.SourceInfo, opts ...ASTFormatOption) (string, error) {
+	unparserOpts := make([]parser.UnparserOption, len(opts))
+	for i, opt := range opts {
+		unparserOpts[i] = opt()
+	}
+	return parser.Unparse(e, info, unparserOpts...)
 }
 
 // RefValueToValue converts between ref.Val and google.api.expr.v1alpha1.Value.

--- a/cel/io_test.go
+++ b/cel/io_test.go
@@ -148,6 +148,47 @@ func TestAstToString(t *testing.T) {
 	}
 }
 
+func TestAstToStringWithOptions(t *testing.T) {
+	stdEnv, err := NewEnv(
+		OptionalTypes(),
+		EnableMacroCallTracking(),
+	)
+	if err != nil {
+		t.Fatalf("NewEnv() failed: %v", err)
+	}
+	in := "a.`b-c` && (x || y)"
+	ast, iss := stdEnv.Parse(in)
+	if iss.Err() != nil {
+		t.Fatalf("stdEnv.Parse(%q) failed: %v", in, iss.Err())
+	}
+	// Default: no backtick escaping
+	exprDefault, err := AstToString(ast)
+	if err != nil {
+		t.Fatalf("AstToString(ast) failed: %v", err)
+	}
+	if exprDefault != "a.b-c && (x || y)" {
+		t.Errorf("got %q, wanted %q", exprDefault, "a.b-c && (x || y)")
+	}
+
+	// Opt-in: backtick escaping
+	exprEscaped, err := AstToString(ast, FormatEscapeIdentifiers(true))
+	if err != nil {
+		t.Fatalf("AstToString(ast) failed: %v", err)
+	}
+	if exprEscaped != in {
+		t.Errorf("got %q, wanted %q", exprEscaped, in)
+	}
+
+	// Word wrap
+	exprWrapped, err := AstToString(ast, FormatWrapOnColumn(5))
+	if err != nil {
+		t.Fatalf("AstToString(ast) failed: %v", err)
+	}
+	if exprWrapped != "a.b-c &&\n(x ||\ny)" {
+		t.Errorf("got %q, wanted %q", exprWrapped, "a.b-c &&\n(x ||\ny)")
+	}
+}
+
 func TestExprToString(t *testing.T) {
 	stdEnv, err := NewEnv(EnableMacroCallTracking())
 	if err != nil {

--- a/parser/options.go
+++ b/parser/options.go
@@ -28,6 +28,7 @@ type options struct {
 	enableOptionalSyntax             bool
 	enableVariadicOperatorASTs       bool
 	enableIdentEscapeSyntax          bool
+	enableCallEscapeSyntax           bool
 	enableHiddenAccumulatorName      bool
 	enablePrattParser                bool
 }
@@ -180,6 +181,15 @@ func EnableVariadicOperatorASTs(varArgASTs bool) Option {
 func EnablePrattParser(enablePrattParser bool) Option {
 	return func(opts *options) error {
 		opts.enablePrattParser = enablePrattParser
+		return nil
+	}
+}
+
+// EnableCallEscapeSyntax enables backtick (`) escaped function and method call identifiers,
+// as well as internal identifiers with '@' characters.
+func EnableCallEscapeSyntax(enableCallEscapeSyntax bool) Option {
+	return func(opts *options) error {
+		opts.enableCallEscapeSyntax = enableCallEscapeSyntax
 		return nil
 	}
 }

--- a/parser/pratt_parser.go
+++ b/parser/pratt_parser.go
@@ -106,6 +106,7 @@ type prattParserWorker struct {
 	enableOptionalSyntax       bool
 	enableVariadicOperatorASTs bool
 	enableIdentEscapeSyntax    bool
+	enableCallEscapeSyntax     bool
 }
 
 // prattParser encapsulates the context necessary to perform Pratt parsing for different expressions.
@@ -147,6 +148,7 @@ func (p *prattParser) Parse(source common.Source) (*ast.AST, *common.Errors) {
 		enableOptionalSyntax:       p.enableOptionalSyntax,
 		enableVariadicOperatorASTs: p.enableVariadicOperatorASTs,
 		enableIdentEscapeSyntax:    p.enableIdentEscapeSyntax,
+		enableCallEscapeSyntax:     p.enableCallEscapeSyntax,
 	}
 	pratt.initTokenStream()
 	out := pratt.parse()
@@ -365,6 +367,9 @@ func (p *prattParserWorker) normalizeIdent(tok token, allowQuoted bool) string {
 		}
 		for _, c := range inner {
 			if !isAlpha(c) && !isDigit(c) && c != '_' && c != '.' && c != '-' && c != '/' && c != ' ' {
+				if c == '@' && p.enableCallEscapeSyntax {
+					continue
+				}
 				p.reportError(tok, "unexpected quoted identifier")
 				return ""
 			}
@@ -481,7 +486,7 @@ func (p *prattParserWorker) parseSelectorChainTail(lhs ast.Expr) ast.Expr {
 				return lhs
 			}
 			isMemberCall := p.peekTok.kind == tokLeftParen
-			field := p.normalizeIdent(fieldTok, !isMemberCall)
+			field := p.normalizeIdent(fieldTok, p.enableCallEscapeSyntax || !isMemberCall)
 			if optional {
 				opID := p.nextID(dotTok)
 				fieldID := p.nextID(fieldTok)
@@ -833,7 +838,7 @@ func (p *prattParserWorker) parseIdentOrCall() ast.Expr {
 		}
 		return p.helper.newExpr(idTok)
 	}
-	idText := p.normalizeIdent(idTok, false)
+	idText := p.normalizeIdent(idTok, p.enableCallEscapeSyntax)
 	if idTok.kind == tokReservedWord {
 		if _, ok := reservedIds[idText]; ok {
 			p.reportError(idTok, "reserved identifier: %s", idText)

--- a/parser/unparser.go
+++ b/parser/unparser.go
@@ -70,7 +70,42 @@ func Unparse(expr ast.Expr, info *ast.SourceInfo, opts ...UnparserOption) (strin
 
 var identifierPartPattern *regexp.Regexp = regexp.MustCompile(`^[A-Za-z_][0-9A-Za-z_]*$`)
 
-func maybeQuoteField(field string) string {
+func (un *unparser) maybeQuoteIdent(name string) string {
+	if !un.options.escapeIdentifiers {
+		return name
+	}
+	if name == "" {
+		return ""
+	}
+	if strings.HasPrefix(name, ".") {
+		return "." + un.maybeQuoteIdent(name[1:])
+	}
+	if strings.Contains(name, ".") {
+		parts := strings.Split(name, ".")
+		for i, part := range parts {
+			parts[i] = un.maybeQuoteIdent(part)
+		}
+		return strings.Join(parts, ".")
+	}
+	if !identifierPartPattern.MatchString(name) || isReservedIdent(name) {
+		return "`" + name + "`"
+	}
+	return name
+}
+
+func (un *unparser) maybeQuoteFunction(fun string) string {
+	return un.maybeQuoteIdent(fun)
+}
+
+func isReservedIdent(name string) bool {
+	_, ok := reservedIds[name]
+	return ok
+}
+
+func (un *unparser) maybeQuoteField(field string) string {
+	if !un.options.escapeIdentifiers {
+		return field
+	}
 	if !identifierPartPattern.MatchString(field) || field == "in" {
 		return "`" + field + "`"
 	}
@@ -221,8 +256,10 @@ func (un *unparser) visitCallFunc(expr ast.Expr) error {
 			return err
 		}
 		un.str.WriteString(".")
+		un.str.WriteString(un.maybeQuoteIdent(fun))
+	} else {
+		un.str.WriteString(un.maybeQuoteFunction(fun))
 	}
-	un.str.WriteString(fun)
 	un.str.WriteString("(")
 	for i, arg := range args {
 		err := un.visit(arg)
@@ -335,7 +372,7 @@ func (un *unparser) visitConst(expr ast.Expr) error {
 }
 
 func (un *unparser) visitIdent(expr ast.Expr) error {
-	un.str.WriteString(expr.AsIdent())
+	un.str.WriteString(un.maybeQuoteIdent(expr.AsIdent()))
 	return nil
 }
 
@@ -387,7 +424,7 @@ func (un *unparser) visitSelectInternal(operand ast.Expr, testOnly bool, op stri
 		return err
 	}
 	un.str.WriteString(op)
-	un.str.WriteString(maybeQuoteField(field))
+	un.str.WriteString(un.maybeQuoteField(field))
 	if testOnly {
 		un.str.WriteString(")")
 	}
@@ -397,7 +434,7 @@ func (un *unparser) visitSelectInternal(operand ast.Expr, testOnly bool, op stri
 func (un *unparser) visitStructMsg(expr ast.Expr) error {
 	m := expr.AsStruct()
 	fields := m.Fields()
-	un.str.WriteString(m.TypeName())
+	un.str.WriteString(un.maybeQuoteFunction(m.TypeName()))
 	un.str.WriteString("{")
 	for i, f := range fields {
 		field := f.AsStructField()
@@ -405,7 +442,7 @@ func (un *unparser) visitStructMsg(expr ast.Expr) error {
 		if field.IsOptional() {
 			un.str.WriteString("?")
 		}
-		un.str.WriteString(maybeQuoteField(f))
+		un.str.WriteString(un.maybeQuoteField(f))
 		un.str.WriteString(": ")
 		v := field.Value()
 		err := un.visit(v)
@@ -611,6 +648,16 @@ type unparserOption struct {
 	wrapOnColumn         int
 	operatorsToWrapOn    map[string]bool
 	wrapAfterColumnLimit bool
+	escapeIdentifiers    bool
+}
+
+// EscapeIdentifiers enables backtick (`) escaping for non-standard and reserved identifiers,
+// function names, and field names when unparsing.
+func EscapeIdentifiers(escape bool) UnparserOption {
+	return func(opt *unparserOption) (*unparserOption, error) {
+		opt.escapeIdentifiers = escape
+		return opt, nil
+	}
 }
 
 // WrapOnColumn wraps the output expression when its string length exceeds a specified limit

--- a/parser/unparser_test.go
+++ b/parser/unparser_test.go
@@ -110,9 +110,6 @@ func TestUnparse(t *testing.T) {
 		{name: "list_lit_opt", in: `[?a, ?b, c]`},
 		{name: "map_lit_opt", in: `{?a: b, c: d}`},
 		{name: "msg_fields_opt", in: `v1alpha1.Expr{?id: id, call_expr: v1alpha1.Call_Expr{function: "name"}}`},
-		{name: "select_quoted", in: "a.`b-c`"},
-		{name: "opt_select_quoted", in: "a.?`b.c`"},
-		{name: "message_create_quoted", in: "MyType{`in`: false}"},
 		// A unary operator whose operand is another unary operator, or a negative numeric
 		// literal, must keep the operand parenthesized. The grammar parses a run of leading
 		// '!' or '-' tokens as a single unary expression and cancels out pairs of them, and
@@ -633,6 +630,73 @@ func TestUnparseErrors(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tc.err.Error()) {
 				t.Errorf("Unparse(%v) got unexpected error: %v, wanted %v", tc.in, err, tc.err)
+			}
+		})
+	}
+}
+
+func TestUnparseEscapedCalls(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{name: "select_escaped", in: "a.`b-c`.d"},
+		{name: "select_escaped_in", in: "a.`in`"},
+		{name: "select_quoted", in: "a.`b-c`"},
+		{name: "opt_select_quoted", in: "a.?`b.c`"},
+		{name: "message_create_quoted", in: "MyType{`in`: false}"},
+		{name: "call_member_escaped", in: "a.`@mapInsert`(b, c)"},
+		{name: "call_global_escaped", in: "`@mapInsert`(a, b)"},
+		{name: "call_namespaced_escaped", in: "cel.`@mapInsert`(a, b)"},
+		{name: "call_escaped_dash", in: "a.`custom-fn`(b)"},
+		{name: "ident_at", in: "`@result` + 1"},
+		{name: "ident_escaped_dash", in: "`my-ident`"},
+		{name: "ident_escaped_keyword", in: "`in`"},
+		{name: "ident_leading_dot_escaped", in: ".`my-ident`"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prsr, err := NewParser(
+				Macros(AllMacros...),
+				EnablePrattParser(true),
+				EnableOptionalSyntax(true),
+				EnableIdentEscapeSyntax(true),
+				EnableCallEscapeSyntax(true),
+			)
+			if err != nil {
+				t.Fatalf("NewParser() failed: %v", err)
+			}
+			p, iss := prsr.Parse(common.NewTextSource(tc.in))
+			if len(iss.GetErrors()) > 0 {
+				t.Fatalf("parser.Parse(%s) failed: %v", tc.in, iss.ToDisplayString())
+			}
+			out, err := Unparse(p.Expr(), p.SourceInfo(), EscapeIdentifiers(true))
+			if err != nil {
+				t.Fatalf("Unparse(%s) failed: %v", tc.in, err)
+			}
+			want := tc.in
+			if tc.out != "" {
+				want = tc.out
+			}
+			if out != want {
+				t.Errorf("Unparse() got '%s', wanted '%s'", out, want)
+			}
+			p2, iss := prsr.Parse(common.NewTextSource(out))
+			if len(iss.GetErrors()) > 0 {
+				t.Fatalf("parser.Parse(%s) roundtrip failed: %v", out, iss.ToDisplayString())
+			}
+			before, err := ast.ExprToProto(p.Expr())
+			if err != nil {
+				t.Fatalf("ast.ExprToProto() failed: %v", err)
+			}
+			after, err := ast.ExprToProto(p2.Expr())
+			if err != nil {
+				t.Fatalf("ast.ExprToProto() failed: %v", err)
+			}
+			if !proto.Equal(before, after) {
+				t.Errorf("Roundtrip Parse() differs from original. Got '%v', wanted '%v'", before, after)
 			}
 		})
 	}


### PR DESCRIPTION
Support escaped function names and the `@` character as an option in the parser.

This should not be exposed on the top-level API, but is available for tooling to use for parsing,
matching, and equivalence.