### PR TITLE
Fix time-related flakiness in ContextEval interrupt checks

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -1239,7 +1239,8 @@ func TestContextEval(t *testing.T) {
 	if iss.Err() != nil {
 		t.Fatalf("env.Compile(expr) failed: %v", iss.Err())
 	}
-	prg, err := env.Program(ast, EvalOptions(OptOptimize|OptTrackState), InterruptCheckFrequency(100))
+	const interruptCheckFrequency = 100
+	prg, err := env.Program(ast, EvalOptions(OptOptimize|OptTrackState), InterruptCheckFrequency(interruptCheckFrequency))
 	if err != nil {
 		t.Fatalf("env.Program() failed: %v", err)
 	}
@@ -1257,10 +1258,19 @@ func TestContextEval(t *testing.T) {
 		t.Errorf("prg.ContextEval() got %v, wanted 1975", out)
 	}
 
-	evalCtx, cancel := context.WithTimeout(ctx, time.Microsecond)
+	// Interrupt the evaluation using a deadline which has already elapsed. Relying on a short
+	// timeout is inherently racy since the evaluation may complete before the deadline timer
+	// fires, whereas an elapsed deadline closes the context's done channel immediately. The
+	// input list is sized well beyond the interrupt check frequency to ensure the interrupt is
+	// observed mid-comprehension rather than after the evaluation completes.
+	interruptItems := make([]int64, interruptCheckFrequency*100)
+	for i := 0; i < len(interruptItems); i++ {
+		interruptItems[i] = int64(i)
+	}
+	evalCtx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Minute))
 	defer cancel()
 
-	out, _, err = prg.ContextEval(evalCtx, map[string]any{"items": items})
+	out, _, err = prg.ContextEval(evalCtx, map[string]any{"items": interruptItems})
 	if err == nil {
 		t.Errorf("Got result %v, wanted timeout error", out)
 	}

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -2082,9 +2082,13 @@ func TestInterpreter_ExhaustiveConditionalExpr(t *testing.T) {
 }
 
 func TestInterpreter_InterruptableEval(t *testing.T) {
-	items := make([]int64, 5000)
-	for i := int64(0); i < 5000; i++ {
-		items[i] = i
+	// The interrupt is only observed once every interruptCheckFrequency iterations, so the
+	// input list is sized well beyond that threshold to ensure the check occurs while the
+	// comprehension is still iterating.
+	const interruptCheckFrequency = 100
+	items := make([]int64, interruptCheckFrequency*50)
+	for i := 0; i < len(items); i++ {
+		items[i] = int64(i)
 	}
 	tc := testCase{
 		expr: `items.map(i, i).map(i, i).size() != 0`,
@@ -2101,11 +2105,14 @@ func TestInterpreter_InterruptableEval(t *testing.T) {
 		t.Fatalf("program(%s) failed: %v", tc.expr, err)
 	}
 
+	// Use a deadline which has already elapsed rather than a short timeout. A timeout-based
+	// deadline is racy as the evaluation may finish before the deadline timer fires, whereas
+	// an elapsed deadline closes the context's done channel immediately.
 	ctx := context.TODO()
-	evalCtx, cancel := context.WithTimeout(ctx, 10*time.Microsecond)
+	evalCtx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Minute))
 	defer cancel()
 
-	frame.SetContext(evalCtx, 100)
+	frame.SetContext(evalCtx, interruptCheckFrequency)
 	out := prg.Exec(frame)
 	frame.Close()
 	if !types.IsError(out) || out.(*types.Err).String() != "operation interrupted" {


### PR DESCRIPTION
Closes #1475 